### PR TITLE
add aria-invalid attr to inputs

### DIFF
--- a/src/Nri/Ui/TextArea/V3.elm
+++ b/src/Nri/Ui/TextArea/V3.elm
@@ -125,11 +125,15 @@ view_ theme model =
                 ]
                 [ Events.onInput model.onInput
                 , Attributes.id (generateId model.label)
-                , Attributes.class "override-sass-styles"
                 , Attributes.autofocus model.autofocus
                 , Attributes.placeholder model.placeholder
                 , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
                 , Attributes.class "override-sass-styles"
+                , Attributes.attribute "aria-invalid" <|
+                    if model.isInError then
+                        "true"
+                    else
+                        "false"
                 ]
                 [ Html.text model.value ]
             ]

--- a/src/Nri/Ui/TextInput/V3.elm
+++ b/src/Nri/Ui/TextInput/V3.elm
@@ -118,6 +118,11 @@ view_ theme model =
             , autofocus model.autofocus
             , type_ inputType.fieldType
             , class "override-sass-styles"
+            , Attributes.attribute "aria-invalid" <|
+                if model.isInError then
+                    "true"
+                else
+                    "false"
             ]
             []
         , if model.showLabel then


### PR DESCRIPTION
to indicate to screen readers that the inputs are in error, and to let capybara and html-test query in-error inputs instead of the `IsInError` class

will allow us to fix spec failures in https://github.com/NoRedInk/NoRedInk/pull/20346

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-invalid_attribute