### PR TITLE
Add forgotten module

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.2.1",
+    "version": "3.3.0",
     "summary": "UI Widgets we use at NRI",
     "repository": "https://github.com/NoRedInk/noredink-ui.git",
     "license": "BSD3",

--- a/elm-package.json
+++ b/elm-package.json
@@ -26,7 +26,8 @@
         "Nri.Ui.Text.Writing.V1",
         "Nri.Ui.Text.V1",
         "Nri.Ui.TextArea.V1",
-        "Nri.Ui.TextInput.V1"
+        "Nri.Ui.TextInput.V1",
+        "Nri.Ui"
     ],
     "dependencies": {
         "NoRedInk/view-extra": "2.0.0 <= v < 3.0.0",


### PR DESCRIPTION
Forgot to add `Nri.Ui` to exposed modules! This PR should do the trick, so that `styled` is exposed.