### PR TITLE
Upgrade Nri Button from V2 -> V3

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -13,6 +13,7 @@
         "Nri.Ui.BannerAlert.V1",
         "Nri.Ui.Button.V1",
         "Nri.Ui.Button.V2",
+        "Nri.Ui.Button.V3",
         "Nri.Ui.Checkbox.V1",
         "Nri.Ui.Checkbox.V2",
         "Nri.Ui.Checkbox.V3",

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -1,0 +1,908 @@
+module Nri.Ui.Button.V3
+    exposing
+        ( ButtonConfig
+        , ButtonContent
+        , ButtonSize(..)
+        , ButtonState(..)
+        , ButtonStyle(..)
+        , LinkConfig
+        , ToggleButtonConfig
+        , button
+        , copyToClipboard
+        , customButton
+        , delete
+        , link
+        , linkExternal
+        , linkExternalWithTracking
+        , linkSpa
+        , linkWithMethod
+        , linkWithTracking
+        , styles
+        , submit
+        , toggleButton
+        )
+
+{-| Changes from V2:
+
+  - Uses Html.Styled
+  - Removes buttonDeprecated
+  - Removes Tiny size
+
+Common NoRedInk buttons. For accessibility purposes, buttons that perform an
+action on the current page should be HTML `<button>` elements and are created here
+with `*Button` functions. Buttons that take the user to a new page should be
+HTML `<a>` elements and are created here with `*Link` functions. Both versions
+should be able to use the same CSS class in all cases.
+
+There will generally be a `*Button` and `*Link` version of each button style.
+(These will be created as they are needed.)
+
+
+## Required styles
+
+@docs styles
+
+
+## Common configs
+
+@docs ButtonSize, ButtonStyle, ButtonState, ButtonContent
+
+
+## `<button>` Buttons
+
+@docs ButtonConfig, button, customButton, delete, copyToClipboard, ToggleButtonConfig, toggleButton
+
+
+## `<a>` Buttons
+
+@docs LinkConfig, link, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
+
+
+## `<input>` Buttons
+
+@docs submit
+
+-}
+
+import Accessibility.Styled exposing (..)
+import Accessibility.Styled.Role as Role
+import Accessibility.Styled.Widget as Widget
+import Css exposing (..)
+import EventExtras
+import Html.Styled
+import Html.Styled.Attributes exposing (..)
+import Html.Styled.Events exposing (onClick)
+import Json.Decode
+import Markdown.Block
+import Markdown.Inline
+import Nri.Ui
+import Nri.Ui.AssetPath as AssetPath exposing (Asset)
+import Nri.Ui.Colors.Extra exposing (withAlpha)
+import Nri.Ui.Colors.V1
+import Nri.Ui.Fonts.V1
+import Nri.Ui.Icon.V3 as Icon exposing (IconType, decorativeIcon, icon)
+
+
+{-| Sizes for buttons and links that have button classes
+
+NOTE: if you add a size here, you need to add Css styles using the sizeStyle helper in the styles definition.
+
+-}
+type ButtonSize
+    = Small
+    | Medium
+    | Large
+
+
+{-| Styleguide-approved styles for your buttons!
+
+Note on borderless buttons:
+A borderless button that performs an action on the current page
+This button is intended to look like a link.
+Only use a borderless button when the clickable text in question follows the same layout/margin/padding as a bordered button
+
+-}
+type ButtonStyle
+    = Primary
+    | Secondary
+    | Borderless
+    | Danger
+    | Premium
+    | Active -- NOTE: this is a one-off hack; do not use
+
+
+{-| Describes the state of a button. Has consequences for appearance and disabled attribute.
+
+  - Enabled: An enabled button. Takes the appearance of ButtonStyle
+  - Unfulfilled: A button which appears with the InactiveColors palette but is not disabled.
+  - Disabled: A button which appears with the InactiveColors palette and is disabled.
+  - Error: A button which appears with the ErrorColors palette and is disabled.
+  - Loading: A button which appears with the LoadingColors palette and is disabled
+  - Success: A button which appears with the InactiveColors palette and is disabled
+
+-}
+type ButtonState
+    = Enabled
+    | Unfulfilled
+    | Disabled
+    | Error
+    | Loading
+    | Success
+
+
+{-| The part of a button that remains constant through different button states
+-}
+type alias ButtonConfig msg =
+    { onClick : msg
+    , size : ButtonSize
+    , style : ButtonStyle
+    , width : Maybe Int
+    }
+
+
+{-| ButtonContent, often changes based on ButtonState. For example, a button in the "Success"
+state may have a different label than a button in the "Error" state
+-}
+type alias ButtonContent =
+    { label : String
+    , state : ButtonState
+    , icon : Maybe IconType
+    }
+
+
+{-| A delightful button which can trigger an effect when clicked!
+
+This button will trigger the passed-in message if the button state is:
+
+  - Enabled
+  - Unfulfilled
+
+This button will be Disabled if the button state is:
+
+  - Disabled
+  - Error
+  - Loading
+  - Success
+
+-}
+button : ButtonConfig msg -> ButtonContent -> Html msg
+button config content =
+    customButton [] config content
+
+
+{-| Exactly the same as button but you can pass in a list of attributes
+-}
+customButton : List (Html.Attribute msg) -> ButtonConfig msg -> ButtonContent -> Html msg
+customButton attributes config content =
+    let
+        buttonStyle =
+            case content.state of
+                Enabled ->
+                    styleToColorPalette config.style
+
+                Disabled ->
+                    InactiveColors
+
+                Error ->
+                    ErrorColors
+
+                Unfulfilled ->
+                    InactiveColors
+
+                Loading ->
+                    LoadingColors
+
+                Success ->
+                    SuccessColors
+
+        disabled =
+            case content.state of
+                Enabled ->
+                    False
+
+                Disabled ->
+                    True
+
+                Error ->
+                    True
+
+                Unfulfilled ->
+                    False
+
+                Loading ->
+                    True
+
+                Success ->
+                    True
+    in
+    Html.button
+        ([ buttonClass config.size config.width buttonStyle
+         , onClick config.onClick
+         , Html.Attributes.disabled disabled
+         , Html.Attributes.type_ "button"
+         , widthStyle config.width
+         ]
+            ++ attributes
+        )
+        (viewLabel content.icon content.label)
+
+
+widthStyle : Maybe Int -> Html.Attribute msg
+widthStyle width =
+    width
+        |> Maybe.map (\w -> [ ( "width", toString w ++ "px" ) ])
+        |> Maybe.withDefault []
+        |> style
+
+
+
+-- COPY TO CLIPBOARD BUTTON
+
+
+{-| Config for copyToClipboard
+-}
+type alias CopyToClipboardConfig =
+    { size : ButtonSize
+    , style : ButtonStyle
+    , copyText : String
+    , buttonLabel : String
+    , withIcon : Bool
+    , width : Maybe Int
+    }
+
+
+{-| See ui/src/Page/Teach/Courses/Assignments/index.coffee
+You will need to hook this up to clipboard.js
+-}
+copyToClipboard : { r | teach_assignments_copyWhite_svg : Asset } -> CopyToClipboardConfig -> Html msg
+copyToClipboard assets config =
+    let
+        maybeIcon =
+            if config.withIcon then
+                Just (Icon.copy assets)
+            else
+                Nothing
+    in
+    Html.button
+        [ buttonClass config.size config.width (styleToColorPalette config.style)
+        , styles.class [ CopyToClipboard ]
+        , Widget.label "Copy URL to clipboard"
+        , attribute "data-clipboard-text" config.copyText
+        , widthStyle config.width
+        ]
+        (viewLabel maybeIcon config.buttonLabel)
+
+
+
+-- DELETE BUTTON
+
+
+type alias DeleteButtonConfig msg =
+    { label : String
+    , onClick : msg
+    }
+
+
+{-| A delete button (blue X)
+-}
+delete : DeleteButtonConfig msg -> Html msg
+delete config =
+    Html.button
+        [ styles.class [ Delete ]
+        , onClick config.onClick
+        , type_ "button"
+        , -- reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Labeling_buttons
+          Widget.label config.label
+        ]
+        []
+
+
+
+-- TOGGLE BUTTON
+
+
+{-| Buttons can be toggled into a pressed state and back again.
+-}
+type alias ToggleButtonConfig msg =
+    { label : String
+    , onSelect : msg
+    , onDeselect : msg
+    , pressed : Bool
+    }
+
+
+{-| -}
+toggleButton : ToggleButtonConfig msg -> Html msg
+toggleButton config =
+    Html.button
+        (if config.pressed then
+            [ onClick config.onDeselect
+            , Widget.pressed <| Just True
+            , styles.class [ Button, Toggled, SizeStyle Medium ]
+
+            -- reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Labeling_buttons
+            , Role.button
+
+            -- Note: setting type: 'button' removes the default behavior of submit
+            -- equivalent to preventDefaultBehavior = false
+            -- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-name
+            , type_ "button"
+            ]
+         else
+            [ onClick config.onSelect
+            , Widget.pressed <| Just False
+            , buttonClass Medium Nothing SecondaryColors
+            , Role.button
+            , type_ "button"
+            ]
+        )
+        (viewLabel Nothing config.label)
+
+
+
+-- SUBMIT BUTTON
+
+
+{-| Inputs can be a clickable thing used in a form
+-}
+type alias InputConfig =
+    { content : Html Never
+    , name : String
+    , size : ButtonSize
+    , style : ButtonStyle
+    , value : String
+    }
+
+
+{-| A submit input that overrides the form's method to PUT
+-}
+submit : InputConfig -> Html c
+submit config =
+    Html.button
+        [ buttonClass config.size Nothing (styleToColorPalette config.style)
+        , name config.name
+        , type_ "submit"
+        , value config.value
+        ]
+        [ Html.map never config.content
+        ]
+
+
+
+-- LINKS THAT LOOK LIKE BUTTONS
+
+
+{-| Links are clickable things with a url.
+
+NOTE: Links do not support two-line labels.
+
+-}
+type alias LinkConfig =
+    { label : String
+    , icon : Maybe IconType
+    , url : String
+    , size : ButtonSize
+    , style : ButtonStyle
+    , width : Maybe Int
+    }
+
+
+{-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to
+some url
+-}
+link : LinkConfig -> Html msg
+link =
+    linkBase <| [ Html.Attributes.target "_self" ]
+
+
+{-| Use this link for routing within a single page app.
+
+This will make a normal <a> tag, but change the onClick behavior to avoid reloading the page.
+
+See <https://github.com/elm-lang/html/issues/110> for details on this implementation.
+
+-}
+linkSpa :
+    (route -> String)
+    -> (route -> msg)
+    ->
+        { label : String
+        , icon : Maybe IconType
+        , size : ButtonSize
+        , style : ButtonStyle
+        , width : Maybe Int
+        , route : route
+        }
+    -> Html.Styled.Html msg
+linkSpa toUrl toMsg config =
+    linkBase
+        [ EventExtras.onClickPreventDefaultForLinkWithHref (toMsg config.route)
+        ]
+        { label = config.label
+        , icon = config.icon
+        , size = config.size
+        , style = config.style
+        , width = config.width
+        , url = toUrl config.route
+        }
+        |> Html.Styled.fromUnstyled
+
+
+{-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to
+some url and have it open to an external site
+-}
+linkExternal : LinkConfig -> Html msg
+linkExternal =
+    linkBase <| [ Html.Attributes.target "_blank" ]
+
+
+{-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to
+some url, and it's an HTTP request (Rails includes JS to make this use the given HTTP method)
+-}
+linkWithMethod : String -> LinkConfig -> Html msg
+linkWithMethod method =
+    linkBase <| [ attribute "data-method" method ]
+
+
+{-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to some url.
+This should only take in messages that result in a Msg that triggers Analytics.trackAndRedirect. For buttons that trigger other effects on the page, please use Nri.Button.button instead
+-}
+linkWithTracking : msg -> LinkConfig -> Html msg
+linkWithTracking onTrack =
+    linkBase <|
+        [ Html.Events.onWithOptions "click"
+            { stopPropagation = False
+            , preventDefault = True
+            }
+            (Json.Decode.succeed onTrack)
+        ]
+
+
+{-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to some url and have it open to an external site
+
+This should only take in messages that result in tracking events. For buttons that trigger other effects on the page, please use Nri.Ui.Button.V2.button instead
+
+-}
+linkExternalWithTracking : msg -> LinkConfig -> Html msg
+linkExternalWithTracking onTrack =
+    linkBase <|
+        [ Html.Attributes.target "_blank"
+        , onClick onTrack
+        ]
+
+
+{-| Helper function for building links with an arbitrary number of Attributes
+-}
+linkBase : List (Html.Attribute msg) -> LinkConfig -> Html msg
+linkBase extraAttrs config =
+    let
+        widthAttributes =
+            Maybe.map
+                (\width ->
+                    [ style
+                        [ ( "width", toString width ++ "px" )
+                        , ( "max-width", "100%" )
+                        ]
+                    ]
+                )
+                config.width
+                |> Maybe.withDefault []
+    in
+    Html.a
+        (buttonClass config.size config.width (styleToColorPalette config.style)
+            :: styles.class [ IsLink ]
+            :: Html.Attributes.href config.url
+            :: widthAttributes
+            ++ extraAttrs
+        )
+        (viewLabel config.icon config.label)
+
+
+
+-- HELPERS
+
+
+type ColorPalette
+    = PrimaryColors
+    | SecondaryColors
+    | BorderlessColors
+    | DangerColors
+    | PremiumColors
+    | ActiveColors -- TODO: merge with Toggled
+    | InactiveColors
+    | LoadingColors
+    | SuccessColors
+    | ErrorColors
+
+
+styleToColorPalette : ButtonStyle -> ColorPalette
+styleToColorPalette style =
+    case style of
+        Primary ->
+            PrimaryColors
+
+        Secondary ->
+            SecondaryColors
+
+        Borderless ->
+            BorderlessColors
+
+        Danger ->
+            DangerColors
+
+        Premium ->
+            PremiumColors
+
+        Active ->
+            ActiveColors
+
+
+buttonClass : ButtonSize -> Maybe Int -> ColorPalette -> Html.Attribute msg
+buttonClass size width colorPalette =
+    styles.class <|
+        List.concat
+            [ [ Button
+              , SizeStyle size
+              , ColorsStyle colorPalette
+              ]
+            , case width of
+                Nothing ->
+                    []
+
+                Just _ ->
+                    [ ExplicitWidth ]
+            ]
+
+
+viewLabel : Maybe IconType -> String -> List (Html msg)
+viewLabel icn label =
+    case icn of
+        Nothing ->
+            renderMarkdown label
+
+        Just iconType ->
+            [ span [ styles.class [ LabelIconAndText ] ]
+                (decorativeIcon iconType
+                    :: renderMarkdown label
+                )
+            ]
+
+
+renderMarkdown : String -> List (Html msg)
+renderMarkdown markdown =
+    case Markdown.Block.parse Nothing markdown of
+        -- It seems to be always first wrapped in a `Paragraph` and never directly a `PlainInline`
+        [ Markdown.Block.Paragraph _ inlines ] ->
+            List.map Markdown.Inline.toHtml inlines
+
+        _ ->
+            [ Html.text markdown ]
+
+
+
+-- STYLES
+
+
+type CssClasses
+    = Button
+    | IsLink
+    | ExplicitWidth
+    | SizeStyle ButtonSize
+    | ColorsStyle ColorPalette
+    | LabelIconAndText
+    | Toggled
+    | Delete
+    | CopyToClipboard
+    | NewStyle
+
+
+{-| TODO: move this to elm-css?
+Cross-browser support for linear gradient backgrounds.
+
+Falls back to the top color if gradients are not supported.
+
+-}
+linearGradient : ( Css.ColorValue compatible1, Css.ColorValue compatible2 ) -> Css.Style
+linearGradient ( top, bottom ) =
+    Css.batch
+        [ Css.property "background" top.value -- Old browsers
+        , Css.property "background" ("-moz-linear-gradient(top," ++ top.value ++ " 0%," ++ bottom.value ++ " 100%)") -- FF3.6+
+        , Css.property "background" ("-webkit-gradient(linear,left top,left bottom,color-stop(0%," ++ top.value ++ "),color-stop(100%," ++ bottom.value ++ "))") -- Chrome, Safari 4+
+        , Css.property "background" ("-webkit-linear-gradient(top," ++ top.value ++ " 0%," ++ bottom.value ++ " 100%)") -- Chrome 10+, Safari 5.1+
+        , Css.property "background" ("-o-linear-gradient(top," ++ top.value ++ " 0%," ++ bottom.value ++ " 100%)") -- Opera 11.10+
+        , Css.property "background" ("-ms-linear-gradient(top," ++ top.value ++ " 0%," ++ bottom.value ++ " 100%)") -- IE10+
+        , Css.property "background" ("linear,to bottom," ++ top.value ++ " 0%," ++ bottom.value ++ " 100%") -- W3C
+        ]
+
+
+{-| Required CSS styles for `Nri.Ui.Button.V2`.
+-}
+styles : Styles.StylesWithAssets Never CssClasses msg { r | icons_xBlue_svg : Asset }
+styles =
+    let
+        sizeStyle size config =
+            Css.Foreign.class (SizeStyle size)
+                [ fontSize (px config.fontSize)
+                , borderRadius (px 8)
+                , Css.height (px config.height)
+                , lineHeight (px config.lineHeight)
+                , padding2 zero (px config.sidePadding)
+                , boxSizing borderBox
+                , minWidth (px config.minWidth)
+                , borderWidth (px 1)
+                , borderBottomWidth (px config.shadowHeight)
+                , Css.Foreign.withClass ExplicitWidth
+                    [ padding2 zero (px 4)
+                    , boxSizing borderBox
+                    ]
+                , Css.Foreign.withClass IsLink
+                    [ lineHeight (px config.height)
+                    ]
+                , Css.Foreign.descendants
+                    [ Css.Foreign.img
+                        [ Css.height (px config.imageHeight)
+                        , marginRight (px <| config.imageHeight / 6)
+                        , position relative
+                        , bottom (px 2)
+                        , verticalAlign middle
+                        ]
+                    , Css.Foreign.svg
+                        [ Css.height (px config.imageHeight) |> important
+                        , Css.width (px config.imageHeight) |> important
+                        , marginRight (px <| config.imageHeight / 6)
+                        , position relative
+                        , bottom (px 2)
+                        , verticalAlign middle
+                        ]
+                    , Css.Foreign.svg
+                        [ Css.important <| Css.height (px config.imageHeight)
+                        , Css.important <| Css.width auto
+                        , maxWidth (px (config.imageHeight * 1.25))
+                        , paddingRight (px <| config.imageHeight / 6)
+                        , position relative
+                        , bottom (px 2)
+                        , verticalAlign middle
+                        ]
+                    ]
+
+                -- Borderless buttons get bigger icons
+                , Css.Foreign.withClass (ColorsStyle BorderlessColors)
+                    [ Css.Foreign.descendants
+                        [ Css.Foreign.img
+                            [ Css.height (px (config.imageHeight * 1.6))
+                            , marginRight (px (config.imageHeight * 1.6 / 6))
+                            ]
+                        , Css.Foreign.svg
+                            [ Css.height (px (config.imageHeight * 1.6)) |> important
+                            , Css.width (px (config.imageHeight * 1.6)) |> important
+                            , marginRight (px (config.imageHeight * 1.6 / 6))
+                            ]
+                        , Css.Foreign.svg
+                            [ Css.important <| Css.height (px (config.imageHeight * 1.6))
+                            , Css.important <| Css.width auto
+                            , maxWidth (px (config.imageHeight * 1.25))
+                            , paddingRight (px (config.imageHeight * 1.6 / 6))
+                            , position relative
+                            , bottom (px 2)
+                            ]
+                        ]
+                    ]
+                ]
+
+        styleStyle style config =
+            Css.Foreign.class (ColorsStyle style)
+                [ color config.text
+                , backgroundColor config.background
+                , fontWeight (int 700)
+                , textAlign center
+                , case config.border of
+                    Nothing ->
+                        borderStyle none
+
+                    Just color ->
+                        Css.batch
+                            [ borderColor color
+                            , borderStyle solid
+                            ]
+                , borderBottomStyle solid
+                , borderBottomColor config.shadow
+                , fontStyle normal
+                , Css.hover
+                    [ color config.text
+                    , backgroundColor config.hover
+                    , Css.disabled
+                        [ backgroundColor config.background
+                        ]
+                    ]
+                , Css.visited
+                    [ color config.text
+                    ]
+                ]
+    in
+    Styles.stylesWithAssets "Nri-Ui-Button-V2-" <|
+        \assets ->
+            [ Css.Foreign.class Button
+                [ cursor pointer
+                , display inlineBlock
+                , -- Specifying the font can and should go away after bootstrap is removed from application.css
+                  Nri.Ui.Fonts.V1.baseFont
+                , textOverflow ellipsis
+                , overflow Css.hidden
+                , textDecoration none
+                , Css.property "background-image" "none"
+                , textShadow none
+                , Css.property "transition" "all 0.2s"
+                , Css.hover
+                    [ textDecoration none
+                    ]
+                , Css.disabled
+                    [ cursor notAllowed
+                    ]
+                , Css.Foreign.withClass IsLink
+                    [ whiteSpace noWrap
+                    ]
+                ]
+            , sizeStyle TinyDeprecated
+                { fontSize = 13
+                , height = 25
+                , lineHeight = 25
+                , sidePadding = 8
+                , minWidth = 50
+                , imageHeight = 0
+                , shadowHeight = 0
+                }
+            , sizeStyle Small
+                { fontSize = 15
+                , height = 36
+                , lineHeight = 15
+                , sidePadding = 16
+                , imageHeight = 15
+                , shadowHeight = 2
+                , minWidth = 75
+                }
+            , sizeStyle Medium
+                { fontSize = 17
+                , height = 45
+                , lineHeight = 19
+                , sidePadding = 16
+                , imageHeight = 15
+                , shadowHeight = 3
+                , minWidth = 100
+                }
+            , sizeStyle Large
+                { fontSize = 20
+                , height = 56
+                , lineHeight = 22
+                , sidePadding = 16
+                , imageHeight = 20
+                , shadowHeight = 4
+                , minWidth = 200
+                }
+            , styleStyle PrimaryColors
+                { background = Nri.Ui.Colors.V1.azure
+                , hover = Nri.Ui.Colors.V1.azureDark
+                , text = Nri.Ui.Colors.V1.white
+                , border = Nothing
+                , shadow = Nri.Ui.Colors.V1.azureDark
+                }
+            , styleStyle SecondaryColors
+                { background = Nri.Ui.Colors.V1.white
+                , hover = Nri.Ui.Colors.V1.glacier
+                , text = Nri.Ui.Colors.V1.azure
+                , border = Just <| Nri.Ui.Colors.V1.azure
+                , shadow = Nri.Ui.Colors.V1.azure
+                }
+            , styleStyle BorderlessColors
+                { background = transparent
+                , hover = transparent
+                , text = Nri.Ui.Colors.V1.azure
+                , border = Nothing
+                , shadow = transparent
+                }
+            , Css.Foreign.class (ColorsStyle BorderlessColors)
+                [ Css.hover
+                    [ textDecoration underline
+                    , Css.disabled
+                        [ textDecoration none
+                        ]
+                    ]
+                ]
+            , styleStyle DangerColors
+                { background = Nri.Ui.Colors.V1.red
+                , hover = Nri.Ui.Colors.V1.redDark
+                , text = Nri.Ui.Colors.V1.white
+                , border = Nothing
+                , shadow = Nri.Ui.Colors.V1.redDark
+                }
+            , styleStyle PremiumColors
+                { background = Nri.Ui.Colors.V1.yellow
+                , hover = Nri.Ui.Colors.V1.ochre
+                , text = Nri.Ui.Colors.V1.navy
+                , border = Nothing
+                , shadow = Nri.Ui.Colors.V1.ochre
+                }
+            , styleStyle LoadingColors
+                { background = Nri.Ui.Colors.V1.glacier
+                , hover = Nri.Ui.Colors.V1.glacier
+                , text = Nri.Ui.Colors.V1.navy
+                , border = Nothing
+                , shadow = Nri.Ui.Colors.V1.glacier
+                }
+            , styleStyle ErrorColors
+                { background = Nri.Ui.Colors.V1.purple
+                , hover = Nri.Ui.Colors.V1.purple
+                , text = Nri.Ui.Colors.V1.white
+                , border = Nothing
+                , shadow = Nri.Ui.Colors.V1.purple
+                }
+            , styleStyle InactiveColors
+                { background = Nri.Ui.Colors.V1.gray92
+                , hover = Nri.Ui.Colors.V1.gray92
+                , text = Nri.Ui.Colors.V1.gray45
+                , border = Nothing
+                , shadow = Nri.Ui.Colors.V1.gray92
+                }
+            , styleStyle ActiveColors
+                { background = Nri.Ui.Colors.V1.glacier
+                , hover = Nri.Ui.Colors.V1.glacier
+                , text = Nri.Ui.Colors.V1.navy
+                , border = Nothing
+                , shadow = Nri.Ui.Colors.V1.gray92
+                }
+            , Css.Foreign.class (ColorsStyle ActiveColors)
+                [ Css.boxShadow none
+                , Css.boxShadow5 inset zero (px 3) zero (withAlpha 0.2 Nri.Ui.Colors.V1.gray20)
+                , border3 (px 1) solid Nri.Ui.Colors.V1.azure
+                ]
+            , styleStyle SuccessColors
+                { background = Nri.Ui.Colors.V1.greenDark
+                , hover = Nri.Ui.Colors.V1.greenDark
+                , text = Nri.Ui.Colors.V1.white
+                , border = Nothing
+                , shadow = Nri.Ui.Colors.V1.greenDark
+                }
+            , Css.Foreign.class (ColorsStyle PremiumColors)
+                [ Css.property "box-shadow" "none"
+                , marginBottom zero
+                ]
+            , Css.Foreign.class (ColorsStyle InactiveColors)
+                [ Css.property "box-shadow" "none"
+                , Css.property "border" "none"
+                , marginBottom zero
+                ]
+            , Css.Foreign.class (ColorsStyle SuccessColors)
+                [ Css.property "box-shadow" "none"
+                , Css.property "border" "none"
+                , marginBottom zero
+                ]
+            , Css.Foreign.class (ColorsStyle ErrorColors)
+                [ Css.property "box-shadow" "none"
+                , Css.property "border" "none"
+                , marginBottom zero
+                ]
+            , Css.Foreign.class (ColorsStyle LoadingColors)
+                [ Css.property "box-shadow" "none"
+                , Css.property "border" "none"
+                , marginBottom zero
+                ]
+            , Css.Foreign.class Delete
+                [ display inlineBlock
+                , backgroundImage (url <| AssetPath.url assets.icons_xBlue_svg)
+                , backgroundRepeat noRepeat
+                , backgroundColor transparent
+                , backgroundPosition center
+                , backgroundSize contain
+                , Css.property "border" "none"
+                , Css.width (px 15)
+                , Css.height (px 15)
+                , margin2 zero (px 6)
+                , cursor pointer
+                ]
+            , Css.Foreign.class Toggled
+                [ color Nri.Ui.Colors.V1.gray20
+                , backgroundColor Nri.Ui.Colors.V1.glacier
+                , boxShadow5 inset zero (px 3) zero (withAlpha 0.2 Nri.Ui.Colors.V1.gray20)
+                , border3 (px 1) solid Nri.Ui.Colors.V1.azure
+                , fontWeight bold
+                ]
+            ]

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -349,10 +349,6 @@ toggleButton config =
         (viewLabel Nothing config.label)
 
 
