### PR TITLE
Separate icon functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,9 +91,6 @@ anaconda-mode/
 .AppleDouble
 .LSOverride
 
-# Icon must end with two \r
-Icon
-
 # Thumbnails
 ._*
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -19,6 +19,7 @@
         "Nri.Ui.Effects.V1",
         "Nri.Ui.Fonts.V1",
         "Nri.Ui.Icon.V1",
+        "Nri.Ui.Icon.V2",
         "Nri.Ui.Modal.V1",
         "Nri.Ui.Outline.V1",
         "Nri.Ui.Palette.V1",

--- a/elm-package.json
+++ b/elm-package.json
@@ -26,6 +26,7 @@
         "Nri.Ui.SegmentedControl.V1",
         "Nri.Ui.SegmentedControl.V2",
         "Nri.Ui.SegmentedControl.V3",
+        "Nri.Ui.SegmentedControl.V4",
         "Nri.Ui.Styles.V1",
         "Nri.Ui.Tabs.V1",
         "Nri.Ui.Text.Writing.V1",

--- a/src/Nri/Ui/Icon/V2.elm
+++ b/src/Nri/Ui/Icon/V2.elm
@@ -1,0 +1,768 @@
+module Nri.Ui.Icon.V2
+    exposing
+        ( IconSize(..)
+        , IconType
+        , activity
+        , add
+        , arrowDown
+        , arrowLeft
+        , arrowRight
+        , assignmentTypeDiagnostic
+        , assignmentTypePractice
+        , assignmentTypeQuiz
+        , assignmentTypeWritingCycle
+        , attention
+        , bang
+        , bulb
+        , button
+        , calendar
+        , caret
+        , checkMark
+        , checkMarkSquiggily
+        , checkMarkSvg
+        , class
+        , clever
+        , clock
+        , close
+        , compassSvg
+        , copy
+        , custom
+        , darkBlueCheckMark
+        , decorativeIcon
+        , document
+        , download
+        , edit
+        , editWriting
+        , equalitySign
+        , exclamation
+        , facebook
+        , flag
+        , flipper
+        , footsteps
+        , gardening
+        , gear
+        , greenCheckMark
+        , help
+        , highFive
+        , icon
+        , key
+        , late
+        , leaderboard
+        , lightBulb
+        , link
+        , linkExternal
+        , lock
+        , lockDeprecated
+        , logo
+        , newspaper
+        , notStarred
+        , okay
+        , openClose
+        , peerReview
+        , performance
+        , personBlue
+        , preview
+        , quickWrite
+        , seeMore
+        , share
+        , sort
+        , sortArrow
+        , speedometer
+        , starred
+        , styles
+        , thumbsUp
+        , twitter
+        , unarchive
+        , writingAssignment
+        , x
+        , xSvg
+        )
+
+{-|
+
+@docs icon, decorativeIcon, link, linkExternal, button
+@docs IconType, IconSize
+@docs styles
+@docs activity
+@docs add
+@docs arrowDown
+@docs arrowLeft
+@docs arrowRight
+@docs assignmentTypeDiagnostic
+@docs assignmentTypePractice
+@docs assignmentTypeQuiz
+@docs assignmentTypeWritingCycle
+@docs attention
+@docs bang
+@docs bulb
+@docs calendar
+@docs caret
+@docs checkMark
+@docs checkMarkSquiggily
+@docs checkMarkSvg
+@docs class
+@docs clever
+@docs clock
+@docs close
+@docs copy
+@docs compassSvg
+@docs custom
+@docs darkBlueCheckMark
+@docs document
+@docs download
+@docs edit
+@docs editWriting
+@docs equalitySign
+@docs exclamation
+@docs facebook
+@docs flag
+@docs flipper
+@docs footsteps
+@docs gardening
+@docs gear
+@docs greenCheckMark
+@docs help
+@docs highFive
+@docs key
+@docs late
+@docs leaderboard
+@docs lightBulb
+@docs lock
+@docs lockDeprecated
+@docs logo
+@docs newspaper
+@docs notStarred
+@docs okay
+@docs openClose
+@docs peerReview
+@docs performance
+@docs personBlue
+@docs preview
+@docs quickWrite
+@docs seeMore
+@docs share
+@docs sort
+@docs sortArrow
+@docs speedometer
+@docs starred
+@docs thumbsUp
+@docs twitter
+@docs unarchive
+@docs writingAssignment
+@docs x
+@docs xSvg
+
+-}
+
+import Accessibility exposing (..)
+import Accessibility.Role as Role
+import Css exposing (..)
+import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import Html.Attributes as Attr exposing (..)
+import Html.Events exposing (onClick)
+import Nri.Ui.AssetPath exposing (Asset(..))
+import Nri.Ui.Colors.V1
+import Nri.Ui.Styles.V1
+import Svg exposing (svg, use)
+import Svg.Attributes exposing (xlinkHref)
+
+
+{-| -}
+type alias IconLinkModel =
+    { alt : String
+    , url : String
+    , icon : IconType
+    , disabled : Bool
+    , size : IconSize
+    }
+
+
+type alias IconButtonModel msg =
+    { alt : String
+    , msg : msg
+    , icon : IconType
+    , disabled : Bool
+    , size : IconSize
+    }
+
+
+{-| An icon that can be rendered using the functions provided by this module.
+-}
+type IconType
+    = ImgIcon Asset
+    | SvgIcon String
+
+
+{-| Used for determining sizes on Icon.buttons and Icon.links
+-}
+type IconSize
+    = Small
+    | Medium
+
+
+iconSizeToCssClass : IconSize -> CssClasses
+iconSizeToCssClass size =
+    case size of
+        Small ->
+            SmallIcon
+
+        Medium ->
+            MediumIcon
+
+
+{-| Create an icon that links to a part of NRI
+Uses our default icon styles (25 x 25 px, azure)
+-}
+link : IconLinkModel -> Html msg
+link =
+    linkBase (Attr.target "_self")
+
+
+{-| Create an accessible icon button with an onClick handler
+Uses our default icon styles (25 x 25 px, azure)
+-}
+button : IconButtonModel msg -> Html msg
+button model =
+    Accessibility.button
+        [ styles.class [ Button, iconSizeToCssClass model.size ]
+        , onClick model.msg
+        , Attr.disabled model.disabled
+        , Attr.type_ "button"
+        ]
+        [ icon
+            { alt = model.alt
+            , icon = model.icon
+            }
+        ]
+
+
+{-| -}
+icon : { alt : String, icon : IconType } -> Html msg
+icon config =
+    case config.icon of
+        SvgIcon iconId ->
+            svg [ svgStyle ]
+                [ Svg.title [] [ Accessibility.text config.alt ]
+                , use [ xlinkHref ("#" ++ iconId) ] []
+                ]
+
+        ImgIcon assetPath ->
+            img config.alt
+                [ Attr.src (Nri.Ui.AssetPath.url assetPath)
+                ]
+
+
+{-| Use this icon for purely decorative content that would be distracting
+rather than helpful on a screenreader.
+-}
+decorativeIcon : IconType -> Html msg
+decorativeIcon iconType =
+    case iconType of
+        SvgIcon iconId ->
+            svg
+                [ svgStyle
+                , Role.img
+                ]
+                [ use [ xlinkHref ("#" ++ iconId) ] []
+                ]
+
+        ImgIcon assetPath ->
+            decorativeImg [ Attr.src (Nri.Ui.AssetPath.url assetPath) ]
+
+
+{-| Create an icon that links to an external site
+Uses our default icon styles (25 x 25 px, azure)
+-}
+linkExternal : IconLinkModel -> Html msg
+linkExternal =
+    linkBase (Attr.target "_blank")
+
+
+linkBase : Attribute Never -> IconLinkModel -> Html msg
+linkBase linkTarget model =
+    span
+        []
+        [ a
+            (linkTarget :: linkAttributes model)
+            [ icon { alt = model.alt, icon = model.icon }
+            ]
+        ]
+
+
+linkAttributes : IconLinkModel -> List (Attribute Never)
+linkAttributes model =
+    if model.disabled then
+        [ styles.class [ Disabled, Link, iconSizeToCssClass model.size ] ]
+    else
+        [ styles.class [ Link, iconSizeToCssClass model.size ], href model.url ]
+
+
+{-| -}
+activity : { r | activity : String } -> IconType
+activity assets =
+    SvgIcon assets.activity
+
+
+{-| -}
+add : { r | icons_plusBlue_svg : Asset } -> IconType
+add assets =
+    ImgIcon assets.icons_plusBlue_svg
+
+
+{-| -}
+arrowDown : { r | arrowDown : String } -> IconType
+arrowDown assets =
+    SvgIcon assets.arrowDown
+
+
+{-| -}
+arrowLeft : { r | leftArrowBlue_png : Asset } -> IconType
+arrowLeft assets =
+    ImgIcon assets.leftArrowBlue_png
+
+
+{-| -}
+arrowRight : { r | icons_arrowRightBlue_svg : Asset } -> IconType
+arrowRight assets =
+    ImgIcon assets.icons_arrowRightBlue_svg
+
+
+{-| -}
+assignmentTypeDiagnostic : { r | diagnostic : String } -> IconType
+assignmentTypeDiagnostic assets =
+    SvgIcon assets.diagnostic
+
+
+{-| -}
+assignmentTypePractice : { r | practice : String } -> IconType
+assignmentTypePractice assets =
+    SvgIcon assets.practice
+
+
+{-| -}
+assignmentTypeQuiz : { r | quiz : String } -> IconType
+assignmentTypeQuiz assets =
+    SvgIcon assets.quiz
+
+
+{-| -}
+assignmentTypeWritingCycle : { r | writingcycle : String } -> IconType
+assignmentTypeWritingCycle assets =
+    SvgIcon assets.writingcycle
+
+
+{-| -}
+attention : { r | attention_svg : Asset } -> IconType
+attention assets =
+    ImgIcon assets.attention_svg
+
+
+{-| -}
+bang : { r | exclamationPoint_svg : Asset } -> IconType
+bang assets =
+    ImgIcon assets.exclamationPoint_svg
+
+
+{-| -}
+bulb : { r | bulb : String } -> IconType
+bulb assets =
+    SvgIcon assets.bulb
+
+
+{-| -}
+calendar : { r | calendar : String } -> IconType
+calendar assets =
+    SvgIcon assets.calendar
+
+
+{-| -}
+caret : { r | icons_arrowDownBlue_svg : Asset } -> IconType
+caret assets =
+    ImgIcon assets.icons_arrowDownBlue_svg
+
+
+{-| -}
+checkMark : { r | iconCheck_png : Asset } -> IconType
+checkMark assets =
+    ImgIcon assets.iconCheck_png
+
+
+{-| -}
+checkMarkSquiggily : { r | squiggly_png : Asset } -> IconType
+checkMarkSquiggily assets =
+    ImgIcon assets.squiggly_png
+
+
+{-| -}
+checkMarkSvg : { r | checkmark : String } -> IconType
+checkMarkSvg assets =
+    SvgIcon assets.checkmark
+
+
+{-| -}
+class : { r | class : String } -> IconType
+class assets =
+    SvgIcon assets.class
+
+
+{-| -}
+clever : { r | clever : String } -> IconType
+clever assets =
+    SvgIcon assets.clever
+
+
+{-| -}
+clock : { r | clock : String } -> IconType
+clock assets =
+    SvgIcon assets.clock
+
+
+{-| -}
+close : { r | icons_xBlue_svg : Asset } -> IconType
+close assets =
+    ImgIcon assets.icons_xBlue_svg
+
+
+{-| -}
+copy : { r | teach_assignments_copyWhite_svg : Asset } -> IconType
+copy assets =
+    ImgIcon assets.teach_assignments_copyWhite_svg
+
+
+{-| -}
+compassSvg : { r | compass : String } -> IconType
+compassSvg assets =
+    SvgIcon assets.compass
+
+
+{-| -}
+custom : Asset -> IconType
+custom asset =
+    ImgIcon asset
+
+
+{-| -}
+darkBlueCheckMark : { r | darkBlueCheckmark_svg : Asset } -> IconType
+darkBlueCheckMark assets =
+    ImgIcon assets.darkBlueCheckmark_svg
+
+
+{-| -}
+document : { r | document : String } -> IconType
+document assets =
+    SvgIcon assets.document
+
+
+{-| -}
+download : { r | download : String } -> IconType
+download assets =
+    SvgIcon assets.download
+
+
+{-| -}
+edit : { r | edit : String } -> IconType
+edit assets =
+    SvgIcon assets.edit
+
+
+{-| -}
+editWriting : { r | editWriting : String } -> IconType
+editWriting assets =
+    SvgIcon assets.editWriting
+
+
+{-| -}
+equalitySign : { r | icons_equals_svg : Asset } -> IconType
+equalitySign assets =
+    ImgIcon assets.icons_equals_svg
+
+
+{-| -}
+exclamation : { r | exclamation : String } -> IconType
+exclamation assets =
+    SvgIcon assets.exclamation
+
+
+{-| -}
+facebook : { r | facebookBlue_svg : Asset } -> IconType
+facebook assets =
+    ImgIcon assets.facebookBlue_svg
+
+
+{-| -}
+flag : { r | iconFlag_png : Asset } -> IconType
+flag assets =
+    ImgIcon assets.iconFlag_png
+
+
+{-| -}
+flipper : { r | flipper : String } -> IconType
+flipper assets =
+    SvgIcon assets.flipper
+
+
+{-| -}
+footsteps : { r | footsteps : String } -> IconType
+footsteps assets =
+    SvgIcon assets.footsteps
+
+
+{-| -}
+gardening : { r | startingOffBadge_png : Asset } -> IconType
+gardening assets =
+    ImgIcon assets.startingOffBadge_png
+
+
+{-| -}
+gear : { r | gear : String } -> IconType
+gear assets =
+    SvgIcon assets.gear
+
+
+{-| -}
+greenCheckMark : { r | smallCheckmark_png : Asset } -> IconType
+greenCheckMark assets =
+    ImgIcon assets.smallCheckmark_png
+
+
+{-| -}
+help : { r | icons_helpBlue_svg : Asset } -> IconType
+help assets =
+    ImgIcon assets.icons_helpBlue_svg
+
+
+{-| -}
+highFive : { r | level3Badge_png : Asset } -> IconType
+highFive assets =
+    ImgIcon assets.level3Badge_png
+
+
+{-| -}
+key : { r | key : String } -> IconType
+key assets =
+    SvgIcon assets.key
+
+
+{-| -}
+late : { r | icons_clockRed_svg : Asset } -> IconType
+late assets =
+    ImgIcon assets.icons_clockRed_svg
+
+
+{-| -}
+leaderboard : { r | leaderboard : String } -> IconType
+leaderboard assets =
+    SvgIcon assets.leaderboard
+
+
+{-| -}
+lightBulb : { r | hint_png : Asset } -> IconType
+lightBulb assets =
+    ImgIcon assets.hint_png
+
+
+{-| -}
+lock : { r | lock : String } -> IconType
+lock assets =
+    SvgIcon assets.lock
+
+
+{-| -}
+lockDeprecated : { r | premiumLock_svg : Asset } -> IconType
+lockDeprecated assets =
+    ImgIcon assets.premiumLock_svg
+
+
+{-| -}
+logo : { r | logoRedBlack_svg : Asset } -> IconType
+logo assets =
+    ImgIcon assets.logoRedBlack_svg
+
+
+{-| -}
+newspaper : { r | newspaper : String } -> IconType
+newspaper assets =
+    SvgIcon assets.newspaper
+
+
+{-| -}
+notStarred : { r | commentNotStarred_png : Asset } -> IconType
+notStarred assets =
+    ImgIcon assets.commentNotStarred_png
+
+
+{-| -}
+okay : { r | level2Badge_png : Asset } -> IconType
+okay assets =
+    ImgIcon assets.level2Badge_png
+
+
+{-| -}
+openClose : { r | openClose : String } -> IconType
+openClose assets =
+    SvgIcon assets.openClose
+
+
+{-| -}
+peerReview : { r | icons_peerReview_svg : Asset } -> IconType
+peerReview assets =
+    ImgIcon assets.icons_peerReview_svg
+
+
+{-| -}
+performance : { r | performance : String } -> IconType
+performance assets =
+    SvgIcon assets.performance
+
+
+{-| -}
+personBlue : { r | personBlue_svg : Asset } -> IconType
+personBlue assets =
+    ImgIcon assets.personBlue_svg
+
+
+{-| -}
+preview : { r | preview : String } -> IconType
+preview assets =
+    SvgIcon assets.preview
+
+
+{-| -}
+quickWrite : { r | icons_quickWrite_svg : Asset } -> IconType
+quickWrite assets =
+    ImgIcon assets.icons_quickWrite_svg
+
+
+{-| -}
+seeMore : { r | seemore : String } -> IconType
+seeMore assets =
+    SvgIcon assets.seemore
+
+
+{-| -}
+share : { r | share : String } -> IconType
+share assets =
+    SvgIcon assets.share
+
+
+{-| -}
+sort : { r | sort : String } -> IconType
+sort assets =
+    SvgIcon assets.sort
+
+
+{-| -}
+sortArrow : { r | sortArrow : String } -> IconType
+sortArrow assets =
+    SvgIcon assets.sortArrow
+
+
+{-| -}
+speedometer : { r | speedometer : String } -> IconType
+speedometer assets =
+    SvgIcon assets.speedometer
+
+
+{-| -}
+starred : { r | commentStarred_png : Asset } -> IconType
+starred assets =
+    ImgIcon assets.commentStarred_png
+
+
+{-| -}
+thumbsUp : { r | level1Badge_png : Asset } -> IconType
+thumbsUp assets =
+    ImgIcon assets.level1Badge_png
+
+
+{-| -}
+twitter : { r | twitterBlue_svg : Asset } -> IconType
+twitter assets =
+    ImgIcon assets.twitterBlue_svg
+
+
+{-| -}
+unarchive : { r | unarchiveBlue2x_png : Asset } -> IconType
+unarchive assets =
+    ImgIcon assets.unarchiveBlue2x_png
+
+
+{-| -}
+writingAssignment : { r | writingAssignment : String } -> IconType
+writingAssignment assets =
+    SvgIcon assets.writingAssignment
+
+
+{-| -}
+x : { r | xWhite_svg : Asset } -> IconType
+x assets =
+    ImgIcon assets.xWhite_svg
+
+
+{-| -}
+xSvg : { r | x : String } -> IconType
+xSvg assets =
+    SvgIcon assets.x
+
+
+{-| Inlining SVG styles because styles.class doesn't work on SVG elements.
+The `className` property of an SVG element isn't a string, it's an object and so
+`styles.class` causes a runtime exception by attempting to overwrite it with
+a string. Another workaround is to use the `Svg.Attributes.class` attribute but
+since `withNamespace` hides a call to `Html.Attributes.class` we can't do it
+properly.
+-}
+svgStyle : Attribute msg
+svgStyle =
+    style
+        [ ( "fill", "currentColor" )
+        , ( "width", "100%" )
+        , ( "height", "100%" )
+        ]
+
+
+type CssClasses
+    = Disabled
+    | Button
+    | Link
+    | SvgIconContainer
+    | SmallIcon
+    | MediumIcon
+
+
+{-| -}
+styles : Nri.Ui.Styles.V1.Styles Never CssClasses msg
+styles =
+    Nri.Ui.Styles.V1.styles "Nri-Ui-Icon-V1-"
+        [ Css.Foreign.class Disabled
+            [ Css.property "cursor" "not-allowed" ]
+        , Css.Foreign.class Button
+            [ backgroundColor transparent
+            , border zero
+            , color Nri.Ui.Colors.V1.azure
+            , fontFamily inherit
+            , Css.property "cursor" "pointer"
+            , padding zero
+            , focus
+                [ backgroundColor transparent
+                ]
+            ]
+        , Css.Foreign.class Link
+            [ color Nri.Ui.Colors.V1.azure
+            , display inlineBlock
+            , fontFamily inherit
+            , Css.property "cursor" "pointer"
+            , padding zero
+            , visited [ color Nri.Ui.Colors.V1.azure ]
+            ]
+        , Css.Foreign.class SmallIcon
+            [ Css.width (px 20)
+            , Css.height (px 20)
+            ]
+        , Css.Foreign.class MediumIcon
+            [ Css.width (px 25)
+            , Css.height (px 25)
+            ]
+        , Css.Foreign.class SvgIconContainer
+            [ fill currentColor ]
+        ]

