### PR TITLE
Upgrade Modal V1 -> Modal V2

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -29,6 +29,7 @@
         "Nri.Ui.Icon.V3",
         "Nri.Ui.InputStyles",
         "Nri.Ui.Modal.V1",
+        "Nri.Ui.Modal.V2",
         "Nri.Ui.Outline.V1",
         "Nri.Ui.Page.V1",
         "Nri.Ui.Palette.V1",

--- a/src/Nri/Ui/Modal/V2.elm
+++ b/src/Nri/Ui/Modal/V2.elm
@@ -1,0 +1,213 @@
+module Nri.Ui.Modal.V2
+    exposing
+        ( Model
+        , info
+        , warning
+        )
+
+{-| Changes from V1:
+
+  - Use Styled Html
+
+@docs Model
+@docs info
+@docs warning
+
+-}
+
+import Accessibility.Styled as Html exposing (..)
+import Accessibility.Styled.Role as Role
+import Accessibility.Styled.Widget as Widget
+import Css
+import Css.Foreign exposing (Snippet, body, children, descendants, everything, selector)
+import Html.Styled
+import Html.Styled.Events exposing (onClick)
+import Nri.Ui
+import Nri.Ui.Colors.Extra
+import Nri.Ui.Colors.V1
+import Nri.Ui.Fonts.V1 as Fonts
+
+
+{-|
+
+  - `onDismiss`: If `Nothing`, the modal will not be dismissable
+  - `visibleTitle`: If `False`, the title will still be used for screen readers
+  - `content`: This will be placed in a `width:100%` div in the main area of the modal
+  - `footerContent`: The optional items here will be stacked below the main content area and center-aligned.
+    Commonly you will either give a list of Nri.Ui.Buttons,
+    or an empty list.
+
+-}
+type alias Model msg =
+    { title : String
+    , visibleTitle : Bool
+    , content : Html msg
+    , footerContent : List (Html msg)
+    , onDismiss : Maybe msg
+    , width : Maybe Int
+    }
+
+
+type ModalType
+    = Info
+    | Warning
+
+
+{-| -}
+info : Model msg -> Html msg
+info =
+    view Info
+
+
+{-| -}
+warning : Model msg -> Html msg
+warning =
+    view Warning
+
+
+view : ModalType -> Model msg -> Html msg
+view modalType { title, visibleTitle, content, onDismiss, footerContent, width } =
+    Nri.Ui.styled div
+        "modal-backdrop-container"
+        ((case modalType of
+            Info ->
+                Css.backgroundColor (Nri.Ui.Colors.Extra.withAlpha 0.9 Nri.Ui.Colors.V1.navy)
+
+            Warning ->
+                Css.backgroundColor (Nri.Ui.Colors.Extra.withAlpha 0.9 Nri.Ui.Colors.V1.gray20)
+         )
+            :: [ Css.height (Css.vh 100)
+               , Css.left Css.zero
+               , Css.overflow Css.hidden
+               , Css.position Css.fixed
+               , Css.top Css.zero
+               , Css.width (Css.pct 100)
+               , Css.zIndex (Css.int 3)
+               ]
+        )
+        [ Role.dialog
+        , Widget.label title
+        , Widget.modal True
+        ]
+        [ Nri.Ui.styled Html.Styled.div
+            "modal-click-catcher"
+            [ Css.bottom Css.zero
+            , Css.left Css.zero
+            , Css.position Css.absolute
+            , Css.right Css.zero
+            , Css.top Css.zero
+            ]
+            (case onDismiss of
+                Nothing ->
+                    []
+
+                Just msg ->
+                    [ onClick msg ]
+            )
+            []
+        , Nri.Ui.styled div
+            "modal-container"
+            [ Css.alignItems Css.center
+            , Css.displayFlex
+            , Css.flexDirection Css.column
+            , Css.flexWrap Css.noWrap
+            , Css.backgroundColor Nri.Ui.Colors.V1.white
+            , Css.borderRadius (Css.px 20)
+            , Css.margin2 (Css.px 75) Css.auto
+            , Css.maxHeight (Css.calc (Css.vh 100) Css.minus (Css.px 150))
+            , Css.padding2 (Css.px 45) Css.zero
+            , Css.position Css.relative -- required for closeButtonContainer
+            , Css.property "box-shadow" "0 1px 10px 0 rgba(0, 0, 0, 0.35)"
+            , case width of
+                Nothing ->
+                    Css.width (Css.px 600)
+
+                Just width ->
+                    Css.width (Css.px (toFloat width))
+            ]
+            []
+            [ -- This global <style> node sets overflow to hidden on the body element,
+              -- thereby preventing the page from scrolling behind the backdrop when the modal is
+              -- open (and this node is present on the page).
+              Css.Foreign.global
+                [ Css.Foreign.body
+                    [ Css.overflow Css.hidden ]
+                ]
+            , if visibleTitle then
+                viewHeader modalType title
+              else
+                text ""
+            , viewContent modalType content
+            , viewFooter footerContent
+            ]
+        ]
+
+
+viewHeader : ModalType -> String -> Html msg
+viewHeader modalType title =
+    Nri.Ui.styled Html.h3
+        "modal-header"
+        ((case modalType of
+            Info ->
+                Css.color Nri.Ui.Colors.V1.navy
+
+            Warning ->
+                Css.color Nri.Ui.Colors.V1.red
+         )
+            :: [ Css.fontWeight (Css.int 700)
+               , Css.lineHeight (Css.px 27)
+               , Css.margin4 Css.zero Css.zero (Css.px 40) Css.zero
+               , Css.fontSize (Css.px 20)
+               , Fonts.baseFont
+               ]
+        )
+        []
+        [ Html.text title
+        ]
+
+
+viewContent : ModalType -> Html msg -> Html msg
+viewContent modalType content =
+    Nri.Ui.styled div
+        "modal-content"
+        [ Css.flexShrink (Css.int 4)
+        , Css.overflowY Css.auto
+        , Css.padding2 Css.zero (Css.px 45)
+        , Css.width (Css.pct 100)
+        ]
+        []
+        [ content ]
+
+
+viewFooter : List (Html msg) -> Html msg
+viewFooter footerContent =
+    case footerContent of
+        [] ->
+            Html.text ""
+
+        _ ->
+            Nri.Ui.styled div
+                "modal-footer"
+                [ Css.alignItems Css.center
+                , Css.displayFlex
+                , Css.flexDirection Css.column
+                , Css.flexGrow (Css.int 2)
+                , Css.flexWrap Css.noWrap
+                , Css.margin4 (Css.px 40) Css.zero Css.zero Css.zero
+                , Css.width (Css.pct 100)
+                ]
+                []
+                (List.map
+                    (\x ->
+                        Nri.Ui.styled div
+                            "modal-footer-item"
+                            [ Css.margin4 (Css.px 10) Css.zero Css.zero Css.zero
+                            , Css.firstChild
+                                [ Css.margin Css.zero
+                                ]
+                            ]
+                            []
+                            [ x ]
+                    )
+                    footerContent
+                )

