### PR TITLE
High-rise buttons

### DIFF
--- a/src/Nri/Ui/Button/V2.elm
+++ b/src/Nri/Ui/Button/V2.elm
@@ -654,13 +654,14 @@ styles =
                 , borderRadius (px 8)
                 , minHeight (px config.minHeight)
                 , lineHeight (px config.lineHeight)
-                , padding2 zero (px config.sidePadding)
+                , padding2 (Css.px 4) (px config.sidePadding)
                 , boxSizing borderBox
                 , minWidth (px config.minWidth)
                 , borderWidth (px 1)
                 , borderBottomWidth (px config.shadowHeight)
                 , Css.Foreign.withClass ExplicitWidth
-                    [ padding2 zero (px 4)
+                    [ paddingLeft (px 4)
+                    , paddingRight (px 4)
                     , boxSizing borderBox
                     ]
                 , Css.Foreign.withClass IsLink

--- a/src/Nri/Ui/Button/V2.elm
+++ b/src/Nri/Ui/Button/V2.elm
@@ -652,7 +652,7 @@ styles =
             Css.Foreign.class (SizeStyle size)
                 [ fontSize (px config.fontSize)
                 , borderRadius (px 8)
-                , Css.height (px config.height)
+                , minHeight (px config.minHeight)
                 , lineHeight (px config.lineHeight)
                 , padding2 zero (px config.sidePadding)
                 , boxSizing borderBox
@@ -664,7 +664,7 @@ styles =
                     , boxSizing borderBox
                     ]
                 , Css.Foreign.withClass IsLink
-                    [ lineHeight (px config.height)
+                    [ lineHeight (px config.minHeight)
                     ]
                 , Css.Foreign.descendants
                     [ Css.Foreign.img
@@ -772,7 +772,7 @@ styles =
                 ]
             , sizeStyle TinyDeprecated
                 { fontSize = 13
-                , height = 25
+                , minHeight = 25
                 , lineHeight = 25
                 , sidePadding = 8
                 , minWidth = 50
@@ -781,7 +781,7 @@ styles =
                 }
             , sizeStyle Small
                 { fontSize = 15
-                , height = 36
+                , minHeight = 36
                 , lineHeight = 15
                 , sidePadding = 16
                 , imageHeight = 15
@@ -790,7 +790,7 @@ styles =
                 }
             , sizeStyle Medium
                 { fontSize = 17
-                , height = 45
+                , minHeight = 45
                 , lineHeight = 19
                 , sidePadding = 16
                 , imageHeight = 15
@@ -799,7 +799,7 @@ styles =
                 }
             , sizeStyle Large
                 { fontSize = 20
-                , height = 56
+                , minHeight = 56
                 , lineHeight = 22
                 , sidePadding = 16
                 , imageHeight = 20

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -721,7 +721,8 @@ sizeStyle size width elementType =
                     ]
 
                 Nothing ->
-                    [ Css.padding2 Css.zero (Css.px 16)
+                    [ Css.paddingLeft (Css.px 16)
+                    , Css.paddingRight (Css.px 16)
                     , Css.minWidth (Css.px config.minWidth)
                     ]
 
@@ -744,6 +745,8 @@ sizeStyle size width elementType =
     [ Css.fontSize (Css.px config.fontSize)
     , Css.borderRadius (Css.px 8)
     , Css.minHeight (Css.px config.minHeight)
+    , Css.paddingTop (Css.px 4)
+    , Css.paddingBottom (Css.px 4)
     , Css.lineHeight (Css.px lineHeightPx)
     , Css.boxSizing Css.borderBox
     , Css.borderWidth (Css.px 1)

--- a/src/Nri/Ui/Button/V3.elm
+++ b/src/Nri/Ui/Button/V3.elm
@@ -691,7 +691,7 @@ sizeStyle size width elementType =
             case size of
                 Small ->
                     { fontSize = 15
-                    , height = 36
+                    , minHeight = 36
                     , imageHeight = 15
                     , shadowHeight = 2
                     , minWidth = 75
@@ -699,7 +699,7 @@ sizeStyle size width elementType =
 
                 Medium ->
                     { fontSize = 17
-                    , height = 45
+                    , minHeight = 45
                     , imageHeight = 15
                     , shadowHeight = 3
                     , minWidth = 100
@@ -707,7 +707,7 @@ sizeStyle size width elementType =
 
                 Large ->
                     { fontSize = 20
-                    , height = 56
+                    , minHeight = 56
                     , imageHeight = 20
                     , shadowHeight = 4
                     , minWidth = 200
@@ -728,7 +728,7 @@ sizeStyle size width elementType =
         lineHeightPx =
             case elementType of
                 Anchor ->
-                    config.height
+                    config.minHeight
 
                 Button ->
                     case size of
@@ -743,7 +743,7 @@ sizeStyle size width elementType =
     in
     [ Css.fontSize (Css.px config.fontSize)
     , Css.borderRadius (Css.px 8)
-    , Css.height (Css.px config.height)
+    , Css.minHeight (Css.px config.minHeight)
     , Css.lineHeight (Css.px lineHeightPx)
     , Css.boxSizing Css.borderBox
     , Css.borderWidth (Css.px 1)


### PR DESCRIPTION
This allows V2 and V3 buttons to grow vertically. Commit messages have more explanation.

I grafted this into the monolith and it works as expected:

![image](https://user-images.githubusercontent.com/348564/46197170-46845600-c309-11e8-9ff3-ea6e0b22703c.png)

I have visually inspected both buttons in the style guide (V3 in the noredink-ui style guide, V2 in the monolith style guide) and checked CSS attributes via Chrome's inspector.

> Hello there, wonderful author of widgets!
> This is `Nri.Ui.Friendly.AI.V1` speaking to you!
> Are you looking to get this awesome work reviewed as quickly as possible, so you can start putting it to use?
> Then feel free to grab a reviewer from the list below and assign them to the PR!
>
> https://paper.dropbox.com/doc/noredink-ui-widget-library-fUK6yq32g187lxw2A60a8#:uid=619243092748985044355046&h2=Reviewers-list
>
> It's best if we have separate pull requests for code changes and package version bumps. If you're just changing code, great! If you're just bumping the version, check out https://github.com/NoRedInk/noredink-ui#deploying.
