### PR TITLE
Decrease modal header margin

### DIFF
--- a/src/Nri/Ui/Modal/V3.elm
+++ b/src/Nri/Ui/Modal/V3.elm
@@ -187,7 +187,7 @@ viewHeader modalType title =
          )
             :: [ Css.fontWeight (Css.int 700)
                , Css.lineHeight (Css.px 27)
-               , Css.margin2 Css.zero (Css.px 65)
+               , Css.margin2 Css.zero (Css.px 49)
                , Css.fontSize (Css.px 20)
                , Fonts.baseFont
                , Css.textAlign Css.center


### PR DESCRIPTION
🍐 'd with Stacey to decrease modal header margin to fit certain text.

Changes this...

![screen shot 2018-12-10 at 3 09 45 pm](https://user-images.githubusercontent.com/386075/49768021-9da29180-fc8f-11e8-926b-39509c293045.png)

to this:

![screen shot 2018-12-10 at 3 09 57 pm](https://user-images.githubusercontent.com/386075/49768024-a1361880-fc8f-11e8-947d-5ebfb11f036b.png)
