### PR TITLE
Extract `Nri.Dropdown`

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -16,6 +16,7 @@
         "Nri.Ui.Checkbox.V1",
         "Nri.Ui.Checkbox.V2",
         "Nri.Ui.Divider.V1",
+        "Nri.Ui.Dropdown.V1",
         "Nri.Ui.Effects.V1",
         "Nri.Ui.Fonts.V1",
         "Nri.Ui.Icon.V1",

--- a/src/Nri/Ui/Dropdown/V1.elm
+++ b/src/Nri/Ui/Dropdown/V1.elm
@@ -1,0 +1,146 @@
+module Nri.Ui.Dropdown.V1
+    exposing
+        ( ViewOptionEntry
+        , view
+        , viewWithoutLabel
+        )
+
+{-|
+
+@docs ViewOptionEntry
+@docs view
+@docs viewWithoutLabel
+
+-}
+
+import Accessibility.Style exposing (invisible)
+import Dict
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (on, targetValue)
+import Json.Decode
+import Nri.Ui.Util exposing (dashify)
+import String
+
+
+{-| This dropdown has atypical select tag behavior.
+
+This dropdown, when closed, will display some default text, no matter
+what is actually selected.
+
+When the dropdown is opened, the first option will display that default text,
+be selected, and disabled. The option the user has actually chosen's displayText
+won't show up at all.
+
+-}
+type alias ViewOptionEntry a =
+    { isSelected : Bool
+    , val : a
+    , displayText : String
+    }
+
+
+{-| -}
+view : String -> List (ViewOptionEntry a) -> (a -> msg) -> Html msg
+view defaultDisplayText optionEntries onSelect =
+    viewWithLabelMarkup True defaultDisplayText optionEntries onSelect
+
+
+{-| -}
+viewWithoutLabel : String -> List (ViewOptionEntry a) -> (a -> msg) -> Html msg
+viewWithoutLabel defaultDisplayText optionEntries onSelect =
+    viewWithLabelMarkup False defaultDisplayText optionEntries onSelect
+
+
+viewWithLabelMarkup : Bool -> String -> List (ViewOptionEntry a) -> (a -> msg) -> Html msg
+viewWithLabelMarkup displayLabel defaultDisplayText optionEntries onSelect =
+    let
+        defaultOption =
+            option
+                [ selected True
+                , disabled True
+                ]
+                [ text defaultDisplayText ]
+
+        options =
+            List.map (viewOption defaultDisplayText) optionEntries
+
+        identifier =
+            dashify (String.toLower defaultDisplayText)
+
+        changeHandlers : List (Attribute msg)
+        changeHandlers =
+            case optionEntries of
+                [] ->
+                    -- If we have no entries, there's no point in having
+                    -- a change handler; it could never fire anyway.
+                    []
+
+                { val } :: _ ->
+                    let
+                        -- When we get a `String` from the `onChange` event,
+                        -- look up the `msg` that goes with it.
+                        msgForValue : String -> msg
+                        msgForValue valString =
+                            case Dict.get valString msgsByVal of
+                                Just msg ->
+                                    msg
+
+                                Nothing ->
+                                    -- If it's somehow not in the Dict
+                                    -- (which should never happen),
+                                    -- fall back on a known `msg` value:
+                                    -- the first one in the list.
+                                    onSelect val
+
+                        msgsByVal : Dict.Dict String msg
+                        msgsByVal =
+                            optionEntries
+                                |> List.map (\{ val } -> ( toString val, onSelect val ))
+                                |> Dict.fromList
+                    in
+                    [ on "change" (Json.Decode.map msgForValue targetValue) ]
+    in
+    span []
+        [ label
+            (if displayLabel then
+                [ for identifier ]
+             else
+                [ for identifier, invisible ]
+            )
+            [ text defaultDisplayText ]
+        , select
+            ([ id identifier
+             , {-
+                  NOTE: form controls are also being styled on a global CSS that
+                  sets a margin.
+
+                  It would be better to remove the margin from the component and
+                  decide whether we need it or not in each use case.
+
+                  It will be really hard to track down and review all of those,
+                  so we reset the margin here as a workaround.
+               -}
+               style [ ( "margin", "0" ) ]
+             ]
+                ++ changeHandlers
+            )
+            (defaultOption :: options)
+        ]
+
+
+viewOption : String -> ViewOptionEntry a -> Html msg
+viewOption defaultDisplayText { isSelected, val, displayText } =
+    if isSelected then
+        option
+            [ value <| toString val
+            , selected isSelected
+            , style [ ( "display", "none" ) ]
+            ]
+            [ text defaultDisplayText ]
+    else
+        option
+            [ value <| toString val
+            , selected isSelected
+            ]
+            [ text displayText ]

--- a/src/Nri/Ui/Dropdown/V1.elm
+++ b/src/Nri/Ui/Dropdown/V1.elm
@@ -1,24 +1,32 @@
 module Nri.Ui.Dropdown.V1
     exposing
