### PR TITLE
Tessa/disclosing

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -25,6 +25,7 @@
         "Nri.Ui.Colors.Extra",
         "Nri.Ui.Colors.V1",
         "Nri.Ui.DisclosureIndicator.V1",
+        "Nri.Ui.DisclosureIndicator.V2",
         "Nri.Ui.Divider.V2",
         "Nri.Ui.Dropdown.V2",
         "Nri.Ui.Effects.V1",

--- a/src/Nri/Ui/DisclosureIndicator/V2.elm
+++ b/src/Nri/Ui/DisclosureIndicator/V2.elm
@@ -18,7 +18,7 @@ from the styleguide examples.)
 A caret that indicates that a section can expand and collapse. When `isOpen` is True, the caret will rotate down.
 "Disclosure indicator" is a standard term for something that indicates that section can expand.
 
-@docs medium, small
+@docs view
 
 -}
 

--- a/src/Nri/Ui/DisclosureIndicator/V2.elm
+++ b/src/Nri/Ui/DisclosureIndicator/V2.elm
@@ -26,8 +26,21 @@ type alias Assets r =
 
 {-| -}
 view : Assets a -> Config -> Html msg
-view =
-    viewWithStyle headerStyle
+view assets config =
+    viewWithStyle
+        [ marginRight (px 10)
+        , width (px 15)
+        , height (px 15)
+        , cursor pointer
+        , property "transition" "transform 0.2s"
+        , if config.isOpen then
+            transform (rotate <| deg 0)
+
+          else
+            transform (rotate <| deg -90)
+        ]
+        assets
+        config
 
 
 {-| The inline variant of the indicator is smaller and occupies
@@ -36,11 +49,23 @@ without breaking text flow. Also, it rotates from right to
 down direction when expanding.
 -}
 viewInline : Assets a -> Config -> Html msg
-viewInline =
-    viewWithStyle inlineStyle
+viewInline assets config =
+    viewWithStyle
+        [ padding2 (px 0) (px 8)
+        , height (px 9)
+        , cursor pointer
+        , property "transition" "transform 0.1s"
+        , if config.isOpen then
+            transform (rotate <| deg 0)
+
+          else
+            transform (rotate <| deg -90)
+        ]
+        assets
+        config
 
 
-viewWithStyle : (Bool -> Css.Style) -> Assets a -> Config -> Html msg
+viewWithStyle : List Css.Style -> Assets a -> Config -> Html msg
 viewWithStyle style assets config =
     let
         label =
@@ -53,37 +78,6 @@ viewWithStyle style assets config =
     img
         [ alt label
         , Attributes.src <| AssetPath.url <| assets.icons_arrowDownBlue_svg
-        , Attributes.css [ style config.isOpen ]
+        , Attributes.css style
         ]
         []
-
-
-headerStyle : Bool -> Css.Style
-headerStyle isOpen =
-    Css.batch
-        [ marginRight (px 10)
-        , width (px 15)
-        , height (px 15)
-        , cursor pointer
-        , property "transition" "transform 0.2s"
-        , if isOpen then
-            transform (rotate <| deg 0)
-
-          else
-            transform (rotate <| deg -90)
-        ]
-
-
-inlineStyle : Bool -> Css.Style
-inlineStyle isOpen =
-    Css.batch
-        [ padding2 (px 0) (px 8)
-        , height (px 9)
-        , cursor pointer
-        , property "transition" "transform 0.1s"
-        , if isOpen then
-            transform (rotate <| deg 0)
-
-          else
-            transform (rotate <| deg -90)
-        ]

--- a/src/Nri/Ui/DisclosureIndicator/V2.elm
+++ b/src/Nri/Ui/DisclosureIndicator/V2.elm
@@ -1,0 +1,89 @@
+module Nri.Ui.DisclosureIndicator.V1 exposing (view, viewInline)
+
+{-| A caret that indicates that a section can expand. When the isOpen attribute is passed in as True, it will rotate. A "disclosure indicator" is a standard term for something that indicates that section can expand.
+
+@docs view, viewInline
+
+-}
+
+import Css exposing (..)
+import Html.Styled as Html exposing (..)
+import Html.Styled.Attributes as Attributes exposing (alt, type_)
+import Nri.Ui.AssetPath as AssetPath
+
+
+type alias Config =
+    { isOpen : Bool
+    , label : String
+    }
+
+
+type alias Assets r =
+    { r
+        | icons_arrowDownBlue_svg : AssetPath.Asset
+    }
+
+
+{-| -}
+view : Assets a -> Config -> Html msg
+view =
+    viewWithStyle headerStyle
+
+
+{-| The inline variant of the indicator is smaller and occupies
+less vertical space so it can be inlined in lists or tables
+without breaking text flow. Also, it rotates from right to
+down direction when expanding.
+-}
+viewInline : Assets a -> Config -> Html msg
+viewInline =
+    viewWithStyle inlineStyle
+
+
+viewWithStyle : (Bool -> Css.Style) -> Assets a -> Config -> Html msg
+viewWithStyle style assets config =
+    let
+        label =
+            if config.isOpen then
+                "hide " ++ config.label
+
+            else
+                "show " ++ config.label
+    in
+    img
+        [ alt label
+        , Attributes.src <| AssetPath.url <| assets.icons_arrowDownBlue_svg
+        , Attributes.css [ style config.isOpen ]
+        ]
+        []
+
+
+headerStyle : Bool -> Css.Style
+headerStyle isOpen =
+    Css.batch
+        [ marginRight (px 10)
+        , width (px 15)
+        , height (px 15)
+        , cursor pointer
+        , property "transition" "transform 0.2s"
+        , if isOpen then
+            transform (rotate <| deg 0)
+
+          else
+            transform (rotate <| deg -90)
+        ]
+
+
+inlineStyle : Bool -> Css.Style
+inlineStyle isOpen =
+    Css.batch
+        [ padding2 (px 0) (px 8)
+        , height (px 9)
+        , cursor pointer
+        , property "transition" "transform 0.1s"
+        , if isOpen then
+            transform (rotate <| deg 0)
+
+          else
+            transform (rotate <| deg -90)
+        ]

