### PR TITLE
clarify wording: we should always merge to master before bumping the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,30 +72,15 @@ You can run this locally to catch errors before you push!
 
 ## Deploying
 
-Once you are ready to publish `master` as a new version, run the following to bump the version in `elm-packages.json`:
+Once your PR is merged, you can publish `master` as a new version:
+
+Run the following to bump && publish the version in `elm-packages.json`:
 
 ```
 elm-package bump
-```
-
-Commit to a branch and open a pull request. Announce the PR in #eng-front-ops-changes to have it reviewed and merged to `master`. Now you can publish the package!
-
-```
-elm-package publish # requires a tag, see below
-```
-
-This will require a tag, so follow the instructions it provides. It should be something like this:
-
-```
-Verifying NoRedInk/noredink-ui 5.10.0 ...
-Version number 5.10.0 verified (MINOR change, 5.9.1 => 5.10.0)
-Error: Libraries must be tagged in git, but tag 5.10.0 was not found.
-
-These tags make it possible to find this specific version on GitHub.
-To tag the most recent commit and push it to GitHub, run this:
-
-    git tag -a 5.10.0 -m "release version 5.10.0"
-    git push origin 5.10.0
+git tag -a 5.10.0 -m "release version 5.10.0"
+git push origin master --tags
+elm-package publish
 ```
 
 You can also add a tag in https://github.com/NoRedInk/noredink-ui/releases/new if you want to add more detail.


### PR DESCRIPTION
@mavnn and I found the wording a little unclear (merge first or bump first?). This clarifies it.