-        ( ViewOptionEntry
+        ( CssClasses
+        , ViewOptionEntry
+        , styles
         , view
         , viewWithoutLabel
         )
 
 {-|
 
+@docs CssClasses
 @docs ViewOptionEntry
+@docs styles
 @docs view
 @docs viewWithoutLabel
 
 -}
 
 import Accessibility.Style exposing (invisible)
+import Css
+import Css.Foreign
 import Dict
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (on, targetValue)
 import Json.Decode
+import Nri.Ui.Colors.V1
+import Nri.Ui.Styles.V1
 import Nri.Ui.Util exposing (dashify)
 import String
 
@@ -110,7 +118,8 @@ viewWithLabelMarkup displayLabel defaultDisplayText optionEntries onSelect =
             )
             [ text defaultDisplayText ]
         , select
-            ([ id identifier
+            ([ styles.class [ Dropdown ]
+             , id identifier
              , {-
                   NOTE: form controls are also being styled on a global CSS that
                   sets a margin.
@@ -144,3 +153,24 @@ viewOption defaultDisplayText { isSelected, val, displayText } =
             , selected isSelected
             ]
             [ text displayText ]
+
+
+{-| -}
+type CssClasses
+    = Dropdown
+
+
+{-| -}
+styles : Nri.Ui.Styles.V1.Styles Never CssClasses c
+styles =
+    Nri.Ui.Styles.V1.styles "Nri-Ui-Dropdown-V1-"
+        [ Css.Foreign.class Dropdown
+            [ Css.backgroundColor Nri.Ui.Colors.V1.white
+            , Css.border3 (Css.px 1) Css.solid Nri.Ui.Colors.V1.gray75
+            , Css.borderRadius (Css.px 8)
+            , Css.color Nri.Ui.Colors.V1.gray20
+            , Css.cursor Css.pointer
+            , Css.fontSize (Css.px 15)
+            , Css.height (Css.px 45)
+            ]
+        ]

--- a/styleguide-app/Examples/Dropdown.elm
+++ b/styleguide-app/Examples/Dropdown.elm
@@ -1,0 +1,58 @@
+module Examples.Dropdown exposing (Msg, State, Value, example, init, update)
+
+{-|
+
+@docs Msg, State, Value, example, init, update,
+
+-}
+
+import Html
+import ModuleExample exposing (Category(..), ModuleExample)
+import Nri.Ui.Dropdown.V1
+
+
+{-| -}
+type alias Value =
+    String
+
+
+{-| -}
+type Msg
+    = ConsoleLog String
+
+
+{-| -}
+type alias State value =
+    List (Nri.Ui.Dropdown.V1.ViewOptionEntry value)
+
+
+{-| -}
+example : (Msg -> msg) -> State Value -> ModuleExample msg
+example parentMessage state =
+    { filename = "Nri/Ui/Dropdown/V1.elm"
+    , category = Inputs
+    , content =
+        [ Html.map parentMessage (Nri.Ui.Dropdown.V1.view "All the foods!" state ConsoleLog)
+        ]
+    }
+
+
+{-| -}
+init : State Value
+init =
+    [ { isSelected = False, val = "Burrito", displayText = "Burrito" }
+    , { isSelected = False, val = "Nacho", displayText = "Nacho" }
+    , { isSelected = False, val = "Horchata", displayText = "Horchata" }
+    ]
+
+
+{-| -}
+update : Msg -> State Value -> ( State Value, Cmd Msg )
+update msg state =
+    case msg of
+        ConsoleLog message ->
+            let
+                _ =
+                    Debug.log "DropdownExample" message
+            in
+            ( state, Cmd.none )

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -15,6 +15,7 @@ import Html.Attributes exposing (..)
 import ModuleExample exposing (Category(..), ModuleExample)
 import Navigation
 import Nri.Ui.AssetPath as AssetPath exposing (Asset(Asset))
+import Nri.Ui.Dropdown.V1
 import Nri.Ui.Icon.V2
 import Nri.Ui.SegmentedControl.V5
 import Nri.Ui.Text.V1 as Text
@@ -140,6 +141,7 @@ styles =
           ]
         , (Examples.Icon.styles |> .css) ()
         , (Examples.SegmentedControl.styles |> .css) ()
+        , (Nri.Ui.Dropdown.V1.styles |> .css) ()
         , (Nri.Ui.Icon.V2.styles |> .css) ()
         , (Nri.Ui.SegmentedControl.V5.styles |> .css) ()
         , (Text.styles |> .css) ()

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -3,6 +3,7 @@ module NriModules exposing (ModuleStates, Msg, init, nriThemedModules, styles, s
 import Assets exposing (assets)
 import DEPRECATED.Css.File exposing (Stylesheet, compile, stylesheet)
 import Examples.Colors
+import Examples.Dropdown
 import Examples.Fonts
 import Examples.Icon
 import Examples.SegmentedControl
@@ -22,20 +23,23 @@ import String.Extra
 
 
 type alias ModuleStates =
-    { segmentedControlState : Examples.SegmentedControl.State
+    { dropdownState : Examples.Dropdown.State Examples.Dropdown.Value
+    , segmentedControlState : Examples.SegmentedControl.State
     , textAreaExampleState : TextAreaExample.State
     }
 
 
 init : ModuleStates
 init =
-    { segmentedControlState = Examples.SegmentedControl.init
+    { dropdownState = Examples.Dropdown.init
+    , segmentedControlState = Examples.SegmentedControl.init
     , textAreaExampleState = TextAreaExample.init
     }
 
 
 type Msg
-    = SegmentedControlMsg Examples.SegmentedControl.Msg
+    = DropdownMsg Examples.Dropdown.Msg
+    | SegmentedControlMsg Examples.SegmentedControl.Msg
     | ShowItWorked String String
     | TextAreaExampleMsg TextAreaExample.Msg
     | NoOp
@@ -44,6 +48,15 @@ type Msg
 update : Msg -> ModuleStates -> ( ModuleStates, Cmd Msg )
 update msg moduleStates =
     case msg of
+        DropdownMsg msg ->
+            let
+                ( dropdownState, cmd ) =
+                    Examples.Dropdown.update msg moduleStates.dropdownState
+            in
+            ( { moduleStates | dropdownState = dropdownState }
+            , Cmd.map DropdownMsg cmd
+            )
+
         SegmentedControlMsg msg ->
             let
                 ( segmentedControlState, cmd ) =
@@ -93,7 +106,8 @@ container width children =
 
 nriThemedModules : ModuleStates -> List (ModuleExample Msg)
 nriThemedModules model =
-    [ Examples.Icon.example
+    [ Examples.Dropdown.example DropdownMsg model.dropdownState
+    , Examples.Icon.example
     , Examples.SegmentedControl.example SegmentedControlMsg model.segmentedControlState
     , Examples.Text.example
     , Examples.Text.Writing.example


### PR DESCRIPTION
##### What it does

Some work needed for CCS, maybe.

We either need `Nri.Dropdown`, `Nri.Select`, or both. This PR pulls out `Nri.Dropdown` now so we aren't blocked later.

##### Diffs

<details>
<summary>Diff of the monolith's `Nri.Dropdown` with this PR's `Nri.Ui.Dropdown.V1`</summary>

```diff
1c1,8
< module Nri.Dropdown exposing (ViewOptionEntry, view, viewWithoutLabel)
---
> module Nri.Ui.Dropdown.V1
>     exposing
>         ( CssClasses
>         , ViewOptionEntry
>         , styles
>         , view
>         , viewWithoutLabel
>         )
5c12,16
< @docs view, viewWithoutLabel, ViewOptionEntry
---
> @docs CssClasses
> @docs ViewOptionEntry
> @docs styles
> @docs view
> @docs viewWithoutLabel
9a21,22
> import Css
> import Css.Foreign
11d23
< import EventExtras exposing (onChange)
14c26,30
< import Html.Attributes.Extra exposing (none)
---
> import Html.Events exposing (on, targetValue)
> import Json.Decode
> import Nri.Ui.Colors.V1
> import Nri.Ui.Styles.V1
> import Nri.Ui.Util exposing (dashify)
16d31
< import Util exposing (dashify)
95c110
<                     [ onChange msgForValue ]
---
>                     [ on "change" (Json.Decode.map msgForValue targetValue) ]
99,104c114,118
<             [ for identifier
<             , if displayLabel then
<                 none
<               else
<                 invisible
<             ]
---
>             (if displayLabel then
>                 [ for identifier ]
>              else
>                 [ for identifier, invisible ]
>             )
107c121,122
<             ([ id identifier
---
>             ([ styles.class [ Dropdown ]
>              , id identifier
140a156,176
> 
> 
> {-| -}
> type CssClasses
>     = Dropdown
> 
> 
> {-| -}
> styles : Nri.Ui.Styles.V1.Styles Never CssClasses c
> styles =
>     Nri.Ui.Styles.V1.styles "Nri-Ui-Dropdown-V1-"
>         [ Css.Foreign.class Dropdown
>             [ Css.backgroundColor Nri.Ui.Colors.V1.white
>             , Css.border3 (Css.px 1) Css.solid Nri.Ui.Colors.V1.gray75
>             , Css.borderRadius (Css.px 8)
>             , Css.color Nri.Ui.Colors.V1.gray20
>             , Css.cursor Css.pointer
>             , Css.fontSize (Css.px 15)
>             , Css.height (Css.px 45)
>             ]
>         ]
```
</details>

##### For review

Followed the "Moving a widget to `noredink-ui`" step of our [process in Paper][].

[process in paper]: https://paper.dropbox.com/doc/noredink-ui-widget-library-fUK6yq32g187lxw2A60a8#:uid=348369002247633329910446&h2=Moving-a-widget-to-noredink-ui