### PR TITLE
Extract tests for select from the monolith

### DIFF
--- a/tests/Spec/Nri/Ui/Select/V1.elm
+++ b/tests/Spec/Nri/Ui/Select/V1.elm
@@ -1,0 +1,43 @@
+module Spec.Nri.Ui.Select.V1 exposing (spec)
+
+import Expect exposing (Expectation)
+import Html
+import Html.Attributes as Attr
+import Nri.Ui.Select.V1
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (..)
+
+
+view : String -> List String -> Query.Single String
+view selected items =
+    Nri.Ui.Select.V1.view
+        { choices = items |> List.map (\x -> { label = x, value = x })
+        , current = selected
+        }
+        |> List.singleton
+        |> -- needed so that Query can find the root node
+           Html.div []
+        |> Query.fromHtml
+
+
+spec : Test
+spec =
+    describe "view"
+        [ test "shows all options" <|
+            \() ->
+                view "Tacos"
+                    [ "Tacos", "Burritos", "Enchiladas" ]
+                    |> Query.find [ tag "select" ]
+                    |> Query.findAll [ tag "option" ]
+                    |> Query.count (Expect.equal 3)
+        , test "selects the current option" <|
+            \() ->
+                view "Burritos"
+                    [ "Tacos", "Burritos", "Enchiladas" ]
+                    |> Query.find
+                        [ tag "option"
+                        , attribute <| Attr.selected True
+                        ]
+                    |> Query.has [ text "Burritos" ]
+        ]


### PR DESCRIPTION
This was forgotten in the extraction PR.
Just moves the tests over verbatim.

<details>
<summary>Diff of the monolith's `Nri.SelectSpec` with this PR's `Spec.Nri.Ui.Select.V1`</summary>

```diff
1c1
< module Nri.SelectSpec exposing (spec)
---
> module Spec.Nri.Ui.Select.V1 exposing (spec)
6c6
< import Nri.Select
---
> import Nri.Ui.Select.V1
14c14
<     Nri.Select.view
---
>     Nri.Ui.Select.V1.view
```
</details>