### PR TITLE
Limit button transitions.

### DIFF
--- a/src/Nri/Ui/Button/V5.elm
+++ b/src/Nri/Ui/Button/V5.elm
@@ -11,6 +11,8 @@ module Nri.Ui.Button.V5 exposing
 
   - Allows links with words exceeding button-width to wrap
   - Standardizes vertical text alignment between buttons and links
+  - Limit CSS transitions to a subset of properties to avoid unintended "zoom"
+    effects.
 
 
 # About:
@@ -567,7 +569,7 @@ buttonStyle =
         , Css.textDecoration Css.none
         , Css.backgroundImage Css.none
         , Css.textShadow Css.none
-        , Css.property "transition" "all 0.2s"
+        , Css.property "transition" "background-color 0.2s, color 0.2s, box-shadow 0.2s, border 0.2s, border-width 0s"
         , Css.boxShadow Css.none
         , Css.border Css.zero
         , Css.marginBottom Css.zero

--- a/src/Nri/Ui/Button/V5.elm
+++ b/src/Nri/Ui/Button/V5.elm
@@ -529,8 +529,9 @@ viewLabel : Maybe IconType -> String -> Html msg
 viewLabel icn label =
     Nri.Ui.styled Html.span
         "button-label-span"
-        [ Css.overflowX Css.hidden
-        , Css.overflowWrap Css.breakWord
+        [ Css.overflow Css.hidden -- Keep scrollbars out of our button
+        , Css.overflowWrap Css.breakWord -- Ensure that words that exceed the button width break instead of disappearing
+        , Css.padding2 (Css.px 2) Css.zero -- Without a bit of bottom padding, text that extends below the baseline, like "g" gets cut off
         ]
         []
         (case icn of

--- a/src/Nri/Ui/Button/V5.elm
+++ b/src/Nri/Ui/Button/V5.elm
@@ -740,7 +740,7 @@ sizeStyle size width =
         sizingAttributes =
             let
                 verticalPaddingPx =
-                    4
+                    2
             in
             [ Css.minHeight (Css.px config.height)
             , Css.paddingTop (Css.px verticalPaddingPx)

--- a/src/Nri/Ui/Button/V5.elm
+++ b/src/Nri/Ui/Button/V5.elm
@@ -208,7 +208,7 @@ customButton attributes config content =
     in
     Nri.Ui.styled Html.button
         (styledName "customButton")
-        (buttonStyles config.size config.width buttonStyle)
+        [ buttonStyles config.size config.width buttonStyle ]
         ([ Events.onClick config.onClick
          , Attributes.disabled disabled
          , Attributes.type_ "button"
@@ -249,7 +249,7 @@ copyToClipboard assets config =
     in
     Nri.Ui.styled Html.button
         (styledName "copyToClipboard")
-        (buttonStyles config.size config.width (styleToColorPalette config.style))
+        [ buttonStyles config.size config.width (styleToColorPalette config.style) ]
         [ Widget.label "Copy URL to clipboard"
         , Attributes.attribute "data-clipboard-text" config.copyText
         ]
@@ -313,21 +313,23 @@ toggleButton config =
     let
         toggledStyles =
             if config.pressed then
-                [ Css.color Colors.gray20
-                , Css.backgroundColor Colors.glacier
-                , Css.boxShadow5 Css.inset Css.zero (Css.px 3) Css.zero (ColorsExtra.withAlpha 0.2 Colors.gray20)
-                , Css.border3 (Css.px 1) Css.solid Colors.azure
-                , Css.fontWeight Css.bold
-                ]
+                Css.batch
+                    [ Css.color Colors.gray20
+                    , Css.backgroundColor Colors.glacier
+                    , Css.boxShadow5 Css.inset Css.zero (Css.px 3) Css.zero (ColorsExtra.withAlpha 0.2 Colors.gray20)
+                    , Css.border3 (Css.px 1) Css.solid Colors.azure
+                    , Css.fontWeight Css.bold
+                    ]
 
             else
-                []
+                Css.batch
+                    []
     in
     Nri.Ui.styled Html.button
         (styledName "toggleButton")
-        (buttonStyles Medium WidthUnbounded SecondaryColors
-            ++ toggledStyles
-        )
+        [ buttonStyles Medium WidthUnbounded SecondaryColors
+        , toggledStyles
+        ]
         [ Events.onClick
             (if config.pressed then
                 config.onDeselect
@@ -470,7 +472,7 @@ linkBase : String -> List (Attribute msg) -> LinkConfig -> Html msg
 linkBase linkFunctionName extraAttrs config =
     Nri.Ui.styled Styled.a
         (styledName linkFunctionName)
-        (buttonStyles config.size config.width (styleToColorPalette config.style))
+        [ buttonStyles config.size config.width (styleToColorPalette config.style) ]
         (Attributes.href config.url
             :: extraAttrs
         )
@@ -512,9 +514,9 @@ styleToColorPalette style =
             PremiumColors
 
 
-buttonStyles : ButtonSize -> ButtonWidth -> ColorPalette -> List Style
+buttonStyles : ButtonSize -> ButtonWidth -> ColorPalette -> Style
 buttonStyles size width colorPalette =
-    List.concat
+    Css.batch
         [ buttonStyle
         , colorStyle colorPalette
         , sizeStyle size width
@@ -553,29 +555,31 @@ renderMarkdown markdown =
 -- STYLES
 
 
-buttonStyle : List Style
+buttonStyle : Style
 buttonStyle =
-    [ Css.cursor Css.pointer
-    , -- Specifying the font can and should go away after bootstrap is removed from application.css
-      Nri.Ui.Fonts.V1.baseFont
-    , Css.textOverflow Css.ellipsis
-    , Css.overflow Css.hidden
-    , Css.textDecoration Css.none
-    , Css.backgroundImage Css.none
-    , Css.textShadow Css.none
-    , Css.property "transition" "all 0.2s"
-    , Css.boxShadow Css.none
-    , Css.border Css.zero
-    , Css.marginBottom Css.zero
-    , Css.hover [ Css.textDecoration Css.none ]
-    , Css.disabled [ Css.cursor Css.notAllowed ]
-    , Css.displayFlex
-    , Css.alignItems Css.center
-    , Css.justifyContent Css.center
-    ]
+    Css.batch
+        [ Css.cursor Css.pointer
+        , Css.display Css.inlineBlock
+        , -- Specifying the font can and should go away after bootstrap is removed from application.css
+          Nri.Ui.Fonts.V1.baseFont
+        , Css.textOverflow Css.ellipsis
+        , Css.overflow Css.hidden
+        , Css.textDecoration Css.none
+        , Css.backgroundImage Css.none
+        , Css.textShadow Css.none
+        , Css.property "transition" "all 0.2s"
+        , Css.boxShadow Css.none
+        , Css.border Css.zero
+        , Css.marginBottom Css.zero
+        , Css.hover [ Css.textDecoration Css.none ]
+        , Css.disabled [ Css.cursor Css.notAllowed ]
+        , Css.displayFlex
+        , Css.alignItems Css.center
+        , Css.justifyContent Css.center
+        ]
 
 
-colorStyle : ColorPalette -> List Style
+colorStyle : ColorPalette -> Style
 colorStyle colorPalette =
     let
         ( config, additionalStyles ) =
@@ -674,33 +678,34 @@ colorStyle colorPalette =
                     , []
                     )
     in
-    [ Css.batch additionalStyles
-    , Css.color config.text
-    , Css.backgroundColor config.background
-    , Css.fontWeight (Css.int 700)
-    , Css.textAlign Css.center
-    , case config.border of
-        Nothing ->
-            Css.borderStyle Css.none
+    Css.batch
+        [ Css.batch additionalStyles
+        , Css.color config.text
+        , Css.backgroundColor config.background
+        , Css.fontWeight (Css.int 700)
+        , Css.textAlign Css.center
+        , case config.border of
+            Nothing ->
+                Css.borderStyle Css.none
 
-        Just color ->
-            Css.batch
-                [ Css.borderColor color
-                , Css.borderStyle Css.solid
-                ]
-    , Css.borderBottomStyle Css.solid
-    , Css.borderBottomColor config.shadow
-    , Css.fontStyle Css.normal
-    , Css.hover
-        [ Css.color config.text
-        , Css.backgroundColor config.hover
-        , Css.disabled [ Css.backgroundColor config.background ]
+            Just color ->
+                Css.batch
+                    [ Css.borderColor color
+                    , Css.borderStyle Css.solid
+                    ]
+        , Css.borderBottomStyle Css.solid
+        , Css.borderBottomColor config.shadow
+        , Css.fontStyle Css.normal
+        , Css.hover
+            [ Css.color config.text
+            , Css.backgroundColor config.hover
+            , Css.disabled [ Css.backgroundColor config.background ]
+            ]
+        , Css.visited [ Css.color config.text ]
         ]
-    , Css.visited [ Css.color config.text ]
-    ]
 
 
-sizeStyle : ButtonSize -> ButtonWidth -> List Style
+sizeStyle : ButtonSize -> ButtonWidth -> Style
 sizeStyle size width =
     let
         config =
@@ -765,41 +770,42 @@ sizeStyle size width =
                 Large ->
                     22
     in
-    [ Css.fontSize (Css.px config.fontSize)
-    , Css.borderRadius (Css.px 8)
-    , Css.lineHeight (Css.px lineHeightPx)
-    , Css.boxSizing Css.borderBox
-    , Css.borderWidth (Css.px 1)
-    , Css.borderBottomWidth (Css.px config.shadowHeight)
-    , Css.batch sizingAttributes
-    , Css.batch widthAttributes
-    , Css.Foreign.descendants
-        [ Css.Foreign.img
-            [ Css.height (Css.px config.imageHeight)
-            , Css.marginRight (Css.px <| config.imageHeight / 6)
-            , Css.position Css.relative
-            , Css.bottom (Css.px 2)
-            , Css.verticalAlign Css.middle
-            ]
-        , Css.Foreign.svg
-            [ Css.height (Css.px config.imageHeight) |> Css.important
-            , Css.width (Css.px config.imageHeight) |> Css.important
-            , Css.marginRight (Css.px <| config.imageHeight / 6)
-            , Css.position Css.relative
-            , Css.bottom (Css.px 2)
-            , Css.verticalAlign Css.middle
-            ]
-        , Css.Foreign.svg
-            [ Css.important <| Css.height (Css.px config.imageHeight)
-            , Css.important <| Css.width Css.auto
-            , Css.maxWidth (Css.px (config.imageHeight * 1.25))
-            , Css.paddingRight (Css.px <| config.imageHeight / 6)
-            , Css.position Css.relative
-            , Css.bottom (Css.px 2)
-            , Css.verticalAlign Css.middle
+    Css.batch
+        [ Css.fontSize (Css.px config.fontSize)
+        , Css.borderRadius (Css.px 8)
+        , Css.lineHeight (Css.px lineHeightPx)
+        , Css.boxSizing Css.borderBox
+        , Css.borderWidth (Css.px 1)
+        , Css.borderBottomWidth (Css.px config.shadowHeight)
+        , Css.batch sizingAttributes
+        , Css.batch widthAttributes
+        , Css.Foreign.descendants
+            [ Css.Foreign.img
+                [ Css.height (Css.px config.imageHeight)
+                , Css.marginRight (Css.px <| config.imageHeight / 6)
+                , Css.position Css.relative
+                , Css.bottom (Css.px 2)
+                , Css.verticalAlign Css.middle
+                ]
+            , Css.Foreign.svg
+                [ Css.height (Css.px config.imageHeight) |> Css.important
+                , Css.width (Css.px config.imageHeight) |> Css.important
+                , Css.marginRight (Css.px <| config.imageHeight / 6)
+                , Css.position Css.relative
+                , Css.bottom (Css.px 2)
+                , Css.verticalAlign Css.middle
+                ]
+            , Css.Foreign.svg
+                [ Css.important <| Css.height (Css.px config.imageHeight)
+                , Css.important <| Css.width Css.auto
+                , Css.maxWidth (Css.px (config.imageHeight * 1.25))
+                , Css.paddingRight (Css.px <| config.imageHeight / 6)
+                , Css.position Css.relative
+                , Css.bottom (Css.px 2)
+                , Css.verticalAlign Css.middle
+                ]
             ]
         ]
-    ]
 
 
 styledName : String -> String


### PR DESCRIPTION
🍐 with @stoeffel.

This does two things:

1. Uses `Css.batch` instead of passing around lists. This shouldn't actually have any effect on the button's behaviour.
2. Limits CSS transitions to `background-color`, `color`, `box-shadow`, and `border` except `border-width`.

The result (with animations slowed to 10%):

![2018-10-11 17 37 36](https://user-images.githubusercontent.com/348564/46816029-66d9f900-cd7c-11e8-8ae6-ca38871c023c.gif)

> Hello there, wonderful author of widgets!
> This is `Nri.Ui.Friendly.AI.V1` speaking to you!
> Are you looking to get this awesome work reviewed as quickly as possible, so you can start putting it to use?
> Then feel free to grab a reviewer from the list below and assign them to the PR!
>
> https://paper.dropbox.com/doc/noredink-ui-widget-library-fUK6yq32g187lxw2A60a8#:uid=619243092748985044355046&h2=Reviewers-list
>
> It's best if we have separate pull requests for code changes and package version bumps. If you're just changing code, great! If you're just bumping the version, check out https://github.com/NoRedInk/noredink-ui#deploying.