--- a/src/Nri/Ui/DisclosureIndicator/V2.elm
+++ b/src/Nri/Ui/DisclosureIndicator/V2.elm
@@ -1,4 +1,4 @@
-module Nri.Ui.DisclosureIndicator.V2 exposing (medium, small)
+module Nri.Ui.DisclosureIndicator.V2 exposing (view)
 
 {-| A caret that indicates that a section can expand. When the isOpen attribute is passed in as True, it will rotate. A "disclosure indicator" is a standard term for something that indicates that section can expand.
 
@@ -16,29 +16,14 @@ import Nri.Ui.Svg.V1 as NriSvg
 
 type alias Config =
     { isOpen : Bool
+    , size : Css.Px
+    , styles : List Css.Style
     }
 
 
 {-| -}
-medium : Config -> Html msg
-medium config =
-    viewWithStyle
-        [ marginRight (px 10) ]
-        (px 15)
-        config
-
-
-{-| -}
-small : Config -> Html msg
-small config =
-    viewWithStyle
-        [ padding2 (px 0) (px 8) ]
-        (px 9)
-        config
-
-
-viewWithStyle : List Css.Style -> Css.Px -> Config -> Html msg
-viewWithStyle style size config =
+view : Config -> Html msg
+view { styles, size, isOpen } =
     div
         [ css
             ([ Css.display Css.inlineBlock
@@ -46,7 +31,7 @@ viewWithStyle style size config =
              , width size
              , height size
              ]
-                ++ style
+                ++ styles
             )
         ]
         [ div
@@ -56,7 +41,7 @@ viewWithStyle style size config =
                 , Css.alignItems Css.center
                 , color Colors.azure
                 , property "transition" "transform 0.1s"
-                , if config.isOpen then
+                , if isOpen then
                     transform (rotate (deg -90))
 
                   else

--- a/src/Nri/Ui/DisclosureIndicator/V2.elm
+++ b/src/Nri/Ui/DisclosureIndicator/V2.elm
@@ -30,15 +30,9 @@ view assets config =
         [ marginRight (px 10)
         , width (px 15)
         , height (px 15)
-        , cursor pointer
-        , property "transition" "transform 0.2s"
-        , if config.isOpen then
-            transform (rotate <| deg 0)
-
-          else
-            transform (rotate <| deg -90)
         ]
         assets
+        config
 
 
 {-| The inline variant of the indicator is smaller and occupies
@@ -51,21 +45,25 @@ viewInline assets config =
     viewWithStyle
         [ padding2 (px 0) (px 8)
         , height (px 9)
-        , cursor pointer
-        , property "transition" "transform 0.1s"
-        , if config.isOpen then
-            transform (rotate <| deg 0)
-
-          else
-            transform (rotate <| deg -90)
         ]
         assets
+        config
 
 
-viewWithStyle : List Css.Style -> Assets a -> Html msg
-viewWithStyle style assets =
+viewWithStyle : List Css.Style -> Assets a -> Config -> Html msg
+viewWithStyle style assets config =
     img
         [ Attributes.src <| AssetPath.url <| assets.icons_arrowDownBlue_svg
-        , Attributes.css style
+        , Attributes.css
+            (style
+                ++ [ cursor pointer
+                   , property "transition" "transform 0.1s"
+                   , if config.isOpen then
+                        transform (rotate <| deg 0)
+
+                     else
+                        transform (rotate <| deg -90)
+                   ]
+            )
         ]
         []

--- a/src/Nri/Ui/DisclosureIndicator/V2.elm
+++ b/src/Nri/Ui/DisclosureIndicator/V2.elm
@@ -1,4 +1,4 @@
-module Nri.Ui.DisclosureIndicator.V2 exposing (view)
+module Nri.Ui.DisclosureIndicator.V2 exposing (medium, large)
 
 {-|
 
@@ -6,11 +6,8 @@ module Nri.Ui.DisclosureIndicator.V2 exposing (view)
 # Changes from V1
 
   - Removes dependency on Icon that makes versioned assets hard to work with
-  - Allows for customized size and styles with a single `view` function
+  - Renames the helpers to `medium` and `large`
   - Removes `Config` in favor of an explicit type annotation
-
-(If you need the old `view` and `viewInline` styles, please copy the configurations
-from the styleguide examples.)
 
 
 # About:
@@ -18,7 +15,7 @@ from the styleguide examples.)
 A caret that indicates that a section can expand and collapse. When `isOpen` is True, the caret will rotate down.
 "Disclosure indicator" is a standard term for something that indicates that section can expand.
 
-@docs view
+@docs medium, large
 
 -}
 
@@ -28,6 +25,18 @@ import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.SpriteSheet exposing (arrowLeft)
 import Nri.Ui.Svg.V1 as NriSvg
+
+
+{-| -}
+medium : List Css.Style -> Bool -> Html msg
+medium styles isOpen =
+    view { isOpen = isOpen, size = px 15, styles = styles }
+
+
+{-| -}
+large : List Css.Style -> Bool -> Html msg
+large styles isOpen =
+    view { isOpen = isOpen, size = px 17, styles = styles }
 
 
 {-| -}

--- a/src/Nri/Ui/DisclosureIndicator/V2.elm
+++ b/src/Nri/Ui/DisclosureIndicator/V2.elm
@@ -8,8 +8,10 @@ module Nri.Ui.DisclosureIndicator.V2 exposing (view, viewInline)
 
 import Css exposing (..)
 import Html.Styled as Html exposing (..)
-import Html.Styled.Attributes as Attributes exposing (alt, type_)
-import Nri.Ui.AssetPath as AssetPath
+import Html.Styled.Attributes exposing (css)
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.SpriteSheet exposing (arrowLeft)
+import Nri.Ui.Svg.V1 as NriSvg
 
 
 type alias Config =
@@ -17,21 +19,12 @@ type alias Config =
     }
 
 
-type alias Assets r =
-    { r
-        | icons_arrowDownBlue_svg : AssetPath.Asset
-    }
-
-
 {-| -}
-view : Assets a -> Config -> Html msg
-view assets config =
+view : Config -> Html msg
+view config =
     viewWithStyle
-        [ marginRight (px 10)
-        , width (px 15)
-        , height (px 15)
-        ]
-        assets
+        [ marginRight (px 10) ]
+        (px 15)
         config
 
 
@@ -40,30 +33,40 @@ less vertical space so it can be inlined in lists or tables
 without breaking text flow. Also, it rotates from right to
 down direction when expanding.
 -}