-
--- SUBMIT BUTTON
-
-
 {-| Inputs can be a clickable thing used in a form
 -}
 type alias InputConfig =

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -216,19 +216,10 @@ customButton attributes config content =
         ([ onClick config.onClick
          , Attributes.disabled disabled
          , Attributes.type_ "button"
-         , widthStyle config.width
          ]
             ++ attributes
         )
         (viewLabel content.icon content.label)
-
-
-widthStyle : Maybe Int -> Attribute msg
-widthStyle width =
-    width
-        |> Maybe.map (\w -> [ ( "width", toString w ++ "px" ) ])
-        |> Maybe.withDefault []
-        |> Attributes.style
 
 
 
@@ -264,7 +255,6 @@ copyToClipboard assets config =
         (buttonStyles config.size config.width (styleToColorPalette config.style) Button)
         [ Widget.label "Copy URL to clipboard"
         , Attributes.attribute "data-clipboard-text" config.copyText
-        , widthStyle config.width
         ]
         (viewLabel maybeIcon config.buttonLabel)
 

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -70,16 +70,16 @@ import Css.Foreign
 import EventExtras
 import Html.Styled as Styled
 import Html.Styled.Attributes as Attributes
-import Html.Styled.Events as Events exposing (onClick)
+import Html.Styled.Events as Events
 import Json.Decode
 import Markdown.Block
 import Markdown.Inline
 import Nri.Ui
 import Nri.Ui.AssetPath as AssetPath exposing (Asset)