--- a/src/Nri/Ui/Modal/V2.elm
+++ b/src/Nri/Ui/Modal/V2.elm
@@ -82,7 +82,10 @@ view modalType { title, visibleTitle, content, onDismiss, footerContent, width }
                , Css.position Css.fixed
                , Css.top Css.zero
                , Css.width (Css.pct 100)
-               , Css.zIndex (Css.int 3)
+               , Css.zIndex (Css.int 200)
+               , Css.displayFlex
+               , Css.alignItems Css.center
+               , Css.justifyContent Css.center
                ]
         )
         [ Role.dialog
@@ -107,23 +110,19 @@ view modalType { title, visibleTitle, content, onDismiss, footerContent, width }
             []
         , Nri.Ui.styled div
             "modal-container"
-            [ Css.alignItems Css.center
-            , Css.displayFlex
-            , Css.flexDirection Css.column
-            , Css.flexWrap Css.noWrap
+            [ Css.width (Css.px 600)
+            , Css.maxHeight <| Css.calc (Css.vh 100) Css.minus (Css.px 100)
+            , Css.padding4 (Css.px 35) Css.zero (Css.px 25) Css.zero
+            , Css.margin2 (Css.px 75) Css.auto
             , Css.backgroundColor Nri.Ui.Colors.V1.white
             , Css.borderRadius (Css.px 20)
-            , Css.margin2 (Css.px 75) Css.auto
-            , Css.maxHeight (Css.calc (Css.vh 100) Css.minus (Css.px 150))
-            , Css.padding2 (Css.px 45) Css.zero
-            , Css.position Css.relative -- required for closeButtonContainer
             , Css.property "box-shadow" "0 1px 10px 0 rgba(0, 0, 0, 0.35)"
-            , case width of
-                Nothing ->
-                    Css.width (Css.px 600)
-
-                Just width ->
-                    Css.width (Css.px (toFloat width))
+            , Css.position Css.relative -- required for closeButtonContainer
+            , Css.displayFlex
+            , Css.alignItems Css.center
+            , Css.flexDirection Css.column
+            , Css.flexWrap Css.noWrap
+            , Fonts.baseFont
             ]
             []
             [ -- This global <style> node sets overflow to hidden on the body element,
@@ -170,10 +169,11 @@ viewContent : ModalType -> Html msg -> Html msg
 viewContent modalType content =
     Nri.Ui.styled div
         "modal-content"
-        [ Css.flexShrink (Css.int 4)
-        , Css.overflowY Css.auto
-        , Css.padding2 Css.zero (Css.px 45)
+        [ Css.overflowY Css.scroll
+        , Css.padding2 (Css.px 30) (Css.px 45)
         , Css.width (Css.pct 100)
+        , Css.minHeight (Css.px 150)
+        , Css.boxSizing Css.borderBox
         ]
         []
         [ content ]

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -176,7 +176,6 @@ viewModal modal =
                             , height (px 200)
                             , backgroundColor Colors.gray75
                             , border3 (px 1) dashed Colors.gray20
-                            , padding (px 20)
                             ]
                         ]
                         [ text "Imagine an image" ]
@@ -198,7 +197,6 @@ viewModal modal =
                                 , height (px 200)
                                 , backgroundColor Colors.gray75
                                 , border3 (px 1) dashed Colors.gray20
-                                , padding (px 20)
                                 ]
                             ]
                             [ text "Imagine an image" ]

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -1,0 +1,220 @@
+module Examples.Modal exposing (Msg, State, example, init, update)
+
+{-|
+
+@docs Msg, State, example, init, update,
+
+-}
+
+import Accessibility.Styled as Html exposing (Html, div, h3, p, text)
+import Css exposing (..)
+import Html.Styled
+import Html.Styled.Attributes exposing (css)
+import ModuleExample exposing (Category(..), ModuleExample)
+import Nri.Ui.Button.V3 as Button
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Modal.V2 as Modal
+
+
+{-| -}
+type Msg
+    = DismissModal
+    | ShowModal ModalType
+
+
+{-| -}
+type alias State =
+    { modal : Maybe ModalType }
+
+
+{-| -}
+example : (Msg -> msg) -> State -> ModuleExample msg
+example parentMessage state =
+    { filename = "Nri.Ui.Modal.V2.elm"
+    , category = Modals
+    , content =
+        [ case state.modal of
+            Just modal ->
+                viewModal modal
+
+            Nothing ->
+                text ""
+        , viewButtons
+        ]
+            |> List.map (Html.map parentMessage)
+            |> List.map Html.Styled.toUnstyled
+    }
+
+
+{-| -}
+init : State
+init =
+    { modal = Nothing }
+
+
+{-| -}
+update : Msg -> State -> ( State, Cmd Msg )
+update msg state =
+    case msg of
+        DismissModal ->
+            ( { state | modal = Nothing }, Cmd.none )
+
+        ShowModal modalType ->
+            ( { state | modal = Just modalType }, Cmd.none )
+
+
+
+-- INTERNAL
+
+
+type ModalType
+    = InfoModal
+    | WarningModal
+    | NoButtonModal
+    | NoDismissModal
+    | NoHeading
+    | ScrolledContentModal
+
+
+viewButtons : Html Msg
+viewButtons =
+    [ ( "Info Modal", "Modal.info", InfoModal )
+    , ( "Warning Modal", "Modal.warning", WarningModal )
+    , ( "No Button Modal", "Modal.info { ... footerContent = [] ... }", NoButtonModal )
+    , ( "No Dismiss Modal", "Modal.info { ... onDismiss Nothing ... }", NoDismissModal )
+    , ( "No Heading", "Modal.info { ... visibleTitle = False ... }", NoHeading )
+    , ( "Scrolled Content"
+      , "Modal.info { content = Html.text 'so much stuff' }"
+      , ScrolledContentModal
+      )
+    ]
+        |> List.map modalLaunchButton
+        |> div []
+
+
+modalLaunchButton : ( String, String, ModalType ) -> Html Msg
+modalLaunchButton ( label, details, modalType ) =
+    div []
+        [ h3 [] [ text label ]
+        , p [] [ text details ]
+        , Button.button
+            { onClick = ShowModal modalType
+            , size = Button.Small
+            , style = Button.Secondary
+            , width = Nothing
+            }
+            { label = label
+            , state = Button.Enabled
+            , icon = Nothing
+            }
+        ]
+
+
+viewModal : ModalType -> Html Msg
+viewModal modal =
+    case modal of
+        InfoModal ->
+            Modal.info
+                { title = "Info Modal"
+                , visibleTitle = True
+                , content = text "This is where the content goes!"
+                , onDismiss = Just DismissModal
+                , width = Nothing
+                , footerContent =
+                    [ modalFooterButton "Primary" Button.Primary
+                    , modalFooterButton "Cancel" Button.Borderless
+                    ]
+                }
+
+        WarningModal ->
+            Modal.warning
+                { title = "Warning Modal"
+                , visibleTitle = True
+                , content = text "This is where the content goes!"
+                , onDismiss = Just DismissModal
+                , width = Nothing
+                , footerContent =
+                    [ modalFooterButton "Primary" Button.Danger
+                    , modalFooterButton "Cancel" Button.Borderless
+                    ]
+                }
+
+        NoButtonModal ->
+            Modal.info
+                { title = "No Buttons"
+                , visibleTitle = True
+                , content = text "This is where the content goes!"
+                , onDismiss = Just DismissModal
+                , width = Nothing
+                , footerContent = []
+                }
+
+        NoDismissModal ->
+            Modal.info
+                { title = "No Dismiss"
+                , visibleTitle = True
+                , content = text "This is where the content goes!"
+                , onDismiss = Nothing
+                , width = Nothing
+                , footerContent =
+                    [ modalFooterButton "Primary" Button.Primary
+                    , modalFooterButton "Cancel" Button.Borderless
+                    ]
+                }
+
+        NoHeading ->
+            Modal.info
+                { title = "Hidden title"
+                , onDismiss = Just DismissModal
+                , visibleTitle = False
+                , footerContent = []
+                , width = Nothing
+                , content =
+                    div
+                        [ css
+                            [ width (pct 100)
+                            , height (px 200)
+                            , backgroundColor Colors.gray75
+                            , border3 (px 1) dashed Colors.gray20
+                            , padding (px 20)
+                            ]
+                        ]
+                        [ text "Imagine an image" ]
+                }
+
+        ScrolledContentModal ->
+            Modal.info
+                { title = "Scrolled Content"
+                , onDismiss = Just DismissModal
+                , visibleTitle = True
+                , footerContent = [ modalFooterButton "Primary" Button.Primary ]
+                , width = Nothing
+                , content =
+                    div []
+                        [ text "\nIt was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season of Light, it was the season of Darkness, it was the spring of hope, it was the winter of despair, we had everything before us, we had nothing before us, we were all going direct to Heaven, we were all going direct the other way – in short, the period was so far like the present period, that some of its noisiest authorities insisted on its being received, for good or for evil, in the superlative degree of comparison only.\n\n\nIt was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season of Light, it was the season of Darkness, it was the spring of hope, it was the winter of despair, we had everything before us, we had nothing before us, we were all going direct to Heaven, we were all going direct the other way – in short, the period was so far like the present period, that some of its noisiest authorities insisted on its being received, for good or for evil, in the superlative degree of comparison only.\n\nIt was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season of Light, it was the season of Darkness, it was the spring of hope, it was the winter of despair, we had everything before us, we had nothing before us, we were all going direct to Heaven, we were all going direct the other way – in short, the period was so far like the present period, that some of its noisiest authorities insisted on its being received, for good or for evil, in the superlative degree of comparison only.\n                          "
+                        , div
+                            [ css
+                                [ width (pct 100)
+                                , height (px 200)
+                                , backgroundColor Colors.gray75
+                                , border3 (px 1) dashed Colors.gray20
+                                , padding (px 20)
+                                ]
+                            ]
+                            [ text "Imagine an image" ]
+                        ]
+                }
+
+
+modalFooterButton : String -> Button.ButtonStyle -> Html Msg
+modalFooterButton label style =
+    Button.button
+        { onClick = DismissModal
+        , size = Button.Large
+        , style = style
+        , width = Just 230
+        }
+        { label = label
+        , state = Button.Enabled
+        , icon = Nothing
+        }

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -10,6 +10,7 @@ import Examples.DisclosureIndicator
 import Examples.Dropdown
 import Examples.Fonts
 import Examples.Icon