--- a/src/Nri/Ui/SegmentedControl/V4.elm
+++ b/src/Nri/Ui/SegmentedControl/V4.elm
@@ -1,0 +1,124 @@
+module Nri.Ui.SegmentedControl.V4 exposing (Config, Icon, Option, styles, view)
+
+{-|
+
+@docs Config, Icon, Option, styles, view
+
+-}
+
+import Accessibility exposing (..)
+import Accessibility.Role as Role
+import Css exposing (..)
+import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import Html
+import Html.Attributes
+import Html.Events
+import Nri.Ui.Colors.Extra exposing (withAlpha)
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.CssFlexBoxWithVendorPrefix as FlexBox
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Icon.V2 as Icon
+import Nri.Ui.Styles.V1
+import View.Extra
+
+
+{-| -}
+type alias Config a msg =
+    { onClick : a -> msg
+    , options : List (Option a)
+    , selected : a
+    }
+
+
+{-| -}
+type alias Option a =
+    { value : a
+    , icon : Maybe Icon
+    , label : String
+    , id : String
+    }
+
+
+{-| -}
+type alias Icon =
+    { alt : String
+    , icon : Icon.IconType
+    }
+
+
+{-| -}
+view : Config a msg -> Html.Html msg
+view config =
+    config.options
+        |> List.map
+            (\option ->
+                Html.div
+                    [ Html.Attributes.id option.id
+                    , Role.tab
+                    , Html.Events.onClick (config.onClick option.value)
+                    , styles.classList
+                        [ ( Tab, True )
+                        , ( Focused, option.value == config.selected )
+                        ]
+                    ]
+                    [ View.Extra.viewJust viewIcon option.icon
+                    , Html.text option.label
+                    ]
+            )
+        |> div [ Role.tabList, styles.class [ SegmentedControl ] ]
+
+
+viewIcon : Icon -> Html msg
+viewIcon icon =
+    Html.span
+        [ styles.class [ IconContainer ] ]
+        [ Icon.icon icon ]
+
+
+type CssClass
+    = SegmentedControl
+    | Tab
+    | IconContainer
+    | Focused
+
+
+{-| -}
+styles : Nri.Ui.Styles.V1.Styles Never CssClass msg
+styles =
+    Nri.Ui.Styles.V1.styles "Nri-Ui-SegmentedControl-V3-"
+        [ Css.Foreign.class SegmentedControl
+            [ FlexBox.displayFlex
+            , cursor pointer
+            ]
+        , Css.Foreign.class Tab
+            [ padding2 (px 6) (px 20)
+            , height (px 45)
+            , Fonts.baseFont
+            , fontSize (px 15)
+            , color Colors.azure
+            , fontWeight bold
+            , lineHeight (px 30)
+            , firstChild
+                [ borderTopLeftRadius (px 8)
+                , borderBottomLeftRadius (px 8)
+                , borderLeft3 (px 1) solid Colors.azure
+                ]
+            , lastChild
+                [ borderTopRightRadius (px 8)
+                , borderBottomRightRadius (px 8)
+                ]
+            , border3 (px 1) solid Colors.azure
+            , borderLeft (px 0)
+            , borderBottom3 (px 3) solid Colors.azure
+            , boxSizing borderBox
+            ]
+        , Css.Foreign.class IconContainer
+            [ marginRight (px 10)
+            ]
+        , Css.Foreign.class Focused
+            [ color Colors.gray20
+            , backgroundColor Colors.glacier
+            , boxShadow5 inset zero (px 3) zero (withAlpha 0.2 Colors.gray20)
+            , borderBottom3 (px 1) solid Colors.azure
+            ]
+        ]

