### PR TITLE
Override sass styles for TextInput and TextArea

### DIFF
--- a/src/Nri/Ui/InputStyles/V2.elm
+++ b/src/Nri/Ui/InputStyles/V2.elm
@@ -146,7 +146,6 @@ input theme isInError =
                         , padding2 inputPaddingVertical (px 14)
                         , fontSize (px 15)
                         , Nri.Ui.Fonts.V1.baseFont
-                        , height (px 45)
                         ]
 
                 Writing ->
@@ -157,7 +156,6 @@ input theme isInError =
                         , lineHeight writingLineHeight
                         , padding writingPadding
                         , paddingTop writingPaddingTop
-                        , height auto
                         , focus
                             [ Css.Foreign.adjacentSiblings
                                 [ Css.Foreign.label
@@ -183,7 +181,6 @@ input theme isInError =
                         , padding2 inputPaddingVertical (px 14)
                         , fontSize (px 15)
                         , Nri.Ui.Fonts.V1.baseFont
-                        , height (px 45)
                         ]
             ]
         ]

--- a/src/Nri/Ui/InputStyles/V2.elm
+++ b/src/Nri/Ui/InputStyles/V2.elm
@@ -31,9 +31,9 @@ import Nri.Ui.Fonts.V1
 
 {-| -}
 type Theme
-    = ContentCreation2
+    = ContentCreation
     | Standard
-    | Writing2
+    | Writing
 
 
 {-| -}
@@ -65,7 +65,7 @@ label theme inError =
                     batch []
                 ]
 
-        ContentCreation2 ->
+        ContentCreation ->
             batch
                 [ sharedStyles
                 , border3 (px 1) solid gray75
@@ -76,7 +76,7 @@ label theme inError =
                 , padding2 (px 2) (px 5)
                 ]
 
-        Writing2 ->
+        Writing ->
             batch
                 [ sharedStyles
                 , padding2 zero (px 5)
@@ -136,51 +136,56 @@ input theme isInError =
                     batch []
                 ]
     in
