### PR TITLE
Lab/fix clickable text question mark alignment

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -10,6 +10,7 @@
         "Nri.Ui.BannerAlert.V2",
         "Nri.Ui.BannerAlert.V3",
         "Nri.Ui.ClickableText.V1",
+        "Nri.Ui.ClickableText.V2",
         "Nri.Ui.Button.V3",
         "Nri.Ui.Button.V4",
         "Nri.Ui.Button.V5",

--- a/src/Nri/Ui/ClickableText/V2.elm
+++ b/src/Nri/Ui/ClickableText/V2.elm
@@ -69,18 +69,12 @@ button :
     }
     -> Html msg
 button config =
-    let
-        fontSize =
-            sizeToPx config.size
-    in
     Nri.Ui.styled Html.button
         (dataDescriptor "button")
-        (clickableTextStyles fontSize)
+        clickableTextStyles
         [ Events.onClick config.onClick
         ]
-        [ icon fontSize config.icon
-        , text config.label
-        ]
+        [ viewContent config ]
 
 
 {-| Creates a `<a>` element
@@ -94,23 +88,27 @@ link :
     -> List (Attribute msg)
     -> Html msg
 link config additionalAttributes =
+    Nri.Ui.styled Html.a
+        (dataDescriptor "link")
+        clickableTextStyles
+        (Attributes.href config.url :: additionalAttributes)
+        [ viewContent config ]
+
+
+viewContent : { a | label : String, size : Size, icon : Maybe Svg } -> Html msg
+viewContent config =
     let
         fontSize =
             sizeToPx config.size
     in
-    Nri.Ui.styled Html.a
-        (dataDescriptor "link")
-        (clickableTextStyles fontSize)
-        (Attributes.href config.url
-            :: additionalAttributes
-        )
+    div [ Attributes.css [ Css.fontSize fontSize ] ]
         [ icon fontSize config.icon
         , text config.label
         ]
 
 
-clickableTextStyles : Css.Px -> List Css.Style
-clickableTextStyles fontSize =
+clickableTextStyles : List Css.Style
+clickableTextStyles =
     [ Css.cursor Css.pointer
     , Nri.Ui.Fonts.V1.baseFont
     , Css.backgroundImage Css.none
@@ -125,7 +123,6 @@ clickableTextStyles fontSize =
     , Css.borderStyle Css.none
     , Css.textDecoration Css.none
     , Css.hover [ Css.textDecoration Css.underline ]
-    , Css.fontSize fontSize
     , Css.padding Css.zero
     ]
 

--- a/src/Nri/Ui/ClickableText/V2.elm
+++ b/src/Nri/Ui/ClickableText/V2.elm
@@ -1,6 +1,6 @@
 module Nri.Ui.ClickableText.V2 exposing
-    ( ButtonConfig, button
-    , LinkConfig, link
+    ( button
+    , link
     , Size(..)
     )
 
@@ -26,12 +26,12 @@ HTML `<a>` elements and are created here with `*Link` functions.
 
 # `<button>` creators
 
-@docs ButtonConfig, button
+@docs button
 
 
 # `<a>` creators
 
-@docs LinkConfig, link
+@docs link
 
 
 # Config
@@ -59,19 +59,15 @@ type Size
     | Large
 
 
-{-| Config for the button
+{-| Creates a `<button>` element
 -}
-type alias ButtonConfig msg =
+button :
     { label : String
     , size : Size
     , icon : Maybe IconType
     , onClick : msg
     }
-
-
-{-| Creates a `<button>` element
--}
-button : ButtonConfig msg -> Html msg
+    -> Html msg
 button config =
     let
         fontSize =
@@ -87,19 +83,16 @@ button config =
         ]
 
 
-{-| Config for the link
+{-| Creates a `<a>` element
 -}
-type alias LinkConfig =
+link :
     { label : String
     , size : Size
     , icon : Maybe IconType
     , url : String
     }
-
-
-{-| Creates a `<a>` element
--}
-link : LinkConfig -> List (Attribute msg) -> Html msg
+    -> List (Attribute msg)
+    -> Html msg
 link config additionalAttributes =
     let
         fontSize =

--- a/src/Nri/Ui/ClickableText/V2.elm
+++ b/src/Nri/Ui/ClickableText/V2.elm
@@ -1,0 +1,168 @@
+module Nri.Ui.ClickableText.V2 exposing
+    ( ButtonConfig, button
+    , LinkConfig, link
+    , Size(..)
+    )
+
+{-|
+
+
+# About:
+
+ClickableText looks different from Nri.Ui.Button in that it displays without margin or padding.
+ClickableText has the suave, traditional look of a "link"!
+
+For accessibility purposes, buttons that perform an action on the current page should be HTML `<button>`
+elements and are created here with `*Button` functions. Buttons that take the user to a new page should be
+HTML `<a>` elements and are created here with `*Link` functions.
+
+
+# `<button>` creators
+
+@docs ButtonConfig, button
+
+
+# `<a>` creators
+
+@docs LinkConfig, link
+
+
+# Config
+
+@docs Size
+
+-}
+
+import Css
+import Css.Global
+import Html.Styled as Html exposing (..)
+import Html.Styled.Attributes as Attributes
+import Html.Styled.Events as Events
+import Nri.Ui
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1
+import Nri.Ui.Icon.V4 as Icon exposing (IconType)
+
+
+{-| Sizes for the button
+-}
+type Size
+    = Small
+    | Medium
+    | Large
+
+
+{-| Config for the button
+-}
+type alias ButtonConfig msg =
+    { label : String
+    , size : Size
+    , icon : Maybe IconType
+    , onClick : msg
+    }
+
+
+{-| Creates a `<button>` element
+-}
+button : ButtonConfig msg -> Html msg
+button config =
+    let
+        fontSize =
+            sizeToPx config.size
+    in
+    Nri.Ui.styled Html.button
+        (dataDescriptor "button")
+        (clickableTextStyles fontSize)
+        [ Events.onClick config.onClick
+        ]
+        [ icon fontSize config.icon
+        , text config.label
+        ]
+
+
+{-| Config for the link
+-}
+type alias LinkConfig =
+    { label : String
+    , size : Size
+    , icon : Maybe IconType
+    , url : String
+    }
+
+
+{-| Creates a `<a>` element
+-}
+link : LinkConfig -> List (Attribute msg) -> Html msg
+link config additionalAttributes =
+    let
+        fontSize =
+            sizeToPx config.size
+    in
+    Nri.Ui.styled Html.a
+        (dataDescriptor "link")
+        (clickableTextStyles fontSize)
+        (Attributes.href config.url
+            :: additionalAttributes
+        )
+        [ icon fontSize config.icon
+        , text config.label
+        ]
+
+
+clickableTextStyles : Css.Px -> List Css.Style
+clickableTextStyles fontSize =
+    [ Css.cursor Css.pointer
+    , -- Specifying the font can and should go away after bootstrap is removed from application.css
+      Nri.Ui.Fonts.V1.baseFont
+    , Css.backgroundImage Css.none
+    , Css.textShadow Css.none
+    , Css.boxShadow Css.none
+    , Css.border Css.zero
+    , Css.disabled [ Css.cursor Css.notAllowed ]
+    , Css.color Colors.azure
+    , Css.backgroundColor Css.transparent
+    , Css.fontWeight (Css.int 600)
+    , Css.textAlign Css.left
+    , Css.borderStyle Css.none
+    , Css.textDecoration Css.none
+    , Css.hover [ Css.textDecoration Css.underline ]
+    , Css.fontSize fontSize
+    , Css.padding Css.zero
+    ]
+
+
+icon : Css.Px -> Maybe IconType -> Html msg
+icon fontSize maybeIcon =
+    case maybeIcon of
+        Just iconType ->
+            -- TODO: We should never use an image here, only SVG
+            Nri.Ui.styled Html.span
+                (dataDescriptor "icon-holder")
+                [ Css.height fontSize
+                , Css.width fontSize
+                , Css.display Css.inlineBlock
+                , Css.marginRight (Css.px 5)
+                ]
+                []
+                [ Icon.decorativeIcon iconType ]
+
+        Nothing ->
+            text ""
+
+
+sizeToPx : Size -> Css.Px
+sizeToPx size =
+    case size of
+        Small ->
+            Css.px 15
+
+        Medium ->
+            Css.px 17
+
+        Large ->
+            Css.px 20
+
+
+dataDescriptor : String -> String
+dataDescriptor descriptor =
+    "clickable-text-v1-" ++ descriptor

--- a/src/Nri/Ui/ClickableText/V2.elm
+++ b/src/Nri/Ui/ClickableText/V2.elm
@@ -41,7 +41,6 @@ HTML `<a>` elements and are created here with `*Link` functions.
 -}
 
 import Css
-import Css.Global
 import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events

--- a/src/Nri/Ui/ClickableText/V2.elm
+++ b/src/Nri/Ui/ClickableText/V2.elm
@@ -101,8 +101,23 @@ viewContent config =
         fontSize =
             sizeToPx config.size
     in
-    div [ Attributes.css [ Css.fontSize fontSize ] ]
-        [ icon fontSize config.icon
+    span [ Attributes.css [ Css.fontSize fontSize ] ]
+        [ case config.icon of
+            Just icon ->
+                div
+                    [ Attributes.css
+                        [ Css.height fontSize
+                        , Css.maxWidth fontSize
+                        , Css.display Css.inlineBlock
+                        , Css.verticalAlign Css.baseline
+                        , Css.marginRight (Css.px 2)
+                        ]
+                    ]
+                    [ NriSvg.toHtml icon
+                    ]
+
+            Nothing ->
+                text ""
         , text config.label
         ]
 
@@ -125,14 +140,6 @@ clickableTextStyles =
     , Css.hover [ Css.textDecoration Css.underline ]
     , Css.padding Css.zero
     ]
-
-
-icon : Css.Px -> Maybe Svg -> Html msg
-icon fontSize maybeIcon =
-    div [ Attributes.css [ Css.height fontSize ] ]
-        [ Maybe.map NriSvg.toHtml maybeIcon
-            |> Maybe.withDefault (text "")
-        ]
 
 
 sizeToPx : Size -> Css.Px

--- a/src/Nri/Ui/ClickableText/V2.elm
+++ b/src/Nri/Ui/ClickableText/V2.elm
@@ -48,7 +48,7 @@ import Html.Styled.Events as Events
 import Nri.Ui
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1
-import Nri.Ui.Icon.V4 as Icon exposing (IconType)
+import Nri.Ui.Svg.V1 as NriSvg exposing (Svg)
 
 
 {-| Sizes for the button
@@ -64,7 +64,7 @@ type Size
 button :
     { label : String
     , size : Size
-    , icon : Maybe IconType
+    , icon : Maybe Svg
     , onClick : msg
     }
     -> Html msg
@@ -88,7 +88,7 @@ button config =
 link :
     { label : String
     , size : Size
-    , icon : Maybe IconType
+    , icon : Maybe Svg
     , url : String
     }
     -> List (Attribute msg)
@@ -130,23 +130,12 @@ clickableTextStyles fontSize =
     ]
 
 
-icon : Css.Px -> Maybe IconType -> Html msg
+icon : Css.Px -> Maybe Svg -> Html msg
 icon fontSize maybeIcon =
-    case maybeIcon of
-        Just iconType ->
-            -- TODO: We should never use an image here, only SVG
-            Nri.Ui.styled Html.span
-                (dataDescriptor "icon-holder")
-                [ Css.height fontSize
-                , Css.width fontSize
-                , Css.display Css.inlineBlock
-                , Css.marginRight (Css.px 5)
-                ]
-                []
-                [ Icon.decorativeIcon iconType ]
-
-        Nothing ->
-            text ""
+    div [ Attributes.css [ Css.height fontSize ] ]
+        [ Maybe.map NriSvg.toHtml maybeIcon
+            |> Maybe.withDefault (text "")
+        ]
 
 
 sizeToPx : Size -> Css.Px

--- a/src/Nri/Ui/ClickableText/V2.elm
+++ b/src/Nri/Ui/ClickableText/V2.elm
@@ -119,8 +119,7 @@ link config additionalAttributes =
 clickableTextStyles : Css.Px -> List Css.Style
 clickableTextStyles fontSize =
     [ Css.cursor Css.pointer
-    , -- Specifying the font can and should go away after bootstrap is removed from application.css
-      Nri.Ui.Fonts.V1.baseFont
+    , Nri.Ui.Fonts.V1.baseFont
     , Css.backgroundImage Css.none
     , Css.textShadow Css.none
     , Css.boxShadow Css.none

--- a/src/Nri/Ui/ClickableText/V2.elm
+++ b/src/Nri/Ui/ClickableText/V2.elm
@@ -7,6 +7,13 @@ module Nri.Ui.ClickableText.V2 exposing
 {-|
 
 
+# Changes from V1
+
+  - Removes dependency on Icon that makes versioned assets hard to work with
+  - Fixes vertical alignment of icons
+  - Inlines configs to make parsing documentation easier
+
+
 # About:
 
 ClickableText looks different from Nri.Ui.Button in that it displays without margin or padding.
@@ -165,4 +172,4 @@ sizeToPx size =
 
 dataDescriptor : String -> String
 dataDescriptor descriptor =
-    "clickable-text-v1-" ++ descriptor
+    "clickable-text-v2-" ++ descriptor

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -34,11 +34,10 @@ type ButtonType
 
 {-| -}
 example :
-    { r | teach_assignments_copyWhite_svg : Asset, x : String }
-    -> (String -> ModuleMessages Msg parentMsg)
+    (String -> ModuleMessages Msg parentMsg)
     -> State
     -> ModuleExample parentMsg
-example assets unnamedMessages state =
+example unnamedMessages state =
     let
         messages =
             unnamedMessages "ClickableTextExample"
@@ -46,7 +45,7 @@ example assets unnamedMessages state =
     { filename = "Nri.Ui.ClickableText.V1"
     , category = Buttons
     , content =
-        [ viewExamples assets messages state ]
+        [ viewExamples messages state ]
     }
 
 
@@ -91,18 +90,17 @@ type alias Model =
 
 
 viewExamples :
-    { r | teach_assignments_copyWhite_svg : Asset, x : String }
-    -> ModuleMessages Msg parentMsg
+    ModuleMessages Msg parentMsg
     -> State
     -> Html parentMsg
-viewExamples assets messages (State control) =
+viewExamples messages (State control) =
     let
         model =
             Control.currentValue control
     in
     [ Control.view (State >> SetState >> messages.wrapper) control
         |> fromUnstyled
-    , buttons assets messages model
+    , buttons messages model
     ]
         |> div []
 
@@ -116,11 +114,10 @@ sizes =
 
 
 buttons :
-    { r | teach_assignments_copyWhite_svg : Asset }
-    -> ModuleMessages Msg parentMsg
+    ModuleMessages Msg parentMsg
     -> Model
     -> Html parentMsg
-buttons assets messages model =
+buttons messages model =
     let
         exampleCell size =
             (case model.buttonType of

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -36,7 +36,7 @@ example unnamedMessages state =
         messages =
             unnamedMessages "ClickableTextExample"
     in
-    { filename = "Nri.Ui.ClickableText.V1"
+    { filename = "Nri.Ui.ClickableText.V2"
     , category = Buttons
     , content =
         [ viewExamples messages state ]

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -10,9 +10,9 @@ import Headings
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css, id)
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample, ModuleMessages)
-import Nri.Ui.AssetPath exposing (Asset)
 import Nri.Ui.ClickableText.V2 as ClickableText exposing (Size(..))
 import Nri.Ui.Icon.V4 as Icon
+import Nri.Ui.Svg.V1 as NriSvg exposing (Svg)
 import Nri.Ui.Text.V2 as Text
 
 
@@ -49,10 +49,20 @@ init assets =
     Control.record Model
         |> Control.field "label" (Control.string "Clickable Text")
         |> Control.field "icon"
-            (Control.maybe False <|
+            (Control.maybe True <|
                 Control.choice
-                    ( "Performance", Control.value (Icon.performance assets) )
-                    [ ( "Lock", Control.value (Icon.lock assets) )
+                    ( "Performance"
+                    , Icon.performance assets
+                        |> Icon.decorativeIcon
+                        |> NriSvg.fromHtml
+                        |> Control.value
+                    )
+                    [ ( "Lock"
+                      , Icon.lock assets
+                            |> Icon.decorativeIcon
+                            |> NriSvg.fromHtml
+                            |> Control.value
+                      )
                     ]
             )
         |> State
@@ -72,7 +82,7 @@ update msg state =
 
 type alias Model =
     { label : String
-    , icon : Maybe Icon.IconType
+    , icon : Maybe Svg
     }
 
 

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -1,7 +1,9 @@
 module Examples.ClickableText exposing (Msg, State, example, init, update)
 
-{- \
-   @docs Msg, State, example, init, update,
+{-|
+
+@docs Msg, State, example, init, update
+
 -}
 
 import Css exposing (middle, verticalAlign)
@@ -98,6 +100,13 @@ viewExamples messages (State control) =
     [ Control.view (State >> SetState >> messages.wrapper) control
         |> fromUnstyled
     , buttons messages model
+    , Text.smallBody
+        [ text "Sometimes, we'll want our clickable links: "
+        , linkView model Small
+        , text " and clickable buttons: "
+        , buttonView messages model Small
+        , text " to show up in-line."
+        ]
     ]
         |> div []
 
@@ -116,23 +125,6 @@ buttons :
     -> Html parentMsg
 buttons messages model =
     let
-        linkView size =
-            ClickableText.link
-                { size = size
-                , label = model.label
-                , icon = model.icon
-                , url = "#"
-                }
-                []
-
-        buttonView size =
-            ClickableText.button
-                { size = size
-                , onClick = messages.showItWorked (Debug.toString size)
-                , label = model.label
-                , icon = model.icon
-                }
-
         exampleCell view =
             view
                 |> List.singleton
@@ -147,10 +139,31 @@ buttons messages model =
         |> List.map (\size -> th [] [ text <| Debug.toString size ])
         |> (\sizeHeadings -> tr [] (th [] [ td [] [] ] :: sizeHeadings))
     , sizes
-        |> List.map (linkView >> exampleCell)
+        |> List.map (linkView model >> exampleCell)
         |> (\linkViews -> tr [] (td [] [ text ".link" ] :: linkViews))
     , sizes
-        |> List.map (buttonView >> exampleCell)
+        |> List.map (buttonView messages model >> exampleCell)
         |> (\buttonViews -> tr [] (td [] [ text ".button" ] :: buttonViews))
     ]
         |> table []
+
+
+linkView : Model -> ClickableText.Size -> Html msg
+linkView model size =
+    ClickableText.link
+        { size = size
+        , label = model.label
+        , icon = model.icon
+        , url = "#"
+        }
+        []
+
+
+buttonView : ModuleMessages Msg parentMsg -> Model -> ClickableText.Size -> Html parentMsg
+buttonView messages model size =
+    ClickableText.button
+        { size = size
+        , onClick = messages.showItWorked (Debug.toString size)
+        , label = model.label
+        , icon = model.icon
+        }

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -11,7 +11,7 @@ import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css, id)
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample, ModuleMessages)
 import Nri.Ui.AssetPath exposing (Asset)
-import Nri.Ui.ClickableText.V1 as ClickableText exposing (Size(..))
+import Nri.Ui.ClickableText.V2 as ClickableText exposing (Size(..))
 import Nri.Ui.Icon.V4 as Icon
 import Nri.Ui.Text.V2 as Text
 

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -27,12 +27,6 @@ type State
 
 
 {-| -}
-type ButtonType
-    = Button
-    | Link
-
-
-{-| -}
 example :
     (String -> ModuleMessages Msg parentMsg)
     -> State
@@ -61,12 +55,6 @@ init assets =
                     [ ( "Lock", Control.value (Icon.lock assets) )
                     ]
             )
-        |> Control.field "button type"
-            (Control.choice
-                ( "Nri.Ui.ClickableText.V1.button", Control.value Button )
-                [ ( "Nri.Ui.ClickableText.V1.link", Control.value Link )
-                ]
-            )
         |> State
 
 
@@ -85,7 +73,6 @@ update msg state =
 type alias Model =
     { label : String
     , icon : Maybe Icon.IconType
-    , buttonType : ButtonType
     }
 
 
@@ -119,25 +106,25 @@ buttons :
     -> Html parentMsg
 buttons messages model =
     let
-        exampleCell size =
-            (case model.buttonType of
-                Link ->
-                    ClickableText.link
-                        { size = size
-                        , label = model.label
-                        , icon = model.icon
-                        , url = "#"
-                        }
-                        []
+        linkView size =
+            ClickableText.link
+                { size = size
+                , label = model.label
+                , icon = model.icon
+                , url = "#"
+                }
+                []
 
-                Button ->
-                    ClickableText.button
-                        { size = size
-                        , onClick = messages.showItWorked (Debug.toString size)
-                        , label = model.label
-                        , icon = model.icon
-                        }
-            )
+        buttonView size =
+            ClickableText.button
+                { size = size
+                , onClick = messages.showItWorked (Debug.toString size)
+                , label = model.label
+                , icon = model.icon
+                }
+
+        exampleCell view =
+            view
                 |> List.singleton
                 |> td
                     [ css
@@ -148,9 +135,12 @@ buttons messages model =
     in
     [ sizes
         |> List.map (\size -> th [] [ text <| Debug.toString size ])
-        |> tr []
+        |> (\sizeHeadings -> tr [] (th [] [ td [] [] ] :: sizeHeadings))
     , sizes
-        |> List.map exampleCell
-        |> tr []
+        |> List.map (linkView >> exampleCell)
+        |> (\linkViews -> tr [] (td [] [ text ".link" ] :: linkViews))
+    , sizes
+        |> List.map (buttonView >> exampleCell)
+        |> (\buttonViews -> tr [] (td [] [ text ".button" ] :: buttonViews))
     ]
         |> table []

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -216,7 +216,7 @@ nriThemedModules model =
     [ Examples.Alert.example
     , Examples.BannerAlert.example
     , Examples.Button.example (exampleMessages ButtonExampleMsg) model.buttonExampleState
-    , Examples.ClickableText.example assets (exampleMessages ClickableTextExampleMsg) model.clickableTextExampleState
+    , Examples.ClickableText.example (exampleMessages ClickableTextExampleMsg) model.clickableTextExampleState
     , Examples.Checkbox.example CheckboxExampleMsg model.checkboxExampleState
     , Examples.Dropdown.example DropdownMsg model.dropdownState
     , Examples.Icon.example


### PR DESCRIPTION
In https://github.com/NoRedInk/NoRedInk/pull/23360, I noticed that the clickable text icons weren't aligned how I would like. This changes the vertical alignment to be baseline.

It also removes the dependency on a specific Icon version.

I merged https://github.com/NoRedInk/noredink-ui/pull/239 so that I could see what I was doing (like, see the icons in context).

<img width="834" alt="Screen Shot 2019-03-28 at 1 06 56 PM" src="https://user-images.githubusercontent.com/8811312/55194504-1ce8a200-5167-11e9-872b-1d2a44630f25.png">

@NoRedInk/design 