### PR TITLE
Add V4 button with unbounded height behaviour

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -14,6 +14,7 @@
         "Nri.Ui.Button.V1",
         "Nri.Ui.Button.V2",
         "Nri.Ui.Button.V3",
+        "Nri.Ui.Button.V4",
         "Nri.Ui.Checkbox.V1",
         "Nri.Ui.Checkbox.V2",
         "Nri.Ui.Checkbox.V3",

--- a/src/Nri/Ui/Button/V4.elm
+++ b/src/Nri/Ui/Button/V4.elm
@@ -1,5 +1,5 @@
 module Nri.Ui.Button.V4 exposing
-    ( ButtonSize(..), ButtonHeight(..), ButtonWidth(..), ButtonStyle(..), ButtonState(..), ButtonContent
+    ( ButtonSize(..), ButtonWidth(..), ButtonStyle(..), ButtonState(..), ButtonContent
     , ButtonConfig, button, customButton, delete, copyToClipboard, ToggleButtonConfig, toggleButton
     , LinkConfig, link, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     )
@@ -9,7 +9,6 @@ module Nri.Ui.Button.V4 exposing
 
 # Changes from V3:
 
-  - Adds `ButtonHeight`.
   - Adds `ButtonWidth`.
 
 
@@ -33,7 +32,7 @@ may be exceptions, for example if button content is supplied by an end-user.
 
 ## Common configs
 
-@docs ButtonSize, ButtonHeight, ButtonWidth, ButtonStyle, ButtonState, ButtonContent
+@docs ButtonSize, ButtonWidth, ButtonStyle, ButtonState, ButtonContent
 
 
 ## `<button>` Buttons
@@ -73,28 +72,6 @@ type ButtonSize
     = Small
     | Medium
     | Large
-
-
-{-| Height sizing behavior for buttons.
-
-A `HeightDefault` button allows only a single line of button text; any more is
-truncated. Use this when the button text is short and static, or has been
-supplied by the user and could be so long as to break layout.
-
-A `HeightBounded Int` or `HeightUnbounded` button grows vertically to
-accommodate some or all the button content. Use this when the button text may
-contain longer text, such as a quiz answer, and where it's more important to
-display the full text than guarantee a fixed layout; i.e. where not having the
-full text could prevent a human from using the site.
-
-`HeightBounded Int` is useful for dealing with user-supplied button content,
-because an upper bound can be placed on how many lines to allow.
-
--}
-type ButtonHeight
-    = HeightDefault
-    | HeightBounded Int
-    | HeightUnbounded
 
 
 {-| Width sizing behavior for buttons.
@@ -149,7 +126,6 @@ type alias ButtonConfig msg =
     { onClick : msg
     , size : ButtonSize
     , style : ButtonStyle
-    , height : ButtonHeight
     , width : ButtonWidth
     }
 
@@ -231,7 +207,7 @@ customButton attributes config content =
     in
     Nri.Ui.styled Html.button
         (styledName "customButton")
-        (buttonStyles config.size config.height config.width buttonStyle Button)
+        (buttonStyles config.size config.width buttonStyle Button)
         ([ Events.onClick config.onClick
          , Attributes.disabled disabled
          , Attributes.type_ "button"
@@ -253,7 +229,6 @@ type alias CopyToClipboardConfig =
     , copyText : String
     , buttonLabel : String
     , withIcon : Bool
-    , height : ButtonHeight
     , width : ButtonWidth
     }
 
@@ -273,7 +248,7 @@ copyToClipboard assets config =
     in
     Nri.Ui.styled Html.button
         (styledName "copyToClipboard")
-        (buttonStyles config.size config.height config.width (styleToColorPalette config.style) Button)
+        (buttonStyles config.size config.width (styleToColorPalette config.style) Button)
         [ Widget.label "Copy URL to clipboard"
         , Attributes.attribute "data-clipboard-text" config.copyText
         ]
@@ -349,7 +324,7 @@ toggleButton config =
     in
     Nri.Ui.styled Html.button
         (styledName "toggleButton")
-        (buttonStyles Medium HeightDefault WidthUnbounded SecondaryColors Button
+        (buttonStyles Medium WidthUnbounded SecondaryColors Button
             ++ toggledStyles
         )
         [ Events.onClick
@@ -495,7 +470,7 @@ linkBase linkFunctionName extraAttrs config =
     Nri.Ui.styled Styled.a
         (styledName linkFunctionName)
         (Css.whiteSpace Css.noWrap
-            :: buttonStyles config.size HeightDefault config.width (styleToColorPalette config.style) Anchor
+            :: buttonStyles config.size config.width (styleToColorPalette config.style) Anchor
         )
         (Attributes.href config.url
             :: extraAttrs
@@ -538,12 +513,12 @@ styleToColorPalette style =
             PremiumColors
 
 
-buttonStyles : ButtonSize -> ButtonHeight -> ButtonWidth -> ColorPalette -> ElementType -> List Style
-buttonStyles size height width colorPalette elementType =
+buttonStyles : ButtonSize -> ButtonWidth -> ColorPalette -> ElementType -> List Style
+buttonStyles size width colorPalette elementType =
     List.concat
         [ buttonStyle
         , colorStyle colorPalette
-        , sizeStyle size height width elementType
+        , sizeStyle size width elementType
         ]
 
 
@@ -722,8 +697,8 @@ type ElementType
     | Button
 
 
-sizeStyle : ButtonSize -> ButtonHeight -> ButtonWidth -> ElementType -> List Style
-sizeStyle size height width elementType =
+sizeStyle : ButtonSize -> ButtonWidth -> ElementType -> List Style
+sizeStyle size width elementType =
     let
         config =
             case size of
@@ -754,44 +729,14 @@ sizeStyle size height width elementType =
         sizingAttributes =
             case elementType of
                 Button ->
-                    case height of
-                        HeightDefault ->
-                            [ Css.height (Css.px config.height)
-                            , Css.whiteSpace Css.noWrap
-                            , Css.paddingTop Css.zero
-                            , Css.paddingBottom Css.zero
-                            ]
-
-                        HeightBounded factor ->
-                            let
-                                verticalPaddingPx =
-                                    4
-
-                                minHeightPx =
-                                    config.height
-
-                                maxHeightPx =
-                                    -- Have to consider padding and shadowHeight
-                                    -- because `box-model` is set to `border-box`.
-                                    (lineHeightPx * toFloat factor)
-                                        + (verticalPaddingPx * 2)
-                                        + config.shadowHeight
-                            in
-                            [ Css.minHeight (Css.px config.height)
-                            , Css.maxHeight (Css.px (max minHeightPx maxHeightPx))
-                            , Css.paddingTop (Css.px verticalPaddingPx)
-                            , Css.paddingBottom (Css.px verticalPaddingPx)
-                            ]
-
-                        HeightUnbounded ->
-                            let
-                                verticalPaddingPx =
-                                    4
-                            in
-                            [ Css.minHeight (Css.px config.height)
-                            , Css.paddingTop (Css.px verticalPaddingPx)
-                            , Css.paddingBottom (Css.px verticalPaddingPx)
-                            ]
+                    let
+                        verticalPaddingPx =
+                            4
+                    in
+                    [ Css.minHeight (Css.px config.height)
+                    , Css.paddingTop (Css.px verticalPaddingPx)
+                    , Css.paddingBottom (Css.px verticalPaddingPx)
+                    ]
 
                 _ ->
                     []

--- a/src/Nri/Ui/Button/V4.elm
+++ b/src/Nri/Ui/Button/V4.elm
@@ -1,0 +1,786 @@
+module Nri.Ui.Button.V4 exposing
+    ( ButtonSize(..), ButtonStyle(..), ButtonState(..), ButtonContent
+    , ButtonConfig, button, customButton, delete, copyToClipboard, ToggleButtonConfig, toggleButton
+    , LinkConfig, link, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
+    )
+
+{-|
+
+
+# Changes from V2:
+
+  - Uses Html.Styled
+  - Removes buttonDeprecated
+  - Removes Tiny size
+  - Removes one-off Active hack
+  - Removes "submit" button - we just used that for forms that were partially in Elm
+
+
+# About:
+
+Common NoRedInk buttons. For accessibility purposes, buttons that perform an
+action on the current page should be HTML `<button>` elements and are created here
+with `*Button` functions. Buttons that take the user to a new page should be
+HTML `<a>` elements and are created here with `*Link` functions. Both versions
+should be able to use the same CSS class in all cases.
+
+There will generally be a `*Button` and `*Link` version of each button style.
+(These will be created as they are needed.)
+
+
+## Common configs
+
+@docs ButtonSize, ButtonStyle, ButtonState, ButtonContent
+
+
+## `<button>` Buttons
+
+@docs ButtonConfig, button, customButton, delete, copyToClipboard, ToggleButtonConfig, toggleButton
+
+
+## `<a>` Buttons
+
+@docs LinkConfig, link, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
+
+-}
+
+import Accessibility.Styled as Html exposing (Attribute, Html)
+import Accessibility.Styled.Role as Role
+import Accessibility.Styled.Widget as Widget
+import Css exposing (Style)
+import Css.Foreign
+import EventExtras.Styled as EventExtras
+import Html.Styled as Styled
+import Html.Styled.Attributes as Attributes
+import Html.Styled.Events as Events
+import Json.Decode
+import Markdown.Block
+import Markdown.Inline
+import Nri.Ui
+import Nri.Ui.AssetPath as AssetPath exposing (Asset)
+import Nri.Ui.Colors.Extra as ColorsExtra
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1
+import Nri.Ui.Icon.V3 as Icon exposing (IconType)
+
+
+{-| Sizes for buttons and links that have button classes
+-}
+type ButtonSize
+    = Small
+    | Medium
+    | Large
+
+
+{-| Styleguide-approved styles for your buttons!
+
+Note on borderless buttons:
+A borderless button that performs an action on the current page
+This button is intended to look like a link.
+Only use a borderless button when the clickable text in question follows the same layout/margin/padding as a bordered button
+
+-}
+type ButtonStyle
+    = Primary
+    | Secondary
+    | Borderless
+    | Danger
+    | Premium
+
+
+{-| Describes the state of a button. Has consequences for appearance and disabled attribute.
+
+  - Enabled: An enabled button. Takes the appearance of ButtonStyle
+  - Unfulfilled: A button which appears with the InactiveColors palette but is not disabled.
+  - Disabled: A button which appears with the InactiveColors palette and is disabled.
+  - Error: A button which appears with the ErrorColors palette and is disabled.
+  - Loading: A button which appears with the LoadingColors palette and is disabled
+  - Success: A button which appears with the SuccessColors palette and is disabled
+
+-}
+type ButtonState
+    = Enabled
+    | Unfulfilled
+    | Disabled
+    | Error
+    | Loading
+    | Success
+
+
+{-| The part of a button that remains constant through different button states
+-}
+type alias ButtonConfig msg =
+    { onClick : msg
+    , size : ButtonSize
+    , style : ButtonStyle
+    , width : Maybe Int
+    }
+
+
+{-| ButtonContent, often changes based on ButtonState. For example, a button in the "Success"
+state may have a different label than a button in the "Error" state
+-}
+type alias ButtonContent =
+    { label : String
+    , state : ButtonState
+    , icon : Maybe IconType
+    }
+
+
+{-| A delightful button which can trigger an effect when clicked!
+
+This button will trigger the passed-in message if the button state is:
+
+  - Enabled
+  - Unfulfilled
+
+This button will be Disabled if the button state is:
+
+  - Disabled
+  - Error
+  - Loading
+  - Success
+
+-}
+button : ButtonConfig msg -> ButtonContent -> Html msg
+button config content =
+    customButton [] config content
+
+
+{-| Exactly the same as button but you can pass in a list of attributes
+-}
+customButton : List (Attribute msg) -> ButtonConfig msg -> ButtonContent -> Html msg
+customButton attributes config content =
+    let
+        buttonStyle =
+            case content.state of
+                Enabled ->
+                    styleToColorPalette config.style
+
+                Disabled ->
+                    InactiveColors
+
+                Error ->
+                    ErrorColors
+
+                Unfulfilled ->
+                    InactiveColors
+
+                Loading ->
+                    LoadingColors
+
+                Success ->
+                    SuccessColors
+
+        disabled =
+            case content.state of
+                Enabled ->
+                    False
+
+                Disabled ->
+                    True
+
+                Error ->
+                    True
+
+                Unfulfilled ->
+                    False
+
+                Loading ->
+                    True
+
+                Success ->
+                    True
+    in
+    Nri.Ui.styled Html.button
+        (styledName "customButton")
+        (buttonStyles config.size config.width buttonStyle Button)
+        ([ Events.onClick config.onClick
+         , Attributes.disabled disabled
+         , Attributes.type_ "button"
+         ]
+            ++ attributes
+        )
+        (viewLabel content.icon content.label)
+
+
+
+-- COPY TO CLIPBOARD BUTTON
+
+
+{-| Config for copyToClipboard
+-}
+type alias CopyToClipboardConfig =
+    { size : ButtonSize
+    , style : ButtonStyle
+    , copyText : String
+    , buttonLabel : String
+    , withIcon : Bool
+    , width : Maybe Int
+    }
+
+
+{-| See ui/src/Page/Teach/Courses/Assignments/index.coffee
+You will need to hook this up to clipboard.js
+-}
+copyToClipboard : { r | teach_assignments_copyWhite_svg : Asset } -> CopyToClipboardConfig -> Html msg
+copyToClipboard assets config =
+    let
+        maybeIcon =
+            if config.withIcon then
+                Just (Icon.copy assets)
+
+            else
+                Nothing
+    in
+    Nri.Ui.styled Html.button
+        (styledName "copyToClipboard")
+        (buttonStyles config.size config.width (styleToColorPalette config.style) Button)
+        [ Widget.label "Copy URL to clipboard"
+        , Attributes.attribute "data-clipboard-text" config.copyText
+        ]
+        (viewLabel maybeIcon config.buttonLabel)
+
+
+
+-- DELETE BUTTON
+
+
+type alias DeleteButtonConfig msg =
+    { label : String
+    , onClick : msg
+    }
+
+
+{-| A delete button (blue X)
+-}
+delete : { r | x : String } -> DeleteButtonConfig msg -> Html msg
+delete assets config =
+    Nri.Ui.styled Html.button
+        (styledName "delete")
+        [ Css.display Css.inlineBlock
+        , Css.backgroundRepeat Css.noRepeat
+        , Css.backgroundColor Css.transparent
+        , Css.backgroundPosition Css.center
+        , Css.backgroundSize Css.contain
+        , Css.border Css.zero
+        , Css.width (Css.px 15)
+        , Css.height (Css.px 15)
+        , Css.padding Css.zero
+        , Css.margin2 Css.zero (Css.px 6)
+        , Css.cursor Css.pointer
+        , Css.color Colors.azure
+        ]
+        [ Events.onClick config.onClick
+        , Attributes.type_ "button"
+        , -- reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Labeling_buttons
+          Widget.label config.label
+        ]
+        [ Icon.icon { alt = "Delete", icon = Icon.xSvg assets } ]
+
+
+
+-- TOGGLE BUTTON
+
+
+{-| Buttons can be toggled into a pressed state and back again.
+-}
+type alias ToggleButtonConfig msg =
+    { label : String
+    , onSelect : msg
+    , onDeselect : msg
+    , pressed : Bool
+    }
+
+
+{-| -}
+toggleButton : ToggleButtonConfig msg -> Html msg
+toggleButton config =
+    let
+        toggledStyles =
+            if config.pressed then
+                [ Css.color Colors.gray20
+                , Css.backgroundColor Colors.glacier
+                , Css.boxShadow5 Css.inset Css.zero (Css.px 3) Css.zero (ColorsExtra.withAlpha 0.2 Colors.gray20)
+                , Css.border3 (Css.px 1) Css.solid Colors.azure
+                , Css.fontWeight Css.bold
+                ]
+
+            else
+                []
+    in
+    Nri.Ui.styled Html.button
+        (styledName "toggleButton")
+        (buttonStyles Medium Nothing SecondaryColors Button
+            ++ toggledStyles
+        )
+        [ Events.onClick
+            (if config.pressed then
+                config.onDeselect
+
+             else
+                config.onSelect
+            )
+        , Widget.pressed <| Just config.pressed
+
+        -- reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Labeling_buttons
+        , Role.button
+
+        -- Note: setting type: 'button' removes the default behavior of submit
+        -- equivalent to preventDefaultBehavior = false
+        -- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-name
+        , Attributes.type_ "button"
+        ]
+        (viewLabel Nothing config.label)
+
+
+{-| Inputs can be a clickable thing used in a form
+-}
+type alias InputConfig =
+    { content : Html Never
+    , name : String
+    , size : ButtonSize
+    , style : ButtonStyle
+    , value : String
+    }
+
+
+
+-- LINKS THAT LOOK LIKE BUTTONS
+
+
+{-| Links are clickable things with a url.
+
+NOTE: Links do not support two-line labels.
+
+-}
+type alias LinkConfig =
+    { label : String
+    , icon : Maybe IconType
+    , url : String
+    , size : ButtonSize
+    , style : ButtonStyle
+    , width : Maybe Int
+    }
+
+
+{-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to
+some url
+-}
+link : LinkConfig -> Html msg
+link =
+    linkBase "link" [ Attributes.target "_self" ]
+
+
+{-| Use this link for routing within a single page app.
+
+This will make a normal <a> tag, but change the Events.onClick behavior to avoid reloading the page.
+
+See <https://github.com/elm-lang/html/issues/110> for details on this implementation.
+
+-}
+linkSpa :
+    (route -> String)
+    -> (route -> msg)
+    ->
+        { label : String
+        , icon : Maybe IconType
+        , size : ButtonSize
+        , style : ButtonStyle
+        , width : Maybe Int
+        , route : route
+        }
+    -> Html msg
+linkSpa toUrl toMsg config =
+    linkBase
+        "linkSpa"
+        [ EventExtras.onClickPreventDefaultForLinkWithHref (toMsg config.route)
+        ]
+        { label = config.label
+        , icon = config.icon
+        , size = config.size
+        , style = config.style
+        , width = config.width
+        , url = toUrl config.route
+        }
+
+
+{-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to
+some url and have it open to an external site
+-}
+linkExternal : LinkConfig -> Html msg
+linkExternal =
+    linkBase "linkExternal" [ Attributes.target "_blank" ]
+
+
+{-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to
+some url, and it's an HTTP request (Rails includes JS to make this use the given HTTP method)
+-}
+linkWithMethod : String -> LinkConfig -> Html msg
+linkWithMethod method =
+    linkBase "linkWithMethod" [ Attributes.attribute "data-method" method ]
+
+
+{-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to some url.
+This should only take in messages that result in a Msg that triggers Analytics.trackAndRedirect. For buttons that trigger other effects on the page, please use Nri.Button.button instead
+-}
+linkWithTracking : msg -> LinkConfig -> Html msg
+linkWithTracking onTrack =
+    linkBase
+        "linkWithTracking"
+        [ Events.onWithOptions "click"
+            { stopPropagation = False
+            , preventDefault = True
+            }
+            (Json.Decode.succeed onTrack)
+        ]
+
+
+{-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to some url and have it open to an external site
+
+This should only take in messages that result in tracking events. For buttons that trigger other effects on the page, please use Nri.Ui.Button.V2.button instead
+
+-}
+linkExternalWithTracking : msg -> LinkConfig -> Html msg
+linkExternalWithTracking onTrack =
+    linkBase
+        "linkExternalWithTracking"
+        [ Attributes.target "_blank"
+        , EventExtras.onClickForLinkWithHref onTrack
+        ]
+
+
+{-| Helper function for building links with an arbitrary number of Attributes
+-}
+linkBase : String -> List (Attribute msg) -> LinkConfig -> Html msg
+linkBase linkFunctionName extraAttrs config =
+    Nri.Ui.styled Styled.a
+        (styledName linkFunctionName)
+        (Css.whiteSpace Css.noWrap
+            :: buttonStyles config.size config.width (styleToColorPalette config.style) Anchor
+        )
+        (Attributes.href config.url
+            :: extraAttrs
+        )
+        (viewLabel config.icon config.label)
+
+
+
+-- HELPERS
+
+
+type ColorPalette
+    = PrimaryColors
+    | SecondaryColors
+    | BorderlessColors
+    | DangerColors
+    | PremiumColors
+    | InactiveColors
+    | LoadingColors
+    | SuccessColors
+    | ErrorColors
+
+
+styleToColorPalette : ButtonStyle -> ColorPalette
+styleToColorPalette style =
+    case style of
+        Primary ->
+            PrimaryColors
+
+        Secondary ->
+            SecondaryColors
+
+        Borderless ->
+            BorderlessColors
+
+        Danger ->
+            DangerColors
+
+        Premium ->
+            PremiumColors
+
+
+buttonStyles : ButtonSize -> Maybe Int -> ColorPalette -> ElementType -> List Style
+buttonStyles size width colorPalette elementType =
+    List.concat
+        [ buttonStyle
+        , colorStyle colorPalette
+        , sizeStyle size width elementType
+        ]
+
+
+viewLabel : Maybe IconType -> String -> List (Html msg)
+viewLabel icn label =
+    case icn of
+        Nothing ->
+            renderMarkdown label
+
+        Just iconType ->
+            [ Html.span [] (Icon.decorativeIcon iconType :: renderMarkdown label) ]
+
+
+renderMarkdown : String -> List (Html msg)
+renderMarkdown markdown =
+    case Markdown.Block.parse Nothing markdown of
+        -- It seems to be always first wrapped in a `Paragraph` and never directly a `PlainInline`
+        [ Markdown.Block.Paragraph _ inlines ] ->
+            List.map (Markdown.Inline.toHtml >> Styled.fromUnstyled) inlines
+
+        _ ->
+            [ Html.text markdown ]
+
+
+
+-- STYLES
+
+
+buttonStyle : List Style
+buttonStyle =
+    [ Css.cursor Css.pointer
+    , Css.display Css.inlineBlock
+    , -- Specifying the font can and should go away after bootstrap is removed from application.css
+      Nri.Ui.Fonts.V1.baseFont
+    , Css.textOverflow Css.ellipsis
+    , Css.overflow Css.hidden
+    , Css.textDecoration Css.none
+    , Css.backgroundImage Css.none
+    , Css.textShadow Css.none
+    , Css.property "transition" "all 0.2s"
+    , Css.boxShadow Css.none
+    , Css.border Css.zero
+    , Css.marginBottom Css.zero
+    , Css.hover [ Css.textDecoration Css.none ]
+    , Css.disabled [ Css.cursor Css.notAllowed ]
+    ]
+
+
+colorStyle : ColorPalette -> List Style
+colorStyle colorPalette =
+    let
+        ( config, additionalStyles ) =
+            case colorPalette of
+                PrimaryColors ->
+                    ( { background = Colors.azure
+                      , hover = Colors.azureDark
+                      , text = Colors.white
+                      , border = Nothing
+                      , shadow = Colors.azureDark
+                      }
+                    , []
+                    )
+
+                SecondaryColors ->
+                    ( { background = Colors.white
+                      , hover = Colors.glacier
+                      , text = Colors.azure
+                      , border = Just <| Colors.azure
+                      , shadow = Colors.azure
+                      }
+                    , []
+                    )
+
+                BorderlessColors ->
+                    ( { background = Css.rgba 0 0 0 0
+                      , hover = Css.rgba 0 0 0 0
+                      , text = Colors.azure
+                      , border = Nothing
+                      , shadow = Css.rgba 0 0 0 0
+                      }
+                    , [ Css.hover
+                            [ Css.textDecoration Css.underline
+                            , Css.disabled [ Css.textDecoration Css.none ]
+                            ]
+                      ]
+                    )
+
+                DangerColors ->
+                    ( { background = Colors.red
+                      , hover = Colors.redDark
+                      , text = Colors.white
+                      , border = Nothing
+                      , shadow = Colors.redDark
+                      }
+                    , []
+                    )
+
+                PremiumColors ->
+                    ( { background = Colors.yellow
+                      , hover = Colors.ochre
+                      , text = Colors.navy
+                      , border = Nothing
+                      , shadow = Colors.ochre
+                      }
+                    , []
+                    )
+
+                InactiveColors ->
+                    ( { background = Colors.gray92
+                      , hover = Colors.gray92
+                      , text = Colors.gray45
+                      , border = Nothing
+                      , shadow = Colors.gray92
+                      }
+                    , []
+                    )
+
+                LoadingColors ->
+                    ( { background = Colors.glacier
+                      , hover = Colors.glacier
+                      , text = Colors.navy
+                      , border = Nothing
+                      , shadow = Colors.glacier
+                      }
+                    , []
+                    )
+
+                SuccessColors ->
+                    ( { background = Colors.greenDark
+                      , hover = Colors.greenDark
+                      , text = Colors.white
+                      , border = Nothing
+                      , shadow = Colors.greenDark
+                      }
+                    , []
+                    )
+
+                ErrorColors ->
+                    ( { background = Colors.purple
+                      , hover = Colors.purple
+                      , text = Colors.white
+                      , border = Nothing
+                      , shadow = Colors.purple
+                      }
+                    , []
+                    )
+    in
+    [ Css.batch additionalStyles
+    , Css.color config.text
+    , Css.backgroundColor config.background
+    , Css.fontWeight (Css.int 700)
+    , Css.textAlign Css.center
+    , case config.border of
+        Nothing ->
+            Css.borderStyle Css.none
+
+        Just color ->
+            Css.batch
+                [ Css.borderColor color
+                , Css.borderStyle Css.solid
+                ]
+    , Css.borderBottomStyle Css.solid
+    , Css.borderBottomColor config.shadow
+    , Css.fontStyle Css.normal
+    , Css.hover
+        [ Css.color config.text
+        , Css.backgroundColor config.hover
+        , Css.disabled [ Css.backgroundColor config.background ]
+        ]
+    , Css.visited [ Css.color config.text ]
+    ]
+
+
+type ElementType
+    = Anchor
+    | Button
+
+
+sizeStyle : ButtonSize -> Maybe Int -> ElementType -> List Style
+sizeStyle size width elementType =
+    let
+        config =
+            case size of
+                Small ->
+                    { fontSize = 15
+                    , minHeight = 36
+                    , imageHeight = 15
+                    , shadowHeight = 2
+                    , minWidth = 75
+                    }
+
+                Medium ->
+                    { fontSize = 17
+                    , minHeight = 45
+                    , imageHeight = 15
+                    , shadowHeight = 3
+                    , minWidth = 100
+                    }
+
+                Large ->
+                    { fontSize = 20
+                    , minHeight = 56
+                    , imageHeight = 20
+                    , shadowHeight = 4
+                    , minWidth = 200
+                    }
+
+        widthAttributes =
+            case width of
+                Just pxWidth ->
+                    [ Css.maxWidth (Css.pct 100)
+                    , Css.width (Css.px <| toFloat pxWidth)
+                    ]
+
+                Nothing ->
+                    [ Css.paddingLeft (Css.px 16)
+                    , Css.paddingRight (Css.px 16)
+                    , Css.minWidth (Css.px config.minWidth)
+                    ]
+
+        lineHeightPx =
+            case elementType of
+                Anchor ->
+                    config.minHeight
+
+                Button ->
+                    case size of
+                        Small ->
+                            15
+
+                        Medium ->
+                            19
+
+                        Large ->
+                            22
+    in
+    [ Css.fontSize (Css.px config.fontSize)
+    , Css.borderRadius (Css.px 8)
+    , Css.minHeight (Css.px config.minHeight)
+    , Css.paddingTop (Css.px 4)
+    , Css.paddingBottom (Css.px 4)
+    , Css.lineHeight (Css.px lineHeightPx)
+    , Css.boxSizing Css.borderBox
+    , Css.borderWidth (Css.px 1)
+    , Css.borderBottomWidth (Css.px config.shadowHeight)
+    , Css.batch widthAttributes
+    , Css.Foreign.descendants
+        [ Css.Foreign.img
+            [ Css.height (Css.px config.imageHeight)
+            , Css.marginRight (Css.px <| config.imageHeight / 6)
+            , Css.position Css.relative
+            , Css.bottom (Css.px 2)
+            , Css.verticalAlign Css.middle
+            ]
+        , Css.Foreign.svg
+            [ Css.height (Css.px config.imageHeight) |> Css.important
+            , Css.width (Css.px config.imageHeight) |> Css.important
+            , Css.marginRight (Css.px <| config.imageHeight / 6)
+            , Css.position Css.relative
+            , Css.bottom (Css.px 2)
+            , Css.verticalAlign Css.middle
+            ]
+        , Css.Foreign.svg
+            [ Css.important <| Css.height (Css.px config.imageHeight)
+            , Css.important <| Css.width Css.auto
+            , Css.maxWidth (Css.px (config.imageHeight * 1.25))
+            , Css.paddingRight (Css.px <| config.imageHeight / 6)
+            , Css.position Css.relative
+            , Css.bottom (Css.px 2)
+            , Css.verticalAlign Css.middle
+            ]
+        ]
+    ]
+
+
+styledName : String -> String
+styledName suffix =
+    "Nri-Ui-Button-V4-" ++ suffix

--- a/src/Nri/Ui/Button/V4.elm
+++ b/src/Nri/Ui/Button/V4.elm
@@ -10,6 +10,8 @@ module Nri.Ui.Button.V4 exposing
 # Changes from V3:
 
   - Adds `ButtonWidth`.
+  - Button now grows vertically to fit content.
+    To limit the height use attributes on its container or consider truncating content before rendering.
 
 
 # About:

--- a/src/Nri/Ui/Button/V4.elm
+++ b/src/Nri/Ui/Button/V4.elm
@@ -1,5 +1,5 @@
 module Nri.Ui.Button.V4 exposing
-    ( ButtonSize(..), ButtonHeight(..), ButtonWidth, ButtonStyle(..), ButtonState(..), ButtonContent
+    ( ButtonSize(..), ButtonHeight(..), ButtonWidth(..), ButtonStyle(..), ButtonState(..), ButtonContent
     , ButtonConfig, button, customButton, delete, copyToClipboard, ToggleButtonConfig, toggleButton
     , LinkConfig, link, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     )
@@ -9,7 +9,8 @@ module Nri.Ui.Button.V4 exposing
 
 # Changes from V3:
 
-  - Adds `ButtonSizing`.
+  - Adds `ButtonHeight`.
+  - Adds `ButtonWidth`.
 
 
 # About:
@@ -92,11 +93,13 @@ type ButtonHeight
 
 {-| Width sizing behavior for buttons.
 
-TODO: Change to a custom type rather than an alias.
+`WidthExact Int` defines a size in `px` for the button's total width, and
+`WidthUnbounded` leaves the maxiumum width unbounded (there is a minimum width).
 
 -}
-type alias ButtonWidth =
-    Maybe Int
+type ButtonWidth
+    = WidthExact Int
+    | WidthUnbounded
 
 
 {-| Styleguide-approved styles for your buttons!
@@ -340,7 +343,7 @@ toggleButton config =
     in
     Nri.Ui.styled Html.button
         (styledName "toggleButton")
-        (buttonStyles Medium HeightFixed Nothing SecondaryColors Button
+        (buttonStyles Medium HeightFixed WidthUnbounded SecondaryColors Button
             ++ toggledStyles
         )
         [ Events.onClick
@@ -789,12 +792,12 @@ sizeStyle size height width elementType =
 
         widthAttributes =
             case width of
-                Just pxWidth ->
+                WidthExact pxWidth ->
                     [ Css.maxWidth (Css.pct 100)
                     , Css.width (Css.px <| toFloat pxWidth)
                     ]
 
-                Nothing ->
+                WidthUnbounded ->
                     [ Css.paddingLeft (Css.px 16)
                     , Css.paddingRight (Css.px 16)
                     , Css.minWidth (Css.px config.minWidth)

--- a/src/Nri/Ui/Button/V4.elm
+++ b/src/Nri/Ui/Button/V4.elm
@@ -24,6 +24,12 @@ should be able to use the same CSS class in all cases.
 There will generally be a `*Button` and `*Link` version of each button style.
 (These will be created as they are needed.)
 
+In general a button should never truncate or obscure its contents. This could
+make it difficult or impossible for a student or teacher to use the site, so in
+general choose buttons that grow to fit their contents. It is better to risk
+weird layout than to block users. Might this be a golden rule? Of course there
+may be exceptions, for example if button content is supplied by an end-user.
+
 
 ## Common configs
 

--- a/src/Nri/Ui/Button/V4.elm
+++ b/src/Nri/Ui/Button/V4.elm
@@ -71,7 +71,7 @@ type ButtonSize
 
 {-| Height sizing behavior for buttons.
 
-A `HeightFixed` button allows only a single line of button text; any more is
+A `HeightDefault` button allows only a single line of button text; any more is
 truncated. Use this when the button text is short and static, or has been
 supplied by the user and could be so long as to break layout.
 
@@ -86,7 +86,7 @@ because an upper bound can be placed on how many lines to allow.
 
 -}
 type ButtonHeight
-    = HeightFixed
+    = HeightDefault
     | HeightBounded Int
     | HeightUnbounded
 
@@ -343,7 +343,7 @@ toggleButton config =
     in
     Nri.Ui.styled Html.button
         (styledName "toggleButton")
-        (buttonStyles Medium HeightFixed WidthUnbounded SecondaryColors Button
+        (buttonStyles Medium HeightDefault WidthUnbounded SecondaryColors Button
             ++ toggledStyles
         )
         [ Events.onClick
@@ -489,7 +489,7 @@ linkBase linkFunctionName extraAttrs config =
     Nri.Ui.styled Styled.a
         (styledName linkFunctionName)
         (Css.whiteSpace Css.noWrap
-            :: buttonStyles config.size HeightFixed config.width (styleToColorPalette config.style) Anchor
+            :: buttonStyles config.size HeightDefault config.width (styleToColorPalette config.style) Anchor
         )
         (Attributes.href config.url
             :: extraAttrs
@@ -749,7 +749,7 @@ sizeStyle size height width elementType =
             case elementType of
                 Button ->
                     case height of
-                        HeightFixed ->
+                        HeightDefault ->
                             [ Css.height (Css.px config.height)
                             , Css.whiteSpace Css.noWrap
                             , Css.paddingTop Css.zero

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -11,7 +11,7 @@ import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample, ModuleMessages)
 import Nri.Ui.AssetPath exposing (Asset)
-import Nri.Ui.Button.V3 as Button
+import Nri.Ui.Button.V4 as Button
 import Nri.Ui.Icon.V3 as Icon
 
 
@@ -43,7 +43,7 @@ example assets unnamedMessages state =
         messages =
             unnamedMessages "ButtonExample"
     in
-    { filename = "Nri.Ui.Button.V3"
+    { filename = "Nri.Ui.Button.V4"
     , category = Buttons
     , content =
         [ viewButtonExamples assets messages state ]

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -63,10 +63,11 @@ init assets =
                     , ( "Lock", Control.value (Icon.lock assets) )
                     ]
             )
-        |> Control.field "sizing (button and copyToClipboard only)"
+        |> Control.field "height (button and copyToClipboard only)"
             (Control.choice
-                [ ( "Nri.Ui.Button.V4.Fixed", Control.value Button.Fixed )
-                , ( "Nri.Ui.Button.V4.GrowsVertically", Control.value Button.GrowsVertically )
+                [ ( "Nri.Ui.Button.V4.HeightFixed", Control.value Button.HeightFixed )
+                , ( "Nri.Ui.Button.V4.HeightBounded 2", Control.value (Button.HeightBounded 2) )
+                , ( "Nri.Ui.Button.V4.HeightUnbounded", Control.value Button.HeightUnbounded )
                 ]
             )
         |> Control.field "width"
@@ -112,8 +113,8 @@ update msg state =
 type alias Model =
     { label : String
     , icon : Maybe Icon.IconType
-    , sizing : Button.ButtonSizing
-    , width : Maybe Int
+    , height : Button.ButtonHeight
+    , width : Button.ButtonWidth
     , buttonType : ButtonType
     , state : Button.ButtonState
     }
@@ -131,7 +132,7 @@ viewButtonExamples assets messages (State control) =
     in
     [ Control.view (State >> SetState >> messages.wrapper) control
         |> fromUnstyled
-    , buttons assets messages model.sizing sizes model
+    , buttons assets messages model.height sizes model
     , toggleButtons messages
     , Button.delete assets
         { label = "Delete Something"
@@ -158,13 +159,6 @@ sizes =
     ]
 
 
-sizings : List Button.ButtonSizing
-sizings =
-    [ Button.GrowsVertically
-    , Button.Fixed
-    ]
-
-
 allStyles : List Button.ButtonStyle
 allStyles =
     [ Button.Primary
@@ -178,13 +172,13 @@ allStyles =
 buttons :
     { r | teach_assignments_copyWhite_svg : Asset }
     -> ModuleMessages Msg parentMsg
-    -> Button.ButtonSizing
+    -> Button.ButtonHeight
     -> List Button.ButtonSize
     -> Model
     -> Html parentMsg
-buttons assets messages sizing sizes model =
+buttons assets messages height sizes model =
     let
-        exampleRow sizing style =
+        exampleRow height style =
             List.concat
                 [ [ td
                         [ css
@@ -194,11 +188,11 @@ buttons assets messages sizing sizes model =
                         [ text <| toString style ]
                   ]
                 , sizes
-                    |> List.map (exampleCell style sizing)
+                    |> List.map (exampleCell style height)
                 ]
                 |> tr []
 
-        exampleCell style sizing size =
+        exampleCell style height size =
             (case model.buttonType of
                 Link ->
                     Button.link
@@ -213,9 +207,9 @@ buttons assets messages sizing sizes model =
                 Button ->
                     Button.button
                         { size = size
-                        , sizing = sizing
                         , style = style
                         , onClick = messages.showItWorked (toString ( style, size ))
+                        , height = model.height
                         , width = model.width
                         }
                         { label = model.label
@@ -227,11 +221,11 @@ buttons assets messages sizing sizes model =
                     Button.copyToClipboard
                         assets
                         { size = size
-                        , sizing = sizing
                         , style = style
                         , copyText = "wire up in your coffee file with clipboard.js"
                         , buttonLabel = model.label
                         , withIcon = model.icon /= Nothing
+                        , height = model.height
                         , width = model.width
                         }
             )
@@ -244,7 +238,7 @@ buttons assets messages sizing sizes model =
                 |> (\cells -> tr [] (th [] [] :: cells))
           ]
         , allStyles
-            |> List.map (exampleRow sizing)
+            |> List.map (exampleRow height)
         ]
         |> table []
 

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -71,11 +71,11 @@ init assets =
                 ]
             )
         |> Control.field "width"
-            (Control.maybe True <|
-                Control.choice
-                    [ ( "120", Control.value 120 )
-                    , ( "70", Control.value 70 )
-                    ]
+            (Control.choice
+                [ ( "Nri.Ui.Button.V4.WidthExact 120", Control.value <| Button.WidthExact 120 )
+                , ( "Nri.Ui.Button.V4.WidthExact 70", Control.value <| Button.WidthExact 70 )
+                , ( "Nri.Ui.Button.V4.WidthUnbounded", Control.value <| Button.WidthUnbounded )
+                ]
             )
         |> Control.field "button type"
             (Control.choice
@@ -142,7 +142,7 @@ viewButtonExamples assets messages (State control) =
         (messages.showItWorked "linkExternalWithTracking clicked")
         { size = Button.Medium
         , style = Button.Secondary
-        , width = Nothing
+        , width = Button.WidthUnbounded
         , label = "linkExternalWithTracking"
         , icon = Nothing
         , url = "#"

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -63,13 +63,6 @@ init assets =
                     , ( "Lock", Control.value (Icon.lock assets) )
                     ]
             )
-        |> Control.field "height (button and copyToClipboard only)"
-            (Control.choice
-                [ ( "Nri.Ui.Button.V4.HeightDefault", Control.value Button.HeightDefault )
-                , ( "Nri.Ui.Button.V4.HeightBounded 2", Control.value (Button.HeightBounded 2) )
-                , ( "Nri.Ui.Button.V4.HeightUnbounded", Control.value Button.HeightUnbounded )
-                ]
-            )
         |> Control.field "width"
             (Control.choice
                 [ ( "Nri.Ui.Button.V4.WidthExact 120", Control.value <| Button.WidthExact 120 )
@@ -113,7 +106,6 @@ update msg state =
 type alias Model =
     { label : String
     , icon : Maybe Icon.IconType
-    , height : Button.ButtonHeight
     , width : Button.ButtonWidth
     , buttonType : ButtonType
     , state : Button.ButtonState
@@ -132,7 +124,7 @@ viewButtonExamples assets messages (State control) =
     in
     [ Control.view (State >> SetState >> messages.wrapper) control
         |> fromUnstyled
-    , buttons assets messages model.height sizes model
+    , buttons assets messages sizes model
     , toggleButtons messages
     , Button.delete assets
         { label = "Delete Something"
@@ -172,13 +164,12 @@ allStyles =
 buttons :
     { r | teach_assignments_copyWhite_svg : Asset }
     -> ModuleMessages Msg parentMsg
-    -> Button.ButtonHeight
     -> List Button.ButtonSize
     -> Model
     -> Html parentMsg
-buttons assets messages height sizes model =
+buttons assets messages sizes model =
     let
-        exampleRow height style =
+        exampleRow style =
             List.concat
                 [ [ td
                         [ css
@@ -188,11 +179,11 @@ buttons assets messages height sizes model =
                         [ text <| toString style ]
                   ]
                 , sizes
-                    |> List.map (exampleCell style height)
+                    |> List.map (exampleCell style)
                 ]
                 |> tr []
 
-        exampleCell style height size =
+        exampleCell style size =
             (case model.buttonType of
                 Link ->
                     Button.link
@@ -209,7 +200,6 @@ buttons assets messages height sizes model =
                         { size = size
                         , style = style
                         , onClick = messages.showItWorked (toString ( style, size ))
-                        , height = model.height
                         , width = model.width
                         }
                         { label = model.label
@@ -225,7 +215,6 @@ buttons assets messages height sizes model =
                         , copyText = "wire up in your coffee file with clipboard.js"
                         , buttonLabel = model.label
                         , withIcon = model.icon /= Nothing
-                        , height = model.height
                         , width = model.width
                         }
             )
@@ -238,7 +227,7 @@ buttons assets messages height sizes model =
                 |> (\cells -> tr [] (th [] [] :: cells))
           ]
         , allStyles
-            |> List.map (exampleRow height)
+            |> List.map exampleRow
         ]
         |> table []
 

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -65,7 +65,7 @@ init assets =
             )
         |> Control.field "height (button and copyToClipboard only)"
             (Control.choice
-                [ ( "Nri.Ui.Button.V4.HeightFixed", Control.value Button.HeightFixed )
+                [ ( "Nri.Ui.Button.V4.HeightDefault", Control.value Button.HeightDefault )
                 , ( "Nri.Ui.Button.V4.HeightBounded 2", Control.value (Button.HeightBounded 2) )
                 , ( "Nri.Ui.Button.V4.HeightUnbounded", Control.value Button.HeightUnbounded )
                 ]


### PR DESCRIPTION
Well, #121 (which I released as 5.18.1 last week) [wasn't popular in the monolith](https://noredink.slack.com/archives/C0VVDLEES/p1538157412000100). This PR instead adds a V4 button. This is very similar to the V3 except that it changes behaviour to allow the button to grow vertically as big as the content. I've put it in the style guide app, so give that a go (`make styleguide-app/elm.js && open styleguide-app/index.html`).

I've also defined `width` using a custom type, with members `WidthExact Int` and `WidthUnbounded`, corresponding exactly to the behaviour of the `Just Int` and `Nothing` of its previous definition.

**Note** that height only applies to `button` and `copyToClipboard` (both of which are ultimately `<button>` elements; `link` and the others are `<a>` elements).

See a  [diff of changes from V3 to V4](https://gist.github.com/leapingfrogs/2800c73f30b2291ed0af4038fc508b83).

> Hello there, wonderful author of widgets!
> This is `Nri.Ui.Friendly.AI.V1` speaking to you!
> Are you looking to get this awesome work reviewed as quickly as possible, so you can start putting it to use?
> Then feel free to grab a reviewer from the list below and assign them to the PR!
>
> https://paper.dropbox.com/doc/noredink-ui-widget-library-fUK6yq32g187lxw2A60a8#:uid=619243092748985044355046&h2=Reviewers-list
>
> It's best if we have separate pull requests for code changes and package version bumps. If you're just changing code, great! If you're just bumping the version, check out https://github.com/NoRedInk/noredink-ui#deploying.
