### PR TITLE
Add elm tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,5 @@ script:
   # Check if all exposed modules compile.
   - elm-package diff
   - elm-format --validate src tests styleguide-app
-  # Uncomment this once we have tests in this repo.
-  # - elm test
+  - elm test
   - cd styleguide-app && elm-make Main.elm -- output=elm.js

--- a/tests/Spec/Nri/Ui/Checkbox/V1.elm
+++ b/tests/Spec/Nri/Ui/Checkbox/V1.elm
@@ -1,0 +1,163 @@
+module Spec.Nri.Ui.Checkbox.V1 exposing (spec)
+
+import Nri.Ui.Checkbox.V1 as Checkbox exposing (IsSelected(..))
+import Nri.Ui.Data.PremiumLevel exposing (PremiumLevel(..))
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+
+
+premiumView config =
+    Checkbox.premium
+        { label = config.label
+        , id = "id"
+        , selected = config.selected
+        , disabled = config.disabled
+        , teacherPremiumLevel = config.teacherPremiumLevel
+        , contentPremiumLevel = config.contentPremiumLevel
+        , showFlagWhenLocked = config.showFlagWhenLocked
+        , onChange = \_ -> ()
+        , onLockedClick = ()
+        , noOpMsg = ()
+        }
+        |> Query.fromHtml
+
+
+spec : Test
+spec =
+    describe "Nri.Ui.Checkbox.V1"
+        [ describe "premium"
+            [ test "displays the label" <|
+                \() ->
+                    premiumView
+                        { label = "i am label"
+                        , selected = Selected
+                        , disabled = False
+                        , teacherPremiumLevel = Free
+                        , contentPremiumLevel = Free
+                        , showFlagWhenLocked = True
+                        }
+                        |> Query.has [ Selector.text "i am label" ]
+            , test "appears selected when Selected is passed in" <|
+                \() ->
+                    premiumView
+                        { label = "i am label"
+                        , selected = Selected
+                        , disabled = False
+                        , teacherPremiumLevel = Free
+                        , contentPremiumLevel = Free
+                        , showFlagWhenLocked = True
+                        }
+                        |> Query.has [ Selector.class "checkbox-Checked" ]
+            , test "appears unselected when NotSelected is passed in" <|
+                \() ->
+                    premiumView
+                        { label = "i am label"
+                        , selected = NotSelected
+                        , disabled = False
+                        , teacherPremiumLevel = Free
+                        , contentPremiumLevel = Free
+                        , showFlagWhenLocked = True
+                        }
+                        |> Query.has [ Selector.class "checkbox-Unchecked" ]
+            , test "appears partially selected when PartiallySelected is passed in" <|
+                \() ->
+                    premiumView
+                        { label = "i am label"
+                        , selected = PartiallySelected
+                        , disabled = False
+                        , teacherPremiumLevel = Free
+                        , contentPremiumLevel = Free
+                        , showFlagWhenLocked = True
+                        }
+                        |> Query.has [ Selector.class "checkbox-Indeterminate" ]
+            , test "appears locked when teacherPremiumLevel < contentPremiumLevel" <|
+                \() ->
+                    premiumView
+                        { label = "i am label"
+                        , selected = PartiallySelected
+                        , disabled = False
+                        , teacherPremiumLevel = Free
+                        , contentPremiumLevel = Premium
+                        , showFlagWhenLocked = True
+                        }
+                        |> Query.has [ Selector.class "checkbox-LockOnInsideClass" ]
+            , test "appears unlocked when teacherPremiumLevel >= contentPremiumLevel" <|
+                \() ->
+                    premiumView
+                        { label = "i am label"
+                        , selected = PartiallySelected
+                        , disabled = False
+                        , teacherPremiumLevel = Premium
+                        , contentPremiumLevel = Premium
+                        , showFlagWhenLocked = True
+                        }
+                        |> Query.hasNot [ Selector.class "checkbox-LockOnInsideClass" ]
+            , test "appears with P flag when teacherPremiumLevel >= contentPremiumLevel" <|
+                \() ->
+                    premiumView
+                        { label = "i am label"
+                        , selected = PartiallySelected
+                        , disabled = False
+                        , teacherPremiumLevel = Premium
+                        , contentPremiumLevel = Premium
+                        , showFlagWhenLocked = False
+                        }
+                        |> Query.has [ Selector.class "checkbox-PremiumClass" ]
+            , test "does not appear with P flag when teacherPremiumLevel < contentPremiumLevel and showFlagWhenLocked = False" <|
+                \() ->
+                    premiumView
+                        { label = "i am label"
+                        , selected = PartiallySelected
+                        , disabled = False
+                        , teacherPremiumLevel = Free
+                        , contentPremiumLevel = Premium
+                        , showFlagWhenLocked = False
+                        }
+                        |> Query.hasNot [ Selector.class "checkbox-PremiumClass" ]
+            , test "appears with P flag for Premium content when teacherPremiumLevel < contentPremiumLevel and showFlagWhenLocked = True" <|
+                \() ->
+                    premiumView
+                        { label = "i am label"
+                        , selected = PartiallySelected
+                        , disabled = False
+                        , teacherPremiumLevel = Free
+                        , contentPremiumLevel = Premium
+                        , showFlagWhenLocked = True
+                        }
+                        |> Query.has [ Selector.class "checkbox-PremiumClass" ]
+            , test "never shows P flag for nonPremium content" <|
+                \() ->
+                    premiumView
+                        { label = "i am label"
+                        , selected = PartiallySelected
+                        , disabled = False
+                        , teacherPremiumLevel = Free
+                        , contentPremiumLevel = Free
+                        , showFlagWhenLocked = True
+                        }
+                        |> Query.hasNot [ Selector.class "checkbox-PremiumClass" ]
+            , test "is not disabled when disabled = False and the checkbox is unlocked" <|
+                \() ->
+                    premiumView
+                        { label = "i am label"
+                        , selected = PartiallySelected
+                        , disabled = False
+                        , teacherPremiumLevel = Free
+                        , contentPremiumLevel = Free
+                        , showFlagWhenLocked = True
+                        }
+                        |> Query.has [ Selector.disabled False ]
+            , test "is disabled when disabled = True and the checkbox is unlocked" <|
+                \() ->
+                    premiumView
+                        { label = "i am label"
+                        , selected = PartiallySelected
+                        , disabled = True
+                        , teacherPremiumLevel = Free
+                        , contentPremiumLevel = Free
+                        , showFlagWhenLocked = True
+                        }
+                        |> Query.has [ Selector.disabled True ]
+            ]
+        ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,0 +1,25 @@
+{
+    "version": "1.0.0",
+    "summary": "Test Suites",
+    "repository": "https://github.com/NoRedInk/noredink-ui.git",
+    "license": "BSD3",
+    "source-directories": [
+        "../src",
+        "."
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "NoRedInk/view-extra": "2.0.0 <= v < 3.0.0",
+        "eeue56/elm-html-test": "5.2.0 <= v < 6.0.0",
+        "elm-community/elm-test": "4.0.0 <= v < 5.0.0",
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "pablohirafuji/elm-markdown": "2.0.4 <= v < 3.0.0",
+        "rtfeldman/elm-css": "13.1.1 <= v < 14.0.0",
+        "rtfeldman/elm-css-helpers": "2.1.0 <= v < 3.0.0",
+        "rtfeldman/elm-css-util": "1.0.2 <= v < 2.0.0",
+        "tesk9/accessible-html": "3.0.0 <= v < 4.0.0",
+        "wernerdegroot/listzipper": "3.0.0 <= v < 4.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}


### PR DESCRIPTION
Of the widgets we have in here at the moment, `Checkbox` is the only one with a separate spec file in the monolith. This PR adds that suite and sets us up for adding more specs in the future.

This commit only touches specs, so a release after merging this is unnecessary.