### PR TITLE
Turn off email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,6 @@ script:
   - elm-format --validate src tests styleguide-app
   - elm test
   - cd styleguide-app && elm-make Main.elm --yes --output=elm.js
+
+notifications:
+  email: false


### PR DESCRIPTION
People can add themselves if they want notifications: https://docs.travis-ci.com/user/notifications/#Configuring-email-notifications. But it seems like a better default to not send an email to people.