### PR TITLE
Just use value instead of innerText

### DIFF
--- a/src/Nri/Ui/TextArea/V3.elm
+++ b/src/Nri/Ui/TextArea/V3.elm
@@ -115,6 +115,7 @@ view_ theme model =
                         Css.minHeight heightForStyle
                 ]
                 [ Events.onInput model.onInput
+                , Attributes.value model.value
                 , Attributes.id (generateId model.label)
                 , Attributes.autofocus model.autofocus
                 , Attributes.placeholder model.placeholder
@@ -127,7 +128,7 @@ view_ theme model =
                     else
                         "false"
                 ]
-                [ Html.text model.value ]
+                []
             ]
         , if not model.showLabel then
             Html.label


### PR DESCRIPTION
This makes the textarea resettable from the model. We had to use `innerText` in Elm 0.18 because `value` had problems with synchronizing with the model correctly. Those problems are solved in 0.19.