### PR TITLE
Zamboni/customize page button label

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -32,6 +32,7 @@
         "Nri.Ui.Modal.V3",
         "Nri.Ui.Outline.V2",
         "Nri.Ui.Page.V2",
+        "Nri.Ui.Page.V3",
         "Nri.Ui.Palette.V1",
         "Nri.Ui.PremiumCheckbox.V1",
         "Nri.Ui.PremiumCheckbox.V2",

--- a/elm.json
+++ b/elm.json
@@ -40,6 +40,7 @@
         "Nri.Ui.Modal.V4",
         "Nri.Ui.Outline.V2",
         "Nri.Ui.Page.V2",
+        "Nri.Ui.Page.V3",
         "Nri.Ui.Palette.V1",
         "Nri.Ui.PremiumCheckbox.V1",
         "Nri.Ui.PremiumCheckbox.V2",

--- a/src/Nri/Ui/Page/V3.elm
+++ b/src/Nri/Ui/Page/V3.elm
@@ -1,0 +1,223 @@
+module Nri.Ui.Page.V3 exposing
+    ( DefaultPage, broken, blocked, notFound, noPermission
+    , RecoveryText(..)
+    )
+
+{-| A styled NRI issue page!
+
+@docs DefaultPage, broken, blocked, notFound, noPermission
+
+-}
+
+import Css exposing (..)
+import Html.Styled as Html exposing (Html)
+import Html.Styled.Attributes as Attributes
+import Nri.Ui.Button.V5 as Button
+import Nri.Ui.Text.V2 as Text
+
+
+{-| The default page information is for the button
+which will direct the user back to the main page of
+the SPA. Specify it's name and the message which will
+navigate to the page.
+-}
+type alias DefaultPage msg =
+    { link : msg
+    , recoveryText : RecoveryText String
+    }
+
+
+{-| ReturnTo just needs the name of the page the user
+will be returned to. Reload displays default text to reload
+the current page. Custom is to add flexibility to the button.
+-}
+type RecoveryText a
+    = ReturnTo a
+    | Reload
+    | Custom a
+
+
+{-| For the not found page.
+-}
+notFound : DefaultPage msg -> Html msg
+notFound defaultPage =
+    view
+        { emoji = "\u{1F914}"
+        , title = "We couldn’t find that!"
+        , subtitle = "Feel free to browse around, or check out our help center."
+        , defaultPage = Just defaultPage
+        , details = Nothing
+        }
+
+
+{-| For HTTP errors and other broken states.
+-}
+broken : DefaultPage msg -> Html msg
+broken defaultPage =
+    view
+        { emoji = "😵"
+        , title = "There was a problem!"
+        , subtitle = "You can try again, or check out our help center."
+        , defaultPage = Just defaultPage
+        , details = Nothing
+        }
+
+
+{-| For HTTP errors and other broken states, where link goes to "/".
+-}
+blocked : String -> Html msg
+blocked details =
+    view
+        { emoji = "😵"
+        , title = "There was a problem!"
+        , subtitle = "You can try again, or check out our help center."
+        , defaultPage = Nothing
+        , details = Just details
+        }
+
+
+{-| For pages the user does not have access to.
+-}
+noPermission : DefaultPage msg -> Html msg
+noPermission defaultPage =
+    view
+        { emoji = "\u{1F910}"
+        , title = "You do not have access to this page!"
+        , subtitle = "Talk to a site administrator if you believe you should have access to this page."
+        , defaultPage = Just defaultPage
+        , details = Nothing
+        }
+
+
+
+-- INTERNAL
+
+
+type alias Config msg =
+    { emoji : String
+    , title : String
+    , subtitle : String
+    , defaultPage : Maybe (DefaultPage msg)
+    , details : Maybe String
+    }
+
+
+view : Config msg -> Html msg
+view config =
+    viewContainer
+        [ viewEmoji [ Html.text config.emoji ]
+        , Text.heading [ Html.text config.title ]
+        , Text.tagline [ Html.text config.subtitle ]
+        , viewButton
+            [ viewExit config ]
+        , viewButton
+            [ Button.linkExternal
+                { label = "Get help!"
+                , icon = Nothing
+                , url = "https://noredink.zendesk.com/hc/en-us"
+                , size = Button.Large
+                , style = Button.Secondary
+                , width = Button.WidthExact 260
+                }
+            ]
+        , case config.details of
+            Just details ->
+                viewButton [ viewDetails details ]
+
+            Nothing ->
+                Html.text ""
+        ]
+
+
+viewExit : Config msg -> Html msg
+viewExit config =
+    case config.defaultPage of
+        Just defaultPage ->
+            Button.button
+                { onClick = defaultPage.link
+                , size = Button.Large
+                , style = Button.Primary
+                , width = Button.WidthExact 260
+                }
+                { label =
+                    case defaultPage.recoveryText of
+                        ReturnTo name ->
+                            "Return to " ++ name
+
+                        Reload ->
+                            "Reload the page"
+
+                        Custom text ->
+                            text
+                , state = Button.Enabled
+                , icon = Nothing
+                }
+
+        Nothing ->
+            Button.link
+                { label = "Return to dashboard"
+                , icon = Nothing
+                , url = "/"
+                , size = Button.Large
+                , style = Button.Primary
+                , width = Button.WidthExact 260
+                }
+
+
+viewDetails : String -> Html msg
+viewDetails detailsForEngineers =
+    Html.div []
+        [ Html.styled Html.details
+            [ margin (px 10)
+            , maxWidth (px 700)
+            ]
+            []
+            [ Html.styled Html.summary
+                [ color (hex "8F8F8F") ]
+                []
+                [ Html.text "Details for NoRedInk engineers" ]
+            , Html.styled Html.code
+                [ display block
+                , whiteSpace normal
+                , overflowWrap breakWord
+                , textAlign left
+                , marginTop (px 10)
+                ]
+                []
+                [ Html.text detailsForEngineers ]
+            ]
+        ]
+
+
+viewContainer : List (Html msg) -> Html msg
+viewContainer =
+    Html.styled Html.div
+        [ marginTop (px 80)
+        , displayFlex
+        , flexDirection column
+        , alignItems center
+        ]
+        [ Attributes.attribute "data-page-container" "" ]
+
+
+viewButton : List (Html msg) -> Html msg
+viewButton children =
+    Html.styled Html.div
+        [ marginTop (px 15)
+        ]
+        []
+        [ Html.styled Html.div
+            [ textAlign center ]
+            []
+            children
+        ]
+
+
+viewEmoji : List (Html msg) -> Html msg
+viewEmoji =
+    Html.styled Html.div
+        [ fontSize (px 75)
+        , height (px 98)
+        , lineHeight (px 98)
+        ]
+        []

