### PR TITLE
Textarea v2 adding a minimum height

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -41,6 +41,7 @@
         "Nri.Ui.Text.V1",
         "Nri.Ui.Text.V2",
         "Nri.Ui.TextArea.V1",
+        "Nri.Ui.TextArea.V2",
         "Nri.Ui.TextInput.V1",
         "Nri.Ui"
     ],

--- a/elm-package.json
+++ b/elm-package.json
@@ -55,6 +55,7 @@
         "rtfeldman/elm-css-helpers": "2.1.0 <= v < 3.0.0",
         "rtfeldman/elm-css-util": "1.0.2 <= v < 2.0.0",
         "tesk9/accessible-html": "3.0.0 <= v < 4.0.0",
+        "tesk9/accessible-html-with-css": "1.0.1 <= v < 2.0.0",
         "wernerdegroot/listzipper": "3.0.0 <= v < 4.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"

--- a/src/Nri/Ui/InputStyles.elm
+++ b/src/Nri/Ui/InputStyles.elm
@@ -1,8 +1,13 @@
-module Nri.Ui.InputStyles exposing (Assets, CssClasses(..), styles)
+module Nri.Ui.InputStyles exposing (Assets, CssClasses(..), inputLineHeight, inputPaddingVertical, styles, textAreaHeight, writingLineHeight, writingMinHeight, writingPadding, writingPaddingTop)
 
 {-|
 
 @docs styles, CssClasses
+
+
+## Shared hardcoded values
+
+@docs inputPaddingVertical, inputLineHeight, textAreaHeight, writingLineHeight, writingPadding, writingPaddingTop, writingMinHeight
 
 -}
 
