### PR TITLE
Remove elm-css-util

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -79,7 +79,6 @@
         "pablohirafuji/elm-markdown": "2.0.4 <= v < 3.0.0",
         "rtfeldman/elm-css": "13.1.1 <= v < 15.0.0",
         "rtfeldman/elm-css-helpers": "2.1.0 <= v < 3.0.0",
-        "rtfeldman/elm-css-util": "1.0.2 <= v < 2.0.0",
         "tesk9/accessible-html": "3.0.0 <= v < 4.0.0",
         "tesk9/accessible-html-with-css": "1.0.1 <= v < 2.0.0",
         "wernerdegroot/listzipper": "3.0.0 <= v < 4.0.0"

--- a/src/Nri/Ui/Text/V1.elm
+++ b/src/Nri/Ui/Text/V1.elm
@@ -34,7 +34,6 @@ module Nri.Ui.Text.V1 exposing
 
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, children, descendants, everything, selector)
-import Css.Helpers exposing (identifierToString)
 import Html exposing (..)
 import Html.Styled
 import Html.Styled.Attributes exposing (css)

--- a/src/Nri/Ui/Text/V1.elm
+++ b/src/Nri/Ui/Text/V1.elm
@@ -138,9 +138,45 @@ captionClassString =
     classString captionClasses
 
 
+classToString : CssClasses -> String
+classToString classes =
+    case classes of
+        Text ->
+            "Text"
+
+        Heading ->
+            "Heading"
+
+        Tagline ->
+            "Tagline"
+
+        SubHeading ->
+            "SubHeading"
+
+        SmallHeading ->
+            "SmallHeading"
+
+        MediumBody ->
+            "MediumBody"
+
+        SmallBody ->
+            "SmallBody"
+
+        SmallBodyGray ->
+            "SmallBodyGray"
+
+        Caption ->
+            "Caption"
+
+
+classToNamespacedString : CssClasses -> String
+classToNamespacedString classes =
+    classToString classes ++ namespace
+
+
 classString : List CssClasses -> String
 classString classes =
-    String.join " " (List.map (identifierToString namespace) classes)
+    String.join " " (List.map classToNamespacedString classes)
 
 
 {-| User-generated text.

--- a/src/Nri/Ui/Text/V1.elm
+++ b/src/Nri/Ui/Text/V1.elm
@@ -170,7 +170,7 @@ classToString classes =
 
 classToNamespacedString : CssClasses -> String
 classToNamespacedString classes =
-    classToString classes ++ namespace
+    namespace ++ classToString classes
 
 
 classString : List CssClasses -> String

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -18,7 +18,6 @@
         "pablohirafuji/elm-markdown": "2.0.4 <= v < 3.0.0",
         "rtfeldman/elm-css": "13.1.1 <= v < 15.0.0",
         "rtfeldman/elm-css-helpers": "2.1.0 <= v < 3.0.0",
-        "rtfeldman/elm-css-util": "1.0.2 <= v < 2.0.0",
         "tesk9/accessible-html": "3.0.0 <= v < 4.0.0",
         "tesk9/accessible-html-with-css": "1.0.1 <= v < 2.0.0",
         "wernerdegroot/listzipper": "3.0.0 <= v < 4.0.0"


### PR DESCRIPTION
Removes `rtfeldman/elm-css-util` dependency in preparation for upgrading to Elm 0.19!