### PR TITLE
Bump version to 5.9.1

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "5.9.0",
+    "version": "5.9.1",
     "summary": "UI Widgets we use at NRI",
     "repository": "https://github.com/NoRedInk/noredink-ui.git",
     "license": "BSD3",


### PR DESCRIPTION
Making a new release to address the breaking changes introduced in going from [`5.8.0` to `5.9.0`](https://github.com/NoRedInk/NoRedInk/pull/20877). It's a patch release because `elm-package bump` says it is.