### PR TITLE
Bump Select to V3 to gain powers of new css

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -37,6 +37,7 @@
         "Nri.Ui.SegmentedControl.V5",
         "Nri.Ui.Select.V1",
         "Nri.Ui.Select.V2",
+        "Nri.Ui.Select.V3",
         "Nri.Ui.Styles.V1",
         "Nri.Ui.Table.V1",
         "Nri.Ui.Table.V2",

--- a/src/Nri/Ui/Select/V3.elm
+++ b/src/Nri/Ui/Select/V3.elm
@@ -44,7 +44,7 @@ type alias Config a =
     }
 
 
-{-| TODO: move this to View.Extra
+{-| TODO: Consider moving this to Nri.Ui.Util once the non-0.19-approved `toString` is removed
 -}
 niceId : String -> a -> String
 niceId prefix x =

--- a/src/Nri/Ui/Select/V3.elm
+++ b/src/Nri/Ui/Select/V3.elm
@@ -1,0 +1,106 @@
+module Nri.Ui.Select.V3
+    exposing
+        ( Config
+        , customView
+        , view
+        )
+
+{-| Build a select input.
+
+
+## Upgrading to V3
+
+  - Remove the old styles. V3 uses compile-at-runtime elm-css!
+
+
+# Configure
+
+@docs Config
+
+
+# Render
+
+@docs view, customView
+
+-}
+
+import Css
+import Css.Foreign
+import Dict
+import Html.Styled as Html exposing (..)
+import Html.Styled.Attributes as Attributes exposing (..)
+import Html.Styled.Events exposing (..)
+import Json.Decode exposing (Decoder, andThen, succeed)
+import Nri.Ui
+import Nri.Ui.Colors.V1
+import Nri.Ui.Styles.V1
+import Nri.Ui.Util
+
+
+{-| Select-specific Choice.Config
+-}
+type alias Config a =
+    { choices : List { label : String, value : a }
+    , current : a
+    }
+
+
+{-| TODO: move this to View.Extra
+-}
+niceId : String -> a -> String
+niceId prefix x =
+    prefix ++ "-" ++ Nri.Ui.Util.dashify (Nri.Ui.Util.removePunctuation (toString x))
+
+
+{-| A normal select dropdown
+-}
+view : Config a -> Html a
+view config =
+    customView [] config
+
+
+{-| A select dropdown with custom attributes.
+This should be phased out as the new Select style is implemented,
+all pages should use the new, consistent style.
+-}
+customView : List (Html.Attribute a) -> Config a -> Html a
+customView attributes config =
+    let
+        valueLookup =
+            -- TODO: probably worth using Lazy here, since choices won't change often
+            config.choices
+                |> List.map (\x -> ( niceId "nri-select" x.value, x.value ))
+                |> Dict.fromList
+
+        decodeValue string =
+            Dict.get string valueLookup
+                |> Maybe.map Json.Decode.succeed
+                |> Maybe.withDefault (Json.Decode.fail ("Nri.Select: could not decode the value: " ++ toString string ++ "\nexpected one of: " ++ toString (Dict.keys valueLookup)))
+
+        onSelectHandler =
+            on "change" (targetValue |> andThen decodeValue)
+
+        viewChoice choice =
+            Html.option
+                [ Attributes.id (niceId "nri-select" choice.value)
+                , Attributes.value (niceId "nri-select" choice.value)
+                , Attributes.selected (choice.value == config.current)
+                ]
+                [ Html.text choice.label ]
+    in
+    config.choices
+        |> List.map viewChoice
+        |> Nri.Ui.styled Html.select
+            "nri-select-menu"
+            [ Css.backgroundColor Nri.Ui.Colors.V1.white
+            , Css.border3 (Css.px 1) Css.solid Nri.Ui.Colors.V1.gray75
+            , Css.borderRadius (Css.px 8)
+            , Css.color Nri.Ui.Colors.V1.gray20
+            , Css.cursor Css.pointer
+            , Css.fontSize (Css.px 15)
+            , Css.height (Css.px 45)
+            , Css.width (Css.pct 100)
+            ]
+            (onSelectHandler
+                :: attributes
+            )

--- a/src/Nri/Ui/Select/V3.elm
+++ b/src/Nri/Ui/Select/V3.elm
@@ -1,7 +1,6 @@
 module Nri.Ui.Select.V3
     exposing
         ( Config
-        , customView
         , view
         )
 
@@ -20,7 +19,7 @@ module Nri.Ui.Select.V3
 
 # Render
 
-@docs view, customView
+@docs view
 
 -}
 