--- a/styleguide-app/Assets.elm
+++ b/styleguide-app/Assets.elm
@@ -1,0 +1,151 @@
+module Assets exposing (Assets, assets)
+
+import Nri.Ui.AssetPath as AssetPath exposing (Asset(Asset))
+
+
+type alias Assets =
+    { activity : String
+    , arrowDown : String
+    , attention_svg : Asset
+    , bulb : String
+    , calendar : String
+    , checkmark : String
+    , class : String
+    , clever : String
+    , clock : String
+    , commentNotStarred_png : Asset
+    , commentStarred_png : Asset
+    , compass : String
+    , darkBlueCheckmark_svg : Asset
+    , diagnostic : String
+    , document : String
+    , download : String
+    , edit : String
+    , editWriting : String
+    , exclamation : String
+    , exclamationPoint_svg : Asset
+    , facebookBlue_svg : Asset
+    , flipper : String
+    , footsteps : String
+    , gear : String
+    , hint_png : Asset
+    , iconCalendar_svg : Asset
+    , iconCheck_png : Asset
+    , iconFlag_png : Asset
+    , icons_arrowDownBlue_svg : Asset
+    , icons_arrowRightBlue_svg : Asset
+    , icons_clockRed_svg : Asset
+    , icons_equals_svg : Asset
+    , icons_helpBlue_svg : Asset
+    , icons_peerReview_svg : Asset
+    , icons_plusBlue_svg : Asset
+    , icons_quickWrite_svg : Asset
+    , icons_searchGray_svg : Asset
+    , icons_xBlue_svg : Asset
+    , icons_xBlue_svg : Asset
+    , key : String
+    , leaderboard : String
+    , leftArrowBlue_png : Asset
+    , level1Badge_png : Asset
+    , level2Badge_png : Asset
+    , level3Badge_png : Asset
+    , lock : String
+    , logoRedBlack_svg : Asset
+    , newspaper : String
+    , openClose : String
+    , performance : String
+    , personBlue_svg : Asset
+    , practice : String
+    , premiumLock_svg : Asset
+    , preview : String
+    , quiz : String
+    , seemore : String
+    , share : String
+    , smallCheckmark_png : Asset
+    , sort : String
+    , sortArrow : String
+    , speedometer : String
+    , squiggly_png : Asset
+    , startingOffBadge_png : Asset
+    , teach_assignments_copyWhite_svg : Asset
+    , twitterBlue_svg : Asset
+    , unarchiveBlue2x_png : Asset
+    , writingAssignment : String
+    , writingcycle : String
+    , x : String
+    , xWhite_svg : Asset
+    }
+
+
+assets : Assets
+assets =
+    { activity = ""
+    , arrowDown = ""
+    , attention_svg = Asset ""
+    , bulb = ""
+    , calendar = ""
+    , checkmark = ""
+    , class = ""
+    , clever = ""
+    , clock = ""
+    , commentNotStarred_png = Asset ""
+    , commentStarred_png = Asset ""
+    , compass = ""
+    , darkBlueCheckmark_svg = Asset ""
+    , diagnostic = ""
+    , document = ""
+    , download = ""
+    , edit = ""
+    , editWriting = ""
+    , exclamation = ""
+    , exclamationPoint_svg = Asset ""
+    , facebookBlue_svg = Asset ""
+    , flipper = ""
+    , footsteps = ""
+    , gear = ""
+    , hint_png = Asset ""
+    , iconCalendar_svg = Asset ""
+    , iconCheck_png = Asset ""
+    , iconFlag_png = Asset ""
+    , icons_arrowDownBlue_svg = Asset ""
+    , icons_arrowRightBlue_svg = Asset ""
+    , icons_clockRed_svg = Asset ""
+    , icons_equals_svg = Asset ""
+    , icons_helpBlue_svg = Asset ""
+    , icons_peerReview_svg = Asset ""
+    , icons_plusBlue_svg = Asset ""
+    , icons_quickWrite_svg = Asset ""
+    , icons_searchGray_svg = Asset ""
+    , icons_xBlue_svg = Asset ""
+    , key = ""
+    , leaderboard = ""
+    , leftArrowBlue_png = Asset ""
+    , level1Badge_png = Asset ""
+    , level2Badge_png = Asset ""
+    , level3Badge_png = Asset ""
+    , lock = ""
+    , logoRedBlack_svg = Asset ""
+    , newspaper = ""
+    , openClose = ""
+    , performance = ""
+    , personBlue_svg = Asset ""
+    , practice = ""
+    , premiumLock_svg = Asset ""
+    , preview = ""
+    , quiz = ""
+    , seemore = ""
+    , share = ""
+    , smallCheckmark_png = Asset ""
+    , sort = ""
+    , sortArrow = ""
+    , speedometer = ""
+    , squiggly_png = Asset ""
+    , startingOffBadge_png = Asset ""
+    , teach_assignments_copyWhite_svg = Asset ""
+    , twitterBlue_svg = Asset ""
+    , unarchiveBlue2x_png = Asset ""
+    , writingAssignment = ""
+    , writingcycle = ""
+    , x = ""
+    , xWhite_svg = Asset ""
+    }

