### PR TITLE
More segmented control styling changes

### DIFF
--- a/src/Nri/Ui/SegmentedControl/V5.elm
+++ b/src/Nri/Ui/SegmentedControl/V5.elm
@@ -1,0 +1,138 @@
+module Nri.Ui.SegmentedControl.V5 exposing (Config, CssClass, Icon, Option, styles, view)
+
+{-|
+
+@docs Config, Icon, Option, styles, view, CssClass
+
+-}
+
+import Accessibility exposing (..)
+import Accessibility.Role as Role
+import Css exposing (..)
+import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import Html
+import Html.Attributes
+import Html.Events
+import Nri.Ui.Colors.Extra exposing (withAlpha)
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.CssFlexBoxWithVendorPrefix as FlexBox
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Icon.V2 as Icon
+import Nri.Ui.Styles.V1
+import View.Extra
+
+
+{-| -}
+type alias Config a msg =
+    { onClick : a -> msg
+    , options : List (Option a)
+    , selected : a
+    }
+
+
+{-| -}
+type alias Option a =
+    { value : a
+    , icon : Maybe Icon
+    , label : String
+    , id : String
+    }
+
+
+{-| -}
+type alias Icon =
+    { alt : String
+    , icon : Icon.IconType
+    }
+
+
+focusedClass : a -> a -> CssClass
+focusedClass value selected =
+    if value == selected then
+        Focused
+    else
+        Unfocused
+
+
+{-| -}
+view : Config a msg -> Html.Html msg
+view config =
+    config.options
+        |> List.map
+            (\option ->
+                Html.div
+                    [ Html.Attributes.id option.id
+                    , Role.tab
+                    , Html.Events.onClick (config.onClick option.value)
+                    , styles.class
+                        [ Tab
+                        , focusedClass option.value config.selected
+                        ]
+                    ]
+                    [ View.Extra.viewJust viewIcon option.icon
+                    , Html.text option.label
+                    ]
+            )
+        |> div [ Role.tabList, styles.class [ SegmentedControl ] ]
+
+
+viewIcon : Icon -> Html msg
+viewIcon icon =
+    Html.span
+        [ styles.class [ IconContainer ] ]
+        [ Icon.icon icon ]
+
+
+{-| Classes for styling
+-}
+type CssClass
+    = SegmentedControl
+    | Tab
+    | IconContainer
+    | Focused
+    | Unfocused
+
+
+{-| -}
+styles : Nri.Ui.Styles.V1.Styles Never CssClass msg
+styles =
+    Nri.Ui.Styles.V1.styles "Nri-Ui-SegmentedControl-V5-"
+        [ Css.Foreign.class SegmentedControl
+            [ FlexBox.displayFlex
+            , cursor pointer
+            ]
+        , Css.Foreign.class Tab
+            [ padding2 (px 6) (px 20)
+            , height (px 45)
+            , Fonts.baseFont
+            , fontSize (px 15)
+            , color Colors.azure
+            , fontWeight bold
+            , lineHeight (px 30)
+            , firstChild
+                [ borderTopLeftRadius (px 8)
+                , borderBottomLeftRadius (px 8)
+                , borderLeft3 (px 1) solid Colors.azure
+                ]
+            , lastChild
+                [ borderTopRightRadius (px 8)
+                , borderBottomRightRadius (px 8)
+                ]
+            , border3 (px 1) solid Colors.azure
+            , borderLeft (px 0)
+            , boxSizing borderBox
+            ]
+        , Css.Foreign.class IconContainer
+            [ marginRight (px 10)
+            ]
+        , Css.Foreign.class Focused
+            [ backgroundColor Colors.glacier
+            , boxShadow5 inset zero (px 3) zero (withAlpha 0.2 Colors.gray20)
+            , color Colors.gray20
+            ]
+        , Css.Foreign.class Unfocused
+            [ backgroundColor Colors.white
+            , boxShadow5 inset zero (px -2) zero Colors.azure
+            , color Colors.azure
+            ]
+        ]

--- a/src/Nri/Ui/SegmentedControl/V5.elm
+++ b/src/Nri/Ui/SegmentedControl/V5.elm
@@ -121,6 +121,8 @@ styles =
             , border3 (px 1) solid Colors.azure
             , borderLeft (px 0)
             , boxSizing borderBox
