### PR TITLE
Include all of lib in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "tests"
   },
   "files": [
-    "dist.js"
+    "dist.js",
+    "lib/**/*.js"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
This adds bacl all of the `lib` folder to the published package.

I originally had hoped to use `dist` as the main (which I forgot to update anyways 🤕), but that still wouldn't work currently as browserify doesn't alias it's `require` helper. This means `jetpack` will interpret those as actual `require` calls and things don't work from there.
