### PR TITLE
Extract `Nri.Table`

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -32,6 +32,7 @@
         "Nri.Ui.Select.V1",
         "Nri.Ui.Select.V2",
         "Nri.Ui.Styles.V1",
+        "Nri.Ui.Table.V1",
         "Nri.Ui.Tabs.V1",
         "Nri.Ui.Text.Writing.V1",
         "Nri.Ui.Text.V1",

--- a/src/Nri/Ui/Table/V1.elm
+++ b/src/Nri/Ui/Table/V1.elm
@@ -167,7 +167,7 @@ stylesLoadingColumn rowIndex colIndex width =
 
 table : List CssClasses -> List (Html msg) -> Html msg
 table classes =
-    Html.table [ styles.class classes ]
+    Html.table [ styles.class (Table :: classes) ]
 
 
 tableWithHeader : List CssClasses -> List (Column data msg) -> List (Html msg) -> Html msg
@@ -225,6 +225,9 @@ styles =
             flashAnimation
         , Css.Foreign.class LoadingTable
             fadeInAnimation
+        , Css.Foreign.class Table
+            [ borderCollapse collapse
+            ]
         ]
 
 

--- a/src/Nri/Ui/Table/V1.elm
+++ b/src/Nri/Ui/Table/V1.elm
@@ -2,6 +2,7 @@ module Nri.Ui.Table.V1
     exposing
         ( Column
         , custom
+        , keyframeStyles
         , keyframes
         , string
         , styles
@@ -234,31 +235,39 @@ styles =
 {-| -}
 keyframes : List Nri.Ui.Styles.V1.Keyframe
 keyframes =
-    [ Nri.Ui.Styles.V1.keyframes "Nri-Table-flash"
+    [ Nri.Ui.Styles.V1.keyframes "Nri-Ui-Table-V1-flash"
         [ ( "0%", "opacity: 0.6" )
         , ( "50%", "opacity: 0.2" )
         , ( "100%", "opacity: 0.6" )
         ]
-    , Nri.Ui.Styles.V1.keyframes "Nri-Table-fadein"
+    , Nri.Ui.Styles.V1.keyframes "Nri-Ui-Table-V1-fadein"
         [ ( "from", "opacity: 0" )
         , ( "to", "opacity: 1" )
         ]
     ]
 
 
+{-| -}
+keyframeStyles : Html msg
+keyframeStyles =
+    Html.node "style"
+        []
+        (List.map (Html.text << Nri.Ui.Styles.V1.toString) keyframes)
+
+
 flashAnimation : List Css.Style
 flashAnimation =
-    [ property "-webkit-animation" "Nri-Table-flash 2s infinite"
-    , property "-moz-animation" "Nri-Table-flash 2s infinite"
-    , property "animation" "Nri-Table-flash 2s infinite"
+    [ property "-webkit-animation" "Nri-Ui-Table-V1-flash 2s infinite"
+    , property "-moz-animation" "Nri-Ui-Table-V1-flash 2s infinite"
+    , property "animation" "Nri-Ui-Table-V1-flash 2s infinite"
     , opacity (num 0.6)
     ]
 
 
 fadeInAnimation : List Css.Style
 fadeInAnimation =
-    [ property "-webkit-animation" "Nri-Table-fadein 0.4s 0.2s forwards"
-    , property "-moz-animation" "Nri-Table-fadein 0.4s 0.2s forwards"
-    , property "animation" "Nri-Table-fadein 0.4s 0.2s forwards"
+    [ property "-webkit-animation" "Nri-Ui-Table-V1-fadein 0.4s 0.2s forwards"
+    , property "-moz-animation" "Nri-Ui-Table-V1-fadein 0.4s 0.2s forwards"
+    , property "animation" "Nri-Ui-Table-V1-fadein 0.4s 0.2s forwards"
     , opacity (num 0)
     ]

--- a/src/Nri/Ui/Table/V1.elm
+++ b/src/Nri/Ui/Table/V1.elm
@@ -20,7 +20,7 @@ module Nri.Ui.Table.V1
 
 @docs viewLoading, viewLoadingWithoutHeader
 
-@docs keyframes
+@docs keyframes, keyframeStyles
 
 -}
 

--- a/src/Nri/Ui/Table/V1.elm
+++ b/src/Nri/Ui/Table/V1.elm
@@ -1,0 +1,261 @@
+module Nri.Ui.Table.V1
+    exposing
+        ( Column
+        , custom
+        , keyframes
+        , string
+        , styles
+        , view
+        , viewLoading
+        , viewLoadingWithoutHeader
+        , viewWithoutHeader
+        )
+
+{-|
+
+@docs Column, custom, string, styles
+
+@docs view, viewWithoutHeader
+
+@docs viewLoading, viewLoadingWithoutHeader
+
+@docs keyframes
+
+-}
+
+import Css exposing (..)
+import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import Html exposing (..)
+import Html.Attributes exposing (style)
+import Nri.Ui.Colors.V1 exposing (..)
+import Nri.Ui.Styles.V1 exposing (styles)
+
+
+{-| Closed representation of how to render the header and cells of a column
+in the table
+-}
+type Column data msg
+    = Column (Html msg) (data -> Html msg) Int
+
+
+{-| A column that renders some aspect of a value as text
+-}
+string :
+    { header : String
+    , value : data -> String
+    , width : Int
+    }
+    -> Column data msg
+string { header, value, width } =
+    Column (Html.text header) (value >> Html.text) width
+
+
+{-| A column that renders however you want it to
+-}
+custom :
+    { header : Html msg
+    , view : data -> Html msg
+    , width : Int
+    }
+    -> Column data msg
+custom { header, view, width } =
+    Column header view width
+
+
+
+-- VIEW
+
+
+{-| Displays a table of data without a header row
+-}
+viewWithoutHeader : List (Column data msg) -> List data -> Html msg
+viewWithoutHeader columns data =
+    table [] <|
+        List.map (viewRow columns) data
+
+
+{-| Displays a table of data based on the provided column definitions
+-}
+view : List (Column data msg) -> List data -> Html msg
+view columns data =
+    tableWithHeader [] columns <|
+        List.map (viewRow columns) data
+
+
+viewHeaders : List (Column data msg) -> Html msg
+viewHeaders columns =
+    tr
+        [ styles.class [ Headers ] ]
+        (List.map viewRowHeader columns)
+
+
+viewRowHeader : Column data msg -> Html msg
+viewRowHeader (Column header _ width) =
+    th
+        [ styles.class [ Header ]
+        , style [ ( "width", toString width ++ "px" ) ]
+        ]
+        [ header ]
+
+
+viewRow : List (Column data msg) -> data -> Html msg
+viewRow columns data =
+    tr
+        [ styles.class [ Row ] ]
+        (List.map (viewColumn data) columns)
+
+
+viewColumn : data -> Column data msg -> Html msg
+viewColumn data (Column _ renderer width) =
+    td
+        [ styles.class [ Cell ]
+        , style [ ( "width", toString width ++ "px" ) ]
+        ]
+        [ renderer data ]
+
+
+
+-- VIEW LOADING
+
+
+{-| Display a table with the given columns but instead of data, show blocked
+out text with an interesting animation. This view lets the user know that
+data is on its way and what it will look like when it arrives.
+-}
+viewLoading : List (Column data msg) -> Html msg
+viewLoading columns =
+    tableWithHeader [ LoadingTable ] columns <|
+        List.map (viewLoadingRow columns) (List.range 0 8)
+
+
+{-| Display the loading table without a header row
+-}
+viewLoadingWithoutHeader : List (Column data msg) -> Html msg
+viewLoadingWithoutHeader columns =
+    table [ LoadingTable ] <|
+        List.map (viewLoadingRow columns) (List.range 0 8)
+
+
+viewLoadingRow : List (Column data msg) -> Int -> Html msg
+viewLoadingRow columns index =
+    tr
+        [ styles.class [ Row ] ]
+        (List.indexedMap (viewLoadingColumn index) columns)
+
+
+viewLoadingColumn : Int -> Int -> Column data msg -> Html msg
+viewLoadingColumn rowIndex colIndex (Column _ _ width) =
+    td
+        [ styles.class [ Cell, LoadingCell ]
+        , style (stylesLoadingColumn rowIndex colIndex width)
+        ]
+        [ span [ styles.class [ LoadingContent ] ] [] ]
+
+
+stylesLoadingColumn : Int -> Int -> Int -> List ( String, String )
+stylesLoadingColumn rowIndex colIndex width =
+    [ ( "width", toString width ++ "px" )
+    , ( "animation-delay"
+      , toString (toFloat (rowIndex + colIndex) * 0.1) ++ "s"
+      )
+    ]
+
+
+
+-- HELP
+
+
+table : List CssClasses -> List (Html msg) -> Html msg
+table classes =
+    Html.table [ styles.class classes ]
+
+
+tableWithHeader : List CssClasses -> List (Column data msg) -> List (Html msg) -> Html msg
+tableWithHeader classes columns rows =
+    table classes (viewHeaders columns :: rows)
+
+
+
+-- STYLES
+
+
+type CssClasses
+    = Table
+    | LoadingTable
+    | Row
+    | Cell
+    | Headers
+    | Header
+    | LoadingContent
+    | LoadingCell
+
+
+{-| -}
+styles : Nri.Ui.Styles.V1.Styles Never CssClasses msg
+styles =
+    Nri.Ui.Styles.V1.styles "Nri-Ui-Table-V1-"
+        [ Css.Foreign.class Headers
+            [ borderBottom3 (px 3) solid gray75
+            , height (px 45)
+            , fontSize (px 15)
+            ]
+        , Css.Foreign.class Header
+            [ padding4 (px 15) (px 12) (px 11) (px 12)
+            , textAlign left
+            ]
+        , Css.Foreign.class Row
+            [ height (px 45)
+            , fontSize (px 14)
+            , color gray45
+            , pseudoClass "nth-child(odd)"
+                [ backgroundColor gray96 ]
+            ]
+        , Css.Foreign.class Cell
+            [ width (px 300)
+            , padding2 (px 14) (px 10)
+            ]
+        , Css.Foreign.class LoadingContent
+            [ width (pct 100)
+            , display inlineBlock
+            , height (Css.em 1)
+            , borderRadius (Css.em 1)
+            , backgroundColor gray75
+            ]
+        , Css.Foreign.class LoadingCell
+            flashAnimation
+        , Css.Foreign.class LoadingTable
+            fadeInAnimation
+        ]
+
+
+{-| -}
+keyframes : List Nri.Ui.Styles.V1.Keyframe
+keyframes =
+    [ Nri.Ui.Styles.V1.keyframes "Nri-Table-flash"
+        [ ( "0%", "opacity: 0.6" )
+        , ( "50%", "opacity: 0.2" )
+        , ( "100%", "opacity: 0.6" )
+        ]
+    , Nri.Ui.Styles.V1.keyframes "Nri-Table-fadein"
+        [ ( "from", "opacity: 0" )
+        , ( "to", "opacity: 1" )
+        ]
+    ]
+
+
+flashAnimation : List Css.Style
+flashAnimation =
+    [ property "-webkit-animation" "Nri-Table-flash 2s infinite"
+    , property "-moz-animation" "Nri-Table-flash 2s infinite"
+    , property "animation" "Nri-Table-flash 2s infinite"
+    , opacity (num 0.6)
+    ]
+
+
+fadeInAnimation : List Css.Style
+fadeInAnimation =
+    [ property "-webkit-animation" "Nri-Table-fadein 0.4s 0.2s forwards"
+    , property "-moz-animation" "Nri-Table-fadein 0.4s 0.2s forwards"
+    , property "animation" "Nri-Table-fadein 0.4s 0.2s forwards"
+    , opacity (num 0)
+    ]

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -1,0 +1,89 @@
+module Examples.Table exposing (Msg, State, example, init, update)
+
+{- \
+   @docs Msg, State, example, init, update
+-}
+
+import Html
+import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
+import Nri.Ui.Button.V1 as Button
+import Nri.Ui.Table.V1 as Table
+
+
+{-| -}
+type Msg
+    = NoOp
+
+
+{-| -}
+type alias State =
+    ()
+
+
+{-| -}
+example : (Msg -> msg) -> State -> ModuleExample msg
+example parentMessage state =
+    { filename = "Nri/Table.elm"
+    , category = Layout
+    , content =
+        let
+            columns =
+                [ Table.string
+                    { header = "First Name"
+                    , value = .firstName
+                    , width = 125
+                    }
+                , Table.string
+                    { header = "Last Name"
+                    , value = .lastName
+                    , width = 125
+                    }
+                , Table.custom
+                    { header = Html.text "Actions"
+                    , width = 150
+                    , view =
+                        \_ ->
+                            Button.button
+                                { size = Button.Small
+                                , style = Button.Primary
+                                , onClick = NoOp
+                                }
+                                { label = "Action"
+                                , state = Button.Enabled
+                                }
+                    }
+                ]
+
+            data =
+                [ { firstName = "First1", lastName = "Last1" }
+                , { firstName = "First2", lastName = "Last2" }
+                , { firstName = "First3", lastName = "Last3" }
+                , { firstName = "First4", lastName = "Last4" }
+                , { firstName = "First5", lastName = "Last5" }
+                ]
+        in
+        [ Html.h4 [] [ Html.text "With header" ]
+        , Table.view columns data
+        , Html.h4 [] [ Html.text "Without header" ]
+        , Table.viewWithoutHeader columns data
+        , Html.h4 [] [ Html.text "Loading" ]
+        , Table.viewLoading columns
+        , Html.h4 [] [ Html.text "Loading without header" ]
+        , Table.viewLoadingWithoutHeader columns
+        ]
+            |> List.map (Html.map parentMessage)
+    }
+
+
+{-| -}
+init : State
+init =
+    ()
+
+
+{-| -}
+update : Msg -> State -> ( State, Cmd Msg )
+update msg state =
+    case msg of
+        NoOp ->
+            ( state, Cmd.none )

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -62,7 +62,8 @@ example parentMessage state =
                 , { firstName = "First5", lastName = "Last5" }
                 ]
         in
-        [ Html.h4 [] [ Html.text "With header" ]
+        [ Table.keyframeStyles
+        , Html.h4 [] [ Html.text "With header" ]
         , Table.view columns data
         , Html.h4 [] [ Html.text "Without header" ]
         , Table.viewWithoutHeader columns data

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -8,6 +8,7 @@ import Examples.Fonts
 import Examples.Icon
 import Examples.SegmentedControl
 import Examples.Select
+import Examples.Table
 import Examples.Text
 import Examples.Text.Writing
 import Examples.TextArea as TextAreaExample
@@ -15,11 +16,12 @@ import Html exposing (Html, img)
 import Html.Attributes exposing (..)
 import ModuleExample exposing (Category(..), ModuleExample)
 import Navigation
-import Nri.Ui.AssetPath as AssetPath exposing (Asset(Asset))
+import Nri.Ui.Button.V1 as Button
 import Nri.Ui.Dropdown.V1
 import Nri.Ui.Icon.V2
 import Nri.Ui.SegmentedControl.V5
 import Nri.Ui.Select.V2
+import Nri.Ui.Table.V1 as Table
 import Nri.Ui.Text.V1 as Text
 import Nri.Ui.TextArea.V1 as TextArea
 import String.Extra
@@ -29,6 +31,7 @@ type alias ModuleStates =
     { dropdownState : Examples.Dropdown.State Examples.Dropdown.Value
     , segmentedControlState : Examples.SegmentedControl.State
     , selectState : Examples.Select.State Examples.Select.Value
+    , tableExampleState : Examples.Table.State
     , textAreaExampleState : TextAreaExample.State
     }
 
@@ -38,6 +41,7 @@ init =
     { dropdownState = Examples.Dropdown.init
     , segmentedControlState = Examples.SegmentedControl.init
     , selectState = Examples.Select.init
+    , tableExampleState = Examples.Table.init
     , textAreaExampleState = TextAreaExample.init
     }
 
@@ -47,6 +51,7 @@ type Msg
     | SegmentedControlMsg Examples.SegmentedControl.Msg
     | SelectMsg Examples.Select.Msg
     | ShowItWorked String String
+    | TableExampleMsg Examples.Table.Msg
     | TextAreaExampleMsg TextAreaExample.Msg
     | NoOp
 
@@ -88,6 +93,15 @@ update msg moduleStates =
             in
             ( moduleStates, Cmd.none )
 
+        TableExampleMsg msg ->
+            let
+                ( tableExampleState, cmd ) =
+                    Examples.Table.update msg moduleStates.tableExampleState
+            in
+            ( { moduleStates | tableExampleState = tableExampleState }
+            , Cmd.map TableExampleMsg cmd
+            )
+
         TextAreaExampleMsg msg ->
             let
                 ( textAreaExampleState, cmd ) =
@@ -128,6 +142,7 @@ nriThemedModules model =
     , Examples.Text.example
     , Examples.Text.Writing.example
     , Examples.Fonts.example
+    , Examples.Table.example TableExampleMsg model.tableExampleState
     , TextAreaExample.example TextAreaExampleMsg model.textAreaExampleState
     , Examples.Colors.example
     ]
@@ -156,10 +171,12 @@ styles =
           ]
         , (Examples.Icon.styles |> .css) ()
         , (Examples.SegmentedControl.styles |> .css) ()
+        , (Button.styles |> .css) ()
         , (Nri.Ui.Dropdown.V1.styles |> .css) ()
         , (Nri.Ui.Icon.V2.styles |> .css) ()
         , (Nri.Ui.SegmentedControl.V5.styles |> .css) ()
         , (Nri.Ui.Select.V2.styles |> .css) ()
+        , (Table.styles |> .css) ()
         , (Text.styles |> .css) ()
         , (TextArea.styles |> .css) assets
         ]


### PR DESCRIPTION
This extracts `Nri.Table` from the monolith into CCS.

Two changes were made with regards to the version in the monolith:
- An explicit `border-collapse: collapse` style was added. Without this the table version in this styleguide app looks different from the one in the monolith. In the monolith we inherit the `border-collapse` property from a global style.
- An extra helper function was added `keyframeStyles`. This returns an Html element that can be embedded somewhere in the page of the app that consumes this module. Without these keyframes the loading versions of the module will not show.

##### diff

<details>
<summary>Diff of the monolith's `Nri.Table` with this PR's `Nri.Ui.Table.V1`</summary>

```diff
1c1
< module Nri.Table
---
> module Nri.Ui.Table.V1
4a5
>         , keyframeStyles
22c23
< @docs keyframes
---
> @docs keyframes, keyframeStyles
30d30
< import Nri.Styles exposing (styles)
31a32
> import Nri.Ui.Styles.V1 exposing (styles)
170c171
<     Html.table [ styles.class classes ]
---
>     Html.table [ styles.class (Table :: classes) ]
194c195
< styles : Nri.Styles.Styles Never CssClasses msg
---
> styles : Nri.Ui.Styles.V1.Styles Never CssClasses msg
196c197
<     Nri.Styles.styles "Nri-Table-"
---
>     Nri.Ui.Styles.V1.styles "Nri-Ui-Table-V1-"
227a229,231
>         , Css.Foreign.class Table
>             [ borderCollapse collapse
>             ]
232c236
< keyframes : List Nri.Styles.Keyframe
---
> keyframes : List Nri.Ui.Styles.V1.Keyframe
234c238
<     [ Nri.Styles.keyframes "Nri-Table-flash"
---
>     [ Nri.Ui.Styles.V1.keyframes "Nri-Ui-Table-V1-flash"
239c243
<     , Nri.Styles.keyframes "Nri-Table-fadein"
---
>     , Nri.Ui.Styles.V1.keyframes "Nri-Ui-Table-V1-fadein"
245a250,257
> {-| -}
> keyframeStyles : Html msg
> keyframeStyles =
>     Html.node "style"
>         []
>         (List.map (Html.text << Nri.Ui.Styles.V1.toString) keyframes)
> 
> 
248,250c260,262
<     [ property "-webkit-animation" "Nri-Table-flash 2s infinite"
<     , property "-moz-animation" "Nri-Table-flash 2s infinite"
<     , property "animation" "Nri-Table-flash 2s infinite"
---
>     [ property "-webkit-animation" "Nri-Ui-Table-V1-flash 2s infinite"
>     , property "-moz-animation" "Nri-Ui-Table-V1-flash 2s infinite"
>     , property "animation" "Nri-Ui-Table-V1-flash 2s infinite"
257,259c269,271
<     [ property "-webkit-animation" "Nri-Table-fadein 0.4s 0.2s forwards"
<     , property "-moz-animation" "Nri-Table-fadein 0.4s 0.2s forwards"
<     , property "animation" "Nri-Table-fadein 0.4s 0.2s forwards"
---
>     [ property "-webkit-animation" "Nri-Ui-Table-V1-fadein 0.4s 0.2s forwards"
>     , property "-moz-animation" "Nri-Ui-Table-V1-fadein 0.4s 0.2s forwards"
>     , property "animation" "Nri-Ui-Table-V1-fadein 0.4s 0.2s forwards"
```

</details>


##### For review

Followed the "Moving a widget to `noredink-ui`" step of our [process in Paper][].

[process in paper]: https://paper.dropbox.com/doc/noredink-ui-widget-library-fUK6yq32g187lxw2A60a8#:uid=348369002247633329910446&h2=Moving-a-widget-to-noredink-ui