+import Examples.Modal
 import Examples.Page
 import Examples.SegmentedControl
 import Examples.Select
@@ -26,7 +27,6 @@ import Nri.Ui.Button.V2 as Button
 import Nri.Ui.Dropdown.V1
 import Nri.Ui.Icon.V2
 import Nri.Ui.SegmentedControl.V5
-import Nri.Ui.Text.V2 as Text
 import Nri.Ui.TextArea.V2 as TextArea
 import String.Extra
 
@@ -41,6 +41,7 @@ type alias ModuleStates =
     , textAreaExampleState : TextAreaExample.State
     , textInputExampleState : TextInputExample.State
     , disclosureIndicatorExampleState : Examples.DisclosureIndicator.State
+    , modalExampleState : Examples.Modal.State
     }
 
 
@@ -55,6 +56,7 @@ init =
     , textAreaExampleState = TextAreaExample.init
     , textInputExampleState = TextInputExample.init
     , disclosureIndicatorExampleState = Examples.DisclosureIndicator.init
+    , modalExampleState = Examples.Modal.init
     }
 
 
@@ -69,6 +71,7 @@ type Msg
     | TextAreaExampleMsg TextAreaExample.Msg
     | TextInputExampleMsg TextInputExample.Msg
     | DisclosureIndicatorExampleMsg Examples.DisclosureIndicator.Msg
