### PR TITLE
🐧Fix width for select

### DIFF
--- a/src/Nri/Ui/Select/V5.elm
+++ b/src/Nri/Ui/Select/V5.elm
@@ -77,6 +77,5 @@ view config =
             , Css.cursor Css.pointer
             , Css.fontSize (Css.px 15)
             , Css.height (Css.px 45)
-            , Css.width (Css.pct 100)
             ]
             ([ onSelectHandler ] ++ extraAttrs)


### PR DESCRIPTION
🦊 [Styling regression on teacher assignments index](https://www.pivotaltracker.com/story/show/161937786)

The `width: 100%` was not there in https://github.com/NoRedInk/noredink-ui/blob/6cbf5fece203cc2ef081be1b0584d8f143b236e8/src/Nri/Ui/Select/V1.elm and since the upgrade, it has caused problems. Removing it solves the trouble. @lukewestby Do you know if that style solved a particular problem?
