### PR TITLE
Add `SegmentedControl`

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -21,6 +21,7 @@
         "Nri.Ui.Modal.V1",
         "Nri.Ui.Outline.V1",
         "Nri.Ui.Palette.V1",
+        "Nri.Ui.SegmentedControl.V1",
         "Nri.Ui.Styles.V1",
         "Nri.Ui.Tabs.V1",
         "Nri.Ui.Text.Writing.V1",

--- a/src/Nri/Ui/SegmentedControl/V1.elm
+++ b/src/Nri/Ui/SegmentedControl/V1.elm
@@ -91,6 +91,7 @@ styles =
             , border3 (px 1) solid Colors.azure
             , borderLeft (px 0)
             , borderBottom3 (px 3) solid Colors.azure
+            , boxSizing borderBox
             ]
         , Css.Foreign.class Focused
             [ color Colors.gray20

--- a/src/Nri/Ui/SegmentedControl/V1.elm
+++ b/src/Nri/Ui/SegmentedControl/V1.elm
@@ -1,0 +1,101 @@
+module Nri.Ui.SegmentedControl.V1 exposing (Config, Option, styles, view)
+
+{-|
+
+@docs Config, Option, styles, view
+
+-}
+
+import Accessibility exposing (..)
+import Accessibility.Role as Role
+import Css exposing (..)
+import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import Html
+import Html.Attributes
+import Html.Events
+import Nri.Ui.Colors.Extra exposing (withAlpha)
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.CssFlexBoxWithVendorPrefix as FlexBox
+import Nri.Ui.Fonts.V1
+import Nri.Ui.Styles.V1
+
+
+{-| -}
+type alias Config a msg =
+    { onClick : a -> msg
+    , options : List (Option a)
+    , selected : a
+    }
+
+
+{-| -}
+type alias Option a =
+    { value : a
+    , label : String
+    , id : String
+    }
+
+
+{-| -}
+view : Config a msg -> Html.Html msg
+view config =
+    config.options
+        |> List.map
+            (\option ->
+                Html.div
+                    [ Html.Attributes.id option.id
+                    , Role.tab
+                    , Html.Events.onClick (config.onClick option.value)
+                    , styles.classList
+                        [ ( Tab, True )
+                        , ( Focused, option.value == config.selected )
+                        ]
+                    ]
+                    [ Html.text option.label
+                    ]
+            )
+        |> div [ Role.tabList, styles.class [ SegmentedControl ] ]
+
+
+type CssClass
+    = SegmentedControl
+    | Tab
+    | Focused
+
+
+{-| -}
+styles : Nri.Ui.Styles.V1.Styles Never CssClass msg
+styles =
+    Nri.Ui.Styles.V1.styles "Nri-Ui-SegmentedControl-V1-"
+        [ Css.Foreign.class SegmentedControl
+            [ FlexBox.displayFlex
+            , cursor pointer
+            ]
+        , Css.Foreign.class Tab
+            [ padding2 (px 6) (px 20)
+            , height (px 45)
+            , Nri.Ui.Fonts.V1.baseFont
+            , fontSize (px 15)
+            , color Colors.azure
+            , fontWeight bold
+            , lineHeight (px 30)
+            , firstChild
+                [ borderTopLeftRadius (px 8)
+                , borderBottomLeftRadius (px 8)
+                , borderLeft3 (px 1) solid Colors.azure
+                ]
+            , lastChild
+                [ borderTopRightRadius (px 8)
+                , borderBottomRightRadius (px 8)
+                ]
+            , border3 (px 1) solid Colors.azure
+            , borderLeft (px 0)
+            , borderBottom3 (px 3) solid Colors.azure
+            ]
+        , Css.Foreign.class Focused
+            [ color Colors.gray20
+            , backgroundColor Colors.glacier
+            , boxShadow5 inset zero (px 3) zero (withAlpha 0.2 Colors.gray20)
+            , borderBottom3 (px 1) solid Colors.azure
+            ]
+        ]

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -1,0 +1,60 @@
+module Examples.SegmentedControl exposing (Msg, State, example, init, update)
+
+{-|
+
+@docs Msg, State, example, init, update,
+
+-}
+
+import Html
+import ModuleExample exposing (Category(..), ModuleExample)
+import Nri.Ui.SegmentedControl.V1
+
+
+{-| -}
+type Msg
+    = Select Id
+
+
+{-| -}
+type alias State =
+    Nri.Ui.SegmentedControl.V1.Config Id Msg
+
+
+{-| -}
+example : (Msg -> msg) -> State -> ModuleExample msg
+example parentMessage state =
+    { filename = "Nri/Ui/SegmentedControl/V1.elm"
+    , category = Behaviors
+    , content =
+        [ Html.map parentMessage (Nri.Ui.SegmentedControl.V1.view state)
+        ]
+    }
+
+
+{-| -}
+init : State
+init =
+    { onClick = Select
+    , options =
+        [ { label = "Option A", id = "a", value = "a" }
+        , { label = "Option B", id = "b", value = "b" }
+        ]
+    , selected = "a"
+    }
+
+
+{-| -}
+update : Msg -> State -> ( State, Cmd Msg )
+update msg state =
+    case msg of
+        Select id ->
+            ( { state | selected = id }, Cmd.none )
+
+
+
+-- INTERNAL
+
+
+type alias Id =
+    String

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -3,6 +3,7 @@ module NriModules exposing (ModuleStates, Msg, init, nriThemedModules, styles, s
 import DEPRECATED.Css.File exposing (Stylesheet, compile, stylesheet)
 import Examples.Colors
 import Examples.Fonts
+import Examples.SegmentedControl
 import Examples.Text
 import Examples.Text.Writing
 import Examples.TextArea as TextAreaExample
@@ -11,24 +12,28 @@ import Html.Attributes exposing (..)
 import ModuleExample exposing (Category(..), ModuleExample)
 import Navigation
 import Nri.Ui.AssetPath as AssetPath exposing (Asset(Asset))
+import Nri.Ui.SegmentedControl.V1
 import Nri.Ui.Text.V1 as Text
 import Nri.Ui.TextArea.V1 as TextArea
 import String.Extra
 
 
 type alias ModuleStates =
-    { textAreaExampleState : TextAreaExample.State
+    { segmentedControlState : Examples.SegmentedControl.State
+    , textAreaExampleState : TextAreaExample.State
     }
 
 
 init : ModuleStates
 init =
-    { textAreaExampleState = TextAreaExample.init
+    { segmentedControlState = Examples.SegmentedControl.init
+    , textAreaExampleState = TextAreaExample.init
     }
 
 
 type Msg
-    = ShowItWorked String String
+    = SegmentedControlMsg Examples.SegmentedControl.Msg
+    | ShowItWorked String String
     | TextAreaExampleMsg TextAreaExample.Msg
     | NoOp
 
@@ -36,6 +41,15 @@ type Msg
 update : Msg -> ModuleStates -> ( ModuleStates, Cmd Msg )
 update msg moduleStates =
     case msg of
+        SegmentedControlMsg msg ->
+            let
+                ( segmentedControlState, cmd ) =
+                    Examples.SegmentedControl.update msg moduleStates.segmentedControlState
+            in
+            ( { moduleStates | segmentedControlState = segmentedControlState }
+            , Cmd.map SegmentedControlMsg cmd
+            )
+
         ShowItWorked group message ->
             let
                 _ =
@@ -76,7 +90,8 @@ container width children =
 
 nriThemedModules : ModuleStates -> List (ModuleExample Msg)
 nriThemedModules model =
-    [ Examples.Text.example
+    [ Examples.SegmentedControl.example SegmentedControlMsg model.segmentedControlState
+    , Examples.Text.example
     , Examples.Text.Writing.example
     , Examples.Fonts.example
     , TextAreaExample.example TextAreaExampleMsg model.textAreaExampleState
@@ -105,6 +120,7 @@ styles =
         [ -- NOTE: these will go away as the modules' styles are integrated with Nri.Css.Site.elm
           [ ModuleExample.styles
           ]
+        , (Nri.Ui.SegmentedControl.V1.styles |> .css) ()
         , (Text.styles |> .css) ()
         , (TextArea.styles |> .css) assets
         ]


### PR DESCRIPTION
<details>
<summary>Diff from Monolith</summary>

```diff
1c1
< module Nri.SegmentedControl exposing (Config, Option, styles, view)
---
> module Nri.Ui.SegmentedControl.V1 exposing (Config, Option, styles, view)
12d11
< import Css.FlexBoxWithVendorPrefix as FlexBox
17,20c16,20
< import Nri.Colors as Colors
< import Nri.Colors.Extra exposing (withAlpha)
< import Nri.Stylers
< import Nri.Styles
---
> import Nri.Ui.Colors.Extra exposing (withAlpha)
> import Nri.Ui.Colors.V1 as Colors
> import Nri.Ui.CssFlexBoxWithVendorPrefix as FlexBox
> import Nri.Ui.Fonts.V1
> import Nri.Ui.Styles.V1
67c67
< styles : Nri.Styles.Styles Never CssClass msg
---
> styles : Nri.Ui.Styles.V1.Styles Never CssClass msg
69c69
<     Nri.Styles.styles "Nri-SegmentedControl-"
---
>     Nri.Ui.Styles.V1.styles "Nri-Ui-SegmentedControl-V1-"
77c77,79
<             , Nri.Stylers.makeFont (px 15) Colors.azure
---
>             , Nri.Ui.Fonts.V1.baseFont
>             , fontSize (px 15)
>             , color Colors.azure
```
</details>

<details>
<summary>`elm-package diff` output</summary>

```
Comparing NoRedInk/noredink-ui 3.2.0 to local changes...
This is a MINOR change.

------ Added modules - MINOR ------

    Nri.Ui.SegmentedControl.V1


```
</details>

<details>
<summary>Screenshot of style guide</summary>

![screen shot 2018-03-23 at 19 06 51](https://user-images.githubusercontent.com/1356417/37859188-9d9997dc-2ecd-11e8-9649-6d30106adac1.png)
</details>

##### Questions

1. We're not currently depending on `nri-elm-css`, so we don't have `Nri.Stylers`. I seemed to remember that we're moving away from that. Is that right? I inlined what `Nri.Stylers.makeFont` is in the meantime. If that's not the case, I'm down to add the dependency and use it instead. If we want `Nri.Ui.Stylers.V1` here, I'm down to move it here instead.
1. In the screenshot, the control has a good deal of height. The styles are the same as what's in the monolith, but the monolith's control doesn't have as much height. Any idea what might be up?

    <details>
    <summary>Monolith's height</summary>

    <img width="288" alt="screen shot 2018-03-23 at 19 09 59" src="https://user-images.githubusercontent.com/1356417/37859229-dd11a5da-2ecd-11e8-879b-4d1a39f11648.png">
    </details>