@@ -60,7 +65,7 @@ styles =
         inputStyle =
             [ border3 (px 1) solid gray75
             , borderRadius (px 8)
-            , padding2 (px 8) (px 14)
+            , padding2 inputPaddingVertical (px 14)
             , property "transition" "all 0.1s ease"
             , pseudoClass "placeholder"
                 [ color gray45
@@ -73,7 +78,7 @@ styles =
             , display inlineBlock
             , verticalAlign top
             , marginBottom zero
-            , lineHeight (px 20)
+            , lineHeight inputLineHeight
             , marginTop (px 9)
             , boxShadow6 inset zero (px 2) zero zero gray92
             , property "transition" "all 0.4s ease"
@@ -97,7 +102,7 @@ styles =
             , selector "textarea"
                 [ withClass Input
                     (inputStyle
-                        ++ [ height (px 100)
+                        ++ [ height textAreaHeight
                            , width (pct 100)
                            ]
                     )
@@ -122,10 +127,10 @@ styles =
                     [ class Input
                         [ Nri.Ui.Fonts.V1.quizFont
                         , fontSize (px 20)
-                        , lineHeight (px 25)
-                        , minHeight (px 150)
-                        , padding (px 15)
-                        , paddingTop (px 20)
+                        , lineHeight writingLineHeight
+                        , minHeight writingMinHeight
+                        , padding writingPadding
+                        , paddingTop writingPaddingTop
                         ]
                     , class Label
                         [ border3 (px 1) solid gray75
@@ -246,3 +251,38 @@ type alias Assets r =
         , icons_searchGray_svg : Asset
         , icons_xBlue_svg : Asset
     }
+
+
+inputPaddingVertical : Px
+inputPaddingVertical =
+    px 8
+
+
+inputLineHeight : Px
+inputLineHeight =
+    px 20
+
+
+textAreaHeight : Px
+textAreaHeight =
+    px 100
+
+
+writingLineHeight : Px
+writingLineHeight =
+    px 25
+
+
+writingPadding : Px
+writingPadding =
+    px 15
+
+
+writingPaddingTop : Px
+writingPaddingTop =
+    px 20
+
+
+writingMinHeight : Px
+writingMinHeight =
+    px 150

--- a/src/Nri/Ui/InputStyles.elm
+++ b/src/Nri/Ui/InputStyles.elm
@@ -1,4 +1,4 @@
-module Nri.Ui.InputStyles exposing (Assets, CssClasses(..), inputLineHeight, inputPaddingVertical, styles, textAreaHeight, writingLineHeight, writingPadding, writingPaddingTop)
+module Nri.Ui.InputStyles exposing (Assets, CssClasses(..), inputLineHeight, inputPaddingVertical, styles, textAreaHeight, writingLineHeight, writingMinHeight, writingPadding, writingPaddingTop)
 
 {-|
 
@@ -7,7 +7,7 @@ module Nri.Ui.InputStyles exposing (Assets, CssClasses(..), inputLineHeight, inp
 
 ## Shared hardcoded values
 
-@docs inputPaddingVertical, inputLineHeight, textAreaHeight, writingLineHeight, writingPadding, writingPaddingTop
+@docs inputPaddingVertical, inputLineHeight, textAreaHeight, writingLineHeight, writingPadding, writingPaddingTop, writingMinHeight
 
 -}
 
@@ -146,7 +146,7 @@ styles =
                         , borderColor azure
                         ]
                     , selector "textarea"
-                        [ minHeight (px 150)
+                        [ minHeight writingMinHeight
                         ]
                     , selector "input"
                         [ textAlign center
@@ -288,3 +288,8 @@ writingPadding =
 writingPaddingTop : Px
 writingPaddingTop =
     px 20
+
+
+writingMinHeight : Px
+writingMinHeight =
+    px 150

--- a/src/Nri/Ui/TextArea/V2.elm
+++ b/src/Nri/Ui/TextArea/V2.elm
@@ -13,8 +13,9 @@ module Nri.Ui.TextArea.V2
 
 ## Upgrading from V2
 
-The Model now takes a minimumHeight field, which needs to be specified
-explicitly using an elm-css length value.
+  - The Model now takes a minimumHeight field, which needs to be specified
+    explicitly using an elm-css length value.
+  - The view now returns `Html.Styled` rather than plain `Html`.
 
 
 ## The Nri styleguide-specified textarea with overlapping label

--- a/src/Nri/Ui/TextArea/V2.elm
+++ b/src/Nri/Ui/TextArea/V2.elm
@@ -211,7 +211,15 @@ calculateMinHeight textAreaStyle specifiedHeight =
                     singleLineHeight
 
         DefaultHeight ->
-            InputStyles.textAreaHeight
+            case textAreaStyle of
+                DefaultStyle ->
+                    InputStyles.textAreaHeight
+
+                WritingStyle ->
+                    InputStyles.writingMinHeight
+
+                ContentCreationStyle ->
+                    InputStyles.textAreaHeight
 
 
 singleLineHeight : Css.Px

--- a/src/Nri/Ui/TextArea/V2.elm
+++ b/src/Nri/Ui/TextArea/V2.elm
@@ -1,0 +1,157 @@
+module Nri.Ui.TextArea.V2
+    exposing
+        ( Model
+        , contentCreation
+        , generateId
+        , styles
+        , view
+        , writing
+        )
+
+{-|
+
+
+## Upgrading from V2
+
+The Model now takes a minimumHeight field, which needs to be specified
+explicitly using an elm-css length value.
+
+
+## The Nri styleguide-specified textarea with overlapping label
+
+@docs view, writing, contentCreation, Model, generateId, styles
+
+-}
+
+import Accessibility.Style
+import Css exposing (LengthOrMinMaxDimension)
+import DEPRECATED.Css
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (onInput)
+import Nri.Ui.InputStyles exposing (CssClasses(..))
+import Nri.Ui.Styles.V1
+import Nri.Ui.Util exposing (dashify, removePunctuation)
+
+
+{-| -}
+type alias Model compatible msg =
+    { value : String
+    , autofocus : Bool
+    , onInput : String -> msg
+    , isInError : Bool
+    , autoResize : Bool
+    , placeholder : String
+    , label : String
+    , showLabel : Bool
+    , minimumHeight : LengthOrMinMaxDimension compatible
+    }
+
+
+{-| -}
+view : Model compatible msg -> Html msg
+view model =
+    view_ DefaultStyle model
+
+
+{-| Used for Writing Cycles
+-}
+writing : Model compatible msg -> Html msg
+writing model =
+    view_ WritingStyle model
+
+
+{-| Used for Content Creation
+-}
+contentCreation : Model compatible msg -> Html msg
+contentCreation model =
+    view_ ContentCreationStyle model
+
+
+type TextAreaStyle
+    = DefaultStyle
+    | WritingStyle
+    | ContentCreationStyle
+
+
+{-| -}
+view_ : TextAreaStyle -> Model compatible msg -> Html msg
+view_ textAreaStyle model =
+    let
+        showWritingClass =
+            textAreaStyle == WritingStyle
+
+        showContentCreationClass =
+            textAreaStyle == ContentCreationStyle
+
+        sharedAttributes =
+            [ onInput model.onInput
+            , Html.Attributes.id (generateId model.label)
+            , styles.class [ Input ]
+            , autofocus model.autofocus
+            , placeholder model.placeholder
+            , attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
+
+            -- Html.Styled migration consideration:
+            , [ Css.minHeight model.minimumHeight ] |> DEPRECATED.Css.asPairs |> Html.Attributes.style
+            ]
+    in
+    div
+        [ styles.classList
+            [ ( Container, True )
+            , ( IsInError, model.isInError )
+            , ( Writing, showWritingClass )
+            , ( ContentCreation, showContentCreationClass )
+            ]
+        ]
+        [ if model.autoResize then
+            {- NOTES:
+               The autoresize-textarea element is implemented to pass information applied to itself to an internal
+               textarea element that it inserts into the DOM automatically. Maintaing this behavior may require some
+               changes on your part, as listed below.
+
+               - When adding an Html.Attribute that is a _property_, you must edit Nri/TextArea.js to ensure that a getter and setter
+                 are set up to properly reflect the property to the actual textarea element that autoresize-textarea creates
+               - When adding a new listener from Html.Events, you must edit Nri/TextArea.js to ensure that a listener is set up on
+                 the textarea that will trigger this event on the autoresize-textarea element itself. See AutoresizeTextArea.prototype._onInput
+                 and AutoresizeTextArea.prototype.connectedCallback for an example pertaining to the `input` event
+               - When adding a new Html.Attribute that is an _attribute_, you don't have to do anything. All attributes are
+                 automatically reflected onto the textarea element via AutoresizeTextArea.prototype.attributeChangedCallback
+            -}
+            Html.node "autoresize-textarea"
+                (sharedAttributes
+                    ++ [ -- setting the default value via a text node doesn't play well with the custom element,
+                         -- but we'll be able to switch to the regular value property in 0.19 anyway
+                         defaultValue model.value
+                       ]
+                )
+                []
+          else
+            Html.textarea sharedAttributes
+                [ Html.text model.value ]
+        , if not model.showLabel then
+            Html.label
+                [ for (generateId model.label)
+                , styles.class [ Label ]
+                , Accessibility.Style.invisible
+                ]
+                [ Html.text model.label ]
+          else
+            Html.label
+                [ for (generateId model.label)
+                , styles.class [ Label ]
+                ]
+                [ Html.text model.label ]
+        ]
+
+
+{-| -}
+generateId : String -> String
+generateId labelText =
+    "nri-ui-text-area-" ++ (dashify <| removePunctuation labelText)
+
+
+{-| -}
+styles : Nri.Ui.Styles.V1.StylesWithAssets Never CssClasses msg (Nri.Ui.InputStyles.Assets r)
+styles =
+    Nri.Ui.InputStyles.styles

--- a/src/Nri/Ui/TextArea/V2.elm
+++ b/src/Nri/Ui/TextArea/V2.elm
@@ -19,12 +19,6 @@ module Nri.Ui.TextArea.V2
   - The view now returns `Html.Styled` rather than plain `Html`.
 
 
-### Known issues
-
-  - V2.writing ignores the minimumHeight field; it's fixed to 150px as
-    specified by the internal InputStyles module.
-
-
 ## The Nri styleguide-specified textarea with overlapping label
 
 @docs view, writing, contentCreation, MinimumHeight, Model, generateId, styles
@@ -108,7 +102,10 @@ view_ textAreaStyle model =
             , Attributes.placeholder model.placeholder
             , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
             , Attributes.css
-                [ Css.minHeight minHeight
+                -- FIXME: Css.important is needed here because InputStyles's
+                -- min-height rule has more specificity. It can go away once
+                -- we've fully migrated to Html.Styled.
+                [ Css.important (Css.minHeight minHeight)
                 , Css.boxSizing Css.borderBox
                 ]
             ]

--- a/src/Nri/Ui/TextArea/V2.elm
+++ b/src/Nri/Ui/TextArea/V2.elm
@@ -16,6 +16,10 @@ module Nri.Ui.TextArea.V2
 
   - The Model now takes a minimumHeight field, which needs to be specified
     explicitly either as `DefaultHeight` or `SingleLine`.
+    This is most useful when used in conjunction with `autoResize = True`:
+    the textarea will shrink or expand to the specified height when it is
+    empty.
+
   - The view now returns `Html.Styled` rather than plain `Html`.
 
 

--- a/src/Nri/Ui/TextArea/V2.elm
+++ b/src/Nri/Ui/TextArea/V2.elm
@@ -18,6 +18,12 @@ module Nri.Ui.TextArea.V2
   - The view now returns `Html.Styled` rather than plain `Html`.
 
 
+### Known issues
+
+  - V2.writing ignores the minimumHeight field; it's fixed to 150px as
+    specified by the internal InputStyles module.
+
+
 ## The Nri styleguide-specified textarea with overlapping label
 
 @docs view, writing, contentCreation, Model, generateId, styles

--- a/src/Nri/Ui/TextArea/V2.elm
+++ b/src/Nri/Ui/TextArea/V2.elm
@@ -23,12 +23,12 @@ explicitly using an elm-css length value.
 
 -}
 
-import Accessibility.Style
+import Accessibility.Styled.Style
 import Css exposing (LengthOrMinMaxDimension)
 import DEPRECATED.Css
-import Html exposing (Html)
-import Html.Attributes as Attributes
-import Html.Events as Events
+import Html.Styled as Html exposing (Html)
+import Html.Styled.Attributes as Attributes
+import Html.Styled.Events as Events
 import Nri.Ui.InputStyles exposing (CssClasses(..))
 import Nri.Ui.Styles.V1
 import Nri.Ui.Util exposing (dashify, removePunctuation)
@@ -88,6 +88,7 @@ view_ textAreaStyle model =
             [ Events.onInput model.onInput
             , Attributes.id (generateId model.label)
             , styles.class [ Input ]
+                |> Attributes.fromUnstyled
             , Attributes.autofocus model.autofocus
             , Attributes.placeholder model.placeholder
             , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
@@ -103,6 +104,7 @@ view_ textAreaStyle model =
             , ( Writing, showWritingClass )
             , ( ContentCreation, showContentCreationClass )
             ]
+            |> Attributes.fromUnstyled
         ]
         [ if model.autoResize then
             {- NOTES:
@@ -133,13 +135,15 @@ view_ textAreaStyle model =
             Html.label
                 [ Attributes.for (generateId model.label)
                 , styles.class [ Label ]
-                , Accessibility.Style.invisible
+                    |> Attributes.fromUnstyled
+                , Accessibility.Styled.Style.invisible
                 ]
                 [ Html.text model.label ]
           else
             Html.label
                 [ Attributes.for (generateId model.label)
                 , styles.class [ Label ]
+                    |> Attributes.fromUnstyled
                 ]
                 [ Html.text model.label ]
         ]

--- a/src/Nri/Ui/TextArea/V2.elm
+++ b/src/Nri/Ui/TextArea/V2.elm
@@ -26,9 +26,9 @@ explicitly using an elm-css length value.
 import Accessibility.Style
 import Css exposing (LengthOrMinMaxDimension)
 import DEPRECATED.Css
-import Html exposing (..)
-import Html.Attributes exposing (..)
-import Html.Events exposing (onInput)
+import Html exposing (Html)
+import Html.Attributes as Attributes
+import Html.Events as Events
 import Nri.Ui.InputStyles exposing (CssClasses(..))
 import Nri.Ui.Styles.V1
 import Nri.Ui.Util exposing (dashify, removePunctuation)
@@ -85,18 +85,18 @@ view_ textAreaStyle model =
             textAreaStyle == ContentCreationStyle
 
         sharedAttributes =
-            [ onInput model.onInput
-            , Html.Attributes.id (generateId model.label)
+            [ Events.onInput model.onInput
+            , Attributes.id (generateId model.label)
             , styles.class [ Input ]
-            , autofocus model.autofocus
-            , placeholder model.placeholder
-            , attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
+            , Attributes.autofocus model.autofocus
+            , Attributes.placeholder model.placeholder
+            , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
 
             -- Html.Styled migration consideration:
-            , [ Css.minHeight model.minimumHeight ] |> DEPRECATED.Css.asPairs |> Html.Attributes.style
+            , [ Css.minHeight model.minimumHeight ] |> DEPRECATED.Css.asPairs |> Attributes.style
             ]
     in
-    div
+    Html.div
         [ styles.classList
             [ ( Container, True )
             , ( IsInError, model.isInError )
@@ -122,7 +122,7 @@ view_ textAreaStyle model =
                 (sharedAttributes
                     ++ [ -- setting the default value via a text node doesn't play well with the custom element,
                          -- but we'll be able to switch to the regular value property in 0.19 anyway
-                         defaultValue model.value
+                         Attributes.defaultValue model.value
                        ]
                 )
                 []
@@ -131,14 +131,14 @@ view_ textAreaStyle model =
                 [ Html.text model.value ]
         , if not model.showLabel then
             Html.label
-                [ for (generateId model.label)
+                [ Attributes.for (generateId model.label)
                 , styles.class [ Label ]
                 , Accessibility.Style.invisible
                 ]
                 [ Html.text model.label ]
           else
             Html.label
-                [ for (generateId model.label)
+                [ Attributes.for (generateId model.label)
                 , styles.class [ Label ]
                 ]
                 [ Html.text model.label ]

--- a/src/Nri/Ui/TextArea/V2.elm
+++ b/src/Nri/Ui/TextArea/V2.elm
@@ -25,7 +25,6 @@ explicitly using an elm-css length value.
 
 import Accessibility.Styled.Style
 import Css exposing (LengthOrMinMaxDimension)
-import DEPRECATED.Css
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
@@ -94,7 +93,7 @@ view_ textAreaStyle model =
             , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
 
             -- Html.Styled migration consideration:
-            , [ Css.minHeight model.minimumHeight ] |> DEPRECATED.Css.asPairs |> Attributes.style
+            , Attributes.css [ Css.minHeight model.minimumHeight ]
             ]
     in
     Html.div

--- a/src/Nri/Ui/TextArea/V2.elm
+++ b/src/Nri/Ui/TextArea/V2.elm
@@ -92,8 +92,6 @@ view_ textAreaStyle model =
             , Attributes.autofocus model.autofocus
             , Attributes.placeholder model.placeholder
             , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
-
-            -- Html.Styled migration consideration:
             , Attributes.css [ Css.minHeight model.minimumHeight ]
             ]
     in

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -80,7 +80,7 @@ example parentMessage state =
             , autoResize = state.autoResize
             , placeholder = "Placeholder"
             , showLabel = state.showLabel
-            , minimumHeight = Css.px 100
+            , minimumHeight = TextArea.DefaultHeight
             }
             |> Html.Styled.toUnstyled
         , TextArea.writing
@@ -92,7 +92,7 @@ example parentMessage state =
             , autoResize = state.autoResize
             , placeholder = "Placeholder"
             , showLabel = state.showLabel
-            , minimumHeight = Css.px 100
+            , minimumHeight = TextArea.DefaultHeight
             }
             |> Html.Styled.toUnstyled
         , TextArea.contentCreation
@@ -104,7 +104,7 @@ example parentMessage state =
             , autoResize = state.autoResize
             , placeholder = "Placeholder"
             , showLabel = state.showLabel
-            , minimumHeight = Css.px 100
+            , minimumHeight = TextArea.DefaultHeight
             }
             |> Html.Styled.toUnstyled
         ]

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -82,6 +82,7 @@ example parentMessage state =
             , showLabel = state.showLabel
             , minimumHeight = Css.px 100
             }
+            |> Html.Styled.toUnstyled
         , TextArea.writing
             { value = Maybe.withDefault "" <| Dict.get 2 state.textValues
             , autofocus = False
@@ -93,6 +94,7 @@ example parentMessage state =
             , showLabel = state.showLabel
             , minimumHeight = Css.px 100
             }
+            |> Html.Styled.toUnstyled
         , TextArea.contentCreation
             { value = Maybe.withDefault "" <| Dict.get 3 state.textValues
             , autofocus = False
@@ -104,6 +106,7 @@ example parentMessage state =
             , showLabel = state.showLabel
             , minimumHeight = Css.px 100
             }
+            |> Html.Styled.toUnstyled
         ]
             |> List.map (Html.map parentMessage)
     }

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -6,13 +6,14 @@ module Examples.TextArea exposing (Msg, State, example, init, update)
 
 -}
 
+import Css
 import Dict exposing (Dict)
 import Html
 import Html.Styled
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.Checkbox.V2 as Checkbox
 import Nri.Ui.Text.V2 as Text
-import Nri.Ui.TextArea.V1 as TextArea
+import Nri.Ui.TextArea.V2 as TextArea
 
 
 {-| -}
@@ -79,6 +80,7 @@ example parentMessage state =
             , autoResize = state.autoResize
             , placeholder = "Placeholder"
             , showLabel = state.showLabel
+            , minimumHeight = Css.px 100
             }
         , TextArea.writing
             { value = Maybe.withDefault "" <| Dict.get 2 state.textValues
@@ -89,6 +91,7 @@ example parentMessage state =
             , autoResize = state.autoResize
             , placeholder = "Placeholder"
             , showLabel = state.showLabel
+            , minimumHeight = Css.px 100
             }
         , TextArea.contentCreation
             { value = Maybe.withDefault "" <| Dict.get 3 state.textValues
@@ -99,6 +102,7 @@ example parentMessage state =
             , autoResize = state.autoResize
             , placeholder = "Placeholder"
             , showLabel = state.showLabel
+            , minimumHeight = Css.px 100
             }
         ]
             |> List.map (Html.map parentMessage)

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -77,10 +77,13 @@ example parentMessage state =
             , onInput = InputGiven 1
             , isInError = state.isInError
             , label = "TextArea.view"