-import Nri.Ui.Colors.Extra exposing (withAlpha)
+import Nri.Ui.Colors.Extra as ColorsExtra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1
-import Nri.Ui.Icon.V3 as Icon exposing (IconType, decorativeIcon, icon)
+import Nri.Ui.Icon.V3 as Icon exposing (IconType)
 
 
 {-| Sizes for buttons and links that have button classes
@@ -213,7 +213,7 @@ customButton attributes config content =
     Nri.Ui.styled Html.button
         (styledName "customButton")
         (buttonStyles config.size config.width buttonStyle Button)
-        ([ onClick config.onClick
+        ([ Events.onClick config.onClick
          , Attributes.disabled disabled
          , Attributes.type_ "button"
          ]
@@ -288,7 +288,7 @@ delete assets config =
         , Css.cursor Css.pointer
         , Css.color Colors.azure
         ]
-        [ onClick config.onClick
+        [ Events.onClick config.onClick
         , Attributes.type_ "button"
         , -- reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Labeling_buttons
           Widget.label config.label
@@ -318,7 +318,7 @@ toggleButton config =
             if config.pressed then
                 [ Css.color Colors.gray20
                 , Css.backgroundColor Colors.glacier
-                , Css.boxShadow5 Css.inset Css.zero (Css.px 3) Css.zero (withAlpha 0.2 Colors.gray20)
+                , Css.boxShadow5 Css.inset Css.zero (Css.px 3) Css.zero (ColorsExtra.withAlpha 0.2 Colors.gray20)
                 , Css.border3 (Css.px 1) Css.solid Colors.azure
                 , Css.fontWeight Css.bold
                 ]
@@ -331,7 +331,7 @@ toggleButton config =
             ++ toggledStyles
         )
         (if config.pressed then
-            [ onClick config.onDeselect
+            [ Events.onClick config.onDeselect
             , Widget.pressed <| Just True
 
             -- reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Labeling_buttons
@@ -343,7 +343,7 @@ toggleButton config =
             , Attributes.type_ "button"
             ]
          else
-            [ onClick config.onSelect
+            [ Events.onClick config.onSelect
             , Widget.pressed <| Just False
             , Role.button
             , Attributes.type_ "button"
@@ -396,7 +396,7 @@ link =
 
 {-| Use this link for routing within a single page app.
 
-This will make a normal <a> tag, but change the onClick behavior to avoid reloading the page.
+This will make a normal <a> tag, but change the Events.onClick behavior to avoid reloading the page.
 
 See <https://github.com/elm-lang/html/issues/110> for details on this implementation.
 
@@ -468,7 +468,7 @@ linkExternalWithTracking : msg -> LinkConfig -> Html msg
 linkExternalWithTracking onTrack =
     linkBase
         "linkExternalWithTracking"
-        [ Attributes.target "_blank", onClick onTrack ]
+        [ Attributes.target "_blank", Events.onClick onTrack ]
 
 
 {-| Helper function for building links with an arbitrary number of Attributes
@@ -537,7 +537,7 @@ viewLabel icn label =
             renderMarkdown label
 
         Just iconType ->
-            [ Html.span [] (decorativeIcon iconType :: renderMarkdown label) ]
+            [ Html.span [] (Icon.decorativeIcon iconType :: renderMarkdown label) ]
 
 
 renderMarkdown : String -> List (Html msg)

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -538,8 +538,7 @@ renderMarkdown markdown =
     case Markdown.Block.parse Nothing markdown of
         -- It seems to be always first wrapped in a `Paragraph` and never directly a `PlainInline`
         [ Markdown.Block.Paragraph _ inlines ] ->
-            List.map Markdown.Inline.toHtml inlines
-                |> List.map Styled.fromUnstyled
+            List.map (Markdown.Inline.toHtml >> Styled.fromUnstyled) inlines
 
         _ ->
             [ Html.text markdown ]

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -293,11 +293,7 @@ delete assets config =
         , -- reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Labeling_buttons
           Widget.label config.label
         ]
-        [ Icon.icon
-            { alt = "Delete"
-            , icon = Icon.xSvg assets
-            }
-        ]
+        [ Icon.icon { alt = "Delete", icon = Icon.xSvg assets } ]
 
 
 
@@ -472,9 +468,7 @@ linkExternalWithTracking : msg -> LinkConfig -> Html msg
 linkExternalWithTracking onTrack =
     linkBase
         "linkExternalWithTracking"
-        [ Attributes.target "_blank"
-        , onClick onTrack
-        ]
+        [ Attributes.target "_blank", onClick onTrack ]
 
 
 {-| Helper function for building links with an arbitrary number of Attributes
@@ -483,9 +477,8 @@ linkBase : String -> List (Attribute msg) -> LinkConfig -> Html msg
 linkBase linkFunctionName extraAttrs config =
     Nri.Ui.styled Styled.a
         (styledName linkFunctionName)
-        (buttonStyles config.size config.width (styleToColorPalette config.style) Anchor
-            ++ [ Css.whiteSpace Css.noWrap
-               ]
+        (Css.whiteSpace Css.noWrap
+            :: buttonStyles config.size config.width (styleToColorPalette config.style) Anchor
         )
         (Attributes.href config.url
             :: extraAttrs
@@ -544,12 +537,7 @@ viewLabel icn label =
             renderMarkdown label
 
         Just iconType ->
-            [ Html.span
-                []
-                (decorativeIcon iconType
-                    :: renderMarkdown label
-                )
-            ]
+            [ Html.span [] (decorativeIcon iconType :: renderMarkdown label) ]
 
 
 renderMarkdown : String -> List (Html msg)
@@ -583,12 +571,8 @@ buttonStyle =
     , Css.boxShadow Css.none
     , Css.border Css.zero
     , Css.marginBottom Css.zero
-    , Css.hover
-        [ Css.textDecoration Css.none
-        ]
-    , Css.disabled
-        [ Css.cursor Css.notAllowed
-        ]
+    , Css.hover [ Css.textDecoration Css.none ]
+    , Css.disabled [ Css.cursor Css.notAllowed ]
     ]
 
 
@@ -626,9 +610,7 @@ colorStyle colorPalette =
                       }
                     , [ Css.hover
                             [ Css.textDecoration Css.underline
-                            , Css.disabled
-                                [ Css.textDecoration Css.none
-                                ]
+                            , Css.disabled [ Css.textDecoration Css.none ]
                             ]
                       ]
                     )
@@ -713,13 +695,9 @@ colorStyle colorPalette =
     , Css.hover
         [ Css.color config.text
         , Css.backgroundColor config.hover
-        , Css.disabled
-            [ Css.backgroundColor config.background
-            ]
+        , Css.disabled [ Css.backgroundColor config.background ]
         ]
-    , Css.visited
-        [ Css.color config.text
-        ]
+    , Css.visited [ Css.color config.text ]
     ]
 
 

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -211,8 +211,8 @@ customButton attributes config content =
                     True
     in
     Nri.Ui.styled Html.button
-        "nri-button-v3"
-        (buttonStyles config.size config.width buttonStyle)
+        "Nri-Button-V3-CustomButton"
+        (buttonStyles config.size config.width buttonStyle False)
         ([ onClick config.onClick
          , Attributes.disabled disabled
          , Attributes.type_ "button"
@@ -261,7 +261,7 @@ copyToClipboard assets config =
     in
     Nri.Ui.styled Html.button
         "Nri-Ui-Button-V3-copyToClipboard"
-        (buttonStyles config.size config.width (styleToColorPalette config.style))
+        (buttonStyles config.size config.width (styleToColorPalette config.style) False)
         [ Widget.label "Copy URL to clipboard"
         , attribute "data-clipboard-text" config.copyText
         , widthStyle config.width
@@ -341,7 +341,7 @@ toggleButton config =
     in
     Nri.Ui.styled Html.button
         "Nri-Ui-Button-V3-toggleButton"
-        (buttonStyles Medium Nothing SecondaryColors
+        (buttonStyles Medium Nothing SecondaryColors False
             ++ toggledStyles
         )
         (if config.pressed then
@@ -490,9 +490,9 @@ linkBase : List (Attribute msg) -> LinkConfig -> Html msg
 linkBase extraAttrs config =
     Nri.Ui.styled Html.a
         "Nri-Button-V3-linkBase"
-        (buttonStyles config.size config.width (styleToColorPalette config.style)
-            ++ [ whiteSpace noWrap ]
-         -- TODO: Validate link text doesn't wrap and uses correct line height
+        (buttonStyles config.size config.width (styleToColorPalette config.style) True
+            ++ [ whiteSpace noWrap
+               ]
         )
         (Attributes.href config.url
             :: extraAttrs
@@ -535,12 +535,12 @@ styleToColorPalette style =
             PremiumColors
 
 
-buttonStyles : ButtonSize -> Maybe Int -> ColorPalette -> List Style
-buttonStyles size width colorPalette =
+buttonStyles : ButtonSize -> Maybe Int -> ColorPalette -> Bool -> List Style
+buttonStyles size width colorPalette isLink =
     List.concat
         [ buttonStyle
         , colorStyle colorPalette
-        , sizeStyle size width
+        , sizeStyle size width isLink
         ]
 
 
@@ -604,11 +604,6 @@ buttonStyle =
 colorStyle : ColorPalette -> List Style
 colorStyle colorPalette =
     let
-        --         , Css.Foreign.class (ColorsStyle LoadingColors)
-        --             [ Css.property "box-shadow" "none"
-        --             , Css.property "border" "none"
-        --             , marginBottom zero
-        --             ]
         ( config, additionalStyles ) =
             case colorPalette of
                 PrimaryColors ->
@@ -758,8 +753,8 @@ colorStyle colorPalette =
     ]
 
 
-sizeStyle : ButtonSize -> Maybe Int -> List Style
-sizeStyle size width =
+sizeStyle : ButtonSize -> Maybe Int -> Bool -> List Style
+sizeStyle size width isLink =
     let
         config =
             case size of
@@ -806,11 +801,17 @@ sizeStyle size width =
                         [ padding2 zero (px config.sidePadding)
                         , minWidth (px config.minWidth)
                         ]
+
+        lineHeightPx =
+            if isLink then
+                config.height
+            else
+                config.lineHeight
     in
     [ fontSize (px config.fontSize)
     , borderRadius (px 8)
     , Css.height (px config.height)
-    , lineHeight (px config.lineHeight)
+    , lineHeight (px lineHeightPx)
     , boxSizing borderBox
     , borderWidth (px 1)
     , borderBottomWidth (px config.shadowHeight)

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -62,14 +62,14 @@ There will generally be a `*Button` and `*Link` version of each button style.
 
 -- import EventExtras
 
-import Accessibility.Styled as Html exposing (..)
+import Accessibility.Styled as Html exposing (Attribute, Html)
 import Accessibility.Styled.Role as Role
 import Accessibility.Styled.Widget as Widget
-import Css exposing (..)
+import Css exposing (Style)
 import Css.Foreign
 import EventExtras
 import Html.Styled as Styled
-import Html.Styled.Attributes as Attributes exposing (..)
+import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events exposing (onClick)
 import Json.Decode
 import Markdown.Block
@@ -228,7 +228,7 @@ widthStyle width =
     width
         |> Maybe.map (\w -> [ ( "width", toString w ++ "px" ) ])
         |> Maybe.withDefault []
-        |> style
+        |> Attributes.style
 
 
 
@@ -263,7 +263,7 @@ copyToClipboard assets config =
         (styledName "copyToClipboard")
         (buttonStyles config.size config.width (styleToColorPalette config.style) Button)
         [ Widget.label "Copy URL to clipboard"
-        , attribute "data-clipboard-text" config.copyText
+        , Attributes.attribute "data-clipboard-text" config.copyText
         , widthStyle config.width
         ]
         (viewLabel maybeIcon config.buttonLabel)
@@ -285,21 +285,21 @@ delete : { r | x : String } -> DeleteButtonConfig msg -> Html msg
 delete assets config =
     Nri.Ui.styled Html.button
         (styledName "delete")
-        [ display inlineBlock
-        , backgroundRepeat noRepeat
-        , backgroundColor transparent
-        , backgroundPosition center
-        , backgroundSize contain
+        [ Css.display Css.inlineBlock
+        , Css.backgroundRepeat Css.noRepeat
+        , Css.backgroundColor Css.transparent
+        , Css.backgroundPosition Css.center
+        , Css.backgroundSize Css.contain
         , Css.property "border" "none"
-        , Css.width (px 15)
-        , Css.height (px 15)
-        , padding zero
-        , margin2 zero (px 6)
-        , cursor pointer
-        , color Colors.azure
+        , Css.width (Css.px 15)
+        , Css.height (Css.px 15)
+        , Css.padding Css.zero
+        , Css.margin2 Css.zero (Css.px 6)
+        , Css.cursor Css.pointer
+        , Css.color Colors.azure
         ]
         [ onClick config.onClick
-        , type_ "button"
+        , Attributes.type_ "button"
         , -- reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Labeling_buttons
           Widget.label config.label
         ]
@@ -330,11 +330,11 @@ toggleButton config =
     let
         toggledStyles =
             if config.pressed then
-                [ color Colors.gray20
-                , backgroundColor Colors.glacier
-                , boxShadow5 inset zero (px 3) zero (withAlpha 0.2 Colors.gray20)
-                , border3 (px 1) solid Colors.azure
-                , fontWeight bold
+                [ Css.color Colors.gray20
+                , Css.backgroundColor Colors.glacier
+                , Css.boxShadow5 Css.inset Css.zero (Css.px 3) Css.zero (withAlpha 0.2 Colors.gray20)
+                , Css.border3 (Css.px 1) Css.solid Colors.azure
+                , Css.fontWeight Css.bold
                 ]
             else
                 []
@@ -354,13 +354,13 @@ toggleButton config =
             -- Note: setting type: 'button' removes the default behavior of submit
             -- equivalent to preventDefaultBehavior = false
             -- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-name
-            , type_ "button"
+            , Attributes.type_ "button"
             ]
          else
             [ onClick config.onSelect
             , Widget.pressed <| Just False
             , Role.button
-            , type_ "button"
+            , Attributes.type_ "button"
             ]
         )
         (viewLabel Nothing config.label)
@@ -455,7 +455,7 @@ some url, and it's an HTTP request (Rails includes JS to make this use the given
 -}
 linkWithMethod : String -> LinkConfig -> Html msg
 linkWithMethod method =
-    linkBase "linkWithMethod" [ attribute "data-method" method ]
+    linkBase "linkWithMethod" [ Attributes.attribute "data-method" method ]
 
 
 {-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to some url.
@@ -494,7 +494,7 @@ linkBase linkFunctionName extraAttrs config =
     Nri.Ui.styled Styled.a
         (styledName linkFunctionName)
         (buttonStyles config.size config.width (styleToColorPalette config.style) Anchor
-            ++ [ whiteSpace noWrap
+            ++ [ Css.whiteSpace Css.noWrap
                ]
         )
         (Attributes.href config.url
@@ -554,7 +554,7 @@ viewLabel icn label =
             renderMarkdown label
 
         Just iconType ->
-            [ span
+            [ Html.span
                 []
                 (decorativeIcon iconType
                     :: renderMarkdown label
@@ -580,24 +580,24 @@ renderMarkdown markdown =
 
 buttonStyle : List Style
 buttonStyle =
-    [ cursor pointer
-    , display inlineBlock
+    [ Css.cursor Css.pointer
+    , Css.display Css.inlineBlock
     , -- Specifying the font can and should go away after bootstrap is removed from application.css
       Nri.Ui.Fonts.V1.baseFont
-    , textOverflow ellipsis
-    , overflow Css.hidden
-    , textDecoration none
+    , Css.textOverflow Css.ellipsis
+    , Css.overflow Css.hidden
+    , Css.textDecoration Css.none
     , Css.property "background-image" "none"
-    , textShadow none
+    , Css.textShadow Css.none
     , Css.property "transition" "all 0.2s"
-    , boxShadow none
-    , border zero
-    , marginBottom zero
+    , Css.boxShadow Css.none
+    , Css.border Css.zero
+    , Css.marginBottom Css.zero
     , Css.hover
-        [ textDecoration none
+        [ Css.textDecoration Css.none
         ]
     , Css.disabled
-        [ cursor notAllowed
+        [ Css.cursor Css.notAllowed
         ]
     ]
 
@@ -628,16 +628,16 @@ colorStyle colorPalette =
                     )
 
                 BorderlessColors ->
-                    ( { background = rgba 0 0 0 0
-                      , hover = rgba 0 0 0 0
+                    ( { background = Css.rgba 0 0 0 0
+                      , hover = Css.rgba 0 0 0 0
                       , text = Colors.azure
                       , border = Nothing
-                      , shadow = rgba 0 0 0 0
+                      , shadow = Css.rgba 0 0 0 0
                       }
                     , [ Css.hover
-                            [ textDecoration underline
+                            [ Css.textDecoration Css.underline
                             , Css.disabled
-                                [ textDecoration none
+                                [ Css.textDecoration Css.none
                                 ]
                             ]
                       ]
@@ -703,32 +703,32 @@ colorStyle colorPalette =
                     , []
                     )
     in
-    [ batch additionalStyles
-    , color config.text
-    , backgroundColor config.background
-    , fontWeight (int 700)
-    , textAlign center
+    [ Css.batch additionalStyles
+    , Css.color config.text
+    , Css.backgroundColor config.background
+    , Css.fontWeight (Css.int 700)
+    , Css.textAlign Css.center
     , case config.border of
         Nothing ->
-            borderStyle none
+            Css.borderStyle Css.none
 
         Just color ->
             Css.batch
-                [ borderColor color
-                , borderStyle solid
+                [ Css.borderColor color
+                , Css.borderStyle Css.solid
                 ]
-    , borderBottomStyle solid
-    , borderBottomColor config.shadow
-    , fontStyle normal
+    , Css.borderBottomStyle Css.solid
+    , Css.borderBottomColor config.shadow
+    , Css.fontStyle Css.normal
     , Css.hover
-        [ color config.text
-        , backgroundColor config.hover
+        [ Css.color config.text
+        , Css.backgroundColor config.hover
         , Css.disabled
-            [ backgroundColor config.background
+            [ Css.backgroundColor config.background
             ]
         ]
     , Css.visited
-        [ color config.text
+        [ Css.color config.text
         ]
     ]
 
@@ -776,15 +776,15 @@ sizeStyle size width elementType =
         widthAttributes =
             case width of
                 Just pxWidth ->
-                    batch
-                        [ maxWidth (pct 100)
-                        , Css.width (px <| toFloat pxWidth)
+                    Css.batch
+                        [ Css.maxWidth (Css.pct 100)
+                        , Css.width (Css.px <| toFloat pxWidth)
                         ]
 
                 Nothing ->
-                    batch
-                        [ padding2 zero (px config.sidePadding)
-                        , minWidth (px config.minWidth)
+                    Css.batch
+                        [ Css.padding2 Css.zero (Css.px config.sidePadding)
+                        , Css.minWidth (Css.px config.minWidth)
                         ]
 
         lineHeightPx =
@@ -795,38 +795,38 @@ sizeStyle size width elementType =
                 Button ->
                     config.lineHeight
     in
-    [ fontSize (px config.fontSize)
-    , borderRadius (px 8)
-    , Css.height (px config.height)
-    , lineHeight (px lineHeightPx)
-    , boxSizing borderBox
-    , borderWidth (px 1)
-    , borderBottomWidth (px config.shadowHeight)
+    [ Css.fontSize (Css.px config.fontSize)
+    , Css.borderRadius (Css.px 8)
+    , Css.height (Css.px config.height)
+    , Css.lineHeight (Css.px lineHeightPx)
+    , Css.boxSizing Css.borderBox
+    , Css.borderWidth (Css.px 1)
+    , Css.borderBottomWidth (Css.px config.shadowHeight)
     , widthAttributes
     , Css.Foreign.descendants
         [ Css.Foreign.img
-            [ Css.height (px config.imageHeight)
-            , marginRight (px <| config.imageHeight / 6)
-            , position relative
-            , bottom (px 2)
-            , verticalAlign middle
+            [ Css.height (Css.px config.imageHeight)
+            , Css.marginRight (Css.px <| config.imageHeight / 6)
+            , Css.position Css.relative
+            , Css.bottom (Css.px 2)
+            , Css.verticalAlign Css.middle
             ]
         , Css.Foreign.svg
-            [ Css.height (px config.imageHeight) |> important
-            , Css.width (px config.imageHeight) |> important
-            , marginRight (px <| config.imageHeight / 6)
-            , position relative
-            , bottom (px 2)
-            , verticalAlign middle
+            [ Css.height (Css.px config.imageHeight) |> Css.important
+            , Css.width (Css.px config.imageHeight) |> Css.important
+            , Css.marginRight (Css.px <| config.imageHeight / 6)
+            , Css.position Css.relative
+            , Css.bottom (Css.px 2)
+            , Css.verticalAlign Css.middle
             ]
         , Css.Foreign.svg
-            [ Css.important <| Css.height (px config.imageHeight)
-            , Css.important <| Css.width auto
-            , maxWidth (px (config.imageHeight * 1.25))
-            , paddingRight (px <| config.imageHeight / 6)
-            , position relative
-            , bottom (px 2)
-            , verticalAlign middle
+            [ Css.important <| Css.height (Css.px config.imageHeight)
+            , Css.important <| Css.width Css.auto
+            , Css.maxWidth (Css.px (config.imageHeight * 1.25))
+            , Css.paddingRight (Css.px <| config.imageHeight / 6)
+            , Css.position Css.relative
+            , Css.bottom (Css.px 2)
+            , Css.verticalAlign Css.middle
             ]
         ]
     ]

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -280,7 +280,7 @@ delete assets config =
         , Css.backgroundColor Css.transparent
         , Css.backgroundPosition Css.center
         , Css.backgroundSize Css.contain
-        , Css.property "border" "none"
+        , Css.border Css.zero
         , Css.width (Css.px 15)
         , Css.height (Css.px 15)
         , Css.padding Css.zero
@@ -577,7 +577,7 @@ buttonStyle =
     , Css.textOverflow Css.ellipsis
     , Css.overflow Css.hidden
     , Css.textDecoration Css.none
-    , Css.property "background-image" "none"
+    , Css.backgroundImage Css.none
     , Css.textShadow Css.none
     , Css.property "transition" "all 0.2s"
     , Css.boxShadow Css.none

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -741,16 +741,14 @@ sizeStyle size width elementType =
         widthAttributes =
             case width of
                 Just pxWidth ->
-                    Css.batch
-                        [ Css.maxWidth (Css.pct 100)
-                        , Css.width (Css.px <| toFloat pxWidth)
-                        ]
+                    [ Css.maxWidth (Css.pct 100)
+                    , Css.width (Css.px <| toFloat pxWidth)
+                    ]
 
                 Nothing ->
-                    Css.batch
-                        [ Css.padding2 Css.zero (Css.px config.sidePadding)
-                        , Css.minWidth (Css.px config.minWidth)
-                        ]
+                    [ Css.padding2 Css.zero (Css.px config.sidePadding)
+                    , Css.minWidth (Css.px config.minWidth)
+                    ]
 
         lineHeightPx =
             case elementType of
@@ -767,7 +765,7 @@ sizeStyle size width elementType =
     , Css.boxSizing Css.borderBox
     , Css.borderWidth (Css.px 1)
     , Css.borderBottomWidth (Css.px config.shadowHeight)
-    , widthAttributes
+    , Css.batch widthAttributes
     , Css.Foreign.descendants
         [ Css.Foreign.img
             [ Css.height (Css.px config.imageHeight)

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -211,7 +211,7 @@ customButton attributes config content =
                     True
     in
     Nri.Ui.styled Html.button
-        "Nri-Button-V3-CustomButton"
+        (styledName "customButton")
         (buttonStyles config.size config.width buttonStyle Button)
         ([ onClick config.onClick
          , Attributes.disabled disabled
@@ -260,7 +260,7 @@ copyToClipboard assets config =
                 Nothing
     in
     Nri.Ui.styled Html.button
-        "Nri-Ui-Button-V3-copyToClipboard"
+        (styledName "copyToClipboard")
         (buttonStyles config.size config.width (styleToColorPalette config.style) Button)
         [ Widget.label "Copy URL to clipboard"
         , attribute "data-clipboard-text" config.copyText
@@ -284,7 +284,7 @@ type alias DeleteButtonConfig msg =
 delete : { r | x : String } -> DeleteButtonConfig msg -> Html msg
 delete assets config =
     Nri.Ui.styled Html.button
-        "Nri-Button-V3-delete"
+        (styledName "delete")
         [ display inlineBlock
         , backgroundRepeat noRepeat
         , backgroundColor transparent
@@ -340,7 +340,7 @@ toggleButton config =
                 []
     in
     Nri.Ui.styled Html.button
-        "Nri-Ui-Button-V3-toggleButton"
+        (styledName "toggleButton")
         (buttonStyles Medium Nothing SecondaryColors Button
             ++ toggledStyles
         )
@@ -405,7 +405,7 @@ some url
 -}
 link : LinkConfig -> Html msg
 link =
-    linkBase <| [ Attributes.target "_self" ]
+    linkBase "link" [ Attributes.target "_self" ]
 
 
 {-| Use this link for routing within a single page app.
@@ -429,6 +429,7 @@ linkSpa :
     -> Html msg
 linkSpa toUrl toMsg config =
     linkBase
+        "linkSpa"
         [ EventExtras.onClickPreventDefaultForLinkWithHref (toMsg config.route)
             |> Attributes.fromUnstyled
         ]
@@ -446,7 +447,7 @@ some url and have it open to an external site
 -}
 linkExternal : LinkConfig -> Html msg
 linkExternal =
-    linkBase <| [ Attributes.target "_blank" ]
+    linkBase "linkExternal" [ Attributes.target "_blank" ]
 
 
 {-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to
@@ -454,7 +455,7 @@ some url, and it's an HTTP request (Rails includes JS to make this use the given
 -}
 linkWithMethod : String -> LinkConfig -> Html msg
 linkWithMethod method =
-    linkBase <| [ attribute "data-method" method ]
+    linkBase "linkWithMethod" [ attribute "data-method" method ]
 
 
 {-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to some url.
@@ -462,7 +463,8 @@ This should only take in messages that result in a Msg that triggers Analytics.t
 -}
 linkWithTracking : msg -> LinkConfig -> Html msg
 linkWithTracking onTrack =
-    linkBase <|
+    linkBase
+        "linkWithTracking"
         [ Events.onWithOptions "click"
             { stopPropagation = False
             , preventDefault = True
@@ -478,7 +480,8 @@ This should only take in messages that result in tracking events. For buttons th
 -}
 linkExternalWithTracking : msg -> LinkConfig -> Html msg
 linkExternalWithTracking onTrack =
-    linkBase <|
+    linkBase
+        "linkExternalWithTracking"
         [ Attributes.target "_blank"
         , onClick onTrack
         ]
@@ -486,10 +489,10 @@ linkExternalWithTracking onTrack =
 
 {-| Helper function for building links with an arbitrary number of Attributes
 -}
-linkBase : List (Attribute msg) -> LinkConfig -> Html msg
-linkBase extraAttrs config =
+linkBase : String -> List (Attribute msg) -> LinkConfig -> Html msg
+linkBase linkFunctionName extraAttrs config =
     Nri.Ui.styled Html.a
-        "Nri-Button-V3-linkBase"
+        (styledName linkFunctionName)
         (buttonStyles config.size config.width (styleToColorPalette config.style) Anchor
             ++ [ whiteSpace noWrap
                ]
@@ -827,3 +830,8 @@ sizeStyle size width elementType =
             ]
         ]
     ]
+
+
+styledName : String -> String
+styledName suffix =
+    "Nri-Ui-Button-V3-" ++ suffix

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -591,81 +591,127 @@ buttonStyle =
 colorStyle : ColorPalette -> List Style
 colorStyle colorPalette =
     let
-        config =
+        ( config, additionalStyles ) =
             case colorPalette of
                 PrimaryColors ->
-                    { background = Nri.Ui.Colors.V1.azure
-                    , hover = Nri.Ui.Colors.V1.azureDark
-                    , text = Nri.Ui.Colors.V1.white
-                    , border = Nothing
-                    , shadow = Nri.Ui.Colors.V1.azureDark
-                    }
+                    ( { background = Nri.Ui.Colors.V1.azure
+                      , hover = Nri.Ui.Colors.V1.azureDark
+                      , text = Nri.Ui.Colors.V1.white
+                      , border = Nothing
+                      , shadow = Nri.Ui.Colors.V1.azureDark
+                      }
+                    , []
+                    )
 
                 SecondaryColors ->
-                    { background = Nri.Ui.Colors.V1.white
-                    , hover = Nri.Ui.Colors.V1.glacier
-                    , text = Nri.Ui.Colors.V1.azure
-                    , border = Just <| Nri.Ui.Colors.V1.azure
-                    , shadow = Nri.Ui.Colors.V1.azure
-                    }
+                    ( { background = Nri.Ui.Colors.V1.white
+                      , hover = Nri.Ui.Colors.V1.glacier
+                      , text = Nri.Ui.Colors.V1.azure
+                      , border = Just <| Nri.Ui.Colors.V1.azure
+                      , shadow = Nri.Ui.Colors.V1.azure
+                      }
+                    , []
+                    )
 
                 BorderlessColors ->
-                    { background = rgba 0 0 0 0
-                    , hover = rgba 0 0 0 0
-                    , text = Nri.Ui.Colors.V1.azure
-                    , border = Nothing
-                    , shadow = rgba 0 0 0 0
-                    }
+                    ( { background = rgba 0 0 0 0
+                      , hover = rgba 0 0 0 0
+                      , text = Nri.Ui.Colors.V1.azure
+                      , border = Nothing
+                      , shadow = rgba 0 0 0 0
+                      }
+                    , [ Css.hover
+                            [ textDecoration underline
+                            , Css.disabled
+                                [ textDecoration none
+                                ]
+                            ]
+                      ]
+                      -- TODO: Weird case with borderless
+                      -- , [ Css.Foreign.descendants
+                      --         [ Css.Foreign.img
+                      --             [ Css.height (px (config.imageHeight * 1.6))
+                      --             , marginRight (px (config.imageHeight * 1.6 / 6))
+                      --             ]
+                      --         , Css.Foreign.svg
+                      --             [ Css.height (px (config.imageHeight * 1.6)) |> important
+                      --             , Css.width (px (config.imageHeight * 1.6)) |> important
+                      --             , marginRight (px (config.imageHeight * 1.6 / 6))
+                      --             ]
+                      --         , Css.Foreign.svg
+                      --             [ Css.important <| Css.height (px (config.imageHeight * 1.6))
+                      --             , Css.important <| Css.width auto
+                      --             , maxWidth (px (config.imageHeight * 1.25))
+                      --             , paddingRight (px (config.imageHeight * 1.6 / 6))
+                      --             , position relative
+                      --             , bottom (px 2)
+                      --             ]
+                      --         ]
+                      --   ]
+                    )
 
                 DangerColors ->
-                    { background = Nri.Ui.Colors.V1.red
-                    , hover = Nri.Ui.Colors.V1.redDark
-                    , text = Nri.Ui.Colors.V1.white
-                    , border = Nothing
-                    , shadow = Nri.Ui.Colors.V1.redDark
-                    }
+                    ( { background = Nri.Ui.Colors.V1.red
+                      , hover = Nri.Ui.Colors.V1.redDark
+                      , text = Nri.Ui.Colors.V1.white
+                      , border = Nothing
+                      , shadow = Nri.Ui.Colors.V1.redDark
+                      }
+                    , []
+                    )
 
                 PremiumColors ->
-                    { background = Nri.Ui.Colors.V1.yellow
-                    , hover = Nri.Ui.Colors.V1.ochre
-                    , text = Nri.Ui.Colors.V1.navy
-                    , border = Nothing
-                    , shadow = Nri.Ui.Colors.V1.ochre
-                    }
+                    ( { background = Nri.Ui.Colors.V1.yellow
+                      , hover = Nri.Ui.Colors.V1.ochre
+                      , text = Nri.Ui.Colors.V1.navy
+                      , border = Nothing
+                      , shadow = Nri.Ui.Colors.V1.ochre
+                      }
+                    , []
+                    )
 
                 InactiveColors ->
-                    { background = Nri.Ui.Colors.V1.gray92
-                    , hover = Nri.Ui.Colors.V1.gray92
-                    , text = Nri.Ui.Colors.V1.gray45
-                    , border = Nothing
-                    , shadow = Nri.Ui.Colors.V1.gray92
-                    }
+                    ( { background = Nri.Ui.Colors.V1.gray92
+                      , hover = Nri.Ui.Colors.V1.gray92
+                      , text = Nri.Ui.Colors.V1.gray45
+                      , border = Nothing
+                      , shadow = Nri.Ui.Colors.V1.gray92
+                      }
+                    , []
+                    )
 
                 LoadingColors ->
-                    { background = Nri.Ui.Colors.V1.glacier
-                    , hover = Nri.Ui.Colors.V1.glacier
-                    , text = Nri.Ui.Colors.V1.navy
-                    , border = Nothing
-                    , shadow = Nri.Ui.Colors.V1.glacier
-                    }
+                    ( { background = Nri.Ui.Colors.V1.glacier
+                      , hover = Nri.Ui.Colors.V1.glacier
+                      , text = Nri.Ui.Colors.V1.navy
+                      , border = Nothing
+                      , shadow = Nri.Ui.Colors.V1.glacier
+                      }
+                    , []
+                    )
 
                 SuccessColors ->
-                    { background = Nri.Ui.Colors.V1.greenDark
-                    , hover = Nri.Ui.Colors.V1.greenDark
-                    , text = Nri.Ui.Colors.V1.white
-                    , border = Nothing
-                    , shadow = Nri.Ui.Colors.V1.greenDark
-                    }
+                    ( { background = Nri.Ui.Colors.V1.greenDark
+                      , hover = Nri.Ui.Colors.V1.greenDark
+                      , text = Nri.Ui.Colors.V1.white
+                      , border = Nothing
+                      , shadow = Nri.Ui.Colors.V1.greenDark
+                      }
+                    , []
+                    )
 
                 ErrorColors ->
-                    { background = Nri.Ui.Colors.V1.purple
-                    , hover = Nri.Ui.Colors.V1.purple
-                    , text = Nri.Ui.Colors.V1.white
-                    , border = Nothing
-                    , shadow = Nri.Ui.Colors.V1.purple
-                    }
+                    ( { background = Nri.Ui.Colors.V1.purple
+                      , hover = Nri.Ui.Colors.V1.purple
+                      , text = Nri.Ui.Colors.V1.white
+                      , border = Nothing
+                      , shadow = Nri.Ui.Colors.V1.purple
+                      }
+                    , []
+                    )
     in
-    [ color config.text
+    [ batch additionalStyles
+    , color config.text
     , backgroundColor config.background
     , fontWeight (int 700)
     , textAlign center
@@ -777,54 +823,10 @@ sizeStyle size width =
             , verticalAlign middle
             ]
         ]
-
-    -- type CssClasses
-    --     = IsLink
-    --     | ExplicitWidth
-    --     | SizeStyle ButtonSize
-    --     | Toggled
-    --     | Delete
-    --     | NewStyle
-    -- styles : Styles.StylesWithAssets Never CssClasses msg { r | icons_xBlue_svg : Asset }
-    -- styles =
-    -- let
-    -- Borderless buttons get bigger icons
-    -- , Css.Foreign.withClass (ColorsStyle BorderlessColors)
-    --     [ Css.Foreign.descendants
-    --         [ Css.Foreign.img
-    --             [ Css.height (px (config.imageHeight * 1.6))
-    --             , marginRight (px (config.imageHeight * 1.6 / 6))
-    --             ]
-    --         , Css.Foreign.svg
-    --             [ Css.height (px (config.imageHeight * 1.6)) |> important
-    --             , Css.width (px (config.imageHeight * 1.6)) |> important
-    --             , marginRight (px (config.imageHeight * 1.6 / 6))
-    --             ]
-    --         , Css.Foreign.svg
-    --             [ Css.important <| Css.height (px (config.imageHeight * 1.6))
-    --             , Css.important <| Css.width auto
-    --             , maxWidth (px (config.imageHeight * 1.25))
-    --             , paddingRight (px (config.imageHeight * 1.6 / 6))
-    --             , position relative
-    --             , bottom (px 2)
-    --             ]
-    --         ]
-    -- ]
     ]
 
 
 
--- in
--- Styles.stylesWithAssets "Nri-Ui-Button-V2-" <|
---     \assets ->
---         , Css.Foreign.class (ColorsStyle BorderlessColors)
---             [ Css.hover
---                 [ textDecoration underline
---                 , Css.disabled
---                     [ textDecoration none
---                     ]
---                 ]
---             ]
 --         , Css.Foreign.class (ColorsStyle PremiumColors)
 --             [ Css.property "box-shadow" "none"
 --             , marginBottom zero

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -707,7 +707,6 @@ sizeStyle size width elementType =
                 Small ->
                     { fontSize = 15
                     , height = 36
-                    , sidePadding = 16
                     , imageHeight = 15
                     , shadowHeight = 2
                     , minWidth = 75
@@ -716,7 +715,6 @@ sizeStyle size width elementType =
                 Medium ->
                     { fontSize = 17
                     , height = 45
-                    , sidePadding = 16
                     , imageHeight = 15
                     , shadowHeight = 3
                     , minWidth = 100
@@ -725,7 +723,6 @@ sizeStyle size width elementType =
                 Large ->
                     { fontSize = 20
                     , height = 56
-                    , sidePadding = 16
                     , imageHeight = 20
                     , shadowHeight = 4
                     , minWidth = 200
@@ -739,7 +736,7 @@ sizeStyle size width elementType =
                     ]
 
                 Nothing ->
-                    [ Css.padding2 Css.zero (Css.px config.sidePadding)
+                    [ Css.padding2 Css.zero (Css.px 16)
                     , Css.minWidth (Css.px config.minWidth)
                     ]
 

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -707,7 +707,6 @@ sizeStyle size width elementType =
                 Small ->
                     { fontSize = 15
                     , height = 36
-                    , lineHeight = 15
                     , sidePadding = 16
                     , imageHeight = 15
                     , shadowHeight = 2
@@ -717,7 +716,6 @@ sizeStyle size width elementType =
                 Medium ->
                     { fontSize = 17
                     , height = 45
-                    , lineHeight = 19
                     , sidePadding = 16
                     , imageHeight = 15
                     , shadowHeight = 3
@@ -727,7 +725,6 @@ sizeStyle size width elementType =
                 Large ->
                     { fontSize = 20
                     , height = 56
-                    , lineHeight = 22
                     , sidePadding = 16
                     , imageHeight = 20
                     , shadowHeight = 4
@@ -752,7 +749,15 @@ sizeStyle size width elementType =
                     config.height
 
                 Button ->
-                    config.lineHeight
+                    case size of
+                        Small ->
+                            15
+
+                        Medium ->
+                            19
+
+                        Large ->
+                            22
     in
     [ Css.fontSize (Css.px config.fontSize)
     , Css.borderRadius (Css.px 8)

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -113,7 +113,7 @@ type ButtonStyle
   - Disabled: A button which appears with the InactiveColors palette and is disabled.
   - Error: A button which appears with the ErrorColors palette and is disabled.
   - Loading: A button which appears with the LoadingColors palette and is disabled
-  - Success: A button which appears with the InactiveColors palette and is disabled
+  - Success: A button which appears with the SuccessColors palette and is disabled
 
 -}
 type ButtonState

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -265,8 +265,7 @@ copyToClipboard assets config =
     Nri.Ui.styled Html.button
         "Nri-Ui-Button-V3-copyToClipboard"
         (buttonStyles config.size config.width (styleToColorPalette config.style))
-        [ -- , styles.class [ CopyToClipboard ] -- TODO
-          Widget.label "Copy URL to clipboard"
+        [ Widget.label "Copy URL to clipboard"
         , attribute "data-clipboard-text" config.copyText
         , widthStyle config.width
         ]
@@ -795,7 +794,6 @@ sizeStyle size =
     --     | LabelIconAndText
     --     | Toggled
     --     | Delete
-    --     | CopyToClipboard
     --     | NewStyle
     -- styles : Styles.StylesWithAssets Never CssClasses msg { r | icons_xBlue_svg : Asset }
     -- styles =

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -80,7 +80,7 @@ import Markdown.Block
 import Markdown.Inline
 import Nri.Ui
 import Nri.Ui.AssetPath as AssetPath exposing (Asset)
-import Nri.Ui.Colors.V1
+import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1
 import Nri.Ui.Icon.V3 as Icon exposing (IconType, decorativeIcon, icon)
 
@@ -284,16 +284,33 @@ type alias DeleteButtonConfig msg =
 
 {-| A delete button (blue X)
 -}
-delete : DeleteButtonConfig msg -> Html msg
-delete config =
-    Html.button
-        [ --styles.class [ Delete ] -- TODO
-          onClick config.onClick
+delete : { r | x : String } -> DeleteButtonConfig msg -> Html msg
+delete assets config =
+    Nri.Ui.styled Html.button
+        "Nri-Button-V3-delete"
+        [ display inlineBlock
+        , backgroundRepeat noRepeat
+        , backgroundColor transparent
+        , backgroundPosition center
+        , backgroundSize contain
+        , Css.property "border" "none"
+        , Css.width (px 15)
+        , Css.height (px 15)
+        , padding zero
+        , margin2 zero (px 6)
+        , cursor pointer
+        , color Colors.azure
+        ]
+        [ onClick config.onClick
         , type_ "button"
         , -- reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Labeling_buttons
           Widget.label config.label
         ]
-        []
+        [ Icon.icon
+            { alt = "Delete"
+            , icon = Icon.xSvg assets
+            }
+        ]
 
 
 
@@ -579,6 +596,9 @@ buttonStyle =
     , Css.property "background-image" "none"
     , textShadow none
     , Css.property "transition" "all 0.2s"
+    , boxShadow none
+    , border zero
+    , marginBottom zero
     , Css.hover
         [ textDecoration none
         ]
@@ -591,24 +611,29 @@ buttonStyle =
 colorStyle : ColorPalette -> List Style
 colorStyle colorPalette =
     let
+        --         , Css.Foreign.class (ColorsStyle LoadingColors)
+        --             [ Css.property "box-shadow" "none"
+        --             , Css.property "border" "none"
+        --             , marginBottom zero
+        --             ]
         ( config, additionalStyles ) =
             case colorPalette of
                 PrimaryColors ->
-                    ( { background = Nri.Ui.Colors.V1.azure
-                      , hover = Nri.Ui.Colors.V1.azureDark
-                      , text = Nri.Ui.Colors.V1.white
+                    ( { background = Colors.azure
+                      , hover = Colors.azureDark
+                      , text = Colors.white
                       , border = Nothing
-                      , shadow = Nri.Ui.Colors.V1.azureDark
+                      , shadow = Colors.azureDark
                       }
                     , []
                     )
 
                 SecondaryColors ->
-                    ( { background = Nri.Ui.Colors.V1.white
-                      , hover = Nri.Ui.Colors.V1.glacier
-                      , text = Nri.Ui.Colors.V1.azure
-                      , border = Just <| Nri.Ui.Colors.V1.azure
-                      , shadow = Nri.Ui.Colors.V1.azure
+                    ( { background = Colors.white
+                      , hover = Colors.glacier
+                      , text = Colors.azure
+                      , border = Just <| Colors.azure
+                      , shadow = Colors.azure
                       }
                     , []
                     )
@@ -616,7 +641,7 @@ colorStyle colorPalette =
                 BorderlessColors ->
                     ( { background = rgba 0 0 0 0
                       , hover = rgba 0 0 0 0
-                      , text = Nri.Ui.Colors.V1.azure
+                      , text = Colors.azure
                       , border = Nothing
                       , shadow = rgba 0 0 0 0
                       }
@@ -651,61 +676,61 @@ colorStyle colorPalette =
                     )
 
                 DangerColors ->
-                    ( { background = Nri.Ui.Colors.V1.red
-                      , hover = Nri.Ui.Colors.V1.redDark
-                      , text = Nri.Ui.Colors.V1.white
+                    ( { background = Colors.red
+                      , hover = Colors.redDark
+                      , text = Colors.white
                       , border = Nothing
-                      , shadow = Nri.Ui.Colors.V1.redDark
+                      , shadow = Colors.redDark
                       }
                     , []
                     )
 
                 PremiumColors ->
-                    ( { background = Nri.Ui.Colors.V1.yellow
-                      , hover = Nri.Ui.Colors.V1.ochre
-                      , text = Nri.Ui.Colors.V1.navy
+                    ( { background = Colors.yellow
+                      , hover = Colors.ochre
+                      , text = Colors.navy
                       , border = Nothing
-                      , shadow = Nri.Ui.Colors.V1.ochre
+                      , shadow = Colors.ochre
                       }
                     , []
                     )
 
                 InactiveColors ->
-                    ( { background = Nri.Ui.Colors.V1.gray92
-                      , hover = Nri.Ui.Colors.V1.gray92
-                      , text = Nri.Ui.Colors.V1.gray45
+                    ( { background = Colors.gray92
+                      , hover = Colors.gray92
+                      , text = Colors.gray45
                       , border = Nothing
-                      , shadow = Nri.Ui.Colors.V1.gray92
+                      , shadow = Colors.gray92
                       }
                     , []
                     )
 
                 LoadingColors ->
-                    ( { background = Nri.Ui.Colors.V1.glacier
-                      , hover = Nri.Ui.Colors.V1.glacier
-                      , text = Nri.Ui.Colors.V1.navy
+                    ( { background = Colors.glacier
+                      , hover = Colors.glacier
+                      , text = Colors.navy
                       , border = Nothing
-                      , shadow = Nri.Ui.Colors.V1.glacier
+                      , shadow = Colors.glacier
                       }
                     , []
                     )
 
                 SuccessColors ->
-                    ( { background = Nri.Ui.Colors.V1.greenDark
-                      , hover = Nri.Ui.Colors.V1.greenDark
-                      , text = Nri.Ui.Colors.V1.white
+                    ( { background = Colors.greenDark
+                      , hover = Colors.greenDark
+                      , text = Colors.white
                       , border = Nothing
-                      , shadow = Nri.Ui.Colors.V1.greenDark
+                      , shadow = Colors.greenDark
                       }
                     , []
                     )
 
                 ErrorColors ->
-                    ( { background = Nri.Ui.Colors.V1.purple
-                      , hover = Nri.Ui.Colors.V1.purple
-                      , text = Nri.Ui.Colors.V1.white
+                    ( { background = Colors.purple
+                      , hover = Colors.purple
+                      , text = Colors.white
                       , border = Nothing
-                      , shadow = Nri.Ui.Colors.V1.purple
+                      , shadow = Colors.purple
                       }
                     , []
                     )
@@ -827,48 +852,11 @@ sizeStyle size width =
 
 
 
---         , Css.Foreign.class (ColorsStyle PremiumColors)
---             [ Css.property "box-shadow" "none"
---             , marginBottom zero
---             ]
---         , Css.Foreign.class (ColorsStyle InactiveColors)
---             [ Css.property "box-shadow" "none"
---             , Css.property "border" "none"
---             , marginBottom zero
---             ]
---         , Css.Foreign.class (ColorsStyle SuccessColors)
---             [ Css.property "box-shadow" "none"
---             , Css.property "border" "none"
---             , marginBottom zero
---             ]
---         , Css.Foreign.class (ColorsStyle ErrorColors)
---             [ Css.property "box-shadow" "none"
---             , Css.property "border" "none"
---             , marginBottom zero
---             ]
---         , Css.Foreign.class (ColorsStyle LoadingColors)
---             [ Css.property "box-shadow" "none"
---             , Css.property "border" "none"
---             , marginBottom zero
---             ]
---         , Css.Foreign.class Delete
---             [ display inlineBlock
---             , backgroundImage (url <| AssetPath.url assets.icons_xBlue_svg)
---             , backgroundRepeat noRepeat
---             , backgroundColor transparent
---             , backgroundPosition center
---             , backgroundSize contain
---             , Css.property "border" "none"
---             , Css.width (px 15)
---             , Css.height (px 15)
---             , margin2 zero (px 6)
---             , cursor pointer
---             ]
 --         , Css.Foreign.class Toggled
---             [ color Nri.Ui.Colors.V1.gray20
---             , backgroundColor Nri.Ui.Colors.V1.glacier
---             , boxShadow5 inset zero (px 3) zero (withAlpha 0.2 Nri.Ui.Colors.V1.gray20)
---             , border3 (px 1) solid Nri.Ui.Colors.V1.azure
+--             [ color Colors.gray20
+--             , backgroundColor Colors.glacier
+--             , boxShadow5 inset zero (px 3) zero (withAlpha 0.2 Colors.gray20)
+--             , border3 (px 1) solid Colors.azure
 --             , fontWeight bold
 --             ]
 --         ]

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -17,16 +17,22 @@ module Nri.Ui.Button.V3
         , linkSpa
         , linkWithMethod
         , linkWithTracking
-        , styles
         , submit
         , toggleButton
         )
 
-{-| Changes from V2:
+{-|
+
+
+# Changes from V2:
 
   - Uses Html.Styled
   - Removes buttonDeprecated
   - Removes Tiny size
+  - Removes one-off Active hack
+
+
+# About:
 
 Common NoRedInk buttons. For accessibility purposes, buttons that perform an
 action on the current page should be HTML `<button>` elements and are created here
@@ -36,11 +42,6 @@ should be able to use the same CSS class in all cases.
 
 There will generally be a `*Button` and `*Link` version of each button style.
 (These will be created as they are needed.)
-
-
-## Required styles
-
-@docs styles
 
 
 ## Common configs
@@ -64,29 +65,27 @@ There will generally be a `*Button` and `*Link` version of each button style.
 
 -}
 
+-- import EventExtras
+
 import Accessibility.Styled exposing (..)
 import Accessibility.Styled.Role as Role
 import Accessibility.Styled.Widget as Widget
 import Css exposing (..)
-import EventExtras
-import Html.Styled
-import Html.Styled.Attributes exposing (..)
-import Html.Styled.Events exposing (onClick)
+import Css.Foreign
+import Html.Styled as Html
+import Html.Styled.Attributes as Attributes exposing (..)
+import Html.Styled.Events as Events exposing (onClick)
 import Json.Decode
 import Markdown.Block
 import Markdown.Inline
 import Nri.Ui
 import Nri.Ui.AssetPath as AssetPath exposing (Asset)
-import Nri.Ui.Colors.Extra exposing (withAlpha)
 import Nri.Ui.Colors.V1
 import Nri.Ui.Fonts.V1
 import Nri.Ui.Icon.V3 as Icon exposing (IconType, decorativeIcon, icon)
 
 
 {-| Sizes for buttons and links that have button classes
-
-NOTE: if you add a size here, you need to add Css styles using the sizeStyle helper in the styles definition.
-
 -}
 type ButtonSize
     = Small
@@ -108,7 +107,6 @@ type ButtonStyle
     | Borderless
     | Danger
     | Premium
-    | Active -- NOTE: this is a one-off hack; do not use
 
 
 {-| Describes the state of a button. Has consequences for appearance and disabled attribute.
@@ -172,7 +170,7 @@ button config content =
 
 {-| Exactly the same as button but you can pass in a list of attributes
 -}
-customButton : List (Html.Attribute msg) -> ButtonConfig msg -> ButtonContent -> Html msg
+customButton : List (Attribute msg) -> ButtonConfig msg -> ButtonContent -> Html msg
 customButton attributes config content =
     let
         buttonStyle =
@@ -215,11 +213,12 @@ customButton attributes config content =
                 Success ->
                     True
     in
-    Html.button
-        ([ buttonClass config.size config.width buttonStyle
-         , onClick config.onClick
-         , Html.Attributes.disabled disabled
-         , Html.Attributes.type_ "button"
+    Nri.Ui.styled Html.button
+        "nri-button-v3"
+        (buttonStyles config.size config.width buttonStyle)
+        ([ onClick config.onClick
+         , Attributes.disabled disabled
+         , Attributes.type_ "button"
          , widthStyle config.width
          ]
             ++ attributes
@@ -227,7 +226,7 @@ customButton attributes config content =
         (viewLabel content.icon content.label)
 
 
-widthStyle : Maybe Int -> Html.Attribute msg
+widthStyle : Maybe Int -> Attribute msg
 widthStyle width =
     width
         |> Maybe.map (\w -> [ ( "width", toString w ++ "px" ) ])
@@ -263,10 +262,11 @@ copyToClipboard assets config =
             else
                 Nothing
     in
-    Html.button
-        [ buttonClass config.size config.width (styleToColorPalette config.style)
-        , styles.class [ CopyToClipboard ]
-        , Widget.label "Copy URL to clipboard"
+    Nri.Ui.styled Html.button
+        "Nri-Ui-Button-V3-copyToClipboard"
+        (buttonStyles config.size config.width (styleToColorPalette config.style))
+        [ -- , styles.class [ CopyToClipboard ] -- TODO
+          Widget.label "Copy URL to clipboard"
         , attribute "data-clipboard-text" config.copyText
         , widthStyle config.width
         ]
@@ -288,8 +288,8 @@ type alias DeleteButtonConfig msg =
 delete : DeleteButtonConfig msg -> Html msg
 delete config =
     Html.button
-        [ styles.class [ Delete ]
-        , onClick config.onClick
+        [ --styles.class [ Delete ] -- TODO
+          onClick config.onClick
         , type_ "button"
         , -- reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Labeling_buttons
           Widget.label config.label
@@ -314,12 +314,14 @@ type alias ToggleButtonConfig msg =
 {-| -}
 toggleButton : ToggleButtonConfig msg -> Html msg
 toggleButton config =
-    Html.button
+    Nri.Ui.styled Html.button
+        "Nri-Ui-Button-V3-toggleButton"
+        (buttonStyles Medium Nothing SecondaryColors)
         (if config.pressed then
             [ onClick config.onDeselect
             , Widget.pressed <| Just True
-            , styles.class [ Button, Toggled, SizeStyle Medium ]
 
+            -- , styles.class [ Button, Toggled, SizeStyle Medium ] -- TODO
             -- reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Labeling_buttons
             , Role.button
 
@@ -331,7 +333,6 @@ toggleButton config =
          else
             [ onClick config.onSelect
             , Widget.pressed <| Just False
-            , buttonClass Medium Nothing SecondaryColors
             , Role.button
             , type_ "button"
             ]
@@ -355,12 +356,16 @@ type alias InputConfig =
 
 
 {-| A submit input that overrides the form's method to PUT
+
+TODO: Should this exist?
+
 -}
 submit : InputConfig -> Html c
 submit config =
-    Html.button
-        [ buttonClass config.size Nothing (styleToColorPalette config.style)
-        , name config.name
+    Nri.Ui.styled Html.button
+        "Nri-Ui-Button-V3-submit"
+        (buttonStyles config.size Nothing (styleToColorPalette config.style))
+        [ name config.name
         , type_ "submit"
         , value config.value
         ]
@@ -392,7 +397,7 @@ some url
 -}
 link : LinkConfig -> Html msg
 link =
-    linkBase <| [ Html.Attributes.target "_self" ]
+    linkBase <| [ Attributes.target "_self" ]
 
 
 {-| Use this link for routing within a single page app.
@@ -413,10 +418,10 @@ linkSpa :
         , width : Maybe Int
         , route : route
         }
-    -> Html.Styled.Html msg
+    -> Html msg
 linkSpa toUrl toMsg config =
     linkBase
-        [ EventExtras.onClickPreventDefaultForLinkWithHref (toMsg config.route)
+        [-- EventExtras.onClickPreventDefaultForLinkWithHref (toMsg config.route) TODO
         ]
         { label = config.label
         , icon = config.icon
@@ -425,7 +430,6 @@ linkSpa toUrl toMsg config =
         , width = config.width
         , url = toUrl config.route
         }
-        |> Html.Styled.fromUnstyled
 
 
 {-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to
@@ -433,7 +437,7 @@ some url and have it open to an external site
 -}
 linkExternal : LinkConfig -> Html msg
 linkExternal =
-    linkBase <| [ Html.Attributes.target "_blank" ]
+    linkBase <| [ Attributes.target "_blank" ]
 
 
 {-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to
@@ -450,7 +454,7 @@ This should only take in messages that result in a Msg that triggers Analytics.t
 linkWithTracking : msg -> LinkConfig -> Html msg
 linkWithTracking onTrack =
     linkBase <|
-        [ Html.Events.onWithOptions "click"
+        [ Events.onWithOptions "click"
             { stopPropagation = False
             , preventDefault = True
             }
@@ -466,34 +470,34 @@ This should only take in messages that result in tracking events. For buttons th
 linkExternalWithTracking : msg -> LinkConfig -> Html msg
 linkExternalWithTracking onTrack =
     linkBase <|
-        [ Html.Attributes.target "_blank"
+        [ Attributes.target "_blank"
         , onClick onTrack
         ]
 
 
 {-| Helper function for building links with an arbitrary number of Attributes
 -}
-linkBase : List (Html.Attribute msg) -> LinkConfig -> Html msg
+linkBase : List (Attribute msg) -> LinkConfig -> Html msg
 linkBase extraAttrs config =
     let
         widthAttributes =
             Maybe.map
-                (\width ->
-                    [ style
-                        [ ( "width", toString width ++ "px" )
-                        , ( "max-width", "100%" )
-                        ]
+                (\widthAttr ->
+                    [ Css.width (px <| toFloat widthAttr)
+                    , maxWidth (pct 100)
                     ]
                 )
                 config.width
                 |> Maybe.withDefault []
     in
-    Html.a
-        (buttonClass config.size config.width (styleToColorPalette config.style)
-            :: styles.class [ IsLink ]
-            :: Html.Attributes.href config.url
-            :: widthAttributes
-            ++ extraAttrs
+    Nri.Ui.styled Html.a
+        "Nri-Button-V3-linkBase"
+        (buttonStyles config.size config.width (styleToColorPalette config.style)
+            ++ widthAttributes
+        )
+        -- :: styles.class [ IsLink ] -- TODO
+        (Attributes.href config.url
+            :: extraAttrs
         )
         (viewLabel config.icon config.label)
 
@@ -508,7 +512,6 @@ type ColorPalette
     | BorderlessColors
     | DangerColors
     | PremiumColors
-    | ActiveColors -- TODO: merge with Toggled
     | InactiveColors
     | LoadingColors
     | SuccessColors
@@ -533,25 +536,12 @@ styleToColorPalette style =
         Premium ->
             PremiumColors
 
-        Active ->
-            ActiveColors
 
-
-buttonClass : ButtonSize -> Maybe Int -> ColorPalette -> Html.Attribute msg
-buttonClass size width colorPalette =
-    styles.class <|
-        List.concat
-            [ [ Button
-              , SizeStyle size
-              , ColorsStyle colorPalette
-              ]
-            , case width of
-                Nothing ->
-                    []
-
-                Just _ ->
-                    [ ExplicitWidth ]
-            ]
+buttonStyles : ButtonSize -> Maybe Int -> ColorPalette -> List Style
+buttonStyles size width colorPalette =
+    List.concat
+        [ colorStyle colorPalette
+        ]
 
 
 viewLabel : Maybe IconType -> String -> List (Html msg)
@@ -561,19 +551,24 @@ viewLabel icn label =
             renderMarkdown label
 
         Just iconType ->
-            [ span [ styles.class [ LabelIconAndText ] ]
+            [ span
+                [-- styles.class [ LabelIconAndText ]  TODO
+                ]
                 (decorativeIcon iconType
                     :: renderMarkdown label
                 )
             ]
 
 
+{-| TODO: does this have a styled version?
+-}
 renderMarkdown : String -> List (Html msg)
 renderMarkdown markdown =
     case Markdown.Block.parse Nothing markdown of
         -- It seems to be always first wrapped in a `Paragraph` and never directly a `PlainInline`
         [ Markdown.Block.Paragraph _ inlines ] ->
             List.map Markdown.Inline.toHtml inlines
+                |> List.map Html.fromUnstyled
 
         _ ->
             [ Html.text markdown ]
@@ -583,326 +578,307 @@ renderMarkdown markdown =
 -- STYLES
 
 
-type CssClasses
-    = Button
-    | IsLink
-    | ExplicitWidth
-    | SizeStyle ButtonSize
-    | ColorsStyle ColorPalette
-    | LabelIconAndText
-    | Toggled
-    | Delete
-    | CopyToClipboard
-    | NewStyle
-
-
-{-| TODO: move this to elm-css?
-Cross-browser support for linear gradient backgrounds.
-
-Falls back to the top color if gradients are not supported.
-
--}
-linearGradient : ( Css.ColorValue compatible1, Css.ColorValue compatible2 ) -> Css.Style
-linearGradient ( top, bottom ) =
-    Css.batch
-        [ Css.property "background" top.value -- Old browsers
-        , Css.property "background" ("-moz-linear-gradient(top," ++ top.value ++ " 0%," ++ bottom.value ++ " 100%)") -- FF3.6+
-        , Css.property "background" ("-webkit-gradient(linear,left top,left bottom,color-stop(0%," ++ top.value ++ "),color-stop(100%," ++ bottom.value ++ "))") -- Chrome, Safari 4+
-        , Css.property "background" ("-webkit-linear-gradient(top," ++ top.value ++ " 0%," ++ bottom.value ++ " 100%)") -- Chrome 10+, Safari 5.1+
-        , Css.property "background" ("-o-linear-gradient(top," ++ top.value ++ " 0%," ++ bottom.value ++ " 100%)") -- Opera 11.10+
-        , Css.property "background" ("-ms-linear-gradient(top," ++ top.value ++ " 0%," ++ bottom.value ++ " 100%)") -- IE10+
-        , Css.property "background" ("linear,to bottom," ++ top.value ++ " 0%," ++ bottom.value ++ " 100%") -- W3C
+buttonStyle : List Style
+buttonStyle =
+    [ cursor pointer
+    , display inlineBlock
+    , -- Specifying the font can and should go away after bootstrap is removed from application.css
+      Nri.Ui.Fonts.V1.baseFont
+    , textOverflow ellipsis
+    , overflow Css.hidden
+    , textDecoration none
+    , Css.property "background-image" "none"
+    , textShadow none
+    , Css.property "transition" "all 0.2s"
+    , Css.hover
+        [ textDecoration none
+        ]
+    , Css.disabled
+        [ cursor notAllowed
         ]
 
+    -- , Css.Foreign.withClass IsLink -- TODO
+    --     [ whiteSpace noWrap
+    --     ]
+    ]
 
-{-| Required CSS styles for `Nri.Ui.Button.V2`.
--}
-styles : Styles.StylesWithAssets Never CssClasses msg { r | icons_xBlue_svg : Asset }
-styles =
+
+colorStyle : ColorPalette -> List Style
+colorStyle colorPalette =
     let
-        sizeStyle size config =
-            Css.Foreign.class (SizeStyle size)
-                [ fontSize (px config.fontSize)
-                , borderRadius (px 8)
-                , Css.height (px config.height)
-                , lineHeight (px config.lineHeight)
-                , padding2 zero (px config.sidePadding)
-                , boxSizing borderBox
-                , minWidth (px config.minWidth)
-                , borderWidth (px 1)
-                , borderBottomWidth (px config.shadowHeight)
-                , Css.Foreign.withClass ExplicitWidth
-                    [ padding2 zero (px 4)
-                    , boxSizing borderBox
-                    ]
-                , Css.Foreign.withClass IsLink
-                    [ lineHeight (px config.height)
-                    ]
-                , Css.Foreign.descendants
-                    [ Css.Foreign.img
-                        [ Css.height (px config.imageHeight)
-                        , marginRight (px <| config.imageHeight / 6)
-                        , position relative
-                        , bottom (px 2)
-                        , verticalAlign middle
-                        ]
-                    , Css.Foreign.svg
-                        [ Css.height (px config.imageHeight) |> important
-                        , Css.width (px config.imageHeight) |> important
-                        , marginRight (px <| config.imageHeight / 6)
-                        , position relative
-                        , bottom (px 2)
-                        , verticalAlign middle
-                        ]
-                    , Css.Foreign.svg
-                        [ Css.important <| Css.height (px config.imageHeight)
-                        , Css.important <| Css.width auto
-                        , maxWidth (px (config.imageHeight * 1.25))
-                        , paddingRight (px <| config.imageHeight / 6)
-                        , position relative
-                        , bottom (px 2)
-                        , verticalAlign middle
-                        ]
-                    ]
+        config =
+            case colorPalette of
+                PrimaryColors ->
+                    { background = Nri.Ui.Colors.V1.azure
+                    , hover = Nri.Ui.Colors.V1.azureDark
+                    , text = Nri.Ui.Colors.V1.white
+                    , border = Nothing
+                    , shadow = Nri.Ui.Colors.V1.azureDark
+                    }
 
-                -- Borderless buttons get bigger icons
-                , Css.Foreign.withClass (ColorsStyle BorderlessColors)
-                    [ Css.Foreign.descendants
-                        [ Css.Foreign.img
-                            [ Css.height (px (config.imageHeight * 1.6))
-                            , marginRight (px (config.imageHeight * 1.6 / 6))
-                            ]
-                        , Css.Foreign.svg
-                            [ Css.height (px (config.imageHeight * 1.6)) |> important
-                            , Css.width (px (config.imageHeight * 1.6)) |> important
-                            , marginRight (px (config.imageHeight * 1.6 / 6))
-                            ]
-                        , Css.Foreign.svg
-                            [ Css.important <| Css.height (px (config.imageHeight * 1.6))
-                            , Css.important <| Css.width auto
-                            , maxWidth (px (config.imageHeight * 1.25))
-                            , paddingRight (px (config.imageHeight * 1.6 / 6))
-                            , position relative
-                            , bottom (px 2)
-                            ]
-                        ]
-                    ]
-                ]
+                SecondaryColors ->
+                    { background = Nri.Ui.Colors.V1.white
+                    , hover = Nri.Ui.Colors.V1.glacier
+                    , text = Nri.Ui.Colors.V1.azure
+                    , border = Just <| Nri.Ui.Colors.V1.azure
+                    , shadow = Nri.Ui.Colors.V1.azure
+                    }
 
-        styleStyle style config =
-            Css.Foreign.class (ColorsStyle style)
-                [ color config.text
-                , backgroundColor config.background
-                , fontWeight (int 700)
-                , textAlign center
-                , case config.border of
-                    Nothing ->
-                        borderStyle none
+                BorderlessColors ->
+                    { background = rgba 0 0 0 0
+                    , hover = rgba 0 0 0 0
+                    , text = Nri.Ui.Colors.V1.azure
+                    , border = Nothing
+                    , shadow = rgba 0 0 0 0
+                    }
 
-                    Just color ->
-                        Css.batch
-                            [ borderColor color
-                            , borderStyle solid
-                            ]
-                , borderBottomStyle solid
-                , borderBottomColor config.shadow
-                , fontStyle normal
-                , Css.hover
-                    [ color config.text
-                    , backgroundColor config.hover
-                    , Css.disabled
-                        [ backgroundColor config.background
-                        ]
-                    ]
-                , Css.visited
-                    [ color config.text
-                    ]
-                ]
+                DangerColors ->
+                    { background = Nri.Ui.Colors.V1.red
+                    , hover = Nri.Ui.Colors.V1.redDark
+                    , text = Nri.Ui.Colors.V1.white
+                    , border = Nothing
+                    , shadow = Nri.Ui.Colors.V1.redDark
+                    }
+
+                PremiumColors ->
+                    { background = Nri.Ui.Colors.V1.yellow
+                    , hover = Nri.Ui.Colors.V1.ochre
+                    , text = Nri.Ui.Colors.V1.navy
+                    , border = Nothing
+                    , shadow = Nri.Ui.Colors.V1.ochre
+                    }
+
+                InactiveColors ->
+                    { background = Nri.Ui.Colors.V1.gray92
+                    , hover = Nri.Ui.Colors.V1.gray92
+                    , text = Nri.Ui.Colors.V1.gray45
+                    , border = Nothing
+                    , shadow = Nri.Ui.Colors.V1.gray92
+                    }
+
+                LoadingColors ->
+                    { background = Nri.Ui.Colors.V1.glacier
+                    , hover = Nri.Ui.Colors.V1.glacier
+                    , text = Nri.Ui.Colors.V1.navy
+                    , border = Nothing
+                    , shadow = Nri.Ui.Colors.V1.glacier
+                    }
+
+                SuccessColors ->
+                    { background = Nri.Ui.Colors.V1.greenDark
+                    , hover = Nri.Ui.Colors.V1.greenDark
+                    , text = Nri.Ui.Colors.V1.white
+                    , border = Nothing
+                    , shadow = Nri.Ui.Colors.V1.greenDark
+                    }
+
+                ErrorColors ->
+                    { background = Nri.Ui.Colors.V1.purple
+                    , hover = Nri.Ui.Colors.V1.purple
+                    , text = Nri.Ui.Colors.V1.white
+                    , border = Nothing
+                    , shadow = Nri.Ui.Colors.V1.purple
+                    }
     in
-    Styles.stylesWithAssets "Nri-Ui-Button-V2-" <|
-        \assets ->
-            [ Css.Foreign.class Button
-                [ cursor pointer
-                , display inlineBlock
-                , -- Specifying the font can and should go away after bootstrap is removed from application.css
-                  Nri.Ui.Fonts.V1.baseFont
-                , textOverflow ellipsis
-                , overflow Css.hidden
-                , textDecoration none
-                , Css.property "background-image" "none"
-                , textShadow none
-                , Css.property "transition" "all 0.2s"
-                , Css.hover
-                    [ textDecoration none
-                    ]
-                , Css.disabled
-                    [ cursor notAllowed
-                    ]
-                , Css.Foreign.withClass IsLink
-                    [ whiteSpace noWrap
-                    ]
+    [ color config.text
+    , backgroundColor config.background
+    , fontWeight (int 700)
+    , textAlign center
+    , case config.border of
+        Nothing ->
+            borderStyle none
+
+        Just color ->
+            Css.batch
+                [ borderColor color
+                , borderStyle solid
                 ]
-            , sizeStyle TinyDeprecated
-                { fontSize = 13
-                , height = 25
-                , lineHeight = 25
-                , sidePadding = 8
-                , minWidth = 50
-                , imageHeight = 0
-                , shadowHeight = 0
-                }
-            , sizeStyle Small
-                { fontSize = 15
-                , height = 36
-                , lineHeight = 15
-                , sidePadding = 16
-                , imageHeight = 15
-                , shadowHeight = 2
-                , minWidth = 75
-                }
-            , sizeStyle Medium
-                { fontSize = 17
-                , height = 45
-                , lineHeight = 19
-                , sidePadding = 16
-                , imageHeight = 15
-                , shadowHeight = 3
-                , minWidth = 100
-                }
-            , sizeStyle Large
-                { fontSize = 20
-                , height = 56
-                , lineHeight = 22
-                , sidePadding = 16
-                , imageHeight = 20
-                , shadowHeight = 4
-                , minWidth = 200
-                }
-            , styleStyle PrimaryColors
-                { background = Nri.Ui.Colors.V1.azure
-                , hover = Nri.Ui.Colors.V1.azureDark
-                , text = Nri.Ui.Colors.V1.white
-                , border = Nothing
-                , shadow = Nri.Ui.Colors.V1.azureDark
-                }
-            , styleStyle SecondaryColors
-                { background = Nri.Ui.Colors.V1.white
-                , hover = Nri.Ui.Colors.V1.glacier
-                , text = Nri.Ui.Colors.V1.azure
-                , border = Just <| Nri.Ui.Colors.V1.azure
-                , shadow = Nri.Ui.Colors.V1.azure
-                }
-            , styleStyle BorderlessColors
-                { background = transparent
-                , hover = transparent
-                , text = Nri.Ui.Colors.V1.azure
-                , border = Nothing
-                , shadow = transparent
-                }
-            , Css.Foreign.class (ColorsStyle BorderlessColors)
-                [ Css.hover
-                    [ textDecoration underline
-                    , Css.disabled
-                        [ textDecoration none
-                        ]
-                    ]
-                ]
-            , styleStyle DangerColors
-                { background = Nri.Ui.Colors.V1.red
-                , hover = Nri.Ui.Colors.V1.redDark
-                , text = Nri.Ui.Colors.V1.white
-                , border = Nothing
-                , shadow = Nri.Ui.Colors.V1.redDark
-                }
-            , styleStyle PremiumColors
-                { background = Nri.Ui.Colors.V1.yellow
-                , hover = Nri.Ui.Colors.V1.ochre
-                , text = Nri.Ui.Colors.V1.navy
-                , border = Nothing
-                , shadow = Nri.Ui.Colors.V1.ochre
-                }
-            , styleStyle LoadingColors
-                { background = Nri.Ui.Colors.V1.glacier
-                , hover = Nri.Ui.Colors.V1.glacier
-                , text = Nri.Ui.Colors.V1.navy
-                , border = Nothing
-                , shadow = Nri.Ui.Colors.V1.glacier
-                }
-            , styleStyle ErrorColors
-                { background = Nri.Ui.Colors.V1.purple
-                , hover = Nri.Ui.Colors.V1.purple
-                , text = Nri.Ui.Colors.V1.white
-                , border = Nothing
-                , shadow = Nri.Ui.Colors.V1.purple
-                }
-            , styleStyle InactiveColors
-                { background = Nri.Ui.Colors.V1.gray92
-                , hover = Nri.Ui.Colors.V1.gray92
-                , text = Nri.Ui.Colors.V1.gray45
-                , border = Nothing
-                , shadow = Nri.Ui.Colors.V1.gray92
-                }
-            , styleStyle ActiveColors
-                { background = Nri.Ui.Colors.V1.glacier
-                , hover = Nri.Ui.Colors.V1.glacier
-                , text = Nri.Ui.Colors.V1.navy
-                , border = Nothing
-                , shadow = Nri.Ui.Colors.V1.gray92
-                }
-            , Css.Foreign.class (ColorsStyle ActiveColors)
-                [ Css.boxShadow none
-                , Css.boxShadow5 inset zero (px 3) zero (withAlpha 0.2 Nri.Ui.Colors.V1.gray20)
-                , border3 (px 1) solid Nri.Ui.Colors.V1.azure
-                ]
-            , styleStyle SuccessColors
-                { background = Nri.Ui.Colors.V1.greenDark
-                , hover = Nri.Ui.Colors.V1.greenDark
-                , text = Nri.Ui.Colors.V1.white
-                , border = Nothing
-                , shadow = Nri.Ui.Colors.V1.greenDark
-                }
-            , Css.Foreign.class (ColorsStyle PremiumColors)
-                [ Css.property "box-shadow" "none"
-                , marginBottom zero
-                ]
-            , Css.Foreign.class (ColorsStyle InactiveColors)
-                [ Css.property "box-shadow" "none"
-                , Css.property "border" "none"
-                , marginBottom zero
-                ]
-            , Css.Foreign.class (ColorsStyle SuccessColors)
-                [ Css.property "box-shadow" "none"
-                , Css.property "border" "none"
-                , marginBottom zero
-                ]
-            , Css.Foreign.class (ColorsStyle ErrorColors)
-                [ Css.property "box-shadow" "none"
-                , Css.property "border" "none"
-                , marginBottom zero
-                ]
-            , Css.Foreign.class (ColorsStyle LoadingColors)
-                [ Css.property "box-shadow" "none"
-                , Css.property "border" "none"
-                , marginBottom zero
-                ]
-            , Css.Foreign.class Delete
-                [ display inlineBlock
-                , backgroundImage (url <| AssetPath.url assets.icons_xBlue_svg)
-                , backgroundRepeat noRepeat
-                , backgroundColor transparent
-                , backgroundPosition center
-                , backgroundSize contain
-                , Css.property "border" "none"
-                , Css.width (px 15)
-                , Css.height (px 15)
-                , margin2 zero (px 6)
-                , cursor pointer
-                ]
-            , Css.Foreign.class Toggled
-                [ color Nri.Ui.Colors.V1.gray20
-                , backgroundColor Nri.Ui.Colors.V1.glacier
-                , boxShadow5 inset zero (px 3) zero (withAlpha 0.2 Nri.Ui.Colors.V1.gray20)
-                , border3 (px 1) solid Nri.Ui.Colors.V1.azure
-                , fontWeight bold
-                ]
+    , borderBottomStyle solid
+    , borderBottomColor config.shadow
+    , fontStyle normal
+    , Css.hover
+        [ color config.text
+        , backgroundColor config.hover
+        , Css.disabled
+            [ backgroundColor config.background
             ]
+        ]
+    , Css.visited
+        [ color config.text
+        ]
+    ]
+
+
+sizeStyle : ButtonSize -> List Style
+sizeStyle size =
+    let
+        config =
+            case size of
+                Small ->
+                    { fontSize = 15
+                    , height = 36
+                    , lineHeight = 15
+                    , sidePadding = 16
+                    , imageHeight = 15
+                    , shadowHeight = 2
+                    , minWidth = 75
+                    }
+
+                Medium ->
+                    { fontSize = 17
+                    , height = 45
+                    , lineHeight = 19
+                    , sidePadding = 16
+                    , imageHeight = 15
+                    , shadowHeight = 3
+                    , minWidth = 100
+                    }
+
+                Large ->
+                    { fontSize = 20
+                    , height = 56
+                    , lineHeight = 22
+                    , sidePadding = 16
+                    , imageHeight = 20
+                    , shadowHeight = 4
+                    , minWidth = 200
+                    }
+    in
+    [ fontSize (px config.fontSize)
+    , borderRadius (px 8)
+    , Css.height (px config.height)
+    , lineHeight (px config.lineHeight)
+    , padding2 zero (px config.sidePadding)
+    , boxSizing borderBox
+    , minWidth (px config.minWidth)
+    , borderWidth (px 1)
+    , borderBottomWidth (px config.shadowHeight)
+
+    -- , Css.Foreign.withClass ExplicitWidth -- TODO
+    --     [ padding2 zero (px 4)
+    --     , boxSizing borderBox
+    --     ]
+    -- , Css.Foreign.withClass IsLink -- TODO
+    --     [ lineHeight (px config.height)
+    --     ]
+    , Css.Foreign.descendants
+        [ Css.Foreign.img
+            [ Css.height (px config.imageHeight)
+            , marginRight (px <| config.imageHeight / 6)
+            , position relative
+            , bottom (px 2)
+            , verticalAlign middle
+            ]
+        , Css.Foreign.svg
+            [ Css.height (px config.imageHeight) |> important
+            , Css.width (px config.imageHeight) |> important
+            , marginRight (px <| config.imageHeight / 6)
+            , position relative
+            , bottom (px 2)
+            , verticalAlign middle
+            ]
+        , Css.Foreign.svg
+            [ Css.important <| Css.height (px config.imageHeight)
+            , Css.important <| Css.width auto
+            , maxWidth (px (config.imageHeight * 1.25))
+            , paddingRight (px <| config.imageHeight / 6)
+            , position relative
+            , bottom (px 2)
+            , verticalAlign middle
+            ]
+        ]
+
+    -- type CssClasses
+    --     = IsLink
+    --     | ExplicitWidth
+    --     | SizeStyle ButtonSize
+    --     | LabelIconAndText
+    --     | Toggled
+    --     | Delete
+    --     | CopyToClipboard
+    --     | NewStyle
+    -- styles : Styles.StylesWithAssets Never CssClasses msg { r | icons_xBlue_svg : Asset }
+    -- styles =
+    -- let
+    -- Borderless buttons get bigger icons
+    -- , Css.Foreign.withClass (ColorsStyle BorderlessColors)
+    --     [ Css.Foreign.descendants
+    --         [ Css.Foreign.img
+    --             [ Css.height (px (config.imageHeight * 1.6))
+    --             , marginRight (px (config.imageHeight * 1.6 / 6))
+    --             ]
+    --         , Css.Foreign.svg
+    --             [ Css.height (px (config.imageHeight * 1.6)) |> important
+    --             , Css.width (px (config.imageHeight * 1.6)) |> important
+    --             , marginRight (px (config.imageHeight * 1.6 / 6))
+    --             ]
+    --         , Css.Foreign.svg
+    --             [ Css.important <| Css.height (px (config.imageHeight * 1.6))
+    --             , Css.important <| Css.width auto
+    --             , maxWidth (px (config.imageHeight * 1.25))
+    --             , paddingRight (px (config.imageHeight * 1.6 / 6))
+    --             , position relative
+    --             , bottom (px 2)
+    --             ]
+    --         ]
+    -- ]
+    ]
+
+
+
+-- in
+-- Styles.stylesWithAssets "Nri-Ui-Button-V2-" <|
+--     \assets ->
+--         , Css.Foreign.class (ColorsStyle BorderlessColors)
+--             [ Css.hover
+--                 [ textDecoration underline
+--                 , Css.disabled
+--                     [ textDecoration none
+--                     ]
+--                 ]
+--             ]
+--         , Css.Foreign.class (ColorsStyle PremiumColors)
+--             [ Css.property "box-shadow" "none"
+--             , marginBottom zero
+--             ]
+--         , Css.Foreign.class (ColorsStyle InactiveColors)
+--             [ Css.property "box-shadow" "none"
+--             , Css.property "border" "none"
+--             , marginBottom zero
+--             ]
+--         , Css.Foreign.class (ColorsStyle SuccessColors)
+--             [ Css.property "box-shadow" "none"
+--             , Css.property "border" "none"
+--             , marginBottom zero
+--             ]
+--         , Css.Foreign.class (ColorsStyle ErrorColors)
+--             [ Css.property "box-shadow" "none"
+--             , Css.property "border" "none"
+--             , marginBottom zero
+--             ]
+--         , Css.Foreign.class (ColorsStyle LoadingColors)
+--             [ Css.property "box-shadow" "none"
+--             , Css.property "border" "none"
+--             , marginBottom zero
+--             ]
+--         , Css.Foreign.class Delete
+--             [ display inlineBlock
+--             , backgroundImage (url <| AssetPath.url assets.icons_xBlue_svg)
+--             , backgroundRepeat noRepeat
+--             , backgroundColor transparent
+--             , backgroundPosition center
+--             , backgroundSize contain
+--             , Css.property "border" "none"
+--             , Css.width (px 15)
+--             , Css.height (px 15)
+--             , margin2 zero (px 6)
+--             , cursor pointer
+--             ]
+--         , Css.Foreign.class Toggled
+--             [ color Nri.Ui.Colors.V1.gray20
+--             , backgroundColor Nri.Ui.Colors.V1.glacier
+--             , boxShadow5 inset zero (px 3) zero (withAlpha 0.2 Nri.Ui.Colors.V1.gray20)
+--             , border3 (px 1) solid Nri.Ui.Colors.V1.azure
+--             , fontWeight bold
+--             ]
+--         ]

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -330,25 +330,22 @@ toggleButton config =
         (buttonStyles Medium Nothing SecondaryColors Button
             ++ toggledStyles
         )
-        (if config.pressed then
-            [ Events.onClick config.onDeselect
-            , Widget.pressed <| Just True
+        [ Events.onClick
+            (if config.pressed then
+                config.onDeselect
+             else
+                config.onSelect
+            )
+        , Widget.pressed <| Just config.pressed
 
-            -- reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Labeling_buttons
-            , Role.button
+        -- reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Labeling_buttons
+        , Role.button
 
-            -- Note: setting type: 'button' removes the default behavior of submit
-            -- equivalent to preventDefaultBehavior = false
-            -- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-name
-            , Attributes.type_ "button"
-            ]
-         else
-            [ Events.onClick config.onSelect
-            , Widget.pressed <| Just False
-            , Role.button
-            , Attributes.type_ "button"
-            ]
-        )
+        -- Note: setting type: 'button' removes the default behavior of submit
+        -- equivalent to preventDefaultBehavior = false
+        -- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-name
+        , Attributes.type_ "button"
+        ]
         (viewLabel Nothing config.label)
 
 

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -638,27 +638,6 @@ colorStyle colorPalette =
                                 ]
                             ]
                       ]
-                      -- TODO: Weird case with borderless
-                      -- , [ Css.Foreign.descendants
-                      --         [ Css.Foreign.img
-                      --             [ Css.height (px (config.imageHeight * 1.6))
-                      --             , marginRight (px (config.imageHeight * 1.6 / 6))
-                      --             ]
-                      --         , Css.Foreign.svg
-                      --             [ Css.height (px (config.imageHeight * 1.6)) |> important
-                      --             , Css.width (px (config.imageHeight * 1.6)) |> important
-                      --             , marginRight (px (config.imageHeight * 1.6 / 6))
-                      --             ]
-                      --         , Css.Foreign.svg
-                      --             [ Css.important <| Css.height (px (config.imageHeight * 1.6))
-                      --             , Css.important <| Css.width auto
-                      --             , maxWidth (px (config.imageHeight * 1.25))
-                      --             , paddingRight (px (config.imageHeight * 1.6 / 6))
-                      --             , position relative
-                      --             , bottom (px 2)
-                      --             ]
-                      --         ]
-                      --   ]
                     )
 
                 DangerColors ->

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -80,6 +80,7 @@ import Markdown.Block
 import Markdown.Inline
 import Nri.Ui
 import Nri.Ui.AssetPath as AssetPath exposing (Asset)
+import Nri.Ui.Colors.Extra exposing (withAlpha)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1
 import Nri.Ui.Icon.V3 as Icon exposing (IconType, decorativeIcon, icon)
@@ -330,9 +331,23 @@ type alias ToggleButtonConfig msg =
 {-| -}
 toggleButton : ToggleButtonConfig msg -> Html msg
 toggleButton config =
+    let
+        toggledStyles =
+            if config.pressed then
+                [ color Colors.gray20
+                , backgroundColor Colors.glacier
+                , boxShadow5 inset zero (px 3) zero (withAlpha 0.2 Colors.gray20)
+                , border3 (px 1) solid Colors.azure
+                , fontWeight bold
+                ]
+            else
+                []
+    in
     Nri.Ui.styled Html.button
         "Nri-Ui-Button-V3-toggleButton"
-        (buttonStyles Medium Nothing SecondaryColors)
+        (buttonStyles Medium Nothing SecondaryColors
+            ++ toggledStyles
+        )
         (if config.pressed then
             [ onClick config.onDeselect
             , Widget.pressed <| Just True
@@ -849,14 +864,3 @@ sizeStyle size width =
             ]
         ]
     ]
-
-
-
---         , Css.Foreign.class Toggled
---             [ color Colors.gray20
---             , backgroundColor Colors.glacier
---             , boxShadow5 inset zero (px 3) zero (withAlpha 0.2 Colors.gray20)
---             , border3 (px 1) solid Colors.azure
---             , fontWeight bold
---             ]
---         ]

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -212,7 +212,7 @@ customButton attributes config content =
     in
     Nri.Ui.styled Html.button
         "Nri-Button-V3-CustomButton"
-        (buttonStyles config.size config.width buttonStyle False)
+        (buttonStyles config.size config.width buttonStyle Button)
         ([ onClick config.onClick
          , Attributes.disabled disabled
          , Attributes.type_ "button"
@@ -261,7 +261,7 @@ copyToClipboard assets config =
     in
     Nri.Ui.styled Html.button
         "Nri-Ui-Button-V3-copyToClipboard"
-        (buttonStyles config.size config.width (styleToColorPalette config.style) False)
+        (buttonStyles config.size config.width (styleToColorPalette config.style) Button)
         [ Widget.label "Copy URL to clipboard"
         , attribute "data-clipboard-text" config.copyText
         , widthStyle config.width
@@ -341,7 +341,7 @@ toggleButton config =
     in
     Nri.Ui.styled Html.button
         "Nri-Ui-Button-V3-toggleButton"
-        (buttonStyles Medium Nothing SecondaryColors False
+        (buttonStyles Medium Nothing SecondaryColors Button
             ++ toggledStyles
         )
         (if config.pressed then
@@ -490,7 +490,7 @@ linkBase : List (Attribute msg) -> LinkConfig -> Html msg
 linkBase extraAttrs config =
     Nri.Ui.styled Html.a
         "Nri-Button-V3-linkBase"
-        (buttonStyles config.size config.width (styleToColorPalette config.style) True
+        (buttonStyles config.size config.width (styleToColorPalette config.style) Anchor
             ++ [ whiteSpace noWrap
                ]
         )
@@ -535,12 +535,12 @@ styleToColorPalette style =
             PremiumColors
 
 
-buttonStyles : ButtonSize -> Maybe Int -> ColorPalette -> Bool -> List Style
-buttonStyles size width colorPalette isLink =
+buttonStyles : ButtonSize -> Maybe Int -> ColorPalette -> ElementType -> List Style
+buttonStyles size width colorPalette elementType =
     List.concat
         [ buttonStyle
         , colorStyle colorPalette
-        , sizeStyle size width isLink
+        , sizeStyle size width elementType
         ]
 
 
@@ -730,8 +730,13 @@ colorStyle colorPalette =
     ]
 
 
-sizeStyle : ButtonSize -> Maybe Int -> Bool -> List Style
-sizeStyle size width isLink =
+type ElementType
+    = Anchor
+    | Button
+
+
+sizeStyle : ButtonSize -> Maybe Int -> ElementType -> List Style
+sizeStyle size width elementType =
     let
         config =
             case size of
@@ -780,10 +785,12 @@ sizeStyle size width isLink =
                         ]
 
         lineHeightPx =
-            if isLink then
-                config.height
-            else
-                config.lineHeight
+            case elementType of
+                Anchor ->
+                    config.height
+
+                Button ->
+                    config.lineHeight
     in
     [ fontSize (px config.fontSize)
     , borderRadius (px 8)

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -559,8 +559,6 @@ viewLabel icn label =
             ]
 
 
-{-| TODO: does this have a styled version?
--}
 renderMarkdown : String -> List (Html msg)
 renderMarkdown markdown =
     case Markdown.Block.parse Nothing markdown of

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -17,7 +17,6 @@ module Nri.Ui.Button.V3
         , linkSpa
         , linkWithMethod
         , linkWithTracking
-        , submit
         , toggleButton
         )
 
@@ -30,6 +29,7 @@ module Nri.Ui.Button.V3
   - Removes buttonDeprecated
   - Removes Tiny size
   - Removes one-off Active hack
+  - Removes "submit" button - we just used that for forms that were partially in Elm
 
 
 # About:
@@ -57,11 +57,6 @@ There will generally be a `*Button` and `*Link` version of each button style.
 ## `<a>` Buttons
 
 @docs LinkConfig, link, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
-
-
-## `<input>` Buttons
-
-@docs submit
 
 -}
 
@@ -352,7 +347,6 @@ toggleButton config =
             [ onClick config.onDeselect
             , Widget.pressed <| Just True
 
-            -- , styles.class [ Button, Toggled, SizeStyle Medium ] -- TODO
             -- reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Labeling_buttons
             , Role.button
 
@@ -384,24 +378,6 @@ type alias InputConfig =
     , style : ButtonStyle
     , value : String
     }
-
-
-{-| A submit input that overrides the form's method to PUT
-
-TODO: Should this exist?
-
--}
-submit : InputConfig -> Html c
-submit config =
-    Nri.Ui.styled Html.button
-        "Nri-Ui-Button-V3-submit"
-        (buttonStyles config.size Nothing (styleToColorPalette config.style))
-        [ name config.name
-        , type_ "submit"
-        , value config.value
-        ]
-        [ Html.map never config.content
-        ]
 
 
 

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -62,13 +62,13 @@ There will generally be a `*Button` and `*Link` version of each button style.
 
 -- import EventExtras
 
-import Accessibility.Styled exposing (..)
+import Accessibility.Styled as Html exposing (..)
 import Accessibility.Styled.Role as Role
 import Accessibility.Styled.Widget as Widget
 import Css exposing (..)
 import Css.Foreign
 import EventExtras
-import Html.Styled as Html
+import Html.Styled as Styled
 import Html.Styled.Attributes as Attributes exposing (..)
 import Html.Styled.Events as Events exposing (onClick)
 import Json.Decode
@@ -491,7 +491,7 @@ linkExternalWithTracking onTrack =
 -}
 linkBase : String -> List (Attribute msg) -> LinkConfig -> Html msg
 linkBase linkFunctionName extraAttrs config =
-    Nri.Ui.styled Html.a
+    Nri.Ui.styled Styled.a
         (styledName linkFunctionName)
         (buttonStyles config.size config.width (styleToColorPalette config.style) Anchor
             ++ [ whiteSpace noWrap
@@ -568,7 +568,7 @@ renderMarkdown markdown =
         -- It seems to be always first wrapped in a `Paragraph` and never directly a `PlainInline`
         [ Markdown.Block.Paragraph _ inlines ] ->
             List.map Markdown.Inline.toHtml inlines
-                |> List.map Html.fromUnstyled
+                |> List.map Styled.fromUnstyled
 
         _ ->
             [ Html.text markdown ]

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -67,6 +67,7 @@ import Accessibility.Styled.Role as Role
 import Accessibility.Styled.Widget as Widget
 import Css exposing (..)
 import Css.Foreign
+import EventExtras
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes exposing (..)
 import Html.Styled.Events as Events exposing (onClick)
@@ -428,7 +429,8 @@ linkSpa :
     -> Html msg
 linkSpa toUrl toMsg config =
     linkBase
-        [-- EventExtras.onClickPreventDefaultForLinkWithHref (toMsg config.route) TODO
+        [ EventExtras.onClickPreventDefaultForLinkWithHref (toMsg config.route)
+            |> Attributes.fromUnstyled
         ]
         { label = config.label
         , icon = config.icon

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -6,11 +6,11 @@ module Examples.Button exposing (Msg, State, example, init, update)
 
 import Debug.Control as Control exposing (Control)
 import Headings
-import Html exposing (..)
+import Html.Styled exposing (..)
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample, ModuleMessages)
 import Nri.Ui.AssetPath exposing (Asset)
-import Nri.Ui.Button.V2 as Button
-import Nri.Ui.Icon.V2 as Icon
+import Nri.Ui.Button.V3 as Button
+import Nri.Ui.Icon.V3 as Icon
 
 
 {-| -}
@@ -41,10 +41,11 @@ example assets unnamedMessages state =
         messages =
             unnamedMessages "ButtonExample"
     in
-    { filename = "Nri/Button.elm"
+    { filename = "Nri.Ui.Button.V3"
     , category = Buttons
     , content =
         [ viewButtonExamples assets messages state ]
+            |> List.map toUnstyled
     }
 
 
@@ -116,6 +117,7 @@ viewButtonExamples assets messages (State control) =
             Control.currentValue control
     in
     [ Control.view (State >> SetState >> messages.wrapper) control
+        |> fromUnstyled
     , buttons assets messages sizes model
     , toggleButtons messages
     , Button.delete
@@ -208,7 +210,8 @@ buttons assets messages sizes model =
 toggleButtons : ModuleMessages Msg parentMsg -> Html parentMsg
 toggleButtons messages =
     div []
-        [ Headings.h3 [ text "Button toggle" ]
+        [ Headings.h3 [ text "Button toggle" |> toUnstyled ]
+            |> fromUnstyled
         , Button.toggleButton
             { onDeselect = messages.showItWorked "onDeselect"
             , onSelect = messages.showItWorked "onSelect"

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -4,9 +4,11 @@ module Examples.Button exposing (Msg, State, example, init, update)
    @docs Msg, State, example, init, update,
 -}
 
+import Css exposing (middle, verticalAlign)
 import Debug.Control as Control exposing (Control)
 import Headings
 import Html.Styled exposing (..)
+import Html.Styled.Attributes exposing (css)
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample, ModuleMessages)
 import Nri.Ui.AssetPath exposing (Asset)
 import Nri.Ui.Button.V3 as Button
@@ -151,7 +153,12 @@ buttons assets messages sizes model =
     let
         exampleRow style =
             List.concat
-                [ [ td [] [ text <| toString style ]
+                [ [ td
+                        [ css
+                            [ verticalAlign middle
+                            ]
+                        ]
+                        [ text <| toString style ]
                   ]
                 , sizes
                     |> List.map (exampleCell style)

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -32,7 +32,7 @@ type ButtonType
 
 {-| -}
 example :
-    { r | teach_assignments_copyWhite_svg : Asset }
+    { r | teach_assignments_copyWhite_svg : Asset, x : String }
     -> (String -> ModuleMessages Msg parentMsg)
     -> State
     -> ModuleExample parentMsg
@@ -110,7 +110,7 @@ type alias Model =
     }
 
 
-viewButtonExamples : { r | teach_assignments_copyWhite_svg : Asset } -> ModuleMessages Msg parentMsg -> State -> Html parentMsg
+viewButtonExamples : { r | teach_assignments_copyWhite_svg : Asset, x : String } -> ModuleMessages Msg parentMsg -> State -> Html parentMsg
 viewButtonExamples assets messages (State control) =
     let
         model =
@@ -120,7 +120,7 @@ viewButtonExamples assets messages (State control) =
         |> fromUnstyled
     , buttons assets messages sizes model
     , toggleButtons messages
-    , Button.delete
+    , Button.delete assets
         { label = "Delete Something"
         , onClick = messages.showItWorked "delete"
         }


### PR DESCRIPTION
This upgrades Nri.Button V2 to Nri.Button V3 so we can make use of new elm-css! 

This needs thorough @NoRedInk/design review. Make sure the buttons look like they do on the current styleguide in all states. 

To build this: 
- Clone this repo
- `> make styleguide-app/elm.js`
- `> open styleguide-app/index.html`

Post merge TODO: 

- [ ] Run `elm-package bump` to make sure you're bumping to the correct version
