### PR TITLE
Bump to 5.17.0

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "5.16.0",
+    "version": "5.17.0",
     "summary": "UI Widgets we use at NRI",
     "repository": "https://github.com/NoRedInk/noredink-ui.git",
     "license": "BSD3",


### PR DESCRIPTION
Bump to 5.17.0 for https://github.com/NoRedInk/noredink-ui/pull/111: Don't require PremiumLevel; allow general premium levels