### PR TITLE
Introduce Nri.Ui.Table.V2

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -33,6 +33,7 @@
         "Nri.Ui.Select.V2",
         "Nri.Ui.Styles.V1",
         "Nri.Ui.Table.V1",
+        "Nri.Ui.Table.V2",
         "Nri.Ui.Tabs.V1",
         "Nri.Ui.Text.Writing.V1",
         "Nri.Ui.Text.V1",

--- a/src/Nri/Ui/Table/V2.elm
+++ b/src/Nri/Ui/Table/V2.elm
@@ -11,7 +11,20 @@ module Nri.Ui.Table.V2
         , viewWithoutHeader
         )
 
-{-|
+{-| Upgrading from V1:
+
+  - All the `width` fields in column configurations now take an elm-css length
+    value rather than an Integer. Change `width = 100` to `width = px 100` to get
+    the same widths as before.
+  - Tables now by default take the full width of the container they are placed in.
+    If this is not what you want, wrap the table in an element with a fixed width.
+  - The table module now makes use of `Html.Styled` and no longer exposes a
+    separate `styles` value.
+    Check out the [elm-css](http://package.elm-lang.org/packages/rtfeldman/elm-css/14.0.0/Html-Styled)
+    documentation on Html.Styled to see how to work with it.
+  - The default cell padding has been removed and content is not vertically
+    centered in its cell. If you need to overwrite this, wrap your cells in
+    elements providing custom styling to the cell.
 
 @docs Column, custom, string
 

--- a/src/Nri/Ui/Table/V2.elm
+++ b/src/Nri/Ui/Table/V2.elm
@@ -206,7 +206,8 @@ rowStyles =
 
 cellStyles : List Style
 cellStyles =
-    []
+    [ verticalAlign middle
+    ]
 
 
 loadingContentStyles : List Style

--- a/src/Nri/Ui/Table/V2.elm
+++ b/src/Nri/Ui/Table/V2.elm
@@ -38,10 +38,6 @@ type Column data msg
     = Column (Html msg) (data -> Html msg) Style
 
 
-type alias WidthStyle =
-    List ( String, String )
-
-
 {-| A column that renders some aspect of a value as text
 -}
 string :

--- a/src/Nri/Ui/Table/V2.elm
+++ b/src/Nri/Ui/Table/V2.elm
@@ -206,8 +206,7 @@ rowStyles =
 
 cellStyles : List Style
 cellStyles =
-    [ padding2 (px 14) (px 10)
-    ]
+    []
 
 
 loadingContentStyles : List Style

--- a/src/Nri/Ui/Table/V2.elm
+++ b/src/Nri/Ui/Table/V2.elm
@@ -222,7 +222,9 @@ loadingContentStyles =
 
 loadingCellStyles : List Style
 loadingCellStyles =
-    flashAnimation
+    [ batch flashAnimation
+    , padding2 (px 14) (px 10)
+    ]
 
 
 loadingTableStyles : List Style

--- a/src/Nri/Ui/Table/V2.elm
+++ b/src/Nri/Ui/Table/V2.elm
@@ -241,12 +241,12 @@ tableStyles =
 {-| -}
 keyframes : List Nri.Ui.Styles.V1.Keyframe
 keyframes =
-    [ Nri.Ui.Styles.V1.keyframes "Nri-Ui-Table-V1-flash"
+    [ Nri.Ui.Styles.V1.keyframes "Nri-Ui-Table-V2-flash"
         [ ( "0%", "opacity: 0.6" )
         , ( "50%", "opacity: 0.2" )
         , ( "100%", "opacity: 0.6" )
         ]
-    , Nri.Ui.Styles.V1.keyframes "Nri-Ui-Table-V1-fadein"
+    , Nri.Ui.Styles.V1.keyframes "Nri-Ui-Table-V2-fadein"
         [ ( "from", "opacity: 0" )
         , ( "to", "opacity: 1" )
         ]
@@ -263,17 +263,17 @@ keyframeStyles =
 
 flashAnimation : List Css.Style
 flashAnimation =
-    [ property "-webkit-animation" "Nri-Ui-Table-V1-flash 2s infinite"
-    , property "-moz-animation" "Nri-Ui-Table-V1-flash 2s infinite"
-    , property "animation" "Nri-Ui-Table-V1-flash 2s infinite"
+    [ property "-webkit-animation" "Nri-Ui-Table-V2-flash 2s infinite"
+    , property "-moz-animation" "Nri-Ui-Table-V2-flash 2s infinite"
+    , property "animation" "Nri-Ui-Table-V2-flash 2s infinite"
     , opacity (num 0.6)
     ]
 
 
 fadeInAnimation : List Css.Style
 fadeInAnimation =
-    [ property "-webkit-animation" "Nri-Ui-Table-V1-fadein 0.4s 0.2s forwards"
-    , property "-moz-animation" "Nri-Ui-Table-V1-fadein 0.4s 0.2s forwards"
-    , property "animation" "Nri-Ui-Table-V1-fadein 0.4s 0.2s forwards"
+    [ property "-webkit-animation" "Nri-Ui-Table-V2-fadein 0.4s 0.2s forwards"
+    , property "-moz-animation" "Nri-Ui-Table-V2-fadein 0.4s 0.2s forwards"
+    , property "animation" "Nri-Ui-Table-V2-fadein 0.4s 0.2s forwards"
     , opacity (num 0)
     ]

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -67,21 +67,21 @@ example parentMessage state =
                 , { firstName = "First5", lastName = "Last5" }
                 ]
         in
-            [ Html.Styled.toUnstyled Table.keyframeStyles
-            , Html.h4 [] [ Html.text "With header" ]
-            , Table.view columns data
-                |> Html.Styled.toUnstyled
-            , Html.h4 [] [ Html.text "Without header" ]
-            , Table.viewWithoutHeader columns data
-                |> Html.Styled.toUnstyled
-            , Html.h4 [] [ Html.text "Loading" ]
-            , Table.viewLoading columns
-                |> Html.Styled.toUnstyled
-            , Html.h4 [] [ Html.text "Loading without header" ]
-            , Table.viewLoadingWithoutHeader columns
-                |> Html.Styled.toUnstyled
-            ]
-                |> List.map (Html.map parentMessage)
+        [ Html.Styled.toUnstyled Table.keyframeStyles
+        , Html.h4 [] [ Html.text "With header" ]
+        , Table.view columns data
+            |> Html.Styled.toUnstyled
+        , Html.h4 [] [ Html.text "Without header" ]
+        , Table.viewWithoutHeader columns data
+            |> Html.Styled.toUnstyled
+        , Html.h4 [] [ Html.text "Loading" ]
+        , Table.viewLoading columns
+            |> Html.Styled.toUnstyled
+        , Html.h4 [] [ Html.text "Loading without header" ]
+        , Table.viewLoadingWithoutHeader columns
+            |> Html.Styled.toUnstyled
+        ]
+            |> List.map (Html.map parentMessage)
     }
 
 

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -6,6 +6,7 @@ module Examples.Table exposing (Msg, State, example, init, update)
 
 import Css exposing (..)
 import Html
+import Html.Styled
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.Button.V1 as Button
 import Nri.Ui.Table.V2 as Table
@@ -40,7 +41,9 @@ example parentMessage state =
                     , width = calc (pct 50) minus (px 125)
                     }
                 , Table.custom
-                    { header = Html.text "Actions"
+                    { header =
+                        Html.text "Actions"
+                            |> Html.Styled.fromUnstyled
                     , width = px 250
                     , view =
                         \_ ->
@@ -52,6 +55,7 @@ example parentMessage state =
                                 { label = "Action"
                                 , state = Button.Enabled
                                 }
+                                |> Html.Styled.fromUnstyled
                     }
                 ]
 
@@ -63,15 +67,19 @@ example parentMessage state =
                 , { firstName = "First5", lastName = "Last5" }
                 ]
         in
-            [ Table.keyframeStyles
+            [ Html.Styled.toUnstyled Table.keyframeStyles
             , Html.h4 [] [ Html.text "With header" ]
             , Table.view columns data
+                |> Html.Styled.toUnstyled
             , Html.h4 [] [ Html.text "Without header" ]
             , Table.viewWithoutHeader columns data
+                |> Html.Styled.toUnstyled
             , Html.h4 [] [ Html.text "Loading" ]
             , Table.viewLoading columns
+                |> Html.Styled.toUnstyled
             , Html.h4 [] [ Html.text "Loading without header" ]
             , Table.viewLoadingWithoutHeader columns
+                |> Html.Styled.toUnstyled
             ]
                 |> List.map (Html.map parentMessage)
     }

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -4,10 +4,11 @@ module Examples.Table exposing (Msg, State, example, init, update)
    @docs Msg, State, example, init, update
 -}
 
+import Css exposing (..)
 import Html
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.Button.V1 as Button
-import Nri.Ui.Table.V1 as Table
+import Nri.Ui.Table.V2 as Table
 
 
 {-| -}
@@ -31,16 +32,16 @@ example parentMessage state =
                 [ Table.string
                     { header = "First Name"
                     , value = .firstName
-                    , width = 125
+                    , width = calc (pct 50) minus (px 125)
                     }
                 , Table.string
                     { header = "Last Name"
                     , value = .lastName
-                    , width = 125
+                    , width = calc (pct 50) minus (px 125)
                     }
                 , Table.custom
                     { header = Html.text "Actions"
-                    , width = 150
+                    , width = px 250
                     , view =
                         \_ ->
                             Button.button
@@ -62,17 +63,17 @@ example parentMessage state =
                 , { firstName = "First5", lastName = "Last5" }
                 ]
         in
-        [ Table.keyframeStyles
-        , Html.h4 [] [ Html.text "With header" ]
-        , Table.view columns data
-        , Html.h4 [] [ Html.text "Without header" ]
-        , Table.viewWithoutHeader columns data
-        , Html.h4 [] [ Html.text "Loading" ]
-        , Table.viewLoading columns
-        , Html.h4 [] [ Html.text "Loading without header" ]
-        , Table.viewLoadingWithoutHeader columns
-        ]
-            |> List.map (Html.map parentMessage)
+            [ Table.keyframeStyles
+            , Html.h4 [] [ Html.text "With header" ]
+            , Table.view columns data
+            , Html.h4 [] [ Html.text "Without header" ]
+            , Table.viewWithoutHeader columns data
+            , Html.h4 [] [ Html.text "Loading" ]
+            , Table.viewLoading columns
+            , Html.h4 [] [ Html.text "Loading without header" ]
+            , Table.viewLoadingWithoutHeader columns
+            ]
+                |> List.map (Html.map parentMessage)
     }
 
 

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -21,7 +21,7 @@ import Nri.Ui.Dropdown.V1
 import Nri.Ui.Icon.V2
 import Nri.Ui.SegmentedControl.V5
 import Nri.Ui.Select.V2
-import Nri.Ui.Table.V1 as Table
+import Nri.Ui.Table.V2 as Table
 import Nri.Ui.Text.V1 as Text
 import Nri.Ui.TextArea.V1 as TextArea
 import String.Extra

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -63,52 +63,52 @@ update msg moduleStates =
                 ( dropdownState, cmd ) =
                     Examples.Dropdown.update msg moduleStates.dropdownState
             in
-                ( { moduleStates | dropdownState = dropdownState }
-                , Cmd.map DropdownMsg cmd
-                )
+            ( { moduleStates | dropdownState = dropdownState }
+            , Cmd.map DropdownMsg cmd
+            )
 
         SegmentedControlMsg msg ->
             let
                 ( segmentedControlState, cmd ) =
                     Examples.SegmentedControl.update msg moduleStates.segmentedControlState
             in
-                ( { moduleStates | segmentedControlState = segmentedControlState }
-                , Cmd.map SegmentedControlMsg cmd
-                )
+            ( { moduleStates | segmentedControlState = segmentedControlState }
+            , Cmd.map SegmentedControlMsg cmd
+            )
 
         SelectMsg msg ->
             let
                 ( selectState, cmd ) =
                     Examples.Select.update msg moduleStates.selectState
             in
-                ( { moduleStates | selectState = selectState }
-                , Cmd.map SelectMsg cmd
-                )
+            ( { moduleStates | selectState = selectState }
+            , Cmd.map SelectMsg cmd
+            )
 
         ShowItWorked group message ->
             let
                 _ =
                     Debug.log group message
             in
-                ( moduleStates, Cmd.none )
+            ( moduleStates, Cmd.none )
 
         TableExampleMsg msg ->
             let
                 ( tableExampleState, cmd ) =
                     Examples.Table.update msg moduleStates.tableExampleState
             in
-                ( { moduleStates | tableExampleState = tableExampleState }
-                , Cmd.map TableExampleMsg cmd
-                )
+            ( { moduleStates | tableExampleState = tableExampleState }
+            , Cmd.map TableExampleMsg cmd
+            )
 
         TextAreaExampleMsg msg ->
             let
                 ( textAreaExampleState, cmd ) =
                     TextAreaExample.update msg moduleStates.textAreaExampleState
             in
-                ( { moduleStates | textAreaExampleState = textAreaExampleState }
-                , Cmd.map TextAreaExampleMsg cmd
-                )
+            ( { moduleStates | textAreaExampleState = textAreaExampleState }
+            , Cmd.map TextAreaExampleMsg cmd
+            )
 
         NoOp ->
             ( moduleStates, Cmd.none )

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -21,7 +21,6 @@ import Nri.Ui.Dropdown.V1
 import Nri.Ui.Icon.V2
 import Nri.Ui.SegmentedControl.V5
 import Nri.Ui.Select.V2
-import Nri.Ui.Table.V2 as Table
 import Nri.Ui.Text.V1 as Text
 import Nri.Ui.TextArea.V1 as TextArea
 import String.Extra
@@ -64,52 +63,52 @@ update msg moduleStates =
                 ( dropdownState, cmd ) =
                     Examples.Dropdown.update msg moduleStates.dropdownState
             in
-            ( { moduleStates | dropdownState = dropdownState }
-            , Cmd.map DropdownMsg cmd
-            )
+                ( { moduleStates | dropdownState = dropdownState }
+                , Cmd.map DropdownMsg cmd
+                )
 
         SegmentedControlMsg msg ->
             let
                 ( segmentedControlState, cmd ) =
                     Examples.SegmentedControl.update msg moduleStates.segmentedControlState
             in
-            ( { moduleStates | segmentedControlState = segmentedControlState }
-            , Cmd.map SegmentedControlMsg cmd
-            )
+                ( { moduleStates | segmentedControlState = segmentedControlState }
+                , Cmd.map SegmentedControlMsg cmd
+                )
 
         SelectMsg msg ->
             let
                 ( selectState, cmd ) =
                     Examples.Select.update msg moduleStates.selectState
             in
-            ( { moduleStates | selectState = selectState }
-            , Cmd.map SelectMsg cmd
-            )
+                ( { moduleStates | selectState = selectState }
+                , Cmd.map SelectMsg cmd
+                )
 
         ShowItWorked group message ->
             let
                 _ =
                     Debug.log group message
             in
-            ( moduleStates, Cmd.none )
+                ( moduleStates, Cmd.none )
 
         TableExampleMsg msg ->
             let
                 ( tableExampleState, cmd ) =
                     Examples.Table.update msg moduleStates.tableExampleState
             in
-            ( { moduleStates | tableExampleState = tableExampleState }
-            , Cmd.map TableExampleMsg cmd
-            )
+                ( { moduleStates | tableExampleState = tableExampleState }
+                , Cmd.map TableExampleMsg cmd
+                )
 
         TextAreaExampleMsg msg ->
             let
                 ( textAreaExampleState, cmd ) =
                     TextAreaExample.update msg moduleStates.textAreaExampleState
             in
-            ( { moduleStates | textAreaExampleState = textAreaExampleState }
-            , Cmd.map TextAreaExampleMsg cmd
-            )
+                ( { moduleStates | textAreaExampleState = textAreaExampleState }
+                , Cmd.map TextAreaExampleMsg cmd
+                )
 
         NoOp ->
             ( moduleStates, Cmd.none )
@@ -176,7 +175,6 @@ styles =
         , (Nri.Ui.Icon.V2.styles |> .css) ()
         , (Nri.Ui.SegmentedControl.V5.styles |> .css) ()
         , (Nri.Ui.Select.V2.styles |> .css) ()
-        , (Table.styles |> .css) ()
         , (Text.styles |> .css) ()
         , (TextArea.styles |> .css) assets
         ]


### PR DESCRIPTION
#### Changes
This adds a new version of the `Nri.Ui.Table` module with the following powers:

- It allows column widths to be specified using any css-length value. Previously we could only use pixels.
- Since we can now use relative widths in column sizes, tables take up the full available width by default.
- Styles have been ported to use `Html.Styled`.
- The default cell padding has been removed, because some designs like [this](https://paper.dropbox.com/doc/Product-guide-Content-creation-index-p1wpha9HkFp5HChwicL8h) do not want such large paddings, and overriding the default paddings in such instances is hard.

#### Review asks
- Is there a danger in allowing relative column sizes I'm overlooking?
- The `keyframes` styles are still exported separately. Can / should we include these with the other styles somehow?