### PR TITLE
Butteroala  ug text styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # noredink-ui
 
 UI widgets we use.
+
+## Examples
+
+This repo contains an app showcasing all of these UI widgets.
+
+To see them locally:
+
+```
+> cd styleguide-app
+> elm-make Main.elm --output=elm.js
+```
+
+Open `index.html` in your browser.
+
+Alternatively, you may use elm-reactor. Please be aware that you'll need to globally
+install fonts (in particular, Muli) if you go this route.

--- a/src/Nri/Ui/Text/V1.elm
+++ b/src/Nri/Ui/Text/V1.elm
@@ -165,6 +165,9 @@ ugMediumBody =
             , fontSize (px 18)
             , lineHeight (px 30)
             , color gray20
+            , margin4 (px 10) (px 0) (px 0) (px 0)
+            , firstChild [ margin zero ]
+            , firstOfType [ margin zero ]
             ]
         ]
 
@@ -179,6 +182,9 @@ ugSmallBody =
             , fontSize (px 16)
             , lineHeight (px 25)
             , color gray20
+            , margin4 (px 7) (px 0) (px 0) (px 0)
+            , firstChild [ margin zero ]
+            , firstOfType [ margin zero ]
             ]
         ]
 

--- a/src/Nri/Ui/Text/V1.elm
+++ b/src/Nri/Ui/Text/V1.elm
@@ -13,28 +13,31 @@ module Nri.Ui.Text.V1
         , styles
         , subHeading
         , tagline
+        , ugMediumBody
+        , ugSmallBody
         )
 
