### PR TITLE
Bump version to 4.9.0

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.8.0",
+    "version": "4.9.0",
     "summary": "UI Widgets we use at NRI",
     "repository": "https://github.com/NoRedInk/noredink-ui.git",
     "license": "BSD3",


### PR DESCRIPTION
This prepares `noredink-ui` for its next release. I'll merge this as soon as CI is green.