### PR TITLE
Add text area for content creation

### DIFF
--- a/src/Nri/Ui/InputStyles.elm
+++ b/src/Nri/Ui/InputStyles.elm
@@ -28,6 +28,7 @@ type CssClasses
     | IsInError
       -- For textarea
     | Writing
+    | ContentCreation
       -- For date picker inputs
     | DatePickerContainer
     | TimePickerContainer
@@ -151,6 +152,15 @@ styles =
                             , color Nri.Colors.white
                             , borderColor Nri.Colors.purple
                             ]
+                        ]
+                    ]
+                ]
+            , class ContentCreation
+                [ descendants
+                    [ class Label
+                        [ border3 (px 1) solid Nri.Colors.gray75
+                        , borderRadius (px 4)
+                        , Nri.Stylers.makeFont (Css.px 11) Nri.Colors.gray45
                         ]
                     ]
                 ]

--- a/src/Nri/Ui/TextArea/V1.elm
+++ b/src/Nri/Ui/TextArea/V1.elm
@@ -1,6 +1,7 @@
 module Nri.Ui.TextArea.V1
     exposing
         ( Model
+        , contentCreation
         , generateId
         , styles
         , view
@@ -12,7 +13,7 @@ module Nri.Ui.TextArea.V1
 
 ## The Nri styleguide-specified textarea with overlapping label
 
-@docs view, writing, Model, generateId, styles
+@docs view, writing, contentCreation, Model, generateId, styles
 
 -}
 
@@ -50,9 +51,17 @@ writing model =
     view_ WritingStyle model
 
 
+{-| Used for Content Creation
+-}
+contentCreation : Model msg -> Html msg
+contentCreation model =
+    view_ ContentCreationStyle model
+
+
 type TextAreaStyle
     = DefaultStyle
     | WritingStyle
+    | ContentCreationStyle
 
 
 {-| -}
@@ -61,6 +70,9 @@ view_ textAreaStyle model =
     let
         showWritingClass =
             textAreaStyle == WritingStyle
+
+        showContentCreationClass =
+            textAreaStyle == ContentCreationStyle
 
         sharedAttributes =
             [ onInput model.onInput
@@ -76,6 +88,7 @@ view_ textAreaStyle model =
             [ ( Container, True )
             , ( IsInError, model.isInError )
             , ( Writing, showWritingClass )
+            , ( ContentCreation, showContentCreationClass )
             ]
         ]
         [ if model.autoResize then

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -6,10 +6,10 @@ module Examples.TextArea exposing (Msg, State, example, init, update)
 
 import Dict exposing (Dict)
 import Html
-import Nri.Ui.Checkbox.V1 as Checkbox
-import Nri.Ui.TextArea.V1 as TextArea
-import Nri.Ui.Text.V1 as Text
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
+import Nri.Ui.Checkbox.V1 as Checkbox
+import Nri.Ui.Text.V1 as Text
+import Nri.Ui.TextArea.V1 as TextArea
 
 
 {-| -}
@@ -82,6 +82,16 @@ example parentMessage state =
             , onInput = InputGiven 2
             , isInError = state.isInError
             , label = "TextArea.writing"
+            , autoResize = state.autoResize
+            , placeholder = "Placeholder"
+            , showLabel = state.showLabel
+            }
+        , TextArea.contentCreation
+            { value = Maybe.withDefault "" <| Dict.get 3 state.textValues
+            , autofocus = False
+            , onInput = InputGiven 3
+            , isInError = state.isInError
+            , label = "TextArea.contentCreation"
             , autoResize = state.autoResize
             , placeholder = "Placeholder"
             , showLabel = state.showLabel


### PR DESCRIPTION
The styling used for this textarea is not quite the same as the one of the default or writing textareas currently in use.

This reintroduces the same styles that were the default in this repository before merging in text area changes from the monolith, but in a way that only affects CCS (The monolith is not using the TextArea component exposed by this module, yet).

Going to merge this directly!