### PR TITLE
Center a modal header when it wraps to multiple lines

### DIFF
--- a/src/Nri/Ui/Modal/V3.elm
+++ b/src/Nri/Ui/Modal/V3.elm
@@ -190,6 +190,7 @@ viewHeader modalType title =
                , Css.margin2 Css.zero (Css.px 65)
                , Css.fontSize (Css.px 20)
                , Fonts.baseFont
+               , Css.textAlign Css.center
                ]
         )
         []


### PR DESCRIPTION
Needed for https://www.pivotaltracker.com/story/show/162287818

It changes this...

<img width="637" alt="screen shot 2018-12-04 at 3 00 18 pm" src="https://user-images.githubusercontent.com/386075/49478700-5cb10580-f7d5-11e8-8247-aa0ec37fcda7.png">


to this!

<img width="632" alt="screen shot 2018-12-04 at 3 00 12 pm" src="https://user-images.githubusercontent.com/386075/49478703-6175b980-f7d5-11e8-8174-3403703e73f0.png">
