### PR TITLE
Deprecate Styles.V1

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -7,6 +7,7 @@
         "src"
     ],
     "exposed-modules": [
+        "DEPRECATED.Nri.Ui.Styles.V1",
         "Nri.Ui.Alert.V1",
         "Nri.Ui.Alert.V2",
         "Nri.Ui.AssetPath",
@@ -57,7 +58,6 @@
         "Nri.Ui.Select.V2",
         "Nri.Ui.Select.V3",
         "Nri.Ui.Select.V4",
-        "Nri.Ui.Styles.V1",
         "Nri.Ui.Table.V1",
         "Nri.Ui.Table.V2",
         "Nri.Ui.Tabs.V1",

--- a/src/DEPRECATED/Nri/Ui/Styles/V1.elm
+++ b/src/DEPRECATED/Nri/Ui/Styles/V1.elm
@@ -1,9 +1,10 @@
-module Nri.Ui.Styles.V1 exposing
+module DEPRECATED.Nri.Ui.Styles.V1 exposing
     ( Styles, StylesWithAssets, styles, stylesWithExtraStylesheets, stylesWithAssets
     , Keyframe, keyframes, toString
     )
 
-{-| Simplifies using elm-css in modules that expose views
+{-| DEPRECATED - This module is incompatible with Elm 0.19. Puffins are working
+on removing it from existing code. New code should use Html.Styled instead!
 
 
 ## Creating namespaces stylesheets

--- a/src/Nri/Ui/Alert/V1.elm
+++ b/src/Nri/Ui/Alert/V1.elm
@@ -24,10 +24,10 @@ import Accessibility
 import Css
 import Css.Foreign exposing (Snippet, children, descendants, everything, selector)
 import DEPRECATED.Css.File exposing (Stylesheet, compile, stylesheet)
+import DEPRECATED.Nri.Ui.Styles.V1
 import Html exposing (Html)
 import Markdown
 import Nri.Ui.Colors.V1
-import Nri.Ui.Styles.V1
 
 
 {-| -}
@@ -89,9 +89,9 @@ type CssClasses
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClasses msg
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClasses msg
 styles =
-    Nri.Ui.Styles.V1.styles "Nri-Ui-Alert-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-Alert-"
         [ Css.Foreign.class Alert
             [ Css.displayFlex
             , Css.fontSize (Css.px 13)

--- a/src/Nri/Ui/BannerAlert/V1.elm
+++ b/src/Nri/Ui/BannerAlert/V1.elm
@@ -18,10 +18,10 @@ import Accessibility
 import Css
 import Css.Foreign exposing (Snippet, children, descendants, everything, selector)
 import DEPRECATED.Css.File exposing (Stylesheet, compile, stylesheet)
+import DEPRECATED.Nri.Ui.Styles.V1
 import Html exposing (Html)
 import Nri.Ui.Colors.V1
 import Nri.Ui.Fonts.V1
-import Nri.Ui.Styles.V1
 
 
 {-| A banner to show error alerts
@@ -68,9 +68,9 @@ type CssClasses
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClasses b
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClasses b
 styles =
-    Nri.Ui.Styles.V1.styles "Nri-Ui-BannerAlert-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-BannerAlert-"
         [ Css.Foreign.class AlertMessage
             [ Css.fontSize (Css.px 20)
             , Css.fontWeight (Css.int 700)

--- a/src/Nri/Ui/Button/V1.elm
+++ b/src/Nri/Ui/Button/V1.elm
@@ -40,12 +40,12 @@ import Accessibility exposing (..)
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, children, descendants, everything, selector)
 import DEPRECATED.Css.File exposing (Stylesheet, compile, stylesheet)
+import DEPRECATED.Nri.Ui.Styles.V1
 import Html
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
 import Nri.Ui.Colors.V1
 import Nri.Ui.Fonts.V1
-import Nri.Ui.Styles.V1
 
 
 {-| Sizes for buttons that have button classes
@@ -249,7 +249,7 @@ linearGradient ( top, bottom ) =
 
 {-| Required CSS styles for `Nri.Ui.Button`.
 -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClasses msg
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClasses msg
 styles =
     let
         newSizeStyle size config =
@@ -368,7 +368,7 @@ styles =
                     ]
                 ]
     in
-    Nri.Ui.Styles.V1.styles "Nri-Ui-Button-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-Button-"
         [ Css.Foreign.class Button
             [ cursor pointer
             , display inlineBlock

--- a/src/Nri/Ui/Button/V2.elm
+++ b/src/Nri/Ui/Button/V2.elm
@@ -47,6 +47,7 @@ import Accessibility.Role as Role
 import Accessibility.Widget as Widget
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import DEPRECATED.Nri.Ui.Styles.V1 as Styles
 import EventExtras
 import Html
 import Html.Attributes exposing (..)
@@ -60,7 +61,6 @@ import Nri.Ui.Colors.Extra exposing (withAlpha)
 import Nri.Ui.Colors.V1
 import Nri.Ui.Fonts.V1
 import Nri.Ui.Icon.V2 as Icon exposing (IconType, decorativeIcon, icon)
-import Nri.Ui.Styles.V1 as Styles
 
 
 {-| Sizes for buttons and links that have button classes

--- a/src/Nri/Ui/Checkbox/V1.elm
+++ b/src/Nri/Ui/Checkbox/V1.elm
@@ -27,6 +27,7 @@ import Accessibility.Style
 import Accessibility.Widget as Widget
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, children, descendants, everything, selector)
+import DEPRECATED.Nri.Ui.Styles.V1 exposing (Keyframe, StylesWithAssets)
 import Html
 import Html.Attributes as Attributes
 import Html.Events as Events exposing (defaultOptions)
@@ -39,7 +40,6 @@ import Nri.Ui.Data.PremiumLevel as PremiumLevel exposing (PremiumLevel(..))
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.Extra as Attributes
 import Nri.Ui.Html.Extra exposing (onEnter, onKeyUp)
-import Nri.Ui.Styles.V1
 
 
 {-|
@@ -589,9 +589,9 @@ checkboxAssetPath assets checkboxImage =
 
 
 {-| -}
-keyframeCss : Nri.Ui.Styles.V1.Keyframe
+keyframeCss : Keyframe
 keyframeCss =
-    Nri.Ui.Styles.V1.keyframes "pulsate"
+    DEPRECATED.Nri.Ui.Styles.V1.keyframes "pulsate"
         [ ( "0%", "transform: scale(1, 1);" )
         , ( "50%", "transform: scale(1.2);" )
         , ( "100%", "transform: scale(1, 1);" )
@@ -599,7 +599,7 @@ keyframeCss =
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.StylesWithAssets Never CssClasses msg (Assets r)
+styles : StylesWithAssets Never CssClasses msg (Assets r)
 styles =
     (\assets ->
         [ mainSnippet
@@ -615,7 +615,7 @@ styles =
         ]
             |> List.concat
     )
-        |> Nri.Ui.Styles.V1.stylesWithAssets "checkbox-"
+        |> DEPRECATED.Nri.Ui.Styles.V1.stylesWithAssets "checkbox-"
 
 
 {-| The assets used in this module.

--- a/src/Nri/Ui/Checkbox/V2.elm
+++ b/src/Nri/Ui/Checkbox/V2.elm
@@ -27,6 +27,7 @@ import Accessibility.Style
 import Accessibility.Widget as Widget
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, children, descendants, everything, selector)
+import DEPRECATED.Nri.Ui.Styles.V1 exposing (Keyframe, StylesWithAssets)
 import Html
 import Html.Attributes as Attributes
 import Html.Events as Events exposing (defaultOptions)
@@ -39,7 +40,6 @@ import Nri.Ui.Data.PremiumLevel as PremiumLevel exposing (PremiumLevel(..))
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.Extra as Attributes
 import Nri.Ui.Html.Extra exposing (onEnter, onKeyUp)
-import Nri.Ui.Styles.V1
 
 
 {-|
@@ -589,9 +589,9 @@ checkboxAssetPath assets checkboxImage =
 
 
 {-| -}
-keyframeCss : Nri.Ui.Styles.V1.Keyframe
+keyframeCss : Keyframe
 keyframeCss =
-    Nri.Ui.Styles.V1.keyframes "pulsate"
+    DEPRECATED.Nri.Ui.Styles.V1.keyframes "pulsate"
         [ ( "0%", "transform: scale(1, 1);" )
         , ( "50%", "transform: scale(1.2);" )
         , ( "100%", "transform: scale(1, 1);" )
@@ -599,7 +599,7 @@ keyframeCss =
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.StylesWithAssets Never CssClasses msg (Assets r)
+styles : StylesWithAssets Never CssClasses msg (Assets r)
 styles =
     (\assets ->
         [ mainSnippet
@@ -615,7 +615,7 @@ styles =
         ]
             |> List.concat
     )
-        |> Nri.Ui.Styles.V1.stylesWithAssets "checkbox-"
+        |> DEPRECATED.Nri.Ui.Styles.V1.stylesWithAssets "checkbox-"
 
 
 {-| The assets used in this module.

--- a/src/Nri/Ui/Divider/V1.elm
+++ b/src/Nri/Ui/Divider/V1.elm
@@ -9,9 +9,9 @@ module Nri.Ui.Divider.V1 exposing (styles, view)
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, children, descendants, everything, selector)
 import DEPRECATED.Css.File exposing (Stylesheet, compile, stylesheet)
+import DEPRECATED.Nri.Ui.Styles.V1
 import Html exposing (..)
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.Styles.V1
 
 
 type alias Config =
@@ -38,9 +38,9 @@ type CssClasses
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClasses msg
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClasses msg
 styles =
-    Nri.Ui.Styles.V1.styles "Nri-Ui-Divider-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-Divider-"
         [ Css.Foreign.class Container
             [ Css.width (pct 100)
             , Css.displayFlex

--- a/src/Nri/Ui/Dropdown/V1.elm
+++ b/src/Nri/Ui/Dropdown/V1.elm
@@ -19,13 +19,13 @@ module Nri.Ui.Dropdown.V1 exposing
 import Accessibility.Style exposing (invisible)
 import Css
 import Css.Foreign
+import DEPRECATED.Nri.Ui.Styles.V1
 import Dict
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (on, targetValue)
 import Json.Decode
 import Nri.Ui.Colors.V1
-import Nri.Ui.Styles.V1
 import Nri.Ui.Util exposing (dashify)
 import String
 
@@ -162,9 +162,9 @@ type CssClasses
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClasses c
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClasses c
 styles =
-    Nri.Ui.Styles.V1.styles "Nri-Ui-Dropdown-V1-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-Dropdown-V1-"
         [ Css.Foreign.class Dropdown
             [ Css.backgroundColor Nri.Ui.Colors.V1.white
             , Css.border3 (Css.px 1) Css.solid Nri.Ui.Colors.V1.gray75

--- a/src/Nri/Ui/Icon/V1.elm
+++ b/src/Nri/Ui/Icon/V1.elm
@@ -18,11 +18,11 @@ import Accessibility exposing (..)
 import Accessibility.Role as Role
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import DEPRECATED.Nri.Ui.Styles.V1
 import Html.Attributes as Attr exposing (..)
 import Html.Events exposing (onClick)
 import Nri.Ui.AssetPath exposing (Asset(..))
 import Nri.Ui.Colors.V1
-import Nri.Ui.Styles.V1
 import Svg exposing (svg, use)
 import Svg.Attributes exposing (xlinkHref)
 
@@ -544,9 +544,9 @@ type CssClasses
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClasses msg
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClasses msg
 styles =
-    Nri.Ui.Styles.V1.styles "Nri-Ui-Icon-V1-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-Icon-V1-"
         [ Css.Foreign.class Disabled
             [ Css.property "cursor" "not-allowed" ]
         , Css.Foreign.class Button

--- a/src/Nri/Ui/Icon/V2.elm
+++ b/src/Nri/Ui/Icon/V2.elm
@@ -162,13 +162,13 @@ import Accessibility exposing (..)
 import Accessibility.Role as Role
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import DEPRECATED.Nri.Ui.Styles.V1
 import EventExtras
 import Html
 import Html.Attributes as Attr exposing (..)
 import Html.Events exposing (onClick)
 import Nri.Ui.AssetPath exposing (Asset(..))
 import Nri.Ui.Colors.V1
-import Nri.Ui.Styles.V1
 import Svg exposing (svg, use)
 import Svg.Attributes exposing (xlinkHref)
 
@@ -804,9 +804,9 @@ type CssClasses
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClasses msg
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClasses msg
 styles =
-    Nri.Ui.Styles.V1.styles "Nri-Ui-Icon-V1-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-Icon-V1-"
         [ Css.Foreign.class Disabled
             [ Css.property "cursor" "not-allowed" ]
         , Css.Foreign.class Button

--- a/src/Nri/Ui/InputStyles.elm
+++ b/src/Nri/Ui/InputStyles.elm
@@ -16,12 +16,12 @@ module Nri.Ui.InputStyles exposing
 
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import DEPRECATED.Nri.Ui.Styles.V1 as Styles
 import Nri.Ui.AssetPath as AssetPath exposing (Asset)
 import Nri.Ui.Colors.V1 exposing (..)
 import Nri.Ui.CssFlexBoxWithVendorPrefix as FlexBox
 import Nri.Ui.DatePickerConstants
 import Nri.Ui.Fonts.V1
-import Nri.Ui.Styles.V1 as Styles
 
 
 {-| Classes to be used in Nri Inputs such as Nri.TextInput and Nri.TextArea

--- a/src/Nri/Ui/Modal/V1.elm
+++ b/src/Nri/Ui/Modal/V1.elm
@@ -17,6 +17,7 @@ module Nri.Ui.Modal.V1 exposing
 import Css
 import Css.Foreign exposing (Snippet, body, children, descendants, everything, selector)
 import DEPRECATED.Css.File exposing (Stylesheet, compile, stylesheet)
+import DEPRECATED.Nri.Ui.Styles.V1
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.CssHelpers exposing (..)
@@ -24,7 +25,6 @@ import Html.Events exposing (onClick)
 import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1
 import Nri.Ui.Fonts.V1 as Fonts
-import Nri.Ui.Styles.V1
 
 
 type ModalType
@@ -170,9 +170,9 @@ type CssClasses
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClasses b
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClasses b
 styles =
-    Nri.Ui.Styles.V1.styles "Nri-Ui-BannerAlert-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-BannerAlert-"
         [ Css.Foreign.class BackdropContainer
             [ Css.height (Css.vh 100)
             , Css.left Css.zero

--- a/src/Nri/Ui/Outline/V1.elm
+++ b/src/Nri/Ui/Outline/V1.elm
@@ -22,12 +22,12 @@ module Nri.Ui.Outline.V1 exposing
 
 import Css
 import Css.Foreign exposing (Snippet, children, descendants, everything, selector)
+import DEPRECATED.Nri.Ui.Styles.V1 exposing (Styles)
 import Html exposing (Attribute, Html)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Effects.V1
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Palette.V1 exposing (Palette)
-import Nri.Ui.Styles.V1 exposing (Styles)
 
 
 {-| A wrapper for a node rendered into Html. This type exists to prevent us
@@ -161,7 +161,7 @@ labelHeight =
 -}
 styles : Styles a Style b
 styles =
-    Nri.Ui.Styles.V1.styles "Outline" <|
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Outline" <|
         [ Css.Foreign.class Segment
             [ Css.position Css.relative
             , Css.zIndex (Css.int 0)

--- a/src/Nri/Ui/SegmentedControl/V1.elm
+++ b/src/Nri/Ui/SegmentedControl/V1.elm
@@ -10,6 +10,7 @@ import Accessibility exposing (..)
 import Accessibility.Role as Role
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import DEPRECATED.Nri.Ui.Styles.V1
 import Html
 import Html.Attributes
 import Html.Events
@@ -17,7 +18,6 @@ import Nri.Ui.Colors.Extra exposing (withAlpha)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.CssFlexBoxWithVendorPrefix as FlexBox
 import Nri.Ui.Fonts.V1
-import Nri.Ui.Styles.V1
 
 
 {-| -}
@@ -64,9 +64,9 @@ type CssClass
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClass msg
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClass msg
 styles =
-    Nri.Ui.Styles.V1.styles "Nri-Ui-SegmentedControl-V1-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-SegmentedControl-V1-"
         [ Css.Foreign.class SegmentedControl
             [ FlexBox.displayFlex
             , cursor pointer

--- a/src/Nri/Ui/SegmentedControl/V2.elm
+++ b/src/Nri/Ui/SegmentedControl/V2.elm
@@ -10,6 +10,7 @@ import Accessibility exposing (..)
 import Accessibility.Role as Role
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import DEPRECATED.Nri.Ui.Styles.V1
 import Html
 import Html.Attributes
 import Html.Events
@@ -17,7 +18,6 @@ import Nri.Ui.Colors.Extra exposing (withAlpha)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.CssFlexBoxWithVendorPrefix as FlexBox
 import Nri.Ui.Fonts.V1
-import Nri.Ui.Styles.V1
 
 
 {-| -}
@@ -74,9 +74,9 @@ type CssClass
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClass msg
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClass msg
 styles =
-    Nri.Ui.Styles.V1.styles "Nri-Ui-SegmentedControl-V2-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-SegmentedControl-V2-"
         [ Css.Foreign.class SegmentedControl
             [ FlexBox.displayFlex
             , cursor pointer

--- a/src/Nri/Ui/SegmentedControl/V3.elm
+++ b/src/Nri/Ui/SegmentedControl/V3.elm
@@ -10,6 +10,7 @@ import Accessibility exposing (..)
 import Accessibility.Role as Role
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import DEPRECATED.Nri.Ui.Styles.V1
 import Html
 import Html.Attributes
 import Html.Events
@@ -18,7 +19,6 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.CssFlexBoxWithVendorPrefix as FlexBox
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Icon.V1 as Icon
-import Nri.Ui.Styles.V1
 
 
 {-| -}
@@ -89,9 +89,9 @@ type CssClass
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClass msg
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClass msg
 styles =
-    Nri.Ui.Styles.V1.styles "Nri-Ui-SegmentedControl-V3-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-SegmentedControl-V3-"
         [ Css.Foreign.class SegmentedControl
             [ FlexBox.displayFlex
             , cursor pointer

--- a/src/Nri/Ui/SegmentedControl/V4.elm
+++ b/src/Nri/Ui/SegmentedControl/V4.elm
@@ -10,6 +10,7 @@ import Accessibility exposing (..)
 import Accessibility.Role as Role
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import DEPRECATED.Nri.Ui.Styles.V1
 import Html
 import Html.Attributes
 import Html.Events
@@ -18,7 +19,6 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.CssFlexBoxWithVendorPrefix as FlexBox
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Icon.V2 as Icon
-import Nri.Ui.Styles.V1
 
 
 {-| -}
@@ -89,9 +89,9 @@ type CssClass
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClass msg
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClass msg
 styles =
-    Nri.Ui.Styles.V1.styles "Nri-Ui-SegmentedControl-V4-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-SegmentedControl-V4-"
         [ Css.Foreign.class SegmentedControl
             [ FlexBox.displayFlex
             , cursor pointer

--- a/src/Nri/Ui/SegmentedControl/V5.elm
+++ b/src/Nri/Ui/SegmentedControl/V5.elm
@@ -10,6 +10,7 @@ import Accessibility exposing (..)
 import Accessibility.Role as Role
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import DEPRECATED.Nri.Ui.Styles.V1
 import Html
 import Html.Attributes
 import Html.Events
@@ -18,7 +19,6 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.CssFlexBoxWithVendorPrefix as FlexBox
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Icon.V2 as Icon
-import Nri.Ui.Styles.V1
 
 
 {-| -}
@@ -99,9 +99,9 @@ type CssClass
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClass msg
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClass msg
 styles =
-    Nri.Ui.Styles.V1.styles "Nri-Ui-SegmentedControl-V5-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-SegmentedControl-V5-"
         [ Css.Foreign.class SegmentedControl
             [ FlexBox.displayFlex
             , cursor pointer

--- a/src/Nri/Ui/Select/V1.elm
+++ b/src/Nri/Ui/Select/V1.elm
@@ -21,13 +21,13 @@ module Nri.Ui.Select.V1 exposing
 
 import Css
 import Css.Foreign
+import DEPRECATED.Nri.Ui.Styles.V1
 import Dict
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Json.Decode exposing (Decoder, andThen, succeed)
 import Nri.Ui.Colors.V1
-import Nri.Ui.Styles.V1
 import Nri.Ui.Util
 
 
@@ -93,9 +93,9 @@ type CssClasses
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClasses c
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClasses c
 styles =
-    Nri.Ui.Styles.V1.styles "Nri-Ui-Select-V1-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-Select-V1-"
         [ Css.Foreign.class Select
             [ Css.backgroundColor Nri.Ui.Colors.V1.white
             , Css.border3 (Css.px 1) Css.solid Nri.Ui.Colors.V1.gray75

--- a/src/Nri/Ui/Select/V2.elm
+++ b/src/Nri/Ui/Select/V2.elm
@@ -21,13 +21,13 @@ module Nri.Ui.Select.V2 exposing
 
 import Css
 import Css.Foreign
+import DEPRECATED.Nri.Ui.Styles.V1
 import Dict
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Json.Decode exposing (Decoder, andThen, succeed)
 import Nri.Ui.Colors.V1
-import Nri.Ui.Styles.V1
 import Nri.Ui.Util
 
 
@@ -93,9 +93,9 @@ type CssClasses
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClasses c
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClasses c
 styles =
-    Nri.Ui.Styles.V1.styles "Nri-Ui-Select-V2-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-Select-V2-"
         [ Css.Foreign.class Select
             [ Css.backgroundColor Nri.Ui.Colors.V1.white
             , Css.border3 (Css.px 1) Css.solid Nri.Ui.Colors.V1.gray75

--- a/src/Nri/Ui/Table/V1.elm
+++ b/src/Nri/Ui/Table/V1.elm
@@ -19,11 +19,11 @@ module Nri.Ui.Table.V1 exposing
 
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import DEPRECATED.Nri.Ui.Styles.V1 exposing (Keyframe, styles)
 import Html exposing (..)
 import Html.Attributes exposing (style)
 import Nri.Ui.Colors.V1 exposing (..)
 import Nri.Ui.Fonts.V1 exposing (baseFont)
-import Nri.Ui.Styles.V1 exposing (styles)
 
 
 {-| Closed representation of how to render the header and cells of a column
@@ -186,9 +186,9 @@ type CssClasses
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClasses msg
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClasses msg
 styles =
-    Nri.Ui.Styles.V1.styles "Nri-Ui-Table-V1-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-Table-V1-"
         [ Css.Foreign.class Headers
             [ borderBottom3 (px 3) solid gray75
             , height (px 45)
@@ -229,14 +229,14 @@ styles =
 
 
 {-| -}
-keyframes : List Nri.Ui.Styles.V1.Keyframe
+keyframes : List Keyframe
 keyframes =
-    [ Nri.Ui.Styles.V1.keyframes "Nri-Ui-Table-V1-flash"
+    [ DEPRECATED.Nri.Ui.Styles.V1.keyframes "Nri-Ui-Table-V1-flash"
         [ ( "0%", "opacity: 0.6" )
         , ( "50%", "opacity: 0.2" )
         , ( "100%", "opacity: 0.6" )
         ]
-    , Nri.Ui.Styles.V1.keyframes "Nri-Ui-Table-V1-fadein"
+    , DEPRECATED.Nri.Ui.Styles.V1.keyframes "Nri-Ui-Table-V1-fadein"
         [ ( "from", "opacity: 0" )
         , ( "to", "opacity: 1" )
         ]
@@ -248,7 +248,7 @@ keyframeStyles : Html msg
 keyframeStyles =
     Html.node "style"
         []
-        (List.map (Html.text << Nri.Ui.Styles.V1.toString) keyframes)
+        (List.map (Html.text << DEPRECATED.Nri.Ui.Styles.V1.toString) keyframes)
 
 
 flashAnimation : List Css.Style

--- a/src/Nri/Ui/Table/V2.elm
+++ b/src/Nri/Ui/Table/V2.elm
@@ -31,11 +31,11 @@ module Nri.Ui.Table.V2 exposing
 -}
 
 import Css exposing (..)
+import DEPRECATED.Nri.Ui.Styles.V1 exposing (Keyframe)
 import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Colors.V1 exposing (..)
 import Nri.Ui.Fonts.V1 exposing (baseFont)
-import Nri.Ui.Styles.V1
 
 
 {-| Closed representation of how to render the header and cells of a column
@@ -256,14 +256,14 @@ tableStyles =
 
 
 {-| -}
-keyframes : List Nri.Ui.Styles.V1.Keyframe
+keyframes : List Keyframe
 keyframes =
-    [ Nri.Ui.Styles.V1.keyframes "Nri-Ui-Table-V2-flash"
+    [ DEPRECATED.Nri.Ui.Styles.V1.keyframes "Nri-Ui-Table-V2-flash"
         [ ( "0%", "opacity: 0.6" )
         , ( "50%", "opacity: 0.2" )
         , ( "100%", "opacity: 0.6" )
         ]
-    , Nri.Ui.Styles.V1.keyframes "Nri-Ui-Table-V2-fadein"
+    , DEPRECATED.Nri.Ui.Styles.V1.keyframes "Nri-Ui-Table-V2-fadein"
         [ ( "from", "opacity: 0" )
         , ( "to", "opacity: 1" )
         ]
@@ -275,7 +275,7 @@ keyframeStyles : Html msg
 keyframeStyles =
     Html.node "style"
         []
-        (List.map (Html.text << Nri.Ui.Styles.V1.toString) keyframes)
+        (List.map (Html.text << DEPRECATED.Nri.Ui.Styles.V1.toString) keyframes)
 
 
 flashAnimation : List Css.Style

--- a/src/Nri/Ui/Tabs/V1.elm
+++ b/src/Nri/Ui/Tabs/V1.elm
@@ -36,6 +36,7 @@ import Accessibility.Role
 import Accessibility.Widget
 import Css exposing (Style)
 import Css.Foreign exposing (Snippet, children, descendants, everything, selector)
+import DEPRECATED.Nri.Ui.Styles.V1
 import Html exposing (Attribute, Html)
 import Html.Attributes
 import Html.Events
@@ -44,7 +45,6 @@ import List.Zipper exposing (Zipper(..))
 import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1
 import Nri.Ui.Fonts.V1
-import Nri.Ui.Styles.V1
 
 
 {-| This is a better choice for a no-op than "#" because "#" changes your
@@ -267,9 +267,9 @@ type CssClasses
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClasses msg
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClasses msg
 styles =
-    Nri.Ui.Styles.V1.styles "Nri-Ui-Tabs-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-Tabs-"
         [ Css.Foreign.class Container
             [ Css.displayFlex
             , Css.alignItems Css.flexEnd

--- a/src/Nri/Ui/Text/V1.elm
+++ b/src/Nri/Ui/Text/V1.elm
@@ -34,12 +34,12 @@ module Nri.Ui.Text.V1 exposing
 
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, children, descendants, everything, selector)
+import DEPRECATED.Nri.Ui.Styles.V1
 import Html exposing (..)
 import Html.Styled
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Colors.V1 exposing (..)
 import Nri.Ui.Fonts.V1 as Fonts
-import Nri.Ui.Styles.V1
 
 
 {-| This is a Page Heading.
@@ -232,9 +232,9 @@ type CssClasses
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClasses msg
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClasses msg
 styles =
-    Nri.Ui.Styles.V1.styles namespace
+    DEPRECATED.Nri.Ui.Styles.V1.styles namespace
         [ Css.Foreign.class Heading
             [ Fonts.baseFont
             , fontSize (px 30)

--- a/src/Nri/Ui/Text/V2.elm
+++ b/src/Nri/Ui/Text/V2.elm
@@ -24,11 +24,11 @@ module Nri.Ui.Text.V2 exposing
 -}
 
 import Css exposing (..)
+import DEPRECATED.Nri.Ui.Styles.V1
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Colors.V1 exposing (..)
 import Nri.Ui.Fonts.V1 as Fonts
-import Nri.Ui.Styles.V1
 
 
 {-| This is a Page Heading.

--- a/src/Nri/Ui/TextArea/V1.elm
+++ b/src/Nri/Ui/TextArea/V1.elm
@@ -10,11 +10,11 @@ module Nri.Ui.TextArea.V1 exposing (view, writing, contentCreation, Model, gener
 -}
 
 import Accessibility.Style
+import DEPRECATED.Nri.Ui.Styles.V1 exposing (StylesWithAssets)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onInput)
 import Nri.Ui.InputStyles exposing (CssClasses(..))
-import Nri.Ui.Styles.V1
 import Nri.Ui.Util exposing (dashify, removePunctuation)
 
 
@@ -134,6 +134,6 @@ generateId labelText =
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.StylesWithAssets Never CssClasses msg (Nri.Ui.InputStyles.Assets r)
+styles : StylesWithAssets Never CssClasses msg (Nri.Ui.InputStyles.Assets r)
 styles =
     Nri.Ui.InputStyles.styles

--- a/src/Nri/Ui/TextArea/V2.elm
+++ b/src/Nri/Ui/TextArea/V2.elm
@@ -20,11 +20,11 @@ module Nri.Ui.TextArea.V2 exposing (view, writing, contentCreation, Height(..), 
 
 import Accessibility.Styled.Style
 import Css exposing ((|+|))
+import DEPRECATED.Nri.Ui.Styles.V1 exposing (StylesWithAssets)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Nri.Ui.InputStyles as InputStyles exposing (CssClasses(..))
-import Nri.Ui.Styles.V1
 import Nri.Ui.Util exposing (dashify, removePunctuation)
 
 
@@ -230,6 +230,6 @@ generateId labelText =
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.StylesWithAssets Never CssClasses msg (InputStyles.Assets r)
+styles : StylesWithAssets Never CssClasses msg (InputStyles.Assets r)
 styles =
     InputStyles.styles

--- a/src/Nri/Ui/TextInput/V1.elm
+++ b/src/Nri/Ui/TextInput/V1.elm
@@ -27,12 +27,12 @@ module Nri.Ui.TextInput.V1 exposing
 import Accessibility.Style
 import Css exposing (..)
 import Css.Foreign exposing (Snippet, children, descendants, everything, selector)
+import DEPRECATED.Nri.Ui.Styles.V1
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onInput)
 import Nri.Ui.Colors.V1 exposing (..)
 import Nri.Ui.Fonts.V1 as Fonts
-import Nri.Ui.Styles.V1
 import Regex
 
 
@@ -126,7 +126,7 @@ type CssClasses
 
 
 {-| -}
-styles : Nri.Ui.Styles.V1.Styles Never CssClasses msg
+styles : DEPRECATED.Nri.Ui.Styles.V1.Styles Never CssClasses msg
 styles =
     let
         inputStyle =
@@ -155,7 +155,7 @@ styles =
             , Css.marginTop (px 9)
             ]
     in
-    Nri.Ui.Styles.V1.styles "Nri-Ui-TextInput-"
+    DEPRECATED.Nri.Ui.Styles.V1.styles "Nri-Ui-TextInput-"
         [ Css.Foreign.selector "input[type=text]"
             [ Css.Foreign.withClass Input inputStyle ]
         , Css.Foreign.selector "input[type=number]"


### PR DESCRIPTION
**DO NOT MERGE YET!**

We should merge this right before doing a `MAJOR` version bump.

It will require doing a find/replace across all dependent code bases to use `DEPRECATED.Nri.Ui.Styles.V1` instead of `Nri.Ui.Styles.V1`.

The public API of that module is the same as before, but marking it as deprecated will help make sure we aren't using it for new things.