### PR TITLE
disallow major changes in Travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ test: elm-stuff tests/elm-stuff node_modules
 	elm-test
 
 .PHONY: diff
-diff: node_modules
-	elm-package diff
+diff: node_modules elm-stuff
+	if (elm-package diff | tee /dev/stderr | grep -q MAJOR); then echo "MAJOR changes are not allowed!"; exit 1; fi
 
 .PHONY: format
 format: node_modules


### PR DESCRIPTION
A repo administrator can still override this check if we really need to publish a major change, but let's catch the common case.

Aside: is this decision documented anywhere? I've seen several people mention it… could someone in the know please add the rationale to the README or something?

```text
$ make diff                                                                                                                                                                                    master :: 8m :: ⬡
if (elm-package diff | tee /dev/stderr | grep -q MAJOR); then echo "MAJOR changes are not allowed!"; exit 1; fi
Comparing NoRedInk/noredink-ui 4.2.0 to local changes...
This is a MAJOR change.

------ Changes to module Nri.Ui.SegmentedControl.V3 - MAJOR ------

    Added:
        type CssClasses

    Changed:
      - styles : Nri.Ui.Styles.V1.Styles Basics.Never Nri.Ui.SegmentedControl.V3.CssClass msg
      + styles : Nri.Ui.Styles.V1.Styles Basics.Never Nri.Ui.SegmentedControl.V3.CssClasses msg



------ Changes to module Nri.Ui.SegmentedControl.V4 - MAJOR ------

    Added:
        type CssClasses

    Changed:
      - styles : Nri.Ui.Styles.V1.Styles Basics.Never Nri.Ui.SegmentedControl.V4.CssClass msg
      + styles : Nri.Ui.Styles.V1.Styles Basics.Never Nri.Ui.SegmentedControl.V4.CssClasses msg



MAJOR changes are not allowed!
make: *** [diff] Error 1
```