### PR TITLE
textarea uses defaultValue again

### DIFF
--- a/src/Nri/Ui/TextArea/V3.elm
+++ b/src/Nri/Ui/TextArea/V3.elm
@@ -129,13 +129,14 @@ view_ theme model =
                 , Attributes.placeholder model.placeholder
                 , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
                 , Attributes.class "override-sass-styles"
+                , Attributes.defaultValue model.value
                 , Attributes.attribute "aria-invalid" <|
                     if model.isInError then
                         "true"
                     else
                         "false"
                 ]
-                [ Html.text model.value ]
+                []
             ]
         , if not model.showLabel then
             Html.label

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -37,7 +37,7 @@ type alias State =
 {-| -}
 example : (Msg -> msg) -> State -> ModuleExample msg
 example parentMessage state =
-    { filename = "Nri/TextArea.elm"
+    { filename = "Nri.Ui.TextArea.V3"
     , category = Inputs
     , content =
         [ Text.heading [ Html.Styled.text "Textarea controls" ]


### PR DESCRIPTION
TextArea.V3 was causing flakes in the monolith because it used `text` rather than `defaultValue` to set the value. 

Context: https://noredink.slack.com/archives/C0VVDLEES/p1532116237000092

This sets it back to using `defaultValue`

To QA, please test that the textarea in the styleguide app still works properly, and can autoresize, and all that good stuff.
