### PR TITLE
Add assignment type icons for Peer Review and Quick Write

### DIFF
--- a/src/Nri/Ui/Icon/V3.elm
+++ b/src/Nri/Ui/Icon/V3.elm
@@ -11,6 +11,7 @@ module Nri.Ui.Icon.V3 exposing
     , assignmentTypeDiagnostic
     , assignmentTypePeerReview
     , assignmentTypePractice
+    , assignmentTypeQuickWrite
     , assignmentTypeQuiz
     , assignmentTypeWritingCycle
     , attention
@@ -96,6 +97,7 @@ module Nri.Ui.Icon.V3 exposing
 @docs assignmentTypeDiagnostic
 @docs assignmentTypePeerReview
 @docs assignmentTypePractice
+@docs assignmentTypeQuickWrite
 @docs assignmentTypeQuiz
 @docs assignmentTypeWritingCycle
 @docs attention
@@ -440,6 +442,12 @@ assignmentTypePeerReview assets =
 assignmentTypePractice : { r | practice : String } -> IconType
 assignmentTypePractice assets =
     SvgIcon assets.practice
+
+
+{-| -}
+assignmentTypeQuickWrite : { r | icons_quickWriteWhite_svg : Asset } -> IconType
+assignmentTypeQuickWrite assets =
+    ImgIcon assets.icons_quickWriteWhite_svg
 
 
 {-| -}

--- a/src/Nri/Ui/Icon/V3.elm
+++ b/src/Nri/Ui/Icon/V3.elm
@@ -9,6 +9,7 @@ module Nri.Ui.Icon.V3 exposing
     , assignmentStartButtonPrimary
     , assignmentStartButtonSecondary
     , assignmentTypeDiagnostic
+    , assignmentTypePeerReview
     , assignmentTypePractice
     , assignmentTypeQuiz
     , assignmentTypeWritingCycle
@@ -93,6 +94,7 @@ module Nri.Ui.Icon.V3 exposing
 @docs assignmentStartButtonPrimary
 @docs assignmentStartButtonSecondary
 @docs assignmentTypeDiagnostic
+@docs assignmentTypePeerReview
 @docs assignmentTypePractice
 @docs assignmentTypeQuiz
 @docs assignmentTypeWritingCycle
@@ -426,6 +428,12 @@ assignmentStartButtonSecondary assets =
 assignmentTypeDiagnostic : { r | diagnostic : String } -> IconType
 assignmentTypeDiagnostic assets =
     SvgIcon assets.diagnostic
+
+
+{-| -}
+assignmentTypePeerReview : { r | icons_peerReviewWhite_svg : Asset } -> IconType
+assignmentTypePeerReview assets =
+    ImgIcon assets.icons_peerReviewWhite_svg
 
 
 {-| -}

--- a/styleguide-app/Assets.elm
+++ b/styleguide-app/Assets.elm
@@ -46,6 +46,7 @@ type alias Assets =
     , icons_equals_svg : Asset
     , icons_helpBlue_svg : Asset
     , icons_peerReview_svg : Asset
+    , icons_peerReviewWhite_svg : Asset
     , icons_plusBlue_svg : Asset
     , icons_quickWrite_svg : Asset
     , icons_searchGray_svg : Asset
@@ -135,6 +136,7 @@ assets =
     , icons_equals_svg = Asset "assets/images/equals.svg"
     , icons_helpBlue_svg = Asset "assets/images/help-blue.svg"
     , icons_peerReview_svg = Asset "assets/images/peer-review.svg"
+    , icons_peerReviewWhite_svg = Asset "assets/images/peer-review-white.svg"
     , icons_plusBlue_svg = Asset "assets/images/plus-blue.svg"
     , icons_quickWrite_svg = Asset "assets/images/quick-write.svg"
     , icons_searchGray_svg = Asset "assets/images/search-gray.svg"

--- a/styleguide-app/Assets.elm
+++ b/styleguide-app/Assets.elm
@@ -49,6 +49,7 @@ type alias Assets =
     , icons_peerReviewWhite_svg : Asset
     , icons_plusBlue_svg : Asset
     , icons_quickWrite_svg : Asset
+    , icons_quickWriteWhite_svg : Asset
     , icons_searchGray_svg : Asset
     , icons_xBlue_svg : Asset
     , icons_xBlue_svg : Asset
@@ -139,6 +140,7 @@ assets =
     , icons_peerReviewWhite_svg = Asset "assets/images/peer-review-white.svg"
     , icons_plusBlue_svg = Asset "assets/images/plus-blue.svg"
     , icons_quickWrite_svg = Asset "assets/images/quick-write.svg"
