### PR TITLE
Make styleguide-app depend on Elm files in src

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ format: node_modules
 clean:
 	rm -rf node_modules styleguide-app/elm.js $(shell find . -type d -name 'elm-stuff')
 
-styleguide-app/elm.js: styleguide-app/elm-stuff styleguide-app/**/*.elm
+styleguide-app/elm.js: styleguide-app/elm-stuff $(shell find src styleguide-app -type f -name '*.elm')
 	cd styleguide-app; elm-make Main.elm --output=$(@F)
 
 # plumbing


### PR DESCRIPTION
### Motivation:

I was reviewing a PR commit by commit, and was going to follow along the visual changes with the styleguide app. But then, after checking out a new commit, `make styleguide-app/elm.js` wouldn't pick up the changes and said it's already up to date.

### What this does

1. This makes it so that .elm files in `src` are listed as dependencies of the styleguide-app build target.
2. For some reason, `**/*.elm` wasn't working for me, so this also switches to use `$(shell find ..)`. (I tried setting `SHELL:=/bin/bash -O globstar` and it didn't make it rebuild as expected. bash is v4.3.)