### PR TITLE
Extract `Nri.Select`

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -28,6 +28,7 @@
         "Nri.Ui.SegmentedControl.V3",
         "Nri.Ui.SegmentedControl.V4",
         "Nri.Ui.SegmentedControl.V5",
+        "Nri.Ui.Select.V1",
         "Nri.Ui.Styles.V1",
         "Nri.Ui.Tabs.V1",
         "Nri.Ui.Text.Writing.V1",

--- a/src/Nri/Ui/Select/V1.elm
+++ b/src/Nri/Ui/Select/V1.elm
@@ -39,11 +39,7 @@ type alias Config a =
 -}
 niceId : String -> a -> String
 niceId prefix x =
-    x
-        |> toString
-        |> Nri.Ui.Util.removePunctuation
-        |> Nri.Ui.Util.dashify
-        |> (++) (prefix ++ "-")
+    prefix ++ "-" ++ Nri.Ui.Util.dashify (Nri.Ui.Util.removePunctuation (toString x))
 
 
 {-| A normal select dropdown

--- a/src/Nri/Ui/Select/V1.elm
+++ b/src/Nri/Ui/Select/V1.elm
@@ -2,6 +2,7 @@ module Nri.Ui.Select.V1
     exposing
         ( Config
         , customView
+        , styles
         , view
         )
 
@@ -16,14 +17,19 @@ module Nri.Ui.Select.V1
 # Render
 
 @docs view, customView
+@docs styles
 
 -}
 
+import Css
+import Css.Foreign
 import Dict
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Json.Decode exposing (Decoder, andThen, succeed)
+import Nri.Ui.Colors.V1
+import Nri.Ui.Styles.V1
 import Nri.Ui.Util
 
 
@@ -80,4 +86,25 @@ customView attributes config =
     in
     config.choices
         |> List.map viewChoice
-        |> Html.select (onSelectHandler :: attributes)
+        |> Html.select (styles.class [ Select ] :: onSelectHandler :: attributes)
+
+
+{-| -}
+type CssClasses
+    = Select
+
+
+{-| -}
+styles : Nri.Ui.Styles.V1.Styles Never CssClasses c
+styles =
+    Nri.Ui.Styles.V1.styles "Nri-Ui-Select-V1-"
+        [ Css.Foreign.class Select
+            [ Css.backgroundColor Nri.Ui.Colors.V1.white
+            , Css.border3 (Css.px 1) Css.solid Nri.Ui.Colors.V1.gray75
+            , Css.borderRadius (Css.px 8)
+            , Css.color Nri.Ui.Colors.V1.gray20
+            , Css.cursor Css.pointer
+            , Css.fontSize (Css.px 15)
+            , Css.height (Css.px 45)
+            ]
+        ]

