### PR TITLE
Cache the prefix and styles on `Nri.Ui.styled`

### DIFF
--- a/src/Nri/Ui.elm
+++ b/src/Nri/Ui.elm
@@ -40,5 +40,15 @@ Note: normally `attributeMsg` will be the same as `msg`, but we need them to be 
 
 -}
 styled : (List (Attribute attributeMsg) -> List (Html msg) -> Html msg) -> String -> List Style -> List (Attribute attributeMsg) -> List (Html msg) -> Html msg
-styled fn description styles attrs children =
-    fn (attribute "data-nri-description" description :: css styles :: attrs) children
+styled fn description styles =
+    -- Cache the computed css style so we only have to do the hashing once.
+    -- Just like in https://github.com/rtfeldman/elm-css/pull/456
+    let
+        descriptionAttr =
+            attribute "data-nri-description" description
+
+        cssAttr =
+            css styles
+    in
+    \attrs children ->
+        fn (descriptionAttr :: cssAttr :: attrs) children


### PR DESCRIPTION
This applies the same performance optimization as https://github.com/rtfeldman/elm-css/pull/456

It doesn't change the API or the behavior of the function. All it does is change it so when you call `Nri.Ui.styled div "funky" stylesGoHere` it *immediately* calculates the `Attribute` values for `data-nri-description` and `css`, including the hashing calculation for the generated classname.

Then it returns a `List (Attribute msg) -> List (Html msg) -> Html msg` function just like before, except now that function will run faster because the "styled div" function won't have to recalculate those values every time it gets called; it will already have them stored from before.