### PR TITLE
Export CustomElement

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,2 +1,4 @@
 require('./TextArea/V3')
 require('./TextArea/V4')
+
+exports.CustomElement = require('./CustomElement')


### PR DESCRIPTION
This exports `CustomElement` so that we can access it in the monolith.

**Some Quick Background:**

We have some places in the monolith that we use `CustomElement`, and we import it directly from the module root like this:

```coffee
CustomElement = require '@noredink/ui/lib/CustomElement`
```

This doesn't work in `>= 1.1.0` because we added `files` to the `package.json`. This causes npm to no longer pack the `lib` folder, leaving us no way to access `CustomElement`. With this change, it should be exposed again via the `dist` bundle again.