### PR TITLE
WIP improve textarea and fix styling

### DIFF
--- a/src/Nri/Ui/TextArea/V3.elm
+++ b/src/Nri/Ui/TextArea/V3.elm
@@ -28,6 +28,8 @@ import Css exposing ((|+|))
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
+import Json.Encode as Encode
+import Nri.Ui
 import Nri.Ui.InputStyles.V2 as InputStyles
     exposing
         ( Theme(..)
@@ -88,61 +90,36 @@ contentCreation model =
 view_ : Theme -> Model msg -> Html msg
 view_ theme model =
     let
-        minHeight =
+        ( minHeight, autoresize ) =
             case model.height of
                 Fixed ->
-                    []
+                    ( Css.batch [], False )
 
                 AutoResize minimumHeight ->
-                    [ calculateMinHeight theme minimumHeight
-                        |> Css.minHeight
-                    ]
-
-        sharedAttributes =
-            [ Events.onInput model.onInput
-            , Attributes.id (generateId model.label)
-            , Attributes.css
-                [ InputStyles.input theme model.isInError
-                ]
-            , Attributes.autofocus model.autofocus
-            , Attributes.placeholder model.placeholder
-            , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
-            , Attributes.css
-                (minHeight
-                    ++ [ Css.boxSizing Css.borderBox ]
-                )
-            ]
-    in
-    Html.div
-        [ Attributes.css [ Css.position Css.relative ]
-        ]
-        [ case model.height of
-            AutoResize _ ->
-                {- NOTES:
-                   The autoresize-textarea element is implemented to pass information applied to itself to an internal
-                   textarea element that it inserts into the DOM automatically. Maintaing this behavior may require some
-                   changes on your part, as listed below.
-
-                   - When adding an Html.Attribute that is a _property_, you must edit Nri/TextArea.js to ensure that a getter and setter
-                   are set up to properly reflect the property to the actual textarea element that autoresize-textarea creates
-                   - When adding a new listener from Html.Events, you must edit Nri/TextArea.js to ensure that a listener is set up on
-                   the textarea that will trigger this event on the autoresize-textarea element itself. See AutoresizeTextArea.prototype._onInput
-                   and AutoresizeTextArea.prototype.connectedCallback for an example pertaining to the `input` event
-                   - When adding a new Html.Attribute that is an _attribute_, you don't have to do anything. All attributes are
-                   automatically reflected onto the textarea element via AutoresizeTextArea.prototype.attributeChangedCallback
-                -}
-                Html.node "autoresize-textarea"
-                    (sharedAttributes
-                        ++ [ -- setting the default value via a text node doesn't play well with the custom element,
-                             -- but we'll be able to switch to the regular value property in 0.19 anyway
-                             Attributes.defaultValue model.value
-                           ]
+                    ( Css.minHeight (calculateMinHeight theme minimumHeight)
+                    , True
                     )
-                    []
-
-            Fixed ->
-                Html.textarea sharedAttributes
-                    [ Html.text model.value ]
+    in
+    Nri.Ui.styled Html.div
+        "Nri.TextArea.V3"
+        [ Css.position Css.relative ]
+        []
+        [ Html.node "nri-textarea-v3"
+            [ Attributes.property "autoresize" (Encode.bool autoresize) ]
+            [ Html.textarea
+                [ Events.onInput model.onInput
+                , Attributes.id (generateId model.label)
+                , Attributes.autofocus model.autofocus
+                , Attributes.placeholder model.placeholder
+                , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
+                , Attributes.css
+                    [ minHeight
+                    , Css.boxSizing Css.borderBox
+                    , InputStyles.input theme model.isInError
+                    ]
+                ]
+                [ Html.text model.value ]
+            ]
         , if not model.showLabel then
             Html.label
                 [ Attributes.for (generateId model.label)

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -6,14 +6,13 @@ module Examples.TextArea exposing (Msg, State, example, init, update)
 
 -}
 
-import Css
 import Dict exposing (Dict)
 import Html
 import Html.Styled
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.Checkbox.V2 as Checkbox
 import Nri.Ui.Text.V2 as Text
-import Nri.Ui.TextArea.V2 as TextArea
+import Nri.Ui.TextArea.V3 as TextArea
 
 
 {-| -}

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -24,8 +24,6 @@ import Nri.Ui.Dropdown.V1
 import Nri.Ui.Icon.V2
 import Nri.Ui.SegmentedControl.V5
 import Nri.Ui.Select.V2
-import Nri.Ui.Text.V2 as Text
-import Nri.Ui.TextArea.V2 as TextArea
 import String.Extra
 
 
@@ -206,5 +204,4 @@ styles =
         , (Nri.Ui.Icon.V2.styles |> .css) ()
         , (Nri.Ui.SegmentedControl.V5.styles |> .css) ()
         , (Nri.Ui.Select.V2.styles |> .css) ()
-        , (TextArea.styles |> .css) assets
         ]

--- a/styleguide-app/assets/CustomElement.js
+++ b/styleguide-app/assets/CustomElement.js
@@ -1,0 +1,170 @@
+/**************
+ * WARNING: THIS FILE HAS BEEN COPIED FROM THE MONOLITH
+ */
+
+/**
+ * # CustomElement
+ * 
+ * ## Importing
+ * Just require the file to get the API
+ * ```
+ * CustomElements = require('CustomElements')
+ * ```
+ * 
+ * ## Functions
+ * - `create`: Create and register a custom element
+ * - `makeEvent`: Create a DOM event
+ * 
+ * ## Creating a custom element
+ * ```
+ * CustomElements.create
+ *   # This is where you specify the tag for your custom element. You would
+ *   # use this custom element with `Html.node "my-custom-tag"`.
+ *   tagName: 'my-cool-button'
+ * 
+ *   # Initialize any local variables for the element or do whatever else you
+ *   # might do in a class constructor. Takes no arguments.
+ *   # NOTE: the element is NOT in the DOM at this point.
+ *   initialize: ->
+ *     @_hello = 'world'
+ *     @_button = document.createElement('button')
+ *
+ *   # Do any setup work after the element has been inserted into the DOM.
+ *   # Takes no arguments. This is a proxy for `connectedCallback` (see:
+ *   # https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Using_the_lifecycle_callbacks)
+ *   onConnect: ->
+ *     document.addEventListener('click', @_onDocClick)
+ *     @_button.addEventListener('click', @_onButtonClick)
+ *     @appendChild(@_button)
+ * 
+ *   # Do any teardown work after the element has been removed from the DOM.
+ *   # Takes no arguments. This is a proxy for `disconnectedCallback` (see:
+ *   # https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Using_the_lifecycle_callbacks)
+ *   onDisconnect: ->
+ *     document.removeEventListener('click', @_onDocClick)
+ * 
+ *   # Do any updating when an attribute changes on the element. Note the
+ *   # difference between attributes and properties of an element (see:
+ *   # https://javascript.info/dom-attributes-and-properties). This is a
+ *   # proxy for `attributeChangedCallback` (see:
+ *   # https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Using_the_lifecycle_callbacks).
+ *   # Takes the name of the attribute that changed, the previous string value,
+ *   # and the new string value.
+ *   onAttributeChange: (name, previous, next) ->
+ *     @hello = next if name == 'hello'
+ *   
+ *   # Set up properties. These allow you to expose data to Elm's virtual DOM.
+ *   # You can use any value that can be encoded as a `Json.Encode.Value`.
+ *   # You'll often want to implement updates to some visual detail of your element
+ *   # from within the setter of a property that controls it. Handlers will be
+ *   # automatically bound to the correct value of `@`, so you don't need to worry
+ *   # about method context.
+ *   properties:
+ *     hello:
+ *       get: -> @_hello
+ *       set: (value) ->
+ *         @_hello = value
+ *         @_button.textContent = value
+ *
+ *   # Set up methods that you can call from anywhere else in the configuration.
+ *   # Methods will be automatically bound to the correct value of `@`, so you
+ *   # don't need to worry about method context.
+ *   methods:
+ *     _onDocClick: ->
+ *       alert('document clicked')
+ * 
+ *     _onButtonClick ->
+ *       alert("clicked on #{@_hello} button")
+ * ```
+ * 
+ * ## Creating and triggering a custom event
+ * Pass the string name of the event, like `"input"`, to `CustomElement.makeEvent`
+ * along with some optional details. This purpose of this function is to normalize
+ * the creation of a `CustomEvent` across browsers. If you pass any info to the
+ * second argument, it will be available on `event.detail`. (see:
+ * https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent)
+ * ```
+ * CustomElement.create
+ *   # ...
+ *
+ *   onConnect: ->
+ *     @_textarea.addEventListener('input, @_onTextareaInput)
+ * 
+ *   properties:
+ *     textValue:
+ *       get: -> @_textValue
+ *       set: (value) -> @_textValue = value
+ * 
+ *   methods:
+ *     _onTextareaInput: ->
+ *       @_textValue = @_textarea.value
+ *       @dispatchEvent(CustomElement.makeEvent('textChanged', { text: @_textValue }))
+ * ```
+ */
+
+// Return a function for making an event based on what the browser supports.
+// IE11 doesn't support Event constructor, and uses the old Java-style
+// methods instead
+function makeMakeEvent() {
+  try {
+    // if calling Event with new works, do it that way
+    var testEvent = new CustomEvent('myEvent', { detail: 1 })
+    return function makeEventNewStyle(type, detail) {
+      return new Event(type, { detail: detail })
+    }
+  } catch (_error) {
+    // if calling CustomEvent with new throws an error, do it the old way
+    return function makeEventOldStyle(type, detail) {
+      var event = document.createEvent('CustomEvent')
+      event.initCustomEvent(type, false, false, detail)
+      return event
+    }
+  }  
+}
+
+window.Nri = window.Nri || {}
+var exports = window.Nri.CustomElement = {}
+
+exports.makeEvent = makeMakeEvent()
+
+function noOp() {}
+
+exports.create = function create(config) {
+  if (customElements.get(config.tagName)) {
+    throw Error('Custom element with tag name ' + config.tagName + ' already exists.')
+  }
+
+  config.methods = config.methods || {}
+  config.properties = config.properties || {}
+
+  function CustomElementConstructor() {
+    // This is the best we can do to trick modern browsers into thinking this
+    // is a real, legitimate class constructor and not a plane old JS function.
+    var _this = HTMLElement.call(this) || this
+
+    if (typeof config.initialize === 'function') {
+      config.initialize.call(_this)
+    }
+
+    for (var key in config.methods) {
+      if (!config.methods.hasOwnProperty(key)) continue
+      var method = config.methods[key]
+      if (typeof method !== 'function') continue
+      _this[key] = method.bind(_this)
+    }
+
+    Object.defineProperties(_this, config.properties)
+    return _this
+  }
+
+  // Some browsers respect this in various debugging tools.
+  CustomElementConstructor.displayName = '<' + config.tagName + '> custom element'
+
+  CustomElementConstructor.prototype = Object.create(HTMLElement.prototype)
+  CustomElementConstructor.prototype.constructor = CustomElementConstructor
+  CustomElementConstructor.prototype.connectedCallback = config.onConnect
+  CustomElementConstructor.prototype.disconnectedCallback = config.onDisconnect
+  CustomElementConstructor.prototype.attributeChangedCallback = config.onAttributeChange
+
+  customElements.define(config.tagName, CustomElementConstructor)
+}

--- a/styleguide-app/assets/TextArea.js
+++ b/styleguide-app/assets/TextArea.js
@@ -1,108 +1,50 @@
-function AutoresizeTextArea() {
-  var _this = HTMLElement.call(this) || this;
-  _this._onInput = _this._onInput.bind(_this);
-  _this._textarea = document.createElement("textarea");
-  return _this;
-}
+window.Nri.CustomElement.create({
+  tagName: 'nri-textarea-v3',
 
-AutoresizeTextArea.prototype = Object.create(HTMLElement.prototype);
-AutoresizeTextArea.prototype.constructor = AutoresizeTextArea;
+  initialize: function() {
+    this._autoresize = false
+  },
 
-Object.defineProperties(AutoresizeTextArea.prototype, {
-  defaultValue: {
-    get: function() {
-      return this._textarea.defaultValue;
-    },
-    set: function(value) {
-      this._textarea.defaultValue = value;
+  onConnect: function() {
+    this._textarea = this.querySelector('textarea')
+    this._updateListener()
+  },
+
+  properties: {
+    autoresize: {
+      get: function() {
+        return this._autoresize
+      },
+      set: function(value) {
+        if (value === this._autoresize) return
+        this._autoresize = value
+        if (this._textarea) this._updateListener()
+      }
     }
   },
-  autofocus: {
-    get: function() {
-      return this._textarea.autofocus;
+
+  methods: {
+    _updateListener: function() {
+      if (this._autoresize) {
+        this._textarea.addEventListener('input', this._onInput)
+      } else {
+        this._textarea.removeEventListener('input', this._onInput)
+      }
     },
-    set: function(value) {
-      this._textarea.autofocus = value;
-    }
-  },
-  placeholder: {
-    get: function() {
-      return this._textarea.placeholder;
-    },
-    set: function(value) {
-      this._textarea.placeholder = value;
-    }
-  },
-  value: {
-    get: function() {
-      return this._textarea.value;
-    },
-    set: function(value) {
-      this._textarea.value = value;
+
+    _onInput: function() {
+      var minHeight = this._textarea.style.minHeight ?
+          parseInt(this._textarea.style.minHeight, 10) :
+          parseInt(window.getComputedStyle(this._textarea).height, 10)
+      
+      this._textarea.style.overflowY = 'hidden'
+      this._textarea.style.minHeight = minHeight + 'px'
+      if (this._textarea.scrollHeight > minHeight) {
+        this._textarea.style.height = 'auto'
+        this._textarea.style.height = this._textarea.scrollHeight + 'px'
+      } else {
+        this._textarea.style.height = minHeight + 'px'
+      }
     }
   }
-});
-
-AutoresizeTextArea.prototype._resize = function() {
-  var minHeight = null;
-  if (this._textarea.style.minHeight) {
-    minHeight = parseInt(this._textarea.style.minHeight, 10);
-  } else {
-    minHeight = parseInt(window.getComputedStyle(this._textarea).minHeight, 10);
-  }
-  if (minHeight === 0) {
-    minHeight = parseInt(window.getComputedStyle(this._textarea).height, 10);
-  }
-
-  this._textarea.style.overflowY = "hidden";
-  this._textarea.style.minHeight = minHeight + "px";
-  this._textarea.style.transition = "none";
-  if (this._textarea.scrollHeight > minHeight) {
-    this._textarea.style.height = minHeight + "px";
-    this._textarea.style.height = this._textarea.scrollHeight + "px";
-  } else {
-    this._textarea.style.height = minHeight + "px";
-  }
-};
-
-AutoresizeTextArea.prototype._onInput = function() {
-  this._resize();
-  this.dispatchEvent(new Event("input"));
-};
-
-AutoresizeTextArea.prototype._reflectAttributes = function() {
-  while (this.attributes.length) {
-    var attribute = this.attributes[0];
-    this.removeAttributeNode(attribute);
-    this._textarea.setAttributeNode(attribute);
-  }
-  for (var k in this.dataset) {
-    this._textarea.dataset[k] = this.dataset[k];
-    delete this.dataset[k];
-  }
-};
-
-AutoresizeTextArea.prototype.attributeChangedCallback = function(
-  attribute,
-  previous,
-  next
-) {
-  if (previous && !next) {
-    this._textarea.removeAttribute(attribute);
-  } else {
-    this._textarea.setAttribute(attribute, next);
-  }
-};
-
-AutoresizeTextArea.prototype.connectedCallback = function() {
-  this._textarea.addEventListener("input", this._onInput);
-  this._reflectAttributes();
-  this.appendChild(this._textarea);
-  this._resize();
-};
-
-AutoresizeTextArea.prototype.disconnectedCallback = function() {
-  this._textarea.removeEventListener("input", this._onInput);
-};
-
-customElements.define("autoresize-textarea", AutoresizeTextArea);
+})

--- a/styleguide-app/index.html
+++ b/styleguide-app/index.html
@@ -6,6 +6,7 @@
   <link href="https://fonts.googleapis.com/css?family=Muli:400,400i,600,600i,700,700i,800,800i,900,900i" rel="stylesheet">
   <script src="assets/custom-elements/custom-elements.min.js"></script>
   <script src="assets/custom-elements/native-shim.js"></script>
+  <script src="assets/CustomElement.js"></script>
   <script src="assets/TextArea.js"></script>
   <script src="assets/generated_svgs.js"></script>
 </head>


### PR DESCRIPTION
Instead of having the custom element create a new textarea and then copy all of the attributes we can just wrap an existing textarea with a custom element and optionally have it attach or not. this also degrades more gracefully as the textarea will show up no matter what and the wrapping custom element will just be ignored by browsers that can't even use the polyfill.