### PR TITLE
Update flag icon to bigger more vibrant red

### DIFF
--- a/styleguide-app/assets/images/icon-flag.png
+++ b/styleguide-app/assets/images/icon-flag.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5561d7d259693ebcf7918daf995014f67c6b9f8f137397f0d442b28ff39a3719
-size 242
+oid sha256:0ca4fac243955fd46c714a1befb43cded71c475e15c03fb17d5c3ed6694a6906
+size 1004


### PR DESCRIPTION
This updates the flag icon to a bigger, more vibrant red flag. This only updates the style guide preview and has no functional impact, so I don't think a version bump is required.