### PR TITLE
Make table styles explicit

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.9.0",
+    "version": "4.9.1",
     "summary": "UI Widgets we use at NRI",
     "repository": "https://github.com/NoRedInk/noredink-ui.git",
     "license": "BSD3",

--- a/src/Nri/Ui/Table/V1.elm
+++ b/src/Nri/Ui/Table/V1.elm
@@ -29,6 +29,7 @@ import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descend
 import Html exposing (..)
 import Html.Attributes exposing (style)
 import Nri.Ui.Colors.V1 exposing (..)
+import Nri.Ui.Fonts.V1 exposing (baseFont)
 import Nri.Ui.Styles.V1 exposing (styles)
 
 
@@ -203,6 +204,7 @@ styles =
         , Css.Foreign.class Header
             [ padding4 (px 15) (px 12) (px 11) (px 12)
             , textAlign left
+            , fontWeight bold
             ]
         , Css.Foreign.class Row
             [ height (px 45)
@@ -228,6 +230,7 @@ styles =
             fadeInAnimation
         , Css.Foreign.class Table
             [ borderCollapse collapse
+            , baseFont
             ]
         ]
 


### PR DESCRIPTION
This fixes table styles for places that use a reset.css. It should not make a difference for tables rendered if no reset.css is used (the styleguide included in this package still looks the same), hence no new version of the table module was created.