### PR TITLE
Use correct constructor for custom events when they are available

### DIFF
--- a/lib/CustomElement.js
+++ b/lib/CustomElement.js
@@ -11,7 +11,7 @@ function makeMakeEvent() {
     // if calling Event with new works, do it that way
     var testEvent = new CustomEvent('myEvent', { detail: 1 })
     return function makeEventNewStyle(type, detail) {
-      return new Event(type, { detail: detail })
+      return new CustomEvent(type, { detail: detail })
     }
   } catch (_error) {
     // if calling CustomEvent with new throws an error, do it the old way
@@ -20,7 +20,7 @@ function makeMakeEvent() {
       event.initCustomEvent(type, false, false, detail)
       return event
     }
-  }  
+  }
 }
 
 /**
@@ -39,7 +39,7 @@ function noOp() {}
 
 /**
  * Register a custom element using some straightforward and convenient configuration
- * 
+ *
  * @param {Object} config
  * @param {string} config.tagName The name of the tag for which to create a custom element. Must contain at least one `-` and must not have already been defined.
  * @param {Object<string, Object>} config.properties Getters and setters for properties on the custom element that can be accessed and set with `Html.Attributes.property`. These should map a property name onto a `get` function that returns a value and a `set` function that applies a value from the only argument.
@@ -54,7 +54,7 @@ function noOp() {}
  *   // This is where you specify the tag for your custom element. You would
  *   // use this custom element with `Html.node "my-custom-tag"`.
  *   tagName: 'my-cool-button',
- * 
+ *
  *   // Initialize any local variables for the element or do whatever else you
  *   // might do in a class constructor. Takes no arguments.
  *   // NOTE: the element is NOT in the DOM at this point.
@@ -71,18 +71,18 @@ function noOp() {}
  *     this._button.addEventListener('click', this._onButtonClick)
  *     this.appendChild(this._button)
  *   },
- * 
+ *
  *   // Do any teardown work after the element has been removed from the DOM.
  *   // Takes no arguments. This is a proxy for `disconnectedCallback` (see:
  *   // https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Using_the_lifecycle_callbacks)
  *   onDisconnect: function() {
  *     document.removeEventListener('click', this._onDocClick)
  *   },
- * 
+ *
  *   // Let the custom element runtime know that you want to be notified of
  *   // changes to the `hello` attribute
  *   observedAttributes: ['hello'],
- * 
+ *
  *   // Do any updating when an attribute changes on the element. Note the
  *   // difference between attributes and properties of an element (see:
  *   // https://javascript.info/dom-attributes-and-properties). This is a
@@ -93,7 +93,7 @@ function noOp() {}
  *   onAttributeChange: function(name, previous, next) {
  *     if (name === 'hello') this._hello = next
  *   },
- * 
+ *
  *   // Set up properties. These allow you to expose data to Elm's virtual DOM.
  *   // You can use any value that can be encoded as a `Json.Encode.Value`.
  *   // You'll often want to implement updates to some visual detail of your element


### PR DESCRIPTION
We were correctly checking if the CustomEvent constructor was available but then using `Event`, which wouldn't give us access to the additional details.

This was also fixed in the monolith here: https://github.com/NoRedInk/NoRedInk/pull/20759

Note that the autoresizeable textarea is the only custom element defined in this package and doesn't use `makeEvent`, so this bug didn't cause any real harm.