-            , autoResize = state.autoResize
+            , height =
+                if state.autoResize then
+                    TextArea.AutoResize TextArea.SingleLine
+                else
+                    TextArea.Fixed
             , placeholder = "Placeholder"
             , showLabel = state.showLabel
-            , minimumHeight = TextArea.DefaultHeight
             }
             |> Html.Styled.toUnstyled
         , TextArea.writing
@@ -89,10 +92,13 @@ example parentMessage state =
             , onInput = InputGiven 2
             , isInError = state.isInError
             , label = "TextArea.writing"
-            , autoResize = state.autoResize
+            , height =
+                if state.autoResize then
+                    TextArea.AutoResize TextArea.DefaultHeight
+                else
+                    TextArea.Fixed
             , placeholder = "Placeholder"
             , showLabel = state.showLabel
-            , minimumHeight = TextArea.DefaultHeight
             }
             |> Html.Styled.toUnstyled
         , TextArea.contentCreation
@@ -101,10 +107,13 @@ example parentMessage state =
             , onInput = InputGiven 3
             , isInError = state.isInError
             , label = "TextArea.contentCreation"
-            , autoResize = state.autoResize
+            , height =
+                if state.autoResize then
+                    TextArea.AutoResize TextArea.DefaultHeight
+                else
+                    TextArea.Fixed
             , placeholder = "Placeholder"
             , showLabel = state.showLabel
