### PR TITLE
Revert "Merge pull request #90 from NoRedInk/textarea-blast-from-the-…

### DIFF
--- a/src/Nri/Ui/TextArea/V3.elm
+++ b/src/Nri/Ui/TextArea/V3.elm
@@ -129,14 +129,13 @@ view_ theme model =
                 , Attributes.placeholder model.placeholder
                 , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
                 , Attributes.class "override-sass-styles"
-                , Attributes.defaultValue model.value
                 , Attributes.attribute "aria-invalid" <|
                     if model.isInError then
                         "true"
                     else
                         "false"
                 ]
-                []
+                [ Html.text model.value ]
             ]
         , if not model.showLabel then
             Html.label

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -37,7 +37,7 @@ type alias State =
 {-| -}
 example : (Msg -> msg) -> State -> ModuleExample msg
 example parentMessage state =
-    { filename = "Nri.Ui.TextArea.V3"
+    { filename = "Nri/TextArea.elm"
     , category = Inputs
     , content =
         [ Text.heading [ Html.Styled.text "Textarea controls" ]

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -37,7 +37,7 @@ type alias State =
 {-| -}
 example : (Msg -> msg) -> State -> ModuleExample msg
 example parentMessage state =
-    { filename = "Nri/TextArea.elm"
+    { filename = "Nri.Ui.TextArea.V3"
     , category = Inputs
     , content =
         [ Text.heading [ Html.Styled.text "Textarea controls" ]


### PR DESCRIPTION
We thought the guided_writes_spec is flaking because Textarea.V3 used text instead of defaultValue, leading to missed keystrokes in some Capybara runs, but tried this in https://github.com/NoRedInk/NoRedInk/pull/20790 and still observed the flake.

- Slack conversation: https://noredink.slack.com/archives/C0VVDLEES/p1532116237000092
- Bug report: elm/virtual-dom#107

The actual fix can be found here: https://github.com/NoRedInk/NoRedInk/pull/20822

Reverting this because changing Textarea.V3 to use `defaultValue` does not actually fix the flake, and will result in us needing to update elm specs in the monolith that look for text. 

## Future fixes
This bug seems to only happen in the custom element resizing text area.... can we make that more performant?

