### PR TITLE
Tessa/link docs

### DIFF
--- a/styleguide-app/Examples/Dropdown.elm
+++ b/styleguide-app/Examples/Dropdown.elm
@@ -29,7 +29,7 @@ type alias State value =
 {-| -}
 example : (Msg -> msg) -> State Value -> ModuleExample msg
 example parentMessage state =
-    { name = "Nri.Ui.Dropdown.V1"
+    { name = "Nri.Ui.Dropdown.V2"
     , category = Inputs
     , content =
         [ Html.Styled.map parentMessage (Nri.Ui.Dropdown.V2.view "All the foods!" state ConsoleLog)

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -41,7 +41,7 @@ type alias State value =
 {-| -}
 example : (Msg -> msg) -> State Value -> ModuleExample msg
 example parentMessage state =
-    { name = "Nri.Ui.Select.V3"
+    { name = "Nri.Ui.Select.V5"
     , category = Inputs
     , content =
         [ Html.Styled.map (parentMessage << ConsoleLog) (Select.view state)

--- a/styleguide-app/ModuleExample.elm
+++ b/styleguide-app/ModuleExample.elm
@@ -142,15 +142,26 @@ view showFocusLink { name, content } =
                 []
                 [ Html.text name ]
             , if showFocusLink then
-                Html.a
-                    [ Attributes.href <| "#doodad/" ++ name ]
-                    [ Html.text "see only this" ]
+                viewLink "see only this" ("#doodad/" ++ name)
 
               else
                 Html.text ""
+            , String.replace "." "-" name
+                |> (++) "https://package.elm-lang.org/packages/NoRedInk/noredink-ui/latest/"
+                |> viewLink "view docs"
             ]
         , Html.styled Html.div
             [ padding2 (px 20) zero ]
             []
             content
+        ]
+
+
+viewLink : String -> String -> Html msg
+viewLink text href =
+    Html.a
+        [ Attributes.href href
+        , Attributes.css [ Css.display Css.block ]
+        ]
+        [ Html.text text
         ]


### PR DESCRIPTION
Adds links to the documentation for every styleguide example.

Fixes bad names for Select and Dropdown.

![view docs link](https://user-images.githubusercontent.com/8811312/57547975-af5a9480-7314-11e9-9de2-eedae0ecfa19.gif)
