### PR TITLE
Tweak styles for the CCS textarea

### DIFF
--- a/src/Nri/Ui/InputStyles.elm
+++ b/src/Nri/Ui/InputStyles.elm
@@ -161,6 +161,7 @@ styles =
                         [ border3 (px 1) solid Nri.Colors.gray75
                         , borderRadius (px 4)
                         , Nri.Stylers.makeFont (Css.px 11) Nri.Colors.gray45
+                        , padding2 (px 2) (px 5)
                         ]
                     ]
                 ]


### PR DESCRIPTION
Some paddings were missing in the CCS textarea styles re-introduced in #7. This addresses that.

This PR only affects CCS. Going to merge directly.