### PR TITLE
Intentionally remove a doc comment

### DIFF
--- a/src/Nri/Ui/Button/V2.elm
+++ b/src/Nri/Ui/Button/V2.elm
@@ -41,7 +41,7 @@ There will generally be a `*Button` and `*Link` version of each button style.
 
 ## Common configs
 
-@docs ButtonSize, ButtonStyle, ButtonState, ButtonContent
+@docs ButtonSize, ButtonStyle, ButtonState
 
 
 ## `<button>` Buttons


### PR DESCRIPTION
We shouldn't merge this to master. It's purely meant to demonstrate a problem with CI.

Expected: CI is red, because `elm-package diff` returns an error.
Actual: CI is green.