--- a/src/Nri/Ui/Page/V3.elm
+++ b/src/Nri/Ui/Page/V3.elm
@@ -5,7 +5,7 @@ module Nri.Ui.Page.V3 exposing
 
 {-| A styled NRI issue page!
 
-@docs DefaultPage, broken, blocked, notFound, noPermission
+@docs DefaultPage, broken, blocked, notFound, noPermission, RecoveryText(..)
 
 -}
 

--- a/src/Nri/Ui/Page/V3.elm
+++ b/src/Nri/Ui/Page/V3.elm
@@ -23,7 +23,7 @@ navigate to the page.
 -}
 type alias DefaultPage msg =
     { link : msg
-    , recoveryText : RecoveryText String
+    , recoveryText : RecoveryText
     }
 
 
@@ -31,10 +31,10 @@ type alias DefaultPage msg =
 will be returned to. Reload displays default text to reload
 the current page. Custom is to add flexibility to the button.
 -}
-type RecoveryText a
-    = ReturnTo a
+type RecoveryText
+    = ReturnTo String
     | Reload
-    | Custom a
+    | Custom String
 
 
 {-| For the not found page.
@@ -145,7 +145,7 @@ viewExit config =
                             "Return to " ++ name
 
                         Reload ->
-                            "Reload the page"
+                            "Try again"
 
                         Custom text ->
                             text

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -11,13 +11,13 @@ import Css.Global exposing (Snippet, adjacentSiblings, children, class, descenda
 import Headings
 import Html.Styled as Html exposing (Html)
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
-import Nri.Ui.Page.V2 as Page
+import Nri.Ui.Page.V3 as Page
 
 
 {-| -}
 example : msg -> ModuleExample msg
 example noOp =
-    { name = "Nri.Ui.Page.V1"
+    { name = "Nri.Ui.Page.V3"
     , category = Pages
     , content =
         [ Css.Global.global
@@ -26,20 +26,20 @@ example noOp =
                 , Css.flexWrap Css.wrap
                 ]
             ]
-        , Headings.h4 [ Html.text "Page: Not Found" ]
+        , Headings.h4 [ Html.text "Page: Not Found, recovery text: ReturnTo" ]
         , Page.notFound
             { link = noOp
-            , name = "The Main Page"
+            , recoveryText = Page.ReturnTo "the main page"
             }
-        , Headings.h4 [ Html.text "Page: Broken" ]
+        , Headings.h4 [ Html.text "Page: Broken, recovery text: Reload" ]
         , Page.broken
             { link = noOp
-            , name = "The Main Page"
+            , recoveryText = Page.Reload
             }
-        , Headings.h4 [ Html.text "Page: No Permission" ]
+        , Headings.h4 [ Html.text "Page: No Permission, recovery text: Custom" ]
         , Page.noPermission
             { link = noOp
-            , name = "The Main Page"
+            , recoveryText = Page.Custom "Hit the road, Jack"
             }
         ]
     }

--- a/tests/Spec/Nri/Ui/Page/V3.elm
+++ b/tests/Spec/Nri/Ui/Page/V3.elm
@@ -1,0 +1,50 @@
+module Spec.Nri.Ui.Page.V3 exposing (all)
+
+import Expect exposing (Expectation)
+import Html.Styled as Html
+import Nri.Ui.Page.V3 as Page
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (..)
+
+
+type Msg
+    = NoOp
+
+
+all : Test
+all =
+    describe "Nri.Ui.Page.V3"
+        [ describe "button text"
+            [ test "handles recovery text for ReturnTo" <|
+                \() ->
+                    Page.notFound
+                        { link = NoOp
+                        , recoveryText = Page.ReturnTo "the main page"
+                        }
+                        |> Html.toUnstyled
+                        |> Query.fromHtml
+                        |> Expect.all
+                            [ Query.has [ text "Return to the main page" ] ]
+            , test "handles recovery text for Reload" <|
+                \() ->
+                    Page.notFound
+                        { link = NoOp
+                        , recoveryText = Page.Reload
+                        }
+                        |> Html.toUnstyled
+                        |> Query.fromHtml
+                        |> Expect.all
+                            [ Query.has [ text "Reload the page" ] ]
+            , test "handles recovery text for Custom" <|
+                \() ->
+                    Page.notFound
+                        { link = NoOp
+                        , recoveryText = Page.Custom "cats"
+                        }
+                        |> Html.toUnstyled
+                        |> Query.fromHtml
+                        |> Expect.all
+                            [ Query.has [ text "cats" ] ]
+            ]
+        ]

--- a/tests/Spec/Nri/Ui/Page/V3.elm
+++ b/tests/Spec/Nri/Ui/Page/V3.elm
@@ -35,7 +35,7 @@ all =
                         |> Html.toUnstyled
                         |> Query.fromHtml
                         |> Expect.all
-                            [ Query.has [ text "Reload the page" ] ]
+                            [ Query.has [ text "Try again" ] ]
             , test "handles recovery text for Custom" <|
                 \() ->
                     Page.notFound


### PR DESCRIPTION
Unblocks https://www.pivotaltracker.com/story/show/165920196

Adds a type wrapper for the recovery button label so we can keep the existing `"return to " ++ blah` phrasing, add in a default `Reload the page` text (think for when the page breaks in an unrecoverable way), and adds in a Custom type that lets you set the whole of the button text.

![image](https://user-images.githubusercontent.com/5943972/57661709-d200dd80-75a0-11e9-8a39-2bd59c9af819.png)
![image](https://user-images.githubusercontent.com/5943972/57737933-4cddfd00-7662-11e9-9643-3e34af6b2399.png)
![image](https://user-images.githubusercontent.com/5943972/57661728-e1802680-75a0-11e9-8bab-495dfb86e346.png)

cc @bendansby mostly for the okay on "Reload the page" phrasing since `ReturnTo` is exactly as it was and `Custom` is ... custom.