--- a/styleguide-app/Examples/Icon.elm
+++ b/styleguide-app/Examples/Icon.elm
@@ -6,32 +6,33 @@ module Examples.Icon exposing (example, styles)
 
 -}
 
+import Assets exposing (assets)
 import Css
 import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
 import Html exposing (Html)
 import Html.Attributes exposing (style, title)
 import ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.Colors.V1 exposing (..)
-import Nri.Ui.Icon.V1 as Icon
+import Nri.Ui.Icon.V2 as Icon
 import Nri.Ui.Styles.V1
 
 
 {-| -}
-example : Icon.Assets r -> ModuleExample msg
-example assets =
+example : ModuleExample msg
+example =
     { filename = "Nri/Ui/Icon/V1.elm"
     , category = Icons
     , content =
         [ Html.h3 [] [ Html.text "Icon" ]
         , Html.h4 [] [ Html.text "Images" ]
         , Html.div [ styles.class [ Container ] ]
-            (List.map (viewIcon assets) imageIcons)
+            (List.map viewIcon imageIcons)
         , Html.h4 [] [ Html.text "Scalable Vector Graphics (SVGs)" ]
         , Html.div [ styles.class [ Container ] ]
-            (List.map (viewIcon assets) svgIcons)
+            (List.map viewIcon svgIcons)
         , Html.h5 [] [ Html.text "Assignment Types" ]
         , Html.div [ styles.class [ Container ] ]
-            (List.map (viewIcon assets) assignmentTypeSvgIcons)
+            (List.map viewIcon assignmentTypeSvgIcons)
         ]
     }
 