-viewInline : Assets a -> Config -> Html msg
-viewInline assets config =
+viewInline : Config -> Html msg
+viewInline config =
     viewWithStyle
-        [ padding2 (px 0) (px 8)
-        , height (px 9)
-        ]
-        assets
+        [ padding2 (px 0) (px 8) ]
+        (px 9)
         config
 
 
-viewWithStyle : List Css.Style -> Assets a -> Config -> Html msg
-viewWithStyle style assets config =
-    img
-        [ Attributes.src <| AssetPath.url <| assets.icons_arrowDownBlue_svg
-        , Attributes.css
-            (style
-                ++ [ cursor pointer
-                   , property "transition" "transform 0.1s"
-                   , if config.isOpen then
-                        transform (rotate <| deg 0)
-
-                     else
-                        transform (rotate <| deg -90)
-                   ]
+viewWithStyle : List Css.Style -> Css.Px -> Config -> Html msg
+viewWithStyle style size config =
+    div
+        [ css
+            ([ Css.display Css.inlineBlock
+             , cursor pointer
+             , width size
+             , height size
+             ]
+                ++ style
             )
         ]
-        []
+        [ div
+            [ css
+                [ Css.displayFlex
+                , Css.justifyContent Css.center
+                , Css.alignItems Css.center
+                , color Colors.azure
+                , property "transition" "transform 0.1s"
+                , if config.isOpen then
+                    transform (rotate (deg -90))
+
+                  else
+                    transform (rotate (deg -180))
+                ]
+            ]
+            [ NriSvg.toHtml arrowLeft
+            ]
+        ]

--- a/src/Nri/Ui/DisclosureIndicator/V2.elm
+++ b/src/Nri/Ui/DisclosureIndicator/V2.elm
@@ -1,4 +1,4 @@
-module Nri.Ui.DisclosureIndicator.V1 exposing (view, viewInline)
+module Nri.Ui.DisclosureIndicator.V2 exposing (view, viewInline)
 
 {-| A caret that indicates that a section can expand. When the isOpen attribute is passed in as True, it will rotate. A "disclosure indicator" is a standard term for something that indicates that section can expand.
 

--- a/src/Nri/Ui/DisclosureIndicator/V2.elm
+++ b/src/Nri/Ui/DisclosureIndicator/V2.elm
@@ -1,8 +1,8 @@
-module Nri.Ui.DisclosureIndicator.V2 exposing (view, viewInline)
+module Nri.Ui.DisclosureIndicator.V2 exposing (medium, small)
 
 {-| A caret that indicates that a section can expand. When the isOpen attribute is passed in as True, it will rotate. A "disclosure indicator" is a standard term for something that indicates that section can expand.
 
-@docs view, viewInline
+@docs medium, small
 
 -}
 
@@ -20,21 +20,17 @@ type alias Config =
 
 
 {-| -}
-view : Config -> Html msg
-view config =
+medium : Config -> Html msg
+medium config =
     viewWithStyle
         [ marginRight (px 10) ]
         (px 15)
         config
 
 
-{-| The inline variant of the indicator is smaller and occupies
-less vertical space so it can be inlined in lists or tables
-without breaking text flow. Also, it rotates from right to
-down direction when expanding.
--}
-viewInline : Config -> Html msg
-viewInline config =
+{-| -}
+small : Config -> Html msg
+small config =
     viewWithStyle
         [ padding2 (px 0) (px 8) ]
         (px 9)

--- a/src/Nri/Ui/DisclosureIndicator/V2.elm
+++ b/src/Nri/Ui/DisclosureIndicator/V2.elm
@@ -14,7 +14,6 @@ import Nri.Ui.AssetPath as AssetPath
 
 type alias Config =
     { isOpen : Bool
-    , label : String
     }
 
 
@@ -40,7 +39,6 @@ view assets config =
             transform (rotate <| deg -90)
         ]
         assets
-        config
 
 
 {-| The inline variant of the indicator is smaller and occupies
@@ -62,22 +60,12 @@ viewInline assets config =
             transform (rotate <| deg -90)
         ]
         assets
-        config
 
 
-viewWithStyle : List Css.Style -> Assets a -> Config -> Html msg
-viewWithStyle style assets config =
-    let
-        label =
-            if config.isOpen then
-                "hide " ++ config.label
-
-            else
-                "show " ++ config.label
-    in
+viewWithStyle : List Css.Style -> Assets a -> Html msg
+viewWithStyle style assets =
     img
-        [ alt label
-        , Attributes.src <| AssetPath.url <| assets.icons_arrowDownBlue_svg
+        [ Attributes.src <| AssetPath.url <| assets.icons_arrowDownBlue_svg
         , Attributes.css style
         ]
         []

--- a/src/Nri/Ui/DisclosureIndicator/V2.elm
+++ b/src/Nri/Ui/DisclosureIndicator/V2.elm
@@ -1,6 +1,22 @@
 module Nri.Ui.DisclosureIndicator.V2 exposing (view)
 
-{-| A caret that indicates that a section can expand. When the isOpen attribute is passed in as True, it will rotate. A "disclosure indicator" is a standard term for something that indicates that section can expand.
+{-|
+
+
+# Changes from V1
+
+  - Removes dependency on Icon that makes versioned assets hard to work with
+  - Allows for customized size and styles with a single `view` function
+  - Removes `Config` in favor of an explicit type annotation
+
+(If you need the old `view` and `viewInline` styles, please copy the configurations
+from the styleguide examples.)
+
+
+# About:
+
+A caret that indicates that a section can expand and collapse. When `isOpen` is True, the caret will rotate down.
+"Disclosure indicator" is a standard term for something that indicates that section can expand.
 
 @docs medium, small
 

--- a/src/Nri/Ui/DisclosureIndicator/V2.elm
+++ b/src/Nri/Ui/DisclosureIndicator/V2.elm
@@ -14,15 +14,13 @@ import Nri.Ui.SpriteSheet exposing (arrowLeft)
 import Nri.Ui.Svg.V1 as NriSvg
 
 
-type alias Config =
+{-| -}
+view :
     { isOpen : Bool
     , size : Css.Px
     , styles : List Css.Style
     }
-
-
-{-| -}
-view : Config -> Html msg
+    -> Html msg
 view { styles, size, isOpen } =
     div
         [ css

--- a/src/Nri/Ui/SpriteSheet.elm
+++ b/src/Nri/Ui/SpriteSheet.elm
@@ -1,8 +1,16 @@
-module Nri.Ui.SpriteSheet exposing (checkmark, exclamationMark, bulb)
+module Nri.Ui.SpriteSheet exposing
+    ( arrowLeft
+    , bulb
+    , checkmark
+    , exclamationMark
+    )
 
 {-|
 
-@docs checkmark, exclamationMark, bulb
+@docs arrowLeft
+@docs bulb
+@docs checkmark
+@docs exclamationMark
 
 -}
 
@@ -86,6 +94,25 @@ bulb =
                     ]
                 ]
             ]
+        ]
+        |> fromUnstyled
+        |> NriSvg.fromHtml
+
+
+{-| -}
+arrowLeft : NriSvg.Svg
+arrowLeft =
+    svg
+        [ viewBox "0 0 25 25"
+        , width "100%"
+        , height "100%"
+        , fill "currentcolor"
+        ]
+        [ Svg.path
+            [ fillRule "evenodd"
+            , d "M19.2677026,20.7322696 C20.2443584,21.7070736 20.2443584,23.2915005 19.2677026,24.2677859 C18.7788191,24.7555583 18.139567,25 17.4999444,25 C16.8603219,25 16.2210698,24.7555583 15.7321863,24.2677859 L5.73229742,14.267897 C4.7556416,13.293093 4.7556416,11.7086662 5.73229742,10.7323808 L15.7321863,0.732491861 C16.7084718,-0.244163954 18.2914171,-0.244163954 19.2677026,0.732491861 C20.2443584,1.70729584 20.2443584,3.29172268 19.2677026,4.26800813 L11.0359422,12.5001389 L19.2677026,20.7322696 Z"
+            ]
+            []
         ]
         |> fromUnstyled
         |> NriSvg.fromHtml

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -4,7 +4,6 @@ module Examples.DisclosureIndicator exposing (Msg, State, example, init, update)
    @docs Msg, State, example, init, update,
 -}
 
-import Assets exposing (Assets, assets)
 import Css
 import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
@@ -42,9 +41,7 @@ example parentMessage state =
                 ]
             , onClick (DisclosureIndicatorToggle (not state.disclosed))
             ]