+    | ModalExampleMsg Examples.Modal.Msg
     | NoOp
 
 
@@ -161,6 +164,15 @@ update msg moduleStates =
             , Cmd.map DisclosureIndicatorExampleMsg cmd
             )
 
+        ModalExampleMsg msg ->
+            let
+                ( modalExampleState, cmd ) =
+                    Examples.Modal.update msg moduleStates.modalExampleState
+            in
+            ( { moduleStates | modalExampleState = modalExampleState }
+            , Cmd.map ModalExampleMsg cmd
+            )
+
         NoOp ->
             ( moduleStates, Cmd.none )
 
@@ -201,6 +213,7 @@ nriThemedModules model =
     , TextInputExample.example TextInputExampleMsg model.textInputExampleState
     , Examples.DisclosureIndicator.example DisclosureIndicatorExampleMsg model.disclosureIndicatorExampleState
     , Examples.Colors.example
+    , Examples.Modal.example ModalExampleMsg model.modalExampleState
     ]
 
 


### PR DESCRIPTION
This upgrades Modal V1 -> Modal V2 so that we have access to modals with new elm css!!!

Weirdly, Nri.Ui.Modal.V1 is not used in the monolith yet.

It also uses the current styles in the monolith for V2, because Nri.Modal from the monolith also has newer styles than V1. 🤷‍♀️ 

## QA 
Build the styleguide-app and look at the modal example.