### PR TITLE
Ink  checkbox opacity

### DIFF
--- a/src/Nri/Ui/Checkbox/V3.elm
+++ b/src/Nri/Ui/Checkbox/V3.elm
@@ -61,7 +61,7 @@ type IsSelected
 {-| -}
 type Theme
     = Square
-    | LockOnInside
+    | Locked
 
 
 selectedToMaybe : IsSelected -> Maybe Bool
@@ -119,7 +119,7 @@ buildCheckbox assets modifierClasses model labelContent =
                 , labelContent = labelContent
                 }
 
-            LockOnInside ->
+            Locked ->
                 { containerClasses = toClassList (modifierClasses ++ [ "LockOnInsideClass" ])
                 , labelStyles = lockLabelStyles model assets.checkboxLockOnInside_svg
                 , labelClasses = labelClass model.selected

--- a/src/Nri/Ui/Checkbox/V3.elm
+++ b/src/Nri/Ui/Checkbox/V3.elm
@@ -168,7 +168,6 @@ positioning =
     batch
         [ display inlineBlock
         , padding4 (px 13) zero (px 13) (px 35)
-        , verticalAlign middle
         ]
 
 
@@ -183,10 +182,18 @@ textStyle =
 addIcon : Asset -> Style
 addIcon icon =
     batch
-        [ backgroundImage icon
-        , backgroundRepeat noRepeat
-        , backgroundSize (px 24)
-        , property "background-position" "left center"
+        [ position relative
+        , before
+            [ backgroundImage icon
+            , backgroundRepeat noRepeat
+            , backgroundSize (px 24)
+            , property "content" "''"
+            , position absolute
+            , left zero
+            , top (px 10)
+            , width (px 24)
+            , height (px 24)
+            ]
         ]
 
 

--- a/src/Nri/Ui/Checkbox/V3.elm
+++ b/src/Nri/Ui/Checkbox/V3.elm
@@ -138,10 +138,12 @@ squareLabelStyles model image =
             ]
     in
     css
-        (if model.disabled then
-            [ cursor auto, opacity (num 0.4) ] ++ baseStyles
-         else
-            [ cursor pointer ] ++ baseStyles
+        (baseStyles
+            ++ (if model.disabled then
+                    [ cursor auto, checkboxImageSelector [ opacity (num 0.4) ] ]
+                else
+                    [ cursor pointer ]
+               )
         )
 
 
@@ -156,10 +158,14 @@ lockLabelStyles model image =
             ]
     in
     css
-        (if model.disabled then
-            [ cursor auto, opacity (num 0.4) ] ++ baseStyles
-         else
-            [ cursor pointer ] ++ baseStyles
+        (baseStyles
+            ++ (if model.disabled then
+                    [ cursor auto
+                    , checkboxImageSelector [ opacity (num 0.4) ]
+                    ]
+                else
+                    [ cursor pointer ]
+               )
         )
 
 
@@ -183,7 +189,7 @@ addIcon : Asset -> Style
 addIcon icon =
     batch
         [ position relative
-        , before
+        , checkboxImageSelector
             [ backgroundImage icon
             , backgroundRepeat noRepeat
             , backgroundSize (px 24)
@@ -195,6 +201,11 @@ addIcon icon =
             , height (px 24)
             ]
         ]
+
+
+checkboxImageSelector : List Style -> Style
+checkboxImageSelector =
+    before
 
 
 labelClass : IsSelected -> Html.Styled.Attribute msg

--- a/src/Nri/Ui/PremiumCheckbox/V1.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V1.elm
@@ -68,7 +68,7 @@ premium assets config =
             , disabled = config.disabled
             , theme =
                 if isLocked then
-                    Checkbox.LockOnInside
+                    Checkbox.Locked
                 else
                     Checkbox.Square
             , noOpMsg = config.noOpMsg

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -132,11 +132,11 @@ viewLockedOnInsideCheckbox id state =
     Checkbox.viewWithLabel
         assets
         { identifier = id
-        , label = "I'm a locked Checkbox on the inside"
+        , label = "I'm a locked Checkbox"
         , setterMsg = ToggleCheck id
         , selected = Checkbox.NotSelected
         , disabled = True
-        , theme = Checkbox.LockOnInside
+        , theme = Checkbox.Locked
         , noOpMsg = NoOp
         }
 


### PR DESCRIPTION
Another small change for https://www.pivotaltracker.com/story/show/157794412.

We want to opacify the checkbox images but not the text. See https://github.com/NoRedInk/noredink-ui/pull/74#issuecomment-398883130 and https://github.com/NoRedInk/NoRedInk/pull/20360 for some context.

<img width="453" alt="screen shot 2018-06-25 at 5 48 47 pm" src="https://user-images.githubusercontent.com/8811312/41882905-678ff56a-78a0-11e8-9020-129744e843f7.png">

cc @NoRedInk/design 