### PR TITLE
Add DEPRECATED.Nri.Ui.Styles.V2

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -7,6 +7,7 @@
         "src"
     ],
     "exposed-modules": [
+        "DEPRECATED.Nri.Ui.Styles.V2",
         "Nri.Ui.Alert.V1",
         "Nri.Ui.Alert.V2",
         "Nri.Ui.AssetPath",

--- a/src/DEPRECATED/Nri/Ui/Styles/V2.elm
+++ b/src/DEPRECATED/Nri/Ui/Styles/V2.elm
@@ -1,0 +1,49 @@
+module DEPRECATED.Nri.Ui.Styles.V2 exposing (Keyframe, keyframes, toString)
+
+{-| DEPRECATED. Once we are on elm-css 15.1.0 or later, we should use its
+built-in keyframe functionality.
+
+
+### Keyframe animations
+
+@docs Keyframe, keyframes, toString
+
+-}
+
+
+{-| A CSS keyframe animation that will have vendor prefixes automatically added.
+-}
+type Keyframe
+    = CompiledKeyframe String
+
+
+{-| Create a CSS keyframe animation with appropriate vendor prefixes
+-}
+keyframes : String -> List ( String, String ) -> Keyframe
+keyframes name stops =
+    let
+        stop ( when, what ) =
+            when ++ " {" ++ what ++ "}"
+
+        x prefix =
+            "@"
+                ++ prefix
+                ++ "keyframes "
+                ++ name
+                ++ " {\n"
+                ++ String.join "\n" (List.map stop stops)
+                ++ "\n}\n"
+    in
+    [ "-webkit-", "-moz-", "" ]
+        |> List.map x
+        |> String.join ""
+        |> CompiledKeyframe
+
+
+{-| Turn a [`Keyframe`](#Keyframe) into a string that can be included in a CSS stylesheet.
+-}
+toString : Keyframe -> String
+toString keyframe =
+    case keyframe of
+        CompiledKeyframe compiled ->
+            compiled


### PR DESCRIPTION
This will be a transitional module to help us get through the `elm-css` 15.1.0 transition.