-{-| Text types:
-
-@docs caption
-@docs heading
-@docs mediumBody
-@docs smallBody
-@docs smallBodyGray
-@docs subHeading
-@docs smallHeading
-@docs tagline
-
-Text class strings:
-
-@docs captionClassString
-@docs mediumBodyClassString
-@docs smallBodyClassString
+{-|
 
 @docs styles
 
-Modifying strings to display nicely:
+
+## Semantic text types:
+
+@docs caption, heading, mediumBody, smallBody, smallBodyGray, subHeading, smallHeading, tagline
+
+
+## User-generated text styles:
+
+@docs ugMediumBody,ugSmallBody
+
+
+## Text class strings:
+
+@docs captionClassString, mediumBodyClassString, smallBodyClassString
+
+
+## Modifying strings to display nicely:
 
 @docs noWidow
 
@@ -43,8 +46,9 @@ Modifying strings to display nicely:
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, children, descendants, everything, selector)
 import Css.Helpers exposing (identifierToString)
-import DEPRECATED.Css.File exposing (Stylesheet, compile, stylesheet)
 import Html exposing (..)
+import Html.Styled
+import Html.Styled.Attributes exposing (css)
 import Nri.Colors exposing (..)
 import Nri.Stylers exposing (makeFont)
 import Nri.Ui.Styles.V1
@@ -148,6 +152,24 @@ captionClassString =
 classString : List CssClasses -> String
 classString classes =
     String.join " " (List.map (identifierToString namespace) classes)
+
+
+{-| User-generated text.
+-}
+ugMediumBody : List (Html.Styled.Html msg) -> Html.Styled.Html msg
+ugMediumBody =
+    Html.Styled.p
+        [ css []
+        ]
+
+
+{-| User-generated text.
+-}
+ugSmallBody : List (Html.Styled.Html msg) -> Html.Styled.Html msg
+ugSmallBody =
+    Html.Styled.p
+        [ css []
+        ]
 
 
 namespace : String

--- a/src/Nri/Ui/Text/V1.elm
+++ b/src/Nri/Ui/Text/V1.elm
@@ -164,6 +164,7 @@ ugMediumBody =
             [ quizFont
             , fontSize (px 18)
             , lineHeight (px 30)
+            , whiteSpace preLine
             , color gray20
             , margin4 (px 10) (px 0) (px 0) (px 0)
             , firstChild [ margin zero ]
@@ -181,6 +182,7 @@ ugSmallBody =
             [ quizFont
             , fontSize (px 16)
             , lineHeight (px 25)
+            , whiteSpace preLine
             , color gray20
             , margin4 (px 7) (px 0) (px 0) (px 0)
             , firstChild [ margin zero ]

--- a/src/Nri/Ui/Text/V1.elm
+++ b/src/Nri/Ui/Text/V1.elm
@@ -50,6 +50,7 @@ import Html exposing (..)
 import Html.Styled
 import Html.Styled.Attributes exposing (css)
 import Nri.Colors exposing (..)
+import Nri.Fonts exposing (quizFont)
 import Nri.Stylers exposing (makeFont)
 import Nri.Ui.Styles.V1
 
@@ -159,7 +160,12 @@ classString classes =
 ugMediumBody : List (Html.Styled.Html msg) -> Html.Styled.Html msg
 ugMediumBody =
     Html.Styled.p
-        [ css []
+        [ css
+            [ quizFont
+            , fontSize (px 18)
+            , lineHeight (px 30)
+            , color gray20
+            ]
         ]
 
 
@@ -168,7 +174,12 @@ ugMediumBody =
 ugSmallBody : List (Html.Styled.Html msg) -> Html.Styled.Html msg
 ugSmallBody =
     Html.Styled.p
-        [ css []
+        [ css
+            [ quizFont
+            , fontSize (px 16)
+            , lineHeight (px 25)
+            , color gray20
+            ]
         ]
 
 

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -1,10 +1,13 @@
 module Examples.Text exposing (example)
 
-{- \
-   @docs example
+{-|
+
+@docs example
+
 -}
 
-import Html
+import Html as RootHtml
+import Html.Styled as Html
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.Text.V1 as Text
 
@@ -23,12 +26,14 @@ example =
                     how long the assignment will take.
                 """
         in
-        [ Text.heading [ Html.text "This is the main page heading." ]
-        , Text.tagline [ Html.text "This is a tagline" ]
-        , Text.subHeading [ Html.text "This is a subHeading" ]
-        , Text.mediumBody [ Html.text <| "This is a mediumBody. " ++ longerBody ]
-        , Text.smallBody [ Html.text <| "This is a smallBody. " ++ longerBody ]
-        , Text.smallBodyGray [ Html.text <| "This is a smallBodyGray. " ++ longerBody ]
-        , Text.caption [ Html.text <| "This is a caption. " ++ longerBody ]
+        [ Text.heading [ RootHtml.text "This is the main page heading." ]
+        , Text.tagline [ RootHtml.text "This is a tagline" ]
+        , Text.subHeading [ RootHtml.text "This is a subHeading" ]
+        , Text.mediumBody [ RootHtml.text <| "This is a mediumBody. " ++ longerBody ]
+        , Html.toUnstyled (Text.ugMediumBody [ Html.text <| "This is an ugMediumBody." ])
+        , Text.smallBody [ RootHtml.text <| "This is a smallBody. " ++ longerBody ]
+        , Text.smallBodyGray [ RootHtml.text <| "This is a smallBodyGray. " ++ longerBody ]
+        , Html.toUnstyled (Text.ugSmallBody [ Html.text <| "This is an ugSmallBody." ])
+        , Text.caption [ RootHtml.text <| "This is a caption. " ++ longerBody ]
         ]
     }

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -29,6 +29,7 @@ example =
         [ Text.heading [ RootHtml.text "This is the main page heading." ]
         , Text.tagline [ RootHtml.text "This is a tagline" ]
         , Text.subHeading [ RootHtml.text "This is a subHeading" ]
+        , Text.smallHeading [ RootHtml.text "This is a smallHeading" ]
         , Text.mediumBody [ RootHtml.text <| "This is a mediumBody. " ++ longerBody ]
         , Html.toUnstyled (Text.ugMediumBody [ Html.text <| "This is an ugMediumBody." ])
         , Text.smallBody [ RootHtml.text <| "This is a smallBody. " ++ longerBody ]


### PR DESCRIPTION
Adds helpers for user-generated text styles.

<img width="504" alt="screen shot 2018-03-07 at 2 41 57 pm" src="https://user-images.githubusercontent.com/8811312/37122547-d116ef3e-2215-11e8-95fb-407273b66d7e.png">

@bendansby mediumBody & smallBody have margins on them by default (`margin4 (px 10) (px 0) (px 0) (px 0)` and `margin4 (px 7) (px 0) (px 0) (px 0)` respectively). Would you like for ugMediumBody and ugSmallBody to follow this pattern?