@@ -56,15 +55,6 @@ niceId prefix x =
 -}
 view : Config a -> Html a
 view config =
-    customView [] config
-
-
-{-| A select dropdown with custom attributes.
-This should be phased out as the new Select style is implemented,
-all pages should use the new, consistent style.
--}
-customView : List (Html.Attribute a) -> Config a -> Html a
-customView attributes config =
     let
         valueLookup =
             -- TODO: probably worth using Lazy here, since choices won't change often
@@ -101,6 +91,4 @@ customView attributes config =
             , Css.height (Css.px 45)
             , Css.width (Css.pct 100)
             ]
-            (onSelectHandler
-                :: attributes
-            )
+            [ onSelectHandler ]

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -43,7 +43,7 @@ type alias State value =
 {-| -}
 example : (Msg -> msg) -> State Value -> ModuleExample msg
 example parentMessage state =
-    { filename = "ui/src/Nri/Select.elm"
+    { filename = "Nri.Ui.Select.V3"
     , category = Inputs
     , content =
         [ Html.Styled.map (parentMessage << ConsoleLog) (Select.view state)

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -20,8 +20,9 @@ module Examples.Select
 -}
 
 import Html
+import Html.Styled
 import ModuleExample exposing (Category(..), ModuleExample)
-import Nri.Ui.Select.V2
+import Nri.Ui.Select.V3 as Select
 
 
 {-| -}
@@ -36,7 +37,7 @@ type Msg
 
 {-| -}
 type alias State value =
-    Nri.Ui.Select.V2.Config value
+    Select.Config value
 
 
 {-| -}
@@ -45,7 +46,8 @@ example parentMessage state =
     { filename = "ui/src/Nri/Select.elm"
     , category = Inputs
     , content =
-        [ Html.map (parentMessage << ConsoleLog) (Nri.Ui.Select.V2.view state)
+        [ Html.Styled.map (parentMessage << ConsoleLog) (Select.view state)
+            |> Html.Styled.toUnstyled
         ]
     }
 

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -24,7 +24,6 @@ import Nri.Ui.Button.V2 as Button
 import Nri.Ui.Dropdown.V1
 import Nri.Ui.Icon.V2
 import Nri.Ui.SegmentedControl.V5
-import Nri.Ui.Select.V2
 import Nri.Ui.Text.V2 as Text
 import Nri.Ui.TextArea.V2 as TextArea
 import String.Extra
@@ -216,6 +215,5 @@ styles =
         , (Nri.Ui.Dropdown.V1.styles |> .css) ()
         , (Nri.Ui.Icon.V2.styles |> .css) ()
         , (Nri.Ui.SegmentedControl.V5.styles |> .css) ()
-        , (Nri.Ui.Select.V2.styles |> .css) ()
         , (TextArea.styles |> .css) assets
         ]

--- a/tests/Spec/Nri/Ui/Select.elm
+++ b/tests/Spec/Nri/Ui/Select.elm
@@ -3,8 +3,10 @@ module Spec.Nri.Ui.Select exposing (spec)
 import Expect exposing (Expectation)
 import Html
 import Html.Attributes as Attr
+import Html.Styled
 import Nri.Ui.Select.V1
 import Nri.Ui.Select.V2
+import Nri.Ui.Select.V3
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (..)
@@ -15,6 +17,7 @@ spec =
     describe "view"
         [ describe "V1" (viewSuite Nri.Ui.Select.V1.view)
         , describe "V2" (viewSuite Nri.Ui.Select.V2.view)
+        , describe "V3" (viewSuite (Nri.Ui.Select.V3.view >> Html.Styled.toUnstyled))
         ]
 
 


### PR DESCRIPTION
This PR bumps `Nri.Ui.Select.V2` -> `Nri.Ui.Select.V3` so we can use new elm css and not wait forever for monolithic css to build!

## QA 
- Build styleguide app  `make styleguide-app/elm.js`
- Check out the select menu - should look ok!