+            , FlexBox.flexGrow 1
+            , textAlign center
             ]
         , Css.Foreign.class IconContainer
             [ marginRight (px 10)

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -24,7 +24,7 @@ type alias State =
 {-| -}
 example : (Msg -> msg) -> State -> ModuleExample msg
 example parentMessage state =
-    { filename = "Nri/Ui/SegmentedControl/V3.elm"
+    { filename = "Nri/Ui/SegmentedControl/V4.elm"
     , category = Behaviors
     , content =
         [ Html.map parentMessage (Nri.Ui.SegmentedControl.V4.view state)

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -1,14 +1,30 @@
-module Examples.SegmentedControl exposing (Msg, State, example, init, update)
+module Examples.SegmentedControl
+    exposing
+        ( Msg
+        , State
+        , example
+        , init
+        , styles
+        , update
+        )
 
 {-|
 
-@docs Msg, State, example, init, update,
+@docs Msg
+@docs State
+@docs example
+@docs init
+@docs styles
+@docs update
 
 -}
 
+import Css
+import Css.Foreign
 import Html
 import ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.SegmentedControl.V5
+import Nri.Ui.Styles.V1
 
 
 {-| -}
@@ -27,7 +43,8 @@ example parentMessage state =
     { filename = "Nri/Ui/SegmentedControl/V5.elm"
     , category = Behaviors
     , content =
-        [ Html.map parentMessage (Nri.Ui.SegmentedControl.V5.view state)
+        [ Html.map parentMessage
+            (styles.div Container [ Nri.Ui.SegmentedControl.V5.view state ])
         ]
     }
 
@@ -58,6 +75,21 @@ update msg state =
     case msg of
         Select id ->
             ( { state | selected = id }, Cmd.none )
+
+
+{-| -}
+styles : Nri.Ui.Styles.V1.Styles a b c
+styles =
+    Nri.Ui.Styles.V1.styles
+        "Examples-SegmentedControl-"
+        [ Css.Foreign.class Container
+            [ Css.width (Css.px 500)
+            ]
+        ]
+
+
+type Classes
+    = Container
 
 
 

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -8,7 +8,7 @@ module Examples.SegmentedControl exposing (Msg, State, example, init, update)
 
 import Html
 import ModuleExample exposing (Category(..), ModuleExample)
-import Nri.Ui.SegmentedControl.V4
+import Nri.Ui.SegmentedControl.V5
 
 
 {-| -}
@@ -18,16 +18,16 @@ type Msg
 
 {-| -}
 type alias State =
-    Nri.Ui.SegmentedControl.V4.Config Id Msg
+    Nri.Ui.SegmentedControl.V5.Config Id Msg
 
 
 {-| -}
 example : (Msg -> msg) -> State -> ModuleExample msg
 example parentMessage state =
-    { filename = "Nri/Ui/SegmentedControl/V4.elm"
+    { filename = "Nri/Ui/SegmentedControl/V5.elm"
     , category = Behaviors
     , content =
-        [ Html.map parentMessage (Nri.Ui.SegmentedControl.V4.view state)
+        [ Html.map parentMessage (Nri.Ui.SegmentedControl.V5.view state)
         ]
     }
 

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -15,7 +15,7 @@ import ModuleExample exposing (Category(..), ModuleExample)
 import Navigation
 import Nri.Ui.AssetPath as AssetPath exposing (Asset(Asset))
 import Nri.Ui.Icon.V2
-import Nri.Ui.SegmentedControl.V4
+import Nri.Ui.SegmentedControl.V5
 import Nri.Ui.Text.V1 as Text
 import Nri.Ui.TextArea.V1 as TextArea
 import String.Extra
@@ -126,7 +126,7 @@ styles =
           ]
         , (Examples.Icon.styles |> .css) ()
         , (Nri.Ui.Icon.V2.styles |> .css) ()
-        , (Nri.Ui.SegmentedControl.V4.styles |> .css) ()
+        , (Nri.Ui.SegmentedControl.V5.styles |> .css) ()
         , (Text.styles |> .css) ()
         , (TextArea.styles |> .css) assets
         ]

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -125,6 +125,7 @@ styles =
           [ ModuleExample.styles
           ]
         , (Examples.Icon.styles |> .css) ()
+        , (Examples.SegmentedControl.styles |> .css) ()
         , (Nri.Ui.Icon.V2.styles |> .css) ()
         , (Nri.Ui.SegmentedControl.V5.styles |> .css) ()
         , (Text.styles |> .css) ()


### PR DESCRIPTION
##### What it does

Makes the latest version of segmented control have white backgrounds for unfocused tabs and allows the whole control to grow.

For more reference see: #14 and https://github.com/NoRedInk/content-creation/pull/424#issuecomment-376713618

##### Screenshots

<details>
<summary>Old and busted</summary>

<img width="586" alt="screen shot 2018-03-30 at 09 11 06" src="https://user-images.githubusercontent.com/1356417/38145367-bfba2450-33fd-11e8-8326-9e4deb97da65.png">
</details>

<details>
<summary>New hotness</summary>

<img width="623" alt="screen shot 2018-03-30 at 09 08 34" src="https://user-images.githubusercontent.com/1356417/38145375-c56f11da-33fd-11e8-8b06-0462bbe1914f.png">
</details>