-    case theme of
-        Standard ->
-            batch
-                [ sharedStyles
-                , padding2 inputPaddingVertical (px 14)
-                , fontSize (px 15)
-                , Nri.Ui.Fonts.V1.baseFont
-                , height (px 45)
-                ]
+    batch
+        [ Css.Foreign.withClass "override-sass-styles"
+            [ case theme of
+                Standard ->
+                    batch
+                        [ sharedStyles
+                        , padding2 inputPaddingVertical (px 14)
+                        , fontSize (px 15)
+                        , Nri.Ui.Fonts.V1.baseFont
+                        , height (px 45)
+                        ]
 
-        Writing2 ->
-            batch
-                [ sharedStyles
-                , Nri.Ui.Fonts.V1.quizFont
-                , fontSize (px 20)
-                , lineHeight writingLineHeight
-                , padding writingPadding
-                , paddingTop writingPaddingTop
-                , focus
-                    [ Css.Foreign.adjacentSiblings
-                        [ Css.Foreign.label
-                            [ backgroundColor azure
-                            , color white
-                            , borderColor azure
-                            , if isInError then
-                                batch
-                                    [ backgroundColor purple
+                Writing ->
+                    batch
+                        [ sharedStyles
+                        , Nri.Ui.Fonts.V1.quizFont
+                        , fontSize (px 20)
+                        , lineHeight writingLineHeight
+                        , padding writingPadding
+                        , paddingTop writingPaddingTop
+                        , height auto
+                        , focus
+                            [ Css.Foreign.adjacentSiblings
+                                [ Css.Foreign.label
+                                    [ backgroundColor azure
                                     , color white
-                                    , borderColor purple
+                                    , borderColor azure
+                                    , if isInError then
+                                        batch
+                                            [ backgroundColor purple
+                                            , color white
+                                            , borderColor purple
+                                            ]
+                                      else
+                                        batch []
                                     ]
-                              else
-                                batch []
+                                ]
                             ]
                         ]
-                    ]
-                ]
 
-        ContentCreation2 ->
-            batch
-                [ sharedStyles
-                , padding2 inputPaddingVertical (px 14)
-                , fontSize (px 15)
-                , Nri.Ui.Fonts.V1.baseFont
-                , height (px 45)
-                ]
+                ContentCreation ->
+                    batch
+                        [ sharedStyles
+                        , padding2 inputPaddingVertical (px 14)
+                        , fontSize (px 15)
+                        , Nri.Ui.Fonts.V1.baseFont
+                        , height (px 45)
+                        ]
+            ]
+        ]
 
 
 {-| -}

--- a/src/Nri/Ui/InputStyles/V2.elm
+++ b/src/Nri/Ui/InputStyles/V2.elm
@@ -95,7 +95,8 @@ label theme inError =
                 ]
 
 
-{-| -}
+{-| In order to use these styles in an input module, you will need to add the class "override-sass-styles". This is because sass styles in the monolith have higher precendence than the class styles here.
+-}
 input : Theme -> Bool -> Style
 input theme isInError =
     let

--- a/src/Nri/Ui/TextArea/V3.elm
+++ b/src/Nri/Ui/TextArea/V3.elm
@@ -114,6 +114,7 @@ view_ theme model =
                 ]
                 [ Events.onInput model.onInput
                 , Attributes.id (generateId model.label)
+                , Attributes.class "override-sass-styles"
                 , Attributes.autofocus model.autofocus
                 , Attributes.placeholder model.placeholder
                 , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859

--- a/src/Nri/Ui/TextArea/V3.elm
+++ b/src/Nri/Ui/TextArea/V3.elm
@@ -24,7 +24,7 @@ module Nri.Ui.TextArea.V3
 -}
 
 import Accessibility.Styled.Style
-import Css exposing ((|+|))
+import Css exposing ((|+|), px)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
@@ -95,6 +95,17 @@ view_ theme model =
 
                 Fixed ->
                     []
+
+        heightForStyle =
+            case theme of
+                Standard ->
+                    px 100
+
+                ContentCreation ->
+                    px 100
+
+                Writing ->
+                    px 150
     in
     Html.styled Html.div
         [ Css.position Css.relative ]
@@ -105,6 +116,7 @@ view_ theme model =
             [ Html.styled Html.textarea
                 [ InputStyles.input theme model.isInError
                 , Css.boxSizing Css.borderBox
+                , Css.height heightForStyle
                 , case model.height of
                     AutoResize minimumHeight ->
                         Css.minHeight (calculateMinHeight theme minimumHeight)

--- a/src/Nri/Ui/TextArea/V3.elm
+++ b/src/Nri/Ui/TextArea/V3.elm
@@ -99,13 +99,13 @@ view_ theme model =
         heightForStyle =
             case theme of
                 Standard ->
-                    px 100
+                    InputStyles.textAreaHeight
 
                 ContentCreation ->
-                    px 100
+                    InputStyles.textAreaHeight
 
                 Writing ->
-                    px 150
+                    InputStyles.writingMinHeight
     in
     Html.styled Html.div
         [ Css.position Css.relative ]
@@ -116,13 +116,12 @@ view_ theme model =
             [ Html.styled Html.textarea
                 [ InputStyles.input theme model.isInError
                 , Css.boxSizing Css.borderBox
-                , Css.height heightForStyle
                 , case model.height of
                     AutoResize minimumHeight ->
                         Css.minHeight (calculateMinHeight theme minimumHeight)
 
                     Fixed ->
-                        Css.batch []
+                        Css.minHeight heightForStyle
                 ]
                 [ Events.onInput model.onInput
                 , Attributes.id (generateId model.label)

--- a/src/Nri/Ui/TextArea/V3.elm
+++ b/src/Nri/Ui/TextArea/V3.elm
@@ -74,14 +74,14 @@ view model =
 -}
 writing : Model msg -> Html msg
 writing model =
-    view_ Writing2 model
+    view_ Writing model
 
 
 {-| Used for Content Creation
 -}
 contentCreation : Model msg -> Html msg
 contentCreation model =
-    view_ ContentCreation2 model
+    view_ ContentCreation model
 
 
 {-| -}
@@ -117,6 +117,7 @@ view_ theme model =
                 , Attributes.autofocus model.autofocus
                 , Attributes.placeholder model.placeholder
                 , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
+                , Attributes.class "override-sass-styles"
                 ]
                 [ Html.text model.value ]
             ]
@@ -157,10 +158,10 @@ calculateMinHeight textAreaStyle specifiedHeight =
                 Standard ->
                     singleLineHeight
 
-                Writing2 ->
+                Writing ->
                     writingSingleLineHeight
 
-                ContentCreation2 ->
+                ContentCreation ->
                     singleLineHeight
 
         DefaultHeight ->
@@ -168,10 +169,10 @@ calculateMinHeight textAreaStyle specifiedHeight =
                 Standard ->
                     InputStyles.textAreaHeight
 
-                Writing2 ->
+                Writing ->
                     InputStyles.writingMinHeight
 
-                ContentCreation2 ->
+                ContentCreation ->
                     InputStyles.textAreaHeight
 
 

--- a/src/Nri/Ui/TextInput/V3.elm
+++ b/src/Nri/Ui/TextInput/V3.elm
@@ -22,6 +22,7 @@ module Nri.Ui.TextInput.V3
 
 import Accessibility.Styled.Style as Accessibility
 import Css exposing (batch, center, position, px, relative, textAlign)
+import Css.Foreign
 import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes as Attributes exposing (..)
 import Html.Styled.Events as Events exposing (onInput)
@@ -102,12 +103,14 @@ view_ theme model =
             , css
                 [ InputStyles.input theme model.isInError
                 , if theme == InputStyles.Writing then
-                    batch
+                    Css.Foreign.withClass "override-sass-styles"
                         [ textAlign center
                         , Css.height Css.auto
                         ]
                   else
-                    Css.height (px 45)
+                    Css.Foreign.withClass "override-sass-styles"
+                        [ Css.height (px 45)
+                        ]
                 ]
             , placeholder model.placeholder
             , defaultValue (inputType.toString model.value)

--- a/src/Nri/Ui/TextInput/V3.elm
+++ b/src/Nri/Ui/TextInput/V3.elm
@@ -82,7 +82,7 @@ view model =
 {-| -}
 writing : Model value msg -> Html msg
 writing model =
-    view_ InputStyles.Writing2 model
+    view_ InputStyles.Writing model
 
 
 view_ : Theme -> Model value msg -> Html msg
@@ -101,7 +101,7 @@ view_ theme model =
             [ Attributes.id idValue
             , css
                 [ InputStyles.input theme model.isInError
-                , if theme == InputStyles.Writing2 then
+                , if theme == InputStyles.Writing then
                     textAlign center
                   else
                     batch []
@@ -111,6 +111,7 @@ view_ theme model =
             , onInput (inputType.fromString >> model.onInput)
             , autofocus model.autofocus
             , type_ inputType.fieldType
+            , class "override-sass-styles"
             ]
             []
         , if model.showLabel then

--- a/src/Nri/Ui/TextInput/V3.elm
+++ b/src/Nri/Ui/TextInput/V3.elm
@@ -21,7 +21,7 @@ module Nri.Ui.TextInput.V3
 -}
 
 import Accessibility.Styled.Style as Accessibility
-import Css exposing (batch, center, position, relative, textAlign)
+import Css exposing (batch, center, position, px, relative, textAlign)
 import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes as Attributes exposing (..)
 import Html.Styled.Events as Events exposing (onInput)
@@ -102,9 +102,12 @@ view_ theme model =
             , css
                 [ InputStyles.input theme model.isInError
                 , if theme == InputStyles.Writing then
-                    textAlign center
+                    batch
+                        [ textAlign center
+                        , Css.height Css.auto
+                        ]
                   else
-                    batch []
+                    Css.height (px 45)
                 ]
             , placeholder model.placeholder
             , defaultValue (inputType.toString model.value)


### PR DESCRIPTION
## ⚠️ This branch contains https://github.com/NoRedInk/noredink-ui/pull/70 - merge that first!

Before: 
On the monolith, sass styles from text input are overriding elm-css styles because we are selecting by `input[type=text]`, which has higher precedence than `.mystery_class_name`, leading to weirdness like this: 

<img width="1076" alt="baddies" src="https://user-images.githubusercontent.com/13489089/41009168-282c3e7c-68e4-11e8-9eb9-4a298bc9117f.png">

Now: 
We are adding an additional class selector to elm css `override-sass-styles` so that we can be winners. This is how the writing style should look:

<img width="841" alt="screen shot 2018-06-05 at 5 16 39 pm" src="https://user-images.githubusercontent.com/13489089/41009184-3b56cdd2-68e4-11e8-856e-258dfdae75c0.png">

This branch also adds `TextArea.V3` to the styleguide, which was using V2 before. 

## QA

To test that these override monolith styles, I copied this style tag from the monolith into "styleguide-app/index.html" as such and made sure that the inputs and textareas still looked good.

```
  <style>
    input[type="text"], textarea, input[type="number"], input[type="tel"], input[type="email"], input[type="password"], input[type="date"], input[type="date-local"], input[type="month"], input[type="week"], input[type="time"], input[type="search"], input[type="url"] {
        font-size: 15px;
        color: #333333;
        border: 1px solid #bfbfbf;
        border-radius: 8px;
        padding: 5px 10px;
        height: 45px;
        background: white;
        box-shadow: none;
        -webkit-appearance: none;
        box-shadow: inset 0 3px 0 0 #ebebeb;
        -webkit-transition: all 0.1s ease;
        -moz-transition: all 0.1s ease;
        transition: all 0.1s ease;
    }
    select, input[type="text"], input[type="number"], input[type="tel"], input[type="email"], input[type="password"], input[type="date"], input[type="date-local"], input[type="month"], input[type="week"], input[type="time"], input[type="search"], input[type="url"], textarea, label, .control-group.error .help-inline, .error .help-inline, .statistic-component .overlay, .statistic-component .caption, #navbar, .student-mode-banner, .student-mode-banner a, .nav-tabs, .nav-tabs .tab, .search-input, .course-selector-label, .modal-header, #footer, .alert-notice, .alert-info, .alert-error, .alert-warning, .alert-danger, .login-forgot-link, .log-in-button, .login-line-rule-container span, .login-forgot-username-hint, .login-label, .login-entry-field, .login-submit-button, .popout-google-login-button, .popout-clever-login-button {
        font-family: "Muli", Helvetica, Arial, sans-serif;
    }
  </style>

```