### PR TITLE
Quote PATH when setting env 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NPM_PREFIX=$(realpath .)/node_modules
 PATH:=${NPM_PREFIX}/.bin:${PATH}
-SHELL:=env PATH=${PATH} /bin/sh
+SHELL:=env PATH="${PATH}" /bin/sh
 
 .PHONY: test
 test: elm-stuff tests/elm-stuff node_modules

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NPM_PREFIX=$(realpath .)/node_modules
-PATH:=${NPM_PREFIX}/.bin:${PATH}
-SHELL:=env PATH="${PATH}" /bin/sh
+PATH:="${NPM_PREFIX}/.bin:${PATH}"
+SHELL:=env PATH=${PATH} /bin/sh
 
 .PHONY: test
 test: elm-stuff tests/elm-stuff node_modules


### PR DESCRIPTION
Trying to build locally I hit issues as my path contained spaces (due to VMWare Fusion.app).

This quotes the PATH when setting up the SHELL variable.

> Hello there, wonderful author of widgets!
> This is `Nri.Ui.Friendly.AI.V1` speaking to you!
> Are you looking to get this awesome work reviewed as quickly as possible, so you can start putting it to use?
> Then feel free to grab a reviewer from the list below and assign them to the PR!
>
> https://paper.dropbox.com/doc/noredink-ui-widget-library-fUK6yq32g187lxw2A60a8#:uid=619243092748985044355046&h2=Reviewers-list
>
> It's best if we have separate pull requests for code changes and package version bumps. If you're just changing code, great! If you're just bumping the version, check out https://github.com/NoRedInk/noredink-ui#deploying.
