### PR TITLE
Add max width on details to improve readability

### DIFF
--- a/src/Nri/Ui/Page/V1.elm
+++ b/src/Nri/Ui/Page/V1.elm
@@ -152,7 +152,9 @@ viewDetails : String -> Html.Styled.Html msg
 viewDetails detailsForEngineers =
     Html.Styled.div []
         [ Html.Styled.styled Html.Styled.details
-            [ margin (px 10) ]
+            [ margin (px 10) 
+            , maxWidth (px 700)
+            ]
             []
             [ Html.Styled.styled Html.Styled.summary
                 [ color (hex "8F8F8F") ]

--- a/src/Nri/Ui/Page/V1.elm
+++ b/src/Nri/Ui/Page/V1.elm
@@ -152,7 +152,7 @@ viewDetails : String -> Html.Styled.Html msg
 viewDetails detailsForEngineers =
     Html.Styled.div []
         [ Html.Styled.styled Html.Styled.details
-            [ margin (px 10) 
+            [ margin (px 10)
             , maxWidth (px 700)
             ]
             []


### PR DESCRIPTION
The details in this page are for showing decoder errors and such when the page is broken. Before the text took up the whole screen while now, it is limited to a max with of 700px, so the sentences are easier to read.