+    , icons_quickWriteWhite_svg = Asset "assets/images/quick-write-white.svg"
     , icons_searchGray_svg = Asset "assets/images/search-gray.svg"
     , icons_xBlue_svg = Asset "assets/images/x-blue.svg"
     , key = "icon-key"

--- a/styleguide-app/Examples/Icon.elm
+++ b/styleguide-app/Examples/Icon.elm
@@ -40,6 +40,7 @@ example =
             , { icon = Icon.assignmentTypePractice, background = Light, alt = "Practice" }
             , { icon = Icon.assignmentTypeQuiz, background = Light, alt = "Quiz" }
             , { icon = Icon.assignmentTypeWritingCycle, background = Light, alt = "WritingCycle" }
+            , { icon = Icon.assignmentTypePeerReview, background = Dark, alt = "PeerReview" }
             , { icon = Icon.peerReview, background = Light, alt = "PeerReview" }
             , { icon = Icon.submitting, background = Light, alt = "Submitting" }
             , { icon = Icon.rating, background = Light, alt = "Rating" }

--- a/styleguide-app/Examples/Icon.elm
+++ b/styleguide-app/Examples/Icon.elm
@@ -39,6 +39,7 @@ example =
             [ { icon = Icon.assignmentTypeDiagnostic, background = Light, alt = "Diagnostic" }
             , { icon = Icon.assignmentTypePractice, background = Light, alt = "Practice" }
             , { icon = Icon.assignmentTypeQuiz, background = Light, alt = "Quiz" }
+            , { icon = Icon.assignmentTypeQuickWrite, background = Dark, alt = "QuickWrite" }
             , { icon = Icon.assignmentTypeWritingCycle, background = Light, alt = "WritingCycle" }
             , { icon = Icon.assignmentTypePeerReview, background = Dark, alt = "PeerReview" }
             , { icon = Icon.peerReview, background = Light, alt = "PeerReview" }

--- a/styleguide-app/Examples/Icon.elm
+++ b/styleguide-app/Examples/Icon.elm
@@ -40,15 +40,15 @@ example =
             , { icon = Icon.assignmentTypePractice, background = Light, alt = "Practice" }
             , { icon = Icon.assignmentTypeQuiz, background = Light, alt = "Quiz" }
             , { icon = Icon.assignmentTypeQuickWrite, background = Dark, alt = "QuickWrite" }
-            , { icon = Icon.assignmentTypeWritingCycle, background = Light, alt = "WritingCycle" }
+            , { icon = Icon.quickWrite, background = Light, alt = "QuickWrite" }
             , { icon = Icon.assignmentTypePeerReview, background = Dark, alt = "PeerReview" }
             , { icon = Icon.peerReview, background = Light, alt = "PeerReview" }
             , { icon = Icon.submitting, background = Light, alt = "Submitting" }
             , { icon = Icon.rating, background = Light, alt = "Rating" }
             , { icon = Icon.revising, background = Light, alt = "Revising" }
-            , { icon = Icon.quickWrite, background = Light, alt = "QuickWrite" }
 
             --, { icon = Icon.guidedWrite, background = Light, alt = "GuidedWrite" }
+            , { icon = Icon.assignmentTypeWritingCycle, background = Light, alt = "WritingCycle" }
             , { icon = Icon.writingAssignment, background = Light, alt = "WritingAssignment" }
             ]
         , viewIconSection "Student Assignment Actions"

--- a/styleguide-app/assets/images/peer-review-white.svg
+++ b/styleguide-app/assets/images/peer-review-white.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:318e4b592733c81645cc43d4ccf49f43c7af4b3e6a79140bdac238eb06c1ae75
+size 3069

--- a/styleguide-app/assets/images/quick-write-white.svg
+++ b/styleguide-app/assets/images/quick-write-white.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e8698a165aaee8341bb47d7dc120b1a78ac20859ecb24cedfb26425fe757419
+size 493


### PR DESCRIPTION
Part of https://www.pivotaltracker.com/story/show/161233340

Adds white SVGs for the top-level assignment form
* `Icon.assignmentTypePeerReview`
* `Icon.assignmentTypeQuickWrite`

<img width="719" alt="screen shot 2018-10-15 at 5 29 57 pm" src="https://user-images.githubusercontent.com/1707217/46979583-fc88c780-d09f-11e8-8869-01df98db0d6a.png">