-            [ DisclosureIndicator.view assets
-                { isOpen = state.disclosed
-                }
+            [ DisclosureIndicator.view { isOpen = state.disclosed }
             , Html.text "Item with detail"
             ]
         , Html.h3 [] [ Html.text "Inline indicator" ]
@@ -68,9 +65,7 @@ example parentMessage state =
                 ]
             , onClick (InlineDisclosureIndicatorToggle (not state.inlineDisclosed))
             ]
-            [ DisclosureIndicator.viewInline assets
-                { isOpen = state.inlineDisclosed
-                }
+            [ DisclosureIndicator.viewInline { isOpen = state.inlineDisclosed }
             , Html.text "Item with detail"
             ]
         ]

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -16,12 +16,6 @@ import Nri.Ui.Fonts.V1 as Fonts
 
 
 {-| -}
-type Msg
-    = ToggleMedium Bool
-    | ToggleSmall Bool
-
-
-{-| -}
 type alias State =
     { mediumState : Bool
     , smallState : Bool
@@ -34,35 +28,47 @@ example parentMessage state =
     { name = "Nri.Ui.DisclosureIndicator.V2"
     , category = Widgets
     , content =
-        [ Html.div []
-            [ Html.button
-                [ css
-                    [ Css.borderStyle Css.none
-                    , Css.outline Css.none
-                    , Css.fontSize (Css.px 20)
-                    ]
-                , onClick (ToggleMedium (not state.mediumState))
-                ]
-                [ DisclosureIndicator.view
-                    { isOpen = state.mediumState
-                    , size = Css.px 15
-                    , styles = [ Css.marginRight (Css.px 10) ]
-                    }
-                , Html.text "Item with detail"
-                ]
-            ]
-        , if state.mediumState then
-            code """
-                    DisclosureIndicator.view
-                        { isOpen = state.mediumState
-                        , size = Css.px 15
-                        , styles = [ Css.marginRight (Css.px 10) ]
-                        }
-                    """
+        [ viewExample ToggleMedium
+            state.mediumState
+            (Css.px 20)
+            (DisclosureIndicator.view
+                { isOpen = state.mediumState
+                , size = Css.px 15
+                , styles = [ Css.marginRight (Css.px 10) ]
+                }
+            )
+            """
+            DisclosureIndicator.view
+                { isOpen = state.mediumState
+                , size = Css.px 15
+                , styles = [ Css.marginRight (Css.px 10) ]
+                }
+            """
+        , viewExample ToggleSmall
+            state.smallState
+            (Css.px 16)
+            (DisclosureIndicator.view
+                { isOpen = state.smallState
+                , size = Css.px 9
+                , styles = [ Css.paddingRight (Css.px 8) ]
+                }
+            )
+            """
+            DisclosureIndicator.view
+                { isOpen = state.smallState
+                , size = Css.px 9
+                , styles = [ Css.paddingRight (Css.px 8) ]
+                }
+            """
+        ]
+            |> List.map (Html.map parentMessage)
+    }
 
-          else
-            Html.text ""
-        , Html.div []
+
+viewExample : msg -> Bool -> Css.Px -> Html.Html msg -> String -> Html.Html msg
+viewExample toggle isOpen fontSize disclosureView disclosureCode =
+    Html.div []
+        [ Html.div []
             [ Html.button
                 [ css
                     [ Css.displayFlex
@@ -70,32 +76,20 @@ example parentMessage state =
                     , Css.borderStyle Css.none
                     , Css.outline Css.none
                     , Fonts.baseFont
-                    , Css.fontSize (Css.px 16)
+                    , Css.fontSize fontSize
                     ]
-                , onClick (ToggleSmall (not state.smallState))
+                , onClick toggle
                 ]
-                [ DisclosureIndicator.view
-                    { isOpen = state.smallState
-                    , size = Css.px 9
-                    , styles = [ Css.paddingRight (Css.px 8) ]
-                    }
-                , Html.text "Item with detail"
+                [ disclosureView
+                , Html.text "Open for code example"
                 ]
             ]
-        , if state.smallState then
-            code """
-                    DisclosureIndicator.view
-                        { isOpen = state.smallState
-                        , size = Css.px 9
-                        , styles = [ Css.paddingRight (Css.px 8) ]
-                        }
-                    """
+        , if isOpen then
+            code disclosureCode
 
           else
             Html.text ""
         ]
-            |> List.map (Html.map parentMessage)
-    }
 
 
 code : String -> Html.Html msg
@@ -118,11 +112,17 @@ init =
 
 
 {-| -}
+type Msg
+    = ToggleMedium
+    | ToggleSmall
+
+
+{-| -}
 update : Msg -> State -> ( State, Cmd Msg )
 update msg state =
     case msg of
-        ToggleMedium mediumState ->
-            ( { state | mediumState = mediumState }, Cmd.none )
+        ToggleMedium ->
+            ( { state | mediumState = not state.mediumState }, Cmd.none )
 
-        ToggleSmall mediumState ->
-            ( { state | smallState = mediumState }, Cmd.none )
+        ToggleSmall ->
+            ( { state | smallState = not state.smallState }, Cmd.none )

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -10,7 +10,7 @@ import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
-import Nri.Ui.DisclosureIndicator.V1 as DisclosureIndicatorV1
+import Nri.Ui.DisclosureIndicator.V2 as DisclosureIndicator
 
 
 {-| -}
@@ -29,7 +29,7 @@ type alias State =
 {-| -}
 example : (Msg -> msg) -> State -> ModuleExample msg
 example parentMessage state =
-    { name = "Nri.Ui.DisclosureIndicator.V1"
+    { name = "Nri.Ui.DisclosureIndicator.V2"
     , category = Widgets
     , content =
         [ Html.h3 [] [ Html.text "Panel indicator" ]
@@ -37,7 +37,7 @@ example parentMessage state =
             [ onClick
                 (DisclosureIndicatorToggle <| not state.disclosed)
             ]
-            [ DisclosureIndicatorV1.view assets
+            [ DisclosureIndicator.view assets
                 { isOpen = state.disclosed
                 , label = "Details"
                 }
@@ -56,7 +56,7 @@ example parentMessage state =
             [ css [ inlineIndicatorContainer ]
             , onClick (InlineDisclosureIndicatorToggle <| not state.inlineDisclosed)
             ]
-            [ DisclosureIndicatorV1.viewInline assets
+            [ DisclosureIndicator.viewInline assets
                 { isOpen = state.inlineDisclosed
                 , label = "Details"
                 }

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -39,7 +39,6 @@ example parentMessage state =
             ]
             [ DisclosureIndicator.view assets
                 { isOpen = state.disclosed
-                , label = "Details"
                 }
             ]
         , Html.h3 [] [ Html.text "Inline indicator" ]
@@ -58,7 +57,6 @@ example parentMessage state =
             ]
             [ DisclosureIndicator.viewInline assets
                 { isOpen = state.inlineDisclosed
-                , label = "Details"
                 }
             , Html.span [] [ Html.text "list item with detail" ]
             ]

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -17,8 +17,8 @@ import Nri.Ui.Fonts.V1 as Fonts
 
 {-| -}
 type alias State =
-    { mediumState : Bool
-    , smallState : Bool
+    { largeState : Bool
+    , mediumState : Bool
     }
 
 
@@ -28,38 +28,20 @@ example parentMessage state =
     { name = "Nri.Ui.DisclosureIndicator.V2"
     , category = Widgets
     , content =
-        [ viewExample ToggleMedium
+        [ viewExample ToggleLarge
+            state.largeState
+            (Css.px 17)
+            (DisclosureIndicator.large [ Css.marginRight (Css.px 10) ] state.largeState)
+            ("DisclosureIndicator.large [ Css.marginRight (Css.px 10) ] True"
+                ++ "\nI'm a 17px caret icon."
+            )
+        , viewExample ToggleMedium
             state.mediumState
-            (Css.px 20)
-            (DisclosureIndicator.view
-                { isOpen = state.mediumState
-                , size = Css.px 15
-                , styles = [ Css.marginRight (Css.px 10) ]
-                }
+            (Css.px 15)
+            (DisclosureIndicator.medium [ Css.paddingRight (Css.px 8) ] state.mediumState)
+            ("DisclosureIndicator.medium [ Css.paddingRight (Css.px 8) ] True"
+                ++ "\nI'm a 15px caret icon."
             )
-            """
-            DisclosureIndicator.view
-                { isOpen = state.mediumState
-                , size = Css.px 15
-                , styles = [ Css.marginRight (Css.px 10) ]
-                }
-            """
-        , viewExample ToggleSmall
-            state.smallState
-            (Css.px 16)
-            (DisclosureIndicator.view
-                { isOpen = state.smallState
-                , size = Css.px 9
-                , styles = [ Css.paddingRight (Css.px 8) ]
-                }
-            )
-            """
-            DisclosureIndicator.view
-                { isOpen = state.smallState
-                , size = Css.px 9
-                , styles = [ Css.paddingRight (Css.px 8) ]
-                }
-            """
         ]
             |> List.map (Html.map parentMessage)
     }
@@ -67,7 +49,7 @@ example parentMessage state =
 
 viewExample : msg -> Bool -> Css.Px -> Html.Html msg -> String -> Html.Html msg
 viewExample toggle isOpen fontSize disclosureView disclosureCode =
-    Html.div []
+    Html.div [ css [ Css.margin2 (Css.px 16) Css.zero ] ]
         [ Html.div []
             [ Html.button
                 [ css
@@ -81,7 +63,7 @@ viewExample toggle isOpen fontSize disclosureView disclosureCode =
                 , onClick toggle
                 ]
                 [ disclosureView
-                , Html.text "Open for code example"
+                , Html.text "Toggle me!"
                 ]
             ]
         , if isOpen then
@@ -106,23 +88,23 @@ code copy =
 {-| -}
 init : State
 init =
-    { mediumState = False
-    , smallState = False
+    { largeState = False
+    , mediumState = False
     }
 
 
 {-| -}
 type Msg
-    = ToggleMedium
-    | ToggleSmall
+    = ToggleLarge
+    | ToggleMedium
 
 
 {-| -}
 update : Msg -> State -> ( State, Cmd Msg )
 update msg state =
     case msg of
+        ToggleLarge ->
+            ( { state | largeState = not state.largeState }, Cmd.none )
+
         ToggleMedium ->
             ( { state | mediumState = not state.mediumState }, Cmd.none )
-
-        ToggleSmall ->
-            ( { state | smallState = not state.smallState }, Cmd.none )

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -1,7 +1,9 @@
 module Examples.DisclosureIndicator exposing (Msg, State, example, init, update)
 
-{- \
-   @docs Msg, State, example, init, update,
+{-|
+
+@docs Msg, State, example, init, update
+
 -}
 
 import Css
@@ -15,14 +17,14 @@ import Nri.Ui.Fonts.V1 as Fonts
 
 {-| -}
 type Msg
-    = DisclosureIndicatorToggle Bool
-    | InlineDisclosureIndicatorToggle Bool
+    = ToggleMedium Bool
+    | ToggleSmall Bool
 
 
 {-| -}
 type alias State =
-    { disclosed : Bool
-    , inlineDisclosed : Bool
+    { mediumState : Bool
+    , smallState : Bool
     }
 
 
@@ -39,9 +41,9 @@ example parentMessage state =
                 , Css.outline Css.none
                 , Css.fontSize (Css.px 20)
                 ]
-            , onClick (DisclosureIndicatorToggle (not state.disclosed))
+            , onClick (ToggleMedium (not state.mediumState))
             ]
-            [ DisclosureIndicator.view { isOpen = state.disclosed }
+            [ DisclosureIndicator.medium { isOpen = state.mediumState }
             , Html.text "Item with detail"
             ]
         , Html.h3 [] [ Html.text "Inline indicator" ]
@@ -63,9 +65,9 @@ example parentMessage state =
                 , Fonts.baseFont
                 , Css.fontSize (Css.px 16)
                 ]
-            , onClick (InlineDisclosureIndicatorToggle (not state.inlineDisclosed))
+            , onClick (ToggleSmall (not state.smallState))
             ]
-            [ DisclosureIndicator.viewInline { isOpen = state.inlineDisclosed }
+            [ DisclosureIndicator.small { isOpen = state.smallState }
             , Html.text "Item with detail"
             ]
         ]
@@ -76,8 +78,8 @@ example parentMessage state =
 {-| -}
 init : State
 init =
-    { disclosed = False
-    , inlineDisclosed = False
+    { mediumState = False
+    , smallState = False
     }
 
 
@@ -85,8 +87,8 @@ init =
 update : Msg -> State -> ( State, Cmd Msg )
 update msg state =
     case msg of
-        DisclosureIndicatorToggle disclosed ->
-            ( { state | disclosed = disclosed }, Cmd.none )
+        ToggleMedium mediumState ->
+            ( { state | mediumState = mediumState }, Cmd.none )
 
-        InlineDisclosureIndicatorToggle disclosed ->
-            ( { state | inlineDisclosed = disclosed }, Cmd.none )
+        ToggleSmall mediumState ->
+            ( { state | smallState = mediumState }, Cmd.none )

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -34,45 +34,79 @@ example parentMessage state =
     { name = "Nri.Ui.DisclosureIndicator.V2"
     , category = Widgets
     , content =
-        [ Html.h3 [] [ Html.text "Panel indicator" ]
-        , Html.button
-            [ css
-                [ Css.borderStyle Css.none
-                , Css.outline Css.none
-                , Css.fontSize (Css.px 20)
+        [ Html.div []
+            [ Html.button
+                [ css
+                    [ Css.borderStyle Css.none
+                    , Css.outline Css.none
+                    , Css.fontSize (Css.px 20)
+                    ]
+                , onClick (ToggleMedium (not state.mediumState))
                 ]
-            , onClick (ToggleMedium (not state.mediumState))
-            ]
-            [ DisclosureIndicator.medium { isOpen = state.mediumState }
-            , Html.text "Item with detail"
-            ]
-        , Html.h3 [] [ Html.text "Inline indicator" ]
-        , Html.p []
-            [ Html.text
-                """
-                The inline variant of the indicator is smaller and occupies
-                less vertical space so it can be inlined in lists or tables
-                without breaking text flow. Also, it rotates from right to
-                down direction when expanding.
-                """
-            ]
-        , Html.button
-            [ css
-                [ Css.displayFlex
-                , Css.alignItems Css.center
-                , Css.borderStyle Css.none
-                , Css.outline Css.none
-                , Fonts.baseFont
-                , Css.fontSize (Css.px 16)
+                [ DisclosureIndicator.view
+                    { isOpen = state.mediumState
+                    , size = Css.px 15
+                    , styles = [ Css.marginRight (Css.px 10) ]
+                    }
+                , Html.text "Item with detail"
                 ]
-            , onClick (ToggleSmall (not state.smallState))
             ]
-            [ DisclosureIndicator.small { isOpen = state.smallState }
-            , Html.text "Item with detail"
+        , if state.mediumState then
+            code """
+                    DisclosureIndicator.view
+                        { isOpen = state.mediumState
+                        , size = Css.px 15
+                        , styles = [ Css.marginRight (Css.px 10) ]
+                        }
+                    """
+
+          else
+            Html.text ""
+        , Html.div []
+            [ Html.button
+                [ css
+                    [ Css.displayFlex
+                    , Css.alignItems Css.center
+                    , Css.borderStyle Css.none
+                    , Css.outline Css.none
+                    , Fonts.baseFont
+                    , Css.fontSize (Css.px 16)
+                    ]
+                , onClick (ToggleSmall (not state.smallState))
+                ]
+                [ DisclosureIndicator.view
+                    { isOpen = state.smallState
+                    , size = Css.px 9
+                    , styles = [ Css.paddingRight (Css.px 8) ]
+                    }
+                , Html.text "Item with detail"
+                ]
             ]
+        , if state.smallState then
+            code """
+                    DisclosureIndicator.view
+                        { isOpen = state.smallState
+                        , size = Css.px 9
+                        , styles = [ Css.paddingRight (Css.px 8) ]
+                        }
+                    """
+
+          else
+            Html.text ""
         ]
             |> List.map (Html.map parentMessage)
     }
+
+
+code : String -> Html.Html msg
+code copy =
+    Html.code
+        [ css
+            [ Css.fontSize (Css.px 12)
+            , Css.whiteSpace Css.pre
+            ]
+        ]
+        [ Html.text copy ]
 
 
 {-| -}

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -11,6 +11,7 @@ import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.DisclosureIndicator.V2 as DisclosureIndicator
+import Nri.Ui.Fonts.V1 as Fonts
 
 
 {-| -}
@@ -33,13 +34,18 @@ example parentMessage state =
     , category = Widgets
     , content =
         [ Html.h3 [] [ Html.text "Panel indicator" ]
-        , Html.div
-            [ onClick
-                (DisclosureIndicatorToggle <| not state.disclosed)
+        , Html.button
+            [ css
+                [ Css.borderStyle Css.none
+                , Css.outline Css.none
+                , Css.fontSize (Css.px 20)
+                ]
+            , onClick (DisclosureIndicatorToggle (not state.disclosed))
             ]
             [ DisclosureIndicator.view assets
                 { isOpen = state.disclosed
                 }
+            , Html.text "Item with detail"
             ]
         , Html.h3 [] [ Html.text "Inline indicator" ]
         , Html.p []
@@ -51,14 +57,21 @@ example parentMessage state =
                 down direction when expanding.
                 """
             ]
-        , Html.div
-            [ css [ inlineIndicatorContainer ]
-            , onClick (InlineDisclosureIndicatorToggle <| not state.inlineDisclosed)
+        , Html.button
+            [ css
+                [ Css.displayFlex
+                , Css.alignItems Css.center
+                , Css.borderStyle Css.none
+                , Css.outline Css.none
+                , Fonts.baseFont
+                , Css.fontSize (Css.px 16)
+                ]
+            , onClick (InlineDisclosureIndicatorToggle (not state.inlineDisclosed))
             ]
             [ DisclosureIndicator.viewInline assets
                 { isOpen = state.inlineDisclosed
                 }
-            , Html.span [] [ Html.text "list item with detail" ]
+            , Html.text "Item with detail"
             ]
         ]
             |> List.map (Html.map parentMessage)
@@ -82,11 +95,3 @@ update msg state =
 
         InlineDisclosureIndicatorToggle disclosed ->
             ( { state | inlineDisclosed = disclosed }, Cmd.none )
-
-
-inlineIndicatorContainer : Css.Style
-inlineIndicatorContainer =
-    Css.batch
-        [ Css.displayFlex
-        , Css.alignItems Css.center
-        ]


### PR DESCRIPTION
This adds a new version of the disclosure widget that is not tied to the Icon arrow. This is more or less relevant to https://github.com/NoRedInk/NoRedInk/pull/23592.

![disclosure](https://user-images.githubusercontent.com/8811312/57327888-d02cab00-70c4-11e9-98bb-56d5dd52a0da.gif)