-            , minimumHeight = TextArea.DefaultHeight
             }
             |> Html.Styled.toUnstyled
         ]

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -24,7 +24,7 @@ import Nri.Ui.Icon.V2
 import Nri.Ui.SegmentedControl.V5
 import Nri.Ui.Select.V2
 import Nri.Ui.Text.V2 as Text
-import Nri.Ui.TextArea.V1 as TextArea
+import Nri.Ui.TextArea.V2 as TextArea
 import String.Extra
 
 

--- a/styleguide-app/assets/TextArea.js
+++ b/styleguide-app/assets/TextArea.js
@@ -56,8 +56,9 @@ AutoresizeTextArea.prototype._resize = function() {
 
   this._textarea.style.overflowY = "hidden";
   this._textarea.style.minHeight = minHeight + "px";
+  this._textarea.style.transition = "none";
   if (this._textarea.scrollHeight > minHeight) {
-    this._textarea.style.height = "auto";
+    this._textarea.style.height = minHeight + "px";
     this._textarea.style.height = this._textarea.scrollHeight + "px";
   } else {
     this._textarea.style.height = minHeight + "px";

--- a/styleguide-app/assets/TextArea.js
+++ b/styleguide-app/assets/TextArea.js
@@ -43,7 +43,7 @@ Object.defineProperties(AutoresizeTextArea.prototype, {
   }
 });
 
-AutoresizeTextArea.prototype._onInput = function() {
+AutoresizeTextArea.prototype._resize = function() {
   var minHeight = null;
   if (this._textarea.style.minHeight) {
     minHeight = parseInt(this._textarea.style.minHeight, 10);
@@ -59,7 +59,10 @@ AutoresizeTextArea.prototype._onInput = function() {
   } else {
     this._textarea.style.height = minHeight + "px";
   }
+};
 
+AutoresizeTextArea.prototype._onInput = function() {
+  this._resize();
   this.dispatchEvent(new Event("input"));
 };
 
@@ -91,6 +94,7 @@ AutoresizeTextArea.prototype.connectedCallback = function() {
   this._textarea.addEventListener("input", this._onInput);
   this._reflectAttributes();
   this.appendChild(this._textarea);
+  this._resize();
 };
 
 AutoresizeTextArea.prototype.disconnectedCallback = function() {

--- a/styleguide-app/assets/TextArea.js
+++ b/styleguide-app/assets/TextArea.js
@@ -48,6 +48,9 @@ AutoresizeTextArea.prototype._resize = function() {
   if (this._textarea.style.minHeight) {
     minHeight = parseInt(this._textarea.style.minHeight, 10);
   } else {
+    minHeight = parseInt(window.getComputedStyle(this._textarea).minHeight, 10);
+  }
+  if (minHeight === 0) {
     minHeight = parseInt(window.getComputedStyle(this._textarea).height, 10);
   }
 

--- a/styleguide-app/elm-package.json
+++ b/styleguide-app/elm-package.json
@@ -21,6 +21,7 @@
         "rtfeldman/elm-css-helpers": "2.1.0 <= v < 3.0.0",
         "rtfeldman/elm-css-util": "1.0.2 <= v < 2.0.0",
         "tesk9/accessible-html": "3.0.0 <= v < 4.0.0",
+        "tesk9/accessible-html-with-css": "1.0.1 <= v < 2.0.0",
         "wernerdegroot/listzipper": "3.0.0 <= v < 4.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -19,6 +19,7 @@
         "rtfeldman/elm-css-helpers": "2.1.0 <= v < 3.0.0",
         "rtfeldman/elm-css-util": "1.0.2 <= v < 2.0.0",
         "tesk9/accessible-html": "3.0.0 <= v < 4.0.0",
+        "tesk9/accessible-html-with-css": "1.0.1 <= v < 2.0.0",
         "wernerdegroot/listzipper": "3.0.0 <= v < 4.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"


### PR DESCRIPTION
#### What is this

This is a new version of the `TextArea` widget. It adds the option to set a minimum height for text areas and does some initial work in porting the widget to `Html.Styled` (API is changed, internals still rely on some old fashion styling).