### PR TITLE
Add a .travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+sudo: false
+
+cache:
+  directories:
+    - tests/elm-stuff/build-artifacts
+    - sysconfcpus
+
+before_install:
+  - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+  - | # epic build time improvement - see https://github.com/elm-lang/elm-compiler/issues/1473#issuecomment-245704142
+    if [ ! -d sysconfcpus/bin ];
+    then
+      git clone https://github.com/obmarg/libsysconfcpus.git;
+      cd libsysconfcpus;
+      ./configure --prefix=$TRAVIS_BUILD_DIR/sysconfcpus;
+      make && make install;
+      cd ..;
+    fi
+install:
+  - npm install -g elm@0.18.0 elm-test elm-format@exp
+  - mv $(npm config get prefix)/bin/elm-make $(npm config get prefix)/bin/elm-make-old
+  - printf '%s\n\n' '#!/bin/bash' 'echo "Running elm-make with sysconfcpus -n 2"' '$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old "$@"' > $(npm config get prefix)/bin/elm-make
+  - chmod +x $(npm config get prefix)/bin/elm-make
+  - travis_retry elm-package install --yes
+  - cd tests
+  - npm install
+  - travis_retry elm-package install --yes
+  - cd ..
+
+script:
+  # Check if all exposed modules compile.
+  - elm-package diff
+  - elm-format --validate src tests styleguide-app
+  # Uncomment this once we have tests in this repo.
+  # - elm test
+  - cd styleguide-app && elm-make Main.elm -- output=elm.js


### PR DESCRIPTION
For the most part this is shamelessly lifted from elm-spa-example:

https://github.com/rtfeldman/elm-spa-example/blob/master/.travis.yml

elm-test support is in there, but not yet enabled because we don't have any tests yet.

Considering this doesn't touch any of the actual Elm code I'm going to merge this straight away without review, so I can immediately check that Travis is working.