### PR TITLE
Inline implementation of Styles.V1.styles

### DIFF
--- a/src/Nri/Ui/Styles/V1.elm
+++ b/src/Nri/Ui/Styles/V1.elm
@@ -65,7 +65,22 @@ styles :
     -> List Snippet
     -> Styles id class msg
 styles namespace snippets =
-    stylesWithExtraStylesheets namespace [] snippets
+    let
+        { id, class, classList } =
+            Html.CssHelpers.withNamespace namespace
+
+        sheet =
+            snippets
+                |> DEPRECATED.Css.Namespace.namespace namespace
+                |> stylesheet
+    in
+    { css = \_ -> [ sheet ]
+    , id = id
+    , class = class
+    , classList = classList
+    , div = \cl -> Html.div [ class [ cl ] ]
+    , span = \cl -> Html.span [ class [ cl ] ]
+    }
 
 
 {-| Use this instead of [`styles`](#styles) if you need to


### PR DESCRIPTION
This inlines the implementation of `styles` because it currently relies on `stylesWithExtraStylesheets`, which will need to be removed when we upgrade to `elm-css` 15.1.0 (which no longer includes the deprecated `Stylesheet` type, which `stylesWithExtraStylesheets` uses).