@@ -65,90 +66,90 @@ type Background
     | Dark
 
 
-viewIcon : Icon.Assets r -> { alt : String, background : Background, icon : Icon.IconType } -> Html msg
-viewIcon assets { alt, background, icon } =
-    Html.div [ styles.class [ Cell background ], title alt ] [ Icon.icon assets { alt = alt, icon = icon } ]
+viewIcon : { alt : String, background : Background, icon : Icon.IconType } -> Html msg
+viewIcon { alt, background, icon } =
+    Html.div [ styles.class [ Cell background ], title alt ] [ Icon.icon { alt = alt, icon = icon } ]
 
 
 imageIcons : List { alt : String, background : Background, icon : Icon.IconType }
 imageIcons =
-    [ { icon = Icon.Add, background = Light, alt = "Add" }
-    , { icon = Icon.ArrowLeft, background = Light, alt = "ArrowLeft" }
-    , { icon = Icon.ArrowRight, background = Light, alt = "ArrowRight" }
-    , { icon = Icon.Attention, background = Dark, alt = "Attention" }
-    , { icon = Icon.Bang, background = Dark, alt = "Bang" }
-    , { icon = Icon.Caret, background = Light, alt = "Caret" }
-    , { icon = Icon.CheckMark, background = Dark, alt = "CheckMark" }
-    , { icon = Icon.CheckMarkSquiggily, background = Dark, alt = "CheckMarkSquiggily" }
-    , { icon = Icon.Close, background = Light, alt = "Close" }
-    , { icon = Icon.Copy, background = Dark, alt = "Copy" }
-    , { icon = Icon.DarkBlueCheckMark, background = Light, alt = "DarkBlueCheckMark" }
-    , { icon = Icon.EqualitySign, background = Light, alt = "EqualitySign" }
-    , { icon = Icon.Facebook, background = Light, alt = "Facebook" }
-    , { icon = Icon.Flag, background = Light, alt = "Flag" }
-    , { icon = Icon.Gardening, background = Dark, alt = "Gardening" }
-    , { icon = Icon.GreenCheckMark, background = Light, alt = "GreenCheckMark" }
-    , { icon = Icon.Help, background = Light, alt = "Help" }
-    , { icon = Icon.HighFive, background = Dark, alt = "HighFive" }
-    , { icon = Icon.Late, background = Light, alt = "Late" }
-    , { icon = Icon.LightBulb, background = Light, alt = "LightBulb" }
-    , { icon = Icon.LockDeprecated, background = Light, alt = "LockDeprecated" }
-    , { icon = Icon.Logo, background = Light, alt = "Logo" }
-    , { icon = Icon.NotStarred, background = Light, alt = "NotStarred" }
-    , { icon = Icon.Okay, background = Dark, alt = "Okay" }
-    , { icon = Icon.PeerReview, background = Light, alt = "PeerReview" }
-    , { icon = Icon.PersonBlue, background = Light, alt = "PersonBlue" }
-    , { icon = Icon.QuickWrite, background = Light, alt = "QuickWrite" }
-    , { icon = Icon.Starred, background = Light, alt = "Starred" }
-    , { icon = Icon.ThumbsUp, background = Dark, alt = "ThumbsUp" }
-    , { icon = Icon.Twitter, background = Light, alt = "Twitter" }
-    , { icon = Icon.Unarchive, background = Light, alt = "Unarchive" }
-    , { icon = Icon.X, background = Dark, alt = "X" }
+    [ { icon = Icon.add assets, background = Light, alt = "Add" }
+    , { icon = Icon.arrowLeft assets, background = Light, alt = "ArrowLeft" }
+    , { icon = Icon.arrowRight assets, background = Light, alt = "ArrowRight" }
+    , { icon = Icon.attention assets, background = Dark, alt = "Attention" }
+    , { icon = Icon.bang assets, background = Dark, alt = "Bang" }
+    , { icon = Icon.caret assets, background = Light, alt = "Caret" }
+    , { icon = Icon.checkMark assets, background = Dark, alt = "CheckMark" }
+    , { icon = Icon.checkMarkSquiggily assets, background = Dark, alt = "CheckMarkSquiggily" }
+    , { icon = Icon.close assets, background = Light, alt = "Close" }
+    , { icon = Icon.copy assets, background = Dark, alt = "Copy" }
+    , { icon = Icon.darkBlueCheckMark assets, background = Light, alt = "DarkBlueCheckMark" }
+    , { icon = Icon.equalitySign assets, background = Light, alt = "EqualitySign" }
+    , { icon = Icon.facebook assets, background = Light, alt = "Facebook" }
+    , { icon = Icon.flag assets, background = Light, alt = "Flag" }
+    , { icon = Icon.gardening assets, background = Dark, alt = "Gardening" }
+    , { icon = Icon.greenCheckMark assets, background = Light, alt = "GreenCheckMark" }
+    , { icon = Icon.help assets, background = Light, alt = "Help" }
+    , { icon = Icon.highFive assets, background = Dark, alt = "HighFive" }
+    , { icon = Icon.late assets, background = Light, alt = "Late" }
+    , { icon = Icon.lightBulb assets, background = Light, alt = "LightBulb" }
+    , { icon = Icon.lockDeprecated assets, background = Light, alt = "LockDeprecated" }
+    , { icon = Icon.logo assets, background = Light, alt = "Logo" }
+    , { icon = Icon.notStarred assets, background = Light, alt = "NotStarred" }
+    , { icon = Icon.okay assets, background = Dark, alt = "Okay" }
+    , { icon = Icon.peerReview assets, background = Light, alt = "PeerReview" }
+    , { icon = Icon.personBlue assets, background = Light, alt = "PersonBlue" }
+    , { icon = Icon.quickWrite assets, background = Light, alt = "QuickWrite" }
+    , { icon = Icon.starred assets, background = Light, alt = "Starred" }
+    , { icon = Icon.thumbsUp assets, background = Dark, alt = "ThumbsUp" }
+    , { icon = Icon.twitter assets, background = Light, alt = "Twitter" }
+    , { icon = Icon.unarchive assets, background = Light, alt = "Unarchive" }
+    , { icon = Icon.x assets, background = Dark, alt = "X" }
     ]
 
 
 svgIcons : List { alt : String, background : Background, icon : Icon.IconType }
 svgIcons =
-    [ { icon = Icon.Activity, background = Light, alt = "Activity" }
-    , { icon = Icon.ArrowDown, background = Light, alt = "ArrowDown" }
-    , { icon = Icon.Bulb, background = Light, alt = "Bulb" }
-    , { icon = Icon.Calendar, background = Light, alt = "Calendar" }
-    , { icon = Icon.CheckMarkSvg, background = Light, alt = "CheckMarkSvg" }
-    , { icon = Icon.Class, background = Light, alt = "Class" }
-    , { icon = Icon.Clever, background = Light, alt = "Clever" }
-    , { icon = Icon.Clock, background = Light, alt = "Clock" }
-    , { icon = Icon.CompassSvg, background = Light, alt = "CompassSvg" }
-    , { icon = Icon.Document, background = Light, alt = "Document" }
-    , { icon = Icon.Download, background = Light, alt = "Download" }
-    , { icon = Icon.Edit, background = Light, alt = "Edit" }
-    , { icon = Icon.EditWriting, background = Light, alt = "EditWriting" }
-    , { icon = Icon.Exclamation, background = Light, alt = "Exclamation" }
-    , { icon = Icon.Flipper, background = Light, alt = "Flipper" }
-    , { icon = Icon.Footsteps, background = Light, alt = "Footsteps" }
-    , { icon = Icon.Gear, background = Light, alt = "Gear" }
-    , { icon = Icon.Key, background = Light, alt = "Key" }
-    , { icon = Icon.Leaderboard, background = Light, alt = "Leaderboard" }
-    , { icon = Icon.Lock, background = Light, alt = "Lock" }
-    , { icon = Icon.Newspaper, background = Light, alt = "Newspaper" }
-    , { icon = Icon.OpenClose, background = Light, alt = "OpenClose" }
-    , { icon = Icon.Performance, background = Light, alt = "Performance" }
-    , { icon = Icon.Preview, background = Light, alt = "Preview" }
-    , { icon = Icon.SeeMore, background = Light, alt = "See More" }
-    , { icon = Icon.Share, background = Light, alt = "Share" }
-    , { icon = Icon.Sort, background = Light, alt = "Sort" }
-    , { icon = Icon.SortArrow, background = Light, alt = "SortArrow" }
-    , { icon = Icon.Speedometer, background = Light, alt = "Speedometer" }
-    , { icon = Icon.WritingAssignment, background = Light, alt = "WritingAssignment" }
-    , { icon = Icon.XSvg, background = Light, alt = "XSvg" }
+    [ { icon = Icon.activity assets, background = Light, alt = "Activity" }
+    , { icon = Icon.arrowDown assets, background = Light, alt = "ArrowDown" }
+    , { icon = Icon.bulb assets, background = Light, alt = "Bulb" }
+    , { icon = Icon.calendar assets, background = Light, alt = "Calendar" }
+    , { icon = Icon.checkMarkSvg assets, background = Light, alt = "CheckMarkSvg" }
+    , { icon = Icon.class assets, background = Light, alt = "Class" }
+    , { icon = Icon.clever assets, background = Light, alt = "Clever" }
+    , { icon = Icon.clock assets, background = Light, alt = "Clock" }
+    , { icon = Icon.compassSvg assets, background = Light, alt = "CompassSvg" }
+    , { icon = Icon.document assets, background = Light, alt = "Document" }
+    , { icon = Icon.download assets, background = Light, alt = "Download" }
+    , { icon = Icon.edit assets, background = Light, alt = "Edit" }
+    , { icon = Icon.editWriting assets, background = Light, alt = "EditWriting" }
+    , { icon = Icon.exclamation assets, background = Light, alt = "Exclamation" }
+    , { icon = Icon.flipper assets, background = Light, alt = "Flipper" }
+    , { icon = Icon.footsteps assets, background = Light, alt = "Footsteps" }
+    , { icon = Icon.gear assets, background = Light, alt = "Gear" }
+    , { icon = Icon.key assets, background = Light, alt = "Key" }
+    , { icon = Icon.leaderboard assets, background = Light, alt = "Leaderboard" }
+    , { icon = Icon.lock assets, background = Light, alt = "Lock" }
+    , { icon = Icon.newspaper assets, background = Light, alt = "Newspaper" }
+    , { icon = Icon.openClose assets, background = Light, alt = "OpenClose" }
+    , { icon = Icon.performance assets, background = Light, alt = "Performance" }
+    , { icon = Icon.preview assets, background = Light, alt = "Preview" }
+    , { icon = Icon.seeMore assets, background = Light, alt = "See More" }
+    , { icon = Icon.share assets, background = Light, alt = "Share" }
+    , { icon = Icon.sort assets, background = Light, alt = "Sort" }
+    , { icon = Icon.sortArrow assets, background = Light, alt = "SortArrow" }
+    , { icon = Icon.speedometer assets, background = Light, alt = "Speedometer" }
+    , { icon = Icon.writingAssignment assets, background = Light, alt = "WritingAssignment" }
+    , { icon = Icon.xSvg assets, background = Light, alt = "XSvg" }
     ]
 
 
 assignmentTypeSvgIcons : List { alt : String, background : Background, icon : Icon.IconType }
 assignmentTypeSvgIcons =
-    [ { alt = "Diagnostic", background = Light, icon = Icon.AssignmentType Icon.Diagnostic }
-    , { alt = "Practice", background = Light, icon = Icon.AssignmentType Icon.Practice }
-    , { alt = "Quiz", background = Light, icon = Icon.AssignmentType Icon.Quiz }
-    , { alt = "WritingCycle", background = Light, icon = Icon.AssignmentType Icon.WritingCycle }
+    [ { alt = "Diagnostic", background = Light, icon = Icon.assignmentTypeDiagnostic assets }
+    , { alt = "Practice", background = Light, icon = Icon.assignmentTypePractice assets }
+    , { alt = "Quiz", background = Light, icon = Icon.assignmentTypeQuiz assets }
+    , { alt = "WritingCycle", background = Light, icon = Icon.assignmentTypeWritingCycle assets }
     ]
 
 

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -8,8 +8,7 @@ module Examples.SegmentedControl exposing (Msg, State, example, init, update)
 
 import Html
 import ModuleExample exposing (Category(..), ModuleExample)
-import Nri.Ui.Icon.V1
-import Nri.Ui.SegmentedControl.V3
+import Nri.Ui.SegmentedControl.V4
 
 
 {-| -}
@@ -19,16 +18,16 @@ type Msg
 
 {-| -}
 type alias State =
-    Nri.Ui.SegmentedControl.V3.Config Id Msg
+    Nri.Ui.SegmentedControl.V4.Config Id Msg
 
 
 {-| -}
-example : Nri.Ui.Icon.V1.Assets r -> (Msg -> msg) -> State -> ModuleExample msg
-example assets parentMessage state =
+example : (Msg -> msg) -> State -> ModuleExample msg
+example parentMessage state =
     { filename = "Nri/Ui/SegmentedControl/V3.elm"
     , category = Behaviors
     , content =
-        [ Html.map parentMessage (Nri.Ui.SegmentedControl.V3.view assets state)
+        [ Html.map parentMessage (Nri.Ui.SegmentedControl.V4.view state)
         ]
     }
 

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -1,5 +1,6 @@
 module NriModules exposing (ModuleStates, Msg, init, nriThemedModules, styles, subscriptions, update)
 
+import Assets exposing (assets)
 import DEPRECATED.Css.File exposing (Stylesheet, compile, stylesheet)
 import Examples.Colors
 import Examples.Fonts
@@ -13,8 +14,8 @@ import Html.Attributes exposing (..)
 import ModuleExample exposing (Category(..), ModuleExample)
 import Navigation
 import Nri.Ui.AssetPath as AssetPath exposing (Asset(Asset))
-import Nri.Ui.Icon.V1
-import Nri.Ui.SegmentedControl.V3
+import Nri.Ui.Icon.V2
+import Nri.Ui.SegmentedControl.V4
 import Nri.Ui.Text.V1 as Text
 import Nri.Ui.TextArea.V1 as TextArea
 import String.Extra
@@ -92,8 +93,8 @@ container width children =
 
 nriThemedModules : ModuleStates -> List (ModuleExample Msg)
 nriThemedModules model =
-    [ Examples.Icon.example assets
-    , Examples.SegmentedControl.example assets SegmentedControlMsg model.segmentedControlState
+    [ Examples.Icon.example
+    , Examples.SegmentedControl.example SegmentedControlMsg model.segmentedControlState
     , Examples.Text.example
     , Examples.Text.Writing.example
     , Examples.Fonts.example
@@ -124,156 +125,8 @@ styles =
           [ ModuleExample.styles
           ]
         , (Examples.Icon.styles |> .css) ()
-        , (Nri.Ui.Icon.V1.styles |> .css) ()
-        , (Nri.Ui.SegmentedControl.V3.styles |> .css) ()
+        , (Nri.Ui.Icon.V2.styles |> .css) ()
+        , (Nri.Ui.SegmentedControl.V4.styles |> .css) ()
         , (Text.styles |> .css) ()
         , (TextArea.styles |> .css) assets
         ]
-
-
-type alias Assets =
-    { activity : String
-    , arrowDown : String
-    , attention_svg : Asset
-    , bulb : String
-    , calendar : String
-    , checkmark : String
-    , class : String
-    , clever : String
-    , clock : String
-    , commentNotStarred_png : Asset
-    , commentStarred_png : Asset
-    , compass : String
-    , darkBlueCheckmark_svg : Asset
-    , diagnostic : String
-    , document : String
-    , download : String
-    , edit : String
-    , editWriting : String
-    , exclamation : String
-    , exclamationPoint_svg : Asset
-    , facebookBlue_svg : Asset
-    , flipper : String
-    , footsteps : String
-    , gear : String
-    , hint_png : Asset
-    , iconCalendar_svg : Asset
-    , iconCheck_png : Asset
-    , iconFlag_png : Asset
-    , icons_arrowDownBlue_svg : Asset
-    , icons_arrowRightBlue_svg : Asset
-    , icons_clockRed_svg : Asset
-    , icons_equals_svg : Asset
-    , icons_helpBlue_svg : Asset
-    , icons_peerReview_svg : Asset
-    , icons_plusBlue_svg : Asset
-    , icons_quickWrite_svg : Asset
-    , icons_searchGray_svg : Asset
-    , icons_xBlue_svg : Asset
-    , icons_xBlue_svg : Asset
-    , key : String
-    , leaderboard : String
-    , leftArrowBlue_png : Asset
-    , level1Badge_png : Asset
-    , level2Badge_png : Asset
-    , level3Badge_png : Asset
-    , lock : String
-    , logoRedBlack_svg : Asset
-    , newspaper : String
-    , openClose : String
-    , performance : String
-    , personBlue_svg : Asset
-    , practice : String
-    , premiumLock_svg : Asset
-    , preview : String
-    , quiz : String
-    , seemore : String
-    , share : String
-    , smallCheckmark_png : Asset
-    , sort : String
-    , sortArrow : String
-    , speedometer : String
-    , squiggly_png : Asset
-    , startingOffBadge_png : Asset
-    , teach_assignments_copyWhite_svg : Asset
-    , twitterBlue_svg : Asset
-    , unarchiveBlue2x_png : Asset
-    , writingAssignment : String
-    , writingcycle : String
-    , x : String
-    , xWhite_svg : Asset
-    }
-
-
-assets : Assets
-assets =
-    { activity = ""
-    , arrowDown = ""
-    , attention_svg = Asset ""
-    , bulb = ""
-    , calendar = ""
-    , checkmark = ""
-    , class = ""
-    , clever = ""
-    , clock = ""
-    , commentNotStarred_png = Asset ""
-    , commentStarred_png = Asset ""
-    , compass = ""
-    , darkBlueCheckmark_svg = Asset ""
-    , diagnostic = ""
-    , document = ""
-    , download = ""
-    , edit = ""
-    , editWriting = ""
-    , exclamation = ""
-    , exclamationPoint_svg = Asset ""
-    , facebookBlue_svg = Asset ""
-    , flipper = ""
-    , footsteps = ""
-    , gear = ""
-    , hint_png = Asset ""
-    , iconCalendar_svg = Asset ""
-    , iconCheck_png = Asset ""
-    , iconFlag_png = Asset ""
-    , icons_arrowDownBlue_svg = Asset ""
-    , icons_arrowRightBlue_svg = Asset ""
-    , icons_clockRed_svg = Asset ""
-    , icons_equals_svg = Asset ""
-    , icons_helpBlue_svg = Asset ""
-    , icons_peerReview_svg = Asset ""
-    , icons_plusBlue_svg = Asset ""
-    , icons_quickWrite_svg = Asset ""
-    , icons_searchGray_svg = Asset ""
-    , icons_xBlue_svg = Asset ""
-    , key = ""
-    , leaderboard = ""
-    , leftArrowBlue_png = Asset ""
-    , level1Badge_png = Asset ""
-    , level2Badge_png = Asset ""
-    , level3Badge_png = Asset ""
-    , lock = ""
-    , logoRedBlack_svg = Asset ""
-    , newspaper = ""
-    , openClose = ""
-    , performance = ""
-    , personBlue_svg = Asset ""
-    , practice = ""
-    , premiumLock_svg = Asset ""
-    , preview = ""
-    , quiz = ""
-    , seemore = ""
-    , share = ""
-    , smallCheckmark_png = Asset ""
-    , sort = ""
-    , sortArrow = ""
-    , speedometer = ""
-    , squiggly_png = Asset ""
-    , startingOffBadge_png = Asset ""
-    , teach_assignments_copyWhite_svg = Asset ""
-    , twitterBlue_svg = Asset ""
-    , unarchiveBlue2x_png = Asset ""
-    , writingAssignment = ""
-    , writingcycle = ""
-    , x = ""
-    , xWhite_svg = Asset ""
-    }


### PR DESCRIPTION
#### Changes
This introduces a new version of the `Icon` module in which the `IconType` union has been removed in favor of separate icon constructor functions. This has a number of advantages:

- Rendering a single Icon no longer requires a record containing the assets of all icons. This means services such as CCS only need to provide assets for Icons they actually use.
- Adding a new icon to the module no longer causes a breaking change in `noredink-ui`. This wasn't an issue while `Nri.Icons` lived in the monolith, but as part of a separate package adding an exposed constructor to a union type causes a breaking change.

This PR also introduces a new version of `SegmentedControl`, which is the only widget in `noredink-ui` currently using Icons.

#### Review
Asking a review from Luke because I know you had a large hand in setting up `Nri.Icon`. Also asking a review from Hardy, specifically on whether you feel this approach benefits CCS development. Please feel completely free to remove yourself from the review list for any reason!