--- a/src/Nri/Ui/Select/V1.elm
+++ b/src/Nri/Ui/Select/V1.elm
@@ -1,0 +1,87 @@
+module Nri.Ui.Select.V1
+    exposing
+        ( Config
+        , customView
+        , view
+        )
+
+{-| Build a select input.
+
+
+# Configure
+
+@docs Config
+
+
+# Render
+
+@docs view, customView
+
+-}
+
+import Dict
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
+import Json.Decode exposing (Decoder, andThen, succeed)
+import Nri.Ui.Util
+
+
+{-| Select-specific Choice.Config
+-}
+type alias Config a =
+    { choices : List { label : String, value : a }
+    , current : a
+    }
+
+
+{-| TODO: move this to View.Extra
+-}
+niceId : String -> a -> String
+niceId prefix x =
+    x
+        |> toString
+        |> Nri.Ui.Util.removePunctuation
+        |> Nri.Ui.Util.dashify
+        |> (++) (prefix ++ "-")
+
+
+{-| A normal select dropdown
+-}
+view : Config a -> Html a
+view config =
+    customView [] config
+
+
+{-| A select dropdown with custom attributes.
+This should be phased out as the new Select style is implemented,
+all pages should use the new, consistent style.
+-}
+customView : List (Html.Attribute a) -> Config a -> Html a
+customView attributes config =
+    let
+        valueLookup =
+            -- TODO: probably worth using Lazy here, since choices won't change often
+            config.choices
+                |> List.map (\x -> ( niceId "nri-select" x.value, x.value ))
+                |> Dict.fromList
+
+        decodeValue string =
+            Dict.get string valueLookup
+                |> Maybe.map Json.Decode.succeed
+                |> Maybe.withDefault (Json.Decode.fail ("Nri.Select: could not decode the value: " ++ toString string ++ "\nexpected one of: " ++ toString (Dict.keys valueLookup)))
+
+        onSelectHandler =
+            on "change" (targetValue |> andThen decodeValue)
+
+        viewChoice choice =
+            Html.option
+                [ Html.Attributes.id (niceId "nri-select" choice.value)
+                , Html.Attributes.value (niceId "nri-select" choice.value)
+                , Html.Attributes.selected (choice.value == config.current)
+                ]
+                [ Html.text choice.label ]
+    in
+    config.choices
+        |> List.map viewChoice
+        |> Html.select (onSelectHandler :: attributes)

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -1,0 +1,74 @@
+module Examples.Select
+    exposing
+        ( Msg
+        , State
+        , Value
+        , example
+        , init
+        , update
+        )
+
+{-|
+
+@docs Msg
+@docs State
+@docs Value
+@docs example
+@docs init
+@docs update
+
+-}
+
+import Html
+import ModuleExample exposing (Category(..), ModuleExample)
+import Nri.Ui.Select.V1
+
+
+{-| -}
+type alias Value =
+    String
+
+
+{-| -}
+type Msg
+    = ConsoleLog String
+
+
+{-| -}
+type alias State value =
+    Nri.Ui.Select.V1.Config value
+
+
+{-| -}
+example : (Msg -> msg) -> State Value -> ModuleExample msg
+example parentMessage state =
+    { filename = "ui/src/Nri/Select.elm"
+    , category = Inputs
+    , content =
+        [ Html.map (parentMessage << ConsoleLog) (Nri.Ui.Select.V1.view state)
+        ]
+    }
+
+
+{-| -}
+init : State Value
+init =
+    { current = ""
+    , choices =
+        [ { label = "Tacos", value = "Tacos" }
+        , { label = "Burritos", value = "Burritos" }
+        , { label = "Enchiladas", value = "Enchiladas" }
+        ]
+    }
+
+
+{-| -}
+update : Msg -> State Value -> ( State Value, Cmd Msg )
+update msg state =
+    case msg of
+        ConsoleLog message ->
+            let
+                _ =
+                    Debug.log "SelectExample" message
+            in
+            ( state, Cmd.none )

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -6,6 +6,7 @@ import Examples.Colors
 import Examples.Fonts
 import Examples.Icon
 import Examples.SegmentedControl
+import Examples.Select
 import Examples.Text
 import Examples.Text.Writing
 import Examples.TextArea as TextAreaExample
@@ -23,6 +24,7 @@ import String.Extra
 
 type alias ModuleStates =
     { segmentedControlState : Examples.SegmentedControl.State
+    , selectState : Examples.Select.State Examples.Select.Value
     , textAreaExampleState : TextAreaExample.State
     }
 
@@ -30,12 +32,14 @@ type alias ModuleStates =
 init : ModuleStates
 init =
     { segmentedControlState = Examples.SegmentedControl.init
+    , selectState = Examples.Select.init
     , textAreaExampleState = TextAreaExample.init
     }
 
 
 type Msg
     = SegmentedControlMsg Examples.SegmentedControl.Msg
+    | SelectMsg Examples.Select.Msg
     | ShowItWorked String String
     | TextAreaExampleMsg TextAreaExample.Msg
     | NoOp
