### PR TITLE
Add Nri.Ui.TextInput.V4.generateId

### DIFF
--- a/src/Nri/Ui/TextInput/V4.elm
+++ b/src/Nri/Ui/TextInput/V4.elm
@@ -1,6 +1,7 @@
 module Nri.Ui.TextInput.V4 exposing
     ( Model
     , view, writing
+    , generateId
     , number
     , text
     )
@@ -9,6 +10,7 @@ module Nri.Ui.TextInput.V4 exposing
 
 @docs Model
 @docs view, writing
+@docs generateId
 
 
 ## Input types
@@ -90,7 +92,7 @@ view_ : Theme -> Model value msg -> Html msg
 view_ theme model =
     let
         idValue =
-            "Nri-Ui-TextInput-" ++ dashify model.label
+            generateId model.label
 
         (InputType inputType) =
             model.type_
@@ -144,3 +146,11 @@ view_ theme model =
                 )
                 [ Html.text model.label ]
         ]
+
+
+{-| Gives you the DOM element id that will be used by a `TextInput.view` with the given label.
+This is for use when you need the DOM element id for use in javascript (such as trigger an event to focus a particular text input)
+-}
+generateId : String -> String
+generateId labelText =
+    "Nri-Ui-TextInput-" ++ dashify labelText

--- a/tests/Spec/Nri/Ui/TextInput/V4.elm
+++ b/tests/Spec/Nri/Ui/TextInput/V4.elm
@@ -1,0 +1,37 @@
+module Spec.Nri.Ui.TextInput.V4 exposing (all)
+
+import Expect
+import Html.Styled
+import Nri.Ui.TextInput.V4 as TextInput
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (id, tag)
+
+
+all : Test
+all =
+    let
+        basic =
+            { label = "label"
+            , isInError = False
+            , onInput = identity
+            , onBlur = Nothing
+            , placeholder = "placeholder"
+            , value = "value"
+            , autofocus = False
+            , showLabel = False
+            , type_ = TextInput.text
+            }
+    in
+    describe "Nri.Ui.TextInput.V4"
+        [ test "it uses the same DOM id that generateId produces" <|
+            \() ->
+                TextInput.view
+                    { basic | label = "myLabel" }
+                    |> Html.Styled.toUnstyled
+                    |> Query.fromHtml
+                    |> Query.has
+                        [ tag "input"
+                        , id (TextInput.generateId "myLabel")
+                        ]
+        ]


### PR DESCRIPTION
This parallels `TextArea`, exposing this for the reason described in the added doc comment.

> Hello there, wonderful author of widgets!
> This is `Nri.Ui.Friendly.AI.V1` speaking to you!
> Are you looking to get this awesome work reviewed as quickly as possible, so you can start putting it to use?
> Then feel free to ask Teambot to assign a reviewer to your PR
>
> https://nri-teambot.herokuapp.com
>
> It's best if we have separate pull requests for code changes and package version bumps. If you're just changing code, great! If you're just bumping the version, check out https://github.com/NoRedInk/noredink-ui#deploying.