@@ -51,6 +55,15 @@ update msg moduleStates =
             in
             ( { moduleStates | segmentedControlState = segmentedControlState }
             , Cmd.map SegmentedControlMsg cmd
+            )
+
+        SelectMsg msg ->
+            let
+                ( selectState, cmd ) =
+                    Examples.Select.update msg moduleStates.selectState
+            in
+            ( { moduleStates | selectState = selectState }
+            , Cmd.map SelectMsg cmd
             )
 
         ShowItWorked group message ->
@@ -95,6 +108,7 @@ nriThemedModules : ModuleStates -> List (ModuleExample Msg)
 nriThemedModules model =
     [ Examples.Icon.example
     , Examples.SegmentedControl.example SegmentedControlMsg model.segmentedControlState
+    , Examples.Select.example SelectMsg model.selectState
     , Examples.Text.example
     , Examples.Text.Writing.example
     , Examples.Fonts.example

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -17,6 +17,7 @@ import Navigation
 import Nri.Ui.AssetPath as AssetPath exposing (Asset(Asset))
 import Nri.Ui.Icon.V2
 import Nri.Ui.SegmentedControl.V5
+import Nri.Ui.Select.V1
 import Nri.Ui.Text.V1 as Text
 import Nri.Ui.TextArea.V1 as TextArea
 import String.Extra
@@ -142,6 +143,7 @@ styles =
         , (Examples.SegmentedControl.styles |> .css) ()
         , (Nri.Ui.Icon.V2.styles |> .css) ()
         , (Nri.Ui.SegmentedControl.V5.styles |> .css) ()
+        , (Nri.Ui.Select.V1.styles |> .css) ()
         , (Text.styles |> .css) ()
         , (TextArea.styles |> .css) assets
         ]


### PR DESCRIPTION
##### What it does

Some work needed for CCS, maybe.

We either need `Nri.Dropdown`, `Nri.Select`, or both. This PR pulls out `Nri.Select` now so we aren't blocked later.

##### Diffs

<details>
<summary>Diff of the monolith's `Nri.Select` with this PR's `Nri.Ui.Select.V1`</summary>

```diff
1c1,7
< module Nri.Select exposing (Config, customView, view)
---
> module Nri.Ui.Select.V1
>     exposing
>         ( Config
>         , customView
>         , styles
>         , view
>         )
13a20
> @docs styles
16a24,25
> import Css
> import Css.Foreign
22c31,33
< import Util
---
> import Nri.Ui.Colors.V1
> import Nri.Ui.Styles.V1
> import Nri.Ui.Util
37,41c48
<     x
<         |> toString
<         |> Util.removePunctuation
<         |> Util.dashify
<         |> (++) (prefix ++ "-")
---
>     prefix ++ "-" ++ Nri.Ui.Util.dashify (Nri.Ui.Util.removePunctuation (toString x))
82c89,110
<         |> Html.select (onSelectHandler :: attributes)
---
>         |> Html.select (styles.class [ Select ] :: onSelectHandler :: attributes)
> 
> 
> {-| -}
> type CssClasses
>     = Select
> 
> 
> {-| -}
> styles : Nri.Ui.Styles.V1.Styles Never CssClasses c
> styles =
>     Nri.Ui.Styles.V1.styles "Nri-Ui-Select-V1-"
>         [ Css.Foreign.class Select
>             [ Css.backgroundColor Nri.Ui.Colors.V1.white
>             , Css.border3 (Css.px 1) Css.solid Nri.Ui.Colors.V1.gray75
>             , Css.borderRadius (Css.px 8)
>             , Css.color Nri.Ui.Colors.V1.gray20
>             , Css.cursor Css.pointer
>             , Css.fontSize (Css.px 15)
>             , Css.height (Css.px 45)
>             ]
>         ]
```
</details>


##### For review

Followed the "Moving a widget to `noredink-ui`" step of our [process in Paper][].

[process in paper]: https://paper.dropbox.com/doc/noredink-ui-widget-library-fUK6yq32g187lxw2A60a8#:uid=348369002247633329910446&h2=Moving-a-widget-to-noredink-ui