### PR TITLE
Add ability to provide a default selection to Select

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -38,6 +38,7 @@
         "Nri.Ui.PremiumCheckbox.V2",
         "Nri.Ui.SegmentedControl.V6",
         "Nri.Ui.Select.V5",
+        "Nri.Ui.Select.V6",
         "Nri.Ui.Table.V3",
         "Nri.Ui.Table.V4",
         "Nri.Ui.Tabs.V3",

--- a/elm.json
+++ b/elm.json
@@ -48,6 +48,7 @@
         "Nri.Ui.PremiumCheckbox.V4",
         "Nri.Ui.SegmentedControl.V6",
         "Nri.Ui.Select.V5",
+        "Nri.Ui.Select.V6",
         "Nri.Ui.Svg.V1",
         "Nri.Ui.Slide.V1",
         "Nri.Ui.SlideModal.V1",

--- a/src/Nri/Ui/Select/V6.elm
+++ b/src/Nri/Ui/Select/V6.elm
@@ -77,9 +77,18 @@ view config =
             config.id
                 |> Maybe.map (\id -> [ Attributes.id id ])
                 |> Maybe.withDefault []
+
+        currentVal =
+            if config.current == Nothing && config.defaultDisplayText == Nothing then
+                config.choices
+                    |> List.head
+                    |> Maybe.map .value
+
+            else
+                config.current
     in
     config.choices
-        |> List.map (viewChoice config.current config.valueToString)
+        |> List.map (viewChoice currentVal config.valueToString)
         |> (++) defaultOption
         |> Nri.Ui.styled Html.select
             "nri-select-menu"

--- a/src/Nri/Ui/Select/V6.elm
+++ b/src/Nri/Ui/Select/V6.elm
@@ -1,8 +1,8 @@
-module Nri.Ui.Select.V6 exposing (Config, view)
+module Nri.Ui.Select.V6 exposing (Config, Choice, view)
 
 {-| Build a select input.
 
-@docs Config, view
+@docs Config, Choice, view
 
 -}
 
@@ -28,6 +28,8 @@ type alias Config a =
     }
 
 
+{-| A single possible choice.
+-}
 type alias Choice a =
     { label : String, value : a }
 

--- a/src/Nri/Ui/Select/V6.elm
+++ b/src/Nri/Ui/Select/V6.elm
@@ -105,9 +105,7 @@ view config =
 viewDefaultChoice : Maybe a -> String -> Html a
 viewDefaultChoice current displayText =
     Html.option
-        [ Attributes.id (niceId "nri-select" "default")
-        , Attributes.value (niceId "nri-select" "default")
-        , Attributes.selected (current == Nothing)
+        [ Attributes.selected (current == Nothing)
         , disabled True
         ]
         [ text displayText ]

--- a/src/Nri/Ui/Select/V6.elm
+++ b/src/Nri/Ui/Select/V6.elm
@@ -32,11 +32,9 @@ type alias Choice a =
     { label : String, value : a }
 
 
-{-| TODO: Consider moving this to Nri.Ui.Util once the non-0.19-approved `toString` is removed
--}
-niceId : String -> String -> String
-niceId prefix x =
-    prefix ++ "-" ++ Nri.Ui.Util.dashify (Nri.Ui.Util.removePunctuation x)
+niceId : String -> String
+niceId x =
+    "nri-select-" ++ Nri.Ui.Util.dashify (Nri.Ui.Util.removePunctuation x)
 
 
 {-| A select dropdown
@@ -47,7 +45,7 @@ view config =
         valueLookup =
             -- TODO: probably worth using Lazy here, since choices won't change often
             config.choices
-                |> List.map (\x -> ( niceId "nri-select" (config.valueToString x.value), x.value ))
+                |> List.map (\x -> ( niceId (config.valueToString x.value), x.value ))
                 |> Dict.fromList
 
         decodeValue string =
@@ -120,8 +118,8 @@ viewChoice current toString choice =
                 |> Maybe.withDefault False
     in
     Html.option
-        [ Attributes.id (niceId "nri-select" (toString choice.value))
-        , Attributes.value (niceId "nri-select" (toString choice.value))
+        [ Attributes.id (niceId (toString choice.value))
+        , Attributes.value (niceId (toString choice.value))
         , Attributes.selected isSelected
         ]
         [ Html.text choice.label ]

--- a/src/Nri/Ui/Select/V6.elm
+++ b/src/Nri/Ui/Select/V6.elm
@@ -8,10 +8,10 @@ module Nri.Ui.Select.V6 exposing (Config, view)
 
 import Css
 import Dict
-import Html.Styled as Html exposing (..)
-import Html.Styled.Attributes as Attributes exposing (..)
-import Html.Styled.Events exposing (..)
-import Json.Decode exposing (Decoder, andThen, succeed)
+import Html.Styled as Html exposing (Html)
+import Html.Styled.Attributes as Attributes
+import Html.Styled.Events as Events
+import Json.Decode exposing (Decoder)
 import Nri.Ui
 import Nri.Ui.Colors.V1
 import Nri.Ui.Util
@@ -64,7 +64,7 @@ view config =
                     )
 
         onSelectHandler =
-            on "change" (targetValue |> andThen decodeValue)
+            Events.on "change" (Events.targetValue |> Json.Decode.andThen decodeValue)
 
         defaultOption =
             config.defaultDisplayText
@@ -106,9 +106,9 @@ viewDefaultChoice : Maybe a -> String -> Html a
 viewDefaultChoice current displayText =
     Html.option
         [ Attributes.selected (current == Nothing)
-        , disabled True
+        , Attributes.disabled True
         ]
-        [ text displayText ]
+        [ Html.text displayText ]
 
 
 viewChoice : Maybe a -> (a -> String) -> Choice a -> Html a

--- a/src/Nri/Ui/Select/V6.elm
+++ b/src/Nri/Ui/Select/V6.elm
@@ -1,0 +1,99 @@
+module Nri.Ui.Select.V6 exposing (Config, view)
+
+{-| Build a select input.
+
+@docs Config, view
+
+-}
+
+import Css
+import Dict
+import Html.Styled as Html exposing (..)
+import Html.Styled.Attributes as Attributes exposing (..)
+import Html.Styled.Events exposing (..)
+import Json.Decode exposing (Decoder, andThen, succeed)
+import Nri.Ui
+import Nri.Ui.Colors.V1
+import Nri.Ui.Util
+
+
+{-| Configure a Select
+-}
+type alias Config a =
+    { choices : List { label : String, value : a }
+    , current : a
+    , id : Maybe String
+    , valueToString : a -> String
+    , defaultDisplayText : Maybe String
+    }
+
+
+{-| TODO: Consider moving this to Nri.Ui.Util once the non-0.19-approved `toString` is removed
+-}
+niceId : String -> String -> String
+niceId prefix x =
+    prefix ++ "-" ++ Nri.Ui.Util.dashify (Nri.Ui.Util.removePunctuation x)
+
+
+{-| A select dropdown
+-}
+view : Config a -> Html a
+view config =
+    let
+        valueLookup =
+            -- TODO: probably worth using Lazy here, since choices won't change often
+            config.choices
+                |> List.map (\x -> ( niceId "nri-select" (config.valueToString x.value), x.value ))
+                |> Dict.fromList
+
+        decodeValue string =
+            Dict.get string valueLookup
+                |> Maybe.map Json.Decode.succeed
+                |> Maybe.withDefault (Json.Decode.fail ("Nri.Select: could not decode the value: " ++ string ++ "\nexpected one of: " ++ String.join ", " (Dict.keys valueLookup)))
+
+        onSelectHandler =
+            on "change" (targetValue |> andThen decodeValue)
+
+        defaultOption =
+            case config.defaultDisplayText of
+                Just defaultText ->
+                    [ Html.option
+                        [ Attributes.id (niceId "nri-select" "default")
+                        , Attributes.value (niceId "nri-select" "default")
+                        , Attributes.selected True
+                        , disabled True
+                        ]
+                        [ text defaultText ]
+                    ]
+
+                Nothing ->
+                    []
+
+        viewChoice choice =
+            Html.option
+                [ Attributes.id (niceId "nri-select" (config.valueToString choice.value))
+                , Attributes.value (niceId "nri-select" (config.valueToString choice.value))
+                , Attributes.selected (choice.value == config.current)
+                ]
+                [ Html.text choice.label ]
+
+        extraAttrs =
+            config.id
+                |> Maybe.map (\id -> [ Attributes.id id ])
+                |> Maybe.withDefault []
+    in
+    config.choices
+        |> List.map viewChoice
+        |> (++) defaultOption
+        |> Nri.Ui.styled Html.select
+            "nri-select-menu"
+            [ Css.backgroundColor Nri.Ui.Colors.V1.white
+            , Css.border3 (Css.px 1) Css.solid Nri.Ui.Colors.V1.gray75
+            , Css.borderRadius (Css.px 8)
+            , Css.color Nri.Ui.Colors.V1.gray20
+            , Css.cursor Css.pointer
+            , Css.fontSize (Css.px 15)
+            , Css.height (Css.px 45)
+            , Css.width (Css.pct 100)
+            ]
+            ([ onSelectHandler ] ++ extraAttrs)

--- a/src/Nri/Ui/Select/V6.elm
+++ b/src/Nri/Ui/Select/V6.elm
@@ -53,7 +53,15 @@ view config =
         decodeValue string =
             Dict.get string valueLookup
                 |> Maybe.map Json.Decode.succeed
-                |> Maybe.withDefault (Json.Decode.fail ("Nri.Select: could not decode the value: " ++ string ++ "\nexpected one of: " ++ String.join ", " (Dict.keys valueLookup)))
+                |> Maybe.withDefault
+                    -- At present, elm/virtual-dom throws this failure away.
+                    (Json.Decode.fail
+                        ("Nri.Select: could not decode the value: "
+                            ++ string
+                            ++ "\nexpected one of: "
+                            ++ String.join ", " (Dict.keys valueLookup)
+                        )
+                    )
 
         onSelectHandler =
             on "change" (targetValue |> andThen decodeValue)

--- a/src/Nri/Ui/Select/V6.elm
+++ b/src/Nri/Ui/Select/V6.elm
@@ -45,7 +45,6 @@ view : Config a -> Html a
 view config =
     let
         valueLookup =
-            -- TODO: probably worth using Lazy here, since choices won't change often
             config.choices
                 |> List.map (\x -> ( niceId (config.valueToString x.value), x.value ))
                 |> Dict.fromList

--- a/src/Nri/Ui/Select/V6.elm
+++ b/src/Nri/Ui/Select/V6.elm
@@ -60,17 +60,7 @@ view config =
 
         defaultOption =
             config.defaultDisplayText
-                |> Maybe.map
-                    (\displayText ->
-                        [ Html.option
-                            [ Attributes.id (niceId "nri-select" "default")
-                            , Attributes.value (niceId "nri-select" "default")
-                            , Attributes.selected (config.current == Nothing)
-                            , disabled True
-                            ]
-                            [ text displayText ]
-                        ]
-                    )
+                |> Maybe.map (viewDefaultChoice config.current >> List.singleton)
                 |> Maybe.withDefault []
 
         extraAttrs =
@@ -102,6 +92,17 @@ view config =
             , Css.width (Css.pct 100)
             ]
             ([ onSelectHandler ] ++ extraAttrs)
+
+
+viewDefaultChoice : Maybe a -> String -> Html a
+viewDefaultChoice current displayText =
+    Html.option
+        [ Attributes.id (niceId "nri-select" "default")
+        , Attributes.value (niceId "nri-select" "default")
+        , Attributes.selected (current == Nothing)
+        , disabled True
+        ]
+        [ text displayText ]
 
 
 viewChoice : Maybe a -> (a -> String) -> Choice a -> Html a

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -83,7 +83,7 @@ init =
 {-| -}
 init2 : State2 Value
 init2 =
-    { current = Just "Tacos"
+    { current = Nothing
     , choices =
         [ { label = "Tacos", value = "Tacos" }
         , { label = "Burritos", value = "Burritos" }
@@ -91,7 +91,7 @@ init2 =
         ]
     , id = Nothing
     , valueToString = identity
-    , defaultDisplayText = Just "Select a tortilla based joy"
+    , defaultDisplayText = Nothing
     }
 
 

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -83,7 +83,7 @@ init =
 {-| -}
 init2 : State2 Value
 init2 =
-    { current = ""
+    { current = Just "Tacos"
     , choices =
         [ { label = "Tacos", value = "Tacos" }
         , { label = "Burritos", value = "Burritos" }

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -5,6 +5,7 @@ module Examples.Select exposing
     , example
     , init
     , update
+    , State2, example2, init2, update2
     )
 
 {-|
@@ -21,6 +22,7 @@ module Examples.Select exposing
 import Html.Styled
 import ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.Select.V5 as Select
+import Nri.Ui.Select.V6 as Select6
 
 
 {-| -}
@@ -38,6 +40,10 @@ type alias State value =
     Select.Config value
 
 
+type alias State2 value =
+    Select6.Config value
+
+
 {-| -}
 example : (Msg -> msg) -> State Value -> ModuleExample msg
 example parentMessage state =
@@ -45,6 +51,17 @@ example parentMessage state =
     , category = Inputs
     , content =
         [ Html.Styled.map (parentMessage << ConsoleLog) (Select.view state)
+        ]
+    }
+
+
+{-| -}
+example2 : (Msg -> msg) -> State2 Value -> ModuleExample msg
+example2 parentMessage state =
+    { name = "Nri.Ui.Select.V6"
+    , category = Inputs
+    , content =
+        [ Html.Styled.map (parentMessage << ConsoleLog) (Select6.view state)
         ]
     }
 
@@ -64,8 +81,35 @@ init =
 
 
 {-| -}
+init2 : State2 Value
+init2 =
+    { current = ""
+    , choices =
+        [ { label = "Tacos", value = "Tacos" }
+        , { label = "Burritos", value = "Burritos" }
+        , { label = "Enchiladas", value = "Enchiladas" }
+        ]
+    , id = Nothing
+    , valueToString = identity
+    , defaultDisplayText = Just "Select a tortilla based joy"
+    }
+
+
+{-| -}
 update : Msg -> State Value -> ( State Value, Cmd Msg )
 update msg state =
+    case msg of
+        ConsoleLog message ->
+            let
+                _ =
+                    Debug.log "SelectExample" message
+            in
+            ( state, Cmd.none )
+
+
+{-| -}
+update2 : Msg -> State2 Value -> ( State2 Value, Cmd Msg )
+update2 msg state =
     case msg of
         ConsoleLog message ->
             let

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -5,7 +5,6 @@ module Examples.Select exposing
     , example
     , init
     , update
-    , State2, example2, init2, update2
     )
 
 {-|
@@ -21,8 +20,7 @@ module Examples.Select exposing
 
 import Html.Styled
 import ModuleExample exposing (Category(..), ModuleExample)
-import Nri.Ui.Select.V5 as Select
-import Nri.Ui.Select.V6 as Select6
+import Nri.Ui.Select.V6 as Select
 
 
 {-| -}
@@ -40,14 +38,10 @@ type alias State value =
     Select.Config value
 
 
-type alias State2 value =
-    Select6.Config value
-
-
 {-| -}
 example : (Msg -> msg) -> State Value -> ModuleExample msg
 example parentMessage state =
-    { name = "Nri.Ui.Select.V5"
+    { name = "Nri.Ui.Select.V6"
     , category = Inputs
     , content =
         [ Html.Styled.map (parentMessage << ConsoleLog) (Select.view state)
@@ -56,33 +50,8 @@ example parentMessage state =
 
 
 {-| -}
-example2 : (Msg -> msg) -> State2 Value -> ModuleExample msg
-example2 parentMessage state =
-    { name = "Nri.Ui.Select.V6"
-    , category = Inputs
-    , content =
-        [ Html.Styled.map (parentMessage << ConsoleLog) (Select6.view state)
-        ]
-    }
-
-
-{-| -}
 init : State Value
 init =
-    { current = ""
-    , choices =
-        [ { label = "Tacos", value = "Tacos" }
-        , { label = "Burritos", value = "Burritos" }
-        , { label = "Enchiladas", value = "Enchiladas" }
-        ]
-    , id = Nothing
-    , valueToString = identity
-    }
-
-
-{-| -}
-init2 : State2 Value
-init2 =
     { current = Nothing
     , choices =
         [ { label = "Tacos", value = "Tacos" }
@@ -91,25 +60,13 @@ init2 =
         ]
     , id = Nothing
     , valueToString = identity
-    , defaultDisplayText = Nothing
+    , defaultDisplayText = Just "Select a tasty tortilla based treat!"
     }
 
 
 {-| -}
 update : Msg -> State Value -> ( State Value, Cmd Msg )
 update msg state =
-    case msg of
-        ConsoleLog message ->
-            let
-                _ =
-                    Debug.log "SelectExample" message
-            in
-            ( state, Cmd.none )
-
-
-{-| -}
-update2 : Msg -> State2 Value -> ( State2 Value, Cmd Msg )
-update2 msg state =
     case msg of
         ConsoleLog message ->
             let

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -36,7 +36,6 @@ type alias ModuleStates =
     , dropdownState : Examples.Dropdown.State Examples.Dropdown.Value
     , segmentedControlState : Examples.SegmentedControl.State
     , selectState : Examples.Select.State Examples.Select.Value
-    , selectState2 : Examples.Select.State2 Examples.Select.Value
     , tableExampleState : Examples.Table.State
     , textAreaExampleState : TextAreaExample.State
     , textInputExampleState : TextInputExample.State
@@ -56,7 +55,6 @@ init =
     , dropdownState = Examples.Dropdown.init
     , segmentedControlState = Examples.SegmentedControl.init
     , selectState = Examples.Select.init
-    , selectState2 = Examples.Select.init2
     , tableExampleState = Examples.Table.init
     , textAreaExampleState = TextAreaExample.init
     , textInputExampleState = TextInputExample.init
@@ -75,7 +73,6 @@ type Msg
     | DropdownMsg Examples.Dropdown.Msg
     | SegmentedControlMsg Examples.SegmentedControl.Msg
     | SelectMsg Examples.Select.Msg
-    | SelectMsg2 Examples.Select.Msg
     | ShowItWorked String String
     | TableExampleMsg Examples.Table.Msg
     | TextAreaExampleMsg TextAreaExample.Msg
@@ -140,15 +137,6 @@ update outsideMsg moduleStates =
                     Examples.Select.update msg moduleStates.selectState
             in
             ( { moduleStates | selectState = selectState }
-            , Cmd.map SelectMsg cmd
-            )
-
-        SelectMsg2 msg ->
-            let
-                ( selectState2, cmd ) =
-                    Examples.Select.update2 msg moduleStates.selectState2
-            in
-            ( { moduleStates | selectState2 = selectState2 }
             , Cmd.map SelectMsg cmd
             )
 
@@ -261,7 +249,6 @@ nriThemedModules model =
     , Examples.Page.example NoOp
     , Examples.SegmentedControl.example SegmentedControlMsg model.segmentedControlState
     , Examples.Select.example SelectMsg model.selectState
-    , Examples.Select.example2 SelectMsg2 model.selectState2
     , Examples.Text.example
     , Examples.Text.Writing.example
     , Examples.Fonts.example

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -36,6 +36,7 @@ type alias ModuleStates =
     , dropdownState : Examples.Dropdown.State Examples.Dropdown.Value
     , segmentedControlState : Examples.SegmentedControl.State
     , selectState : Examples.Select.State Examples.Select.Value
+    , selectState2 : Examples.Select.State2 Examples.Select.Value
     , tableExampleState : Examples.Table.State
     , textAreaExampleState : TextAreaExample.State
     , textInputExampleState : TextInputExample.State
@@ -55,6 +56,7 @@ init =
     , dropdownState = Examples.Dropdown.init
     , segmentedControlState = Examples.SegmentedControl.init
     , selectState = Examples.Select.init
+    , selectState2 = Examples.Select.init2
     , tableExampleState = Examples.Table.init
     , textAreaExampleState = TextAreaExample.init
     , textInputExampleState = TextInputExample.init
@@ -73,6 +75,7 @@ type Msg
     | DropdownMsg Examples.Dropdown.Msg
     | SegmentedControlMsg Examples.SegmentedControl.Msg
     | SelectMsg Examples.Select.Msg
+    | SelectMsg2 Examples.Select.Msg
     | ShowItWorked String String
     | TableExampleMsg Examples.Table.Msg
     | TextAreaExampleMsg TextAreaExample.Msg
@@ -137,6 +140,15 @@ update outsideMsg moduleStates =
                     Examples.Select.update msg moduleStates.selectState
             in
             ( { moduleStates | selectState = selectState }
+            , Cmd.map SelectMsg cmd
+            )
+
+        SelectMsg2 msg ->
+            let
+                ( selectState2, cmd ) =
+                    Examples.Select.update2 msg moduleStates.selectState2
+            in
+            ( { moduleStates | selectState2 = selectState2 }
             , Cmd.map SelectMsg cmd
             )
 
@@ -249,6 +261,7 @@ nriThemedModules model =
     , Examples.Page.example NoOp
     , Examples.SegmentedControl.example SegmentedControlMsg model.segmentedControlState
     , Examples.Select.example SelectMsg model.selectState
+    , Examples.Select.example2 SelectMsg2 model.selectState2
     , Examples.Text.example
     , Examples.Text.Writing.example
     , Examples.Fonts.example

--- a/tests/Spec/Nri/Ui/Select.elm
+++ b/tests/Spec/Nri/Ui/Select.elm
@@ -5,6 +5,7 @@ import Html
 import Html.Attributes as Attr
 import Html.Styled
 import Nri.Ui.Select.V5
+import Nri.Ui.Select.V6
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (..)
@@ -14,23 +15,40 @@ spec : Test
 spec =
     describe "view"
         [ describe "V5"
-            (viewSuite
+            (viewSuiteV5
                 (\config ->
-                    { choices = config.choices, current = config.current, id = Nothing, valueToString = identity }
+                    { choices = config.choices
+                    , current = config.current
+                    , id = Nothing
+                    , valueToString = identity
+                    }
                         |> Nri.Ui.Select.V5.view
+                        |> Html.Styled.toUnstyled
+                )
+            )
+        , describe "V6"
+            (viewSuiteV6
+                (\config ->
+                    { choices = config.choices
+                    , current = config.current
+                    , id = Nothing
+                    , valueToString = identity
+                    , defaultDisplayText = config.defaultDisplayText
+                    }
+                        |> Nri.Ui.Select.V6.view
                         |> Html.Styled.toUnstyled
                 )
             )
         ]
 
 
-viewSuite :
+viewSuiteV5 :
     ({ choices : List { label : String, value : String }, current : String } -> Html.Html msg)
     -> List Test
-viewSuite view =
+viewSuiteV5 view =
     [ test "shows all options" <|
         \() ->
-            viewTest
+            viewTestV5
                 view
                 "Tacos"
                 [ "Tacos", "Burritos", "Enchiladas" ]
@@ -39,7 +57,7 @@ viewSuite view =
                 |> Query.count (Expect.equal 3)
     , test "selects the current option" <|
         \() ->
-            viewTest
+            viewTestV5
                 view
                 "Burritos"
                 [ "Tacos", "Burritos", "Enchiladas" ]
@@ -51,17 +69,115 @@ viewSuite view =
     ]
 
 
-viewTest :
+viewTestV5 :
     ({ choices : List { label : a, value : a }, current : b } -> Html.Html msg)
     -> b
     -> List a
     -> Query.Single msg
-viewTest view selected items =
+viewTestV5 view selected items =
     Query.fromHtml
         (Html.div []
             [ view
                 { choices = List.map (\x -> { label = x, value = x }) items
                 , current = selected
+                }
+            ]
+        )
+
+
+viewSuiteV6 :
+    ({ choices : List { label : String, value : String }, current : Maybe String, defaultDisplayText : Maybe String } -> Html.Html msg)
+    -> List Test
+viewSuiteV6 view =
+    [ describe "without a default option"
+        [ test "shows all options" <|
+            \() ->
+                viewTestV6
+                    view
+                    Nothing
+                    Nothing
+                    [ "Tacos", "Burritos", "Enchiladas" ]
+                    |> Query.find [ tag "select" ]
+                    |> Query.findAll [ tag "option" ]
+                    |> Query.count (Expect.equal 3)
+        , test "selects the first option if nothing is selected and there's no default" <|
+            \() ->
+                viewTestV6
+                    view
+                    Nothing
+                    Nothing
+                    [ "Tacos", "Burritos", "Enchiladas" ]
+                    |> Query.find
+                        [ tag "option"
+                        , attribute <| Attr.selected True
+                        ]
+                    |> Query.has [ text "Tacos" ]
+        , test "selects the current option" <|
+            \() ->
+                viewTestV6
+                    view
+                    Nothing
+                    (Just "Burritos")
+                    [ "Tacos", "Burritos", "Enchiladas" ]
+                    |> Query.find
+                        [ tag "option"
+                        , attribute <| Attr.selected True
+                        ]
+                    |> Query.has [ text "Burritos" ]
+        ]
+    , describe "with a default option"
+        [ test "shows all options" <|
+            \() ->
+                viewTestV6
+                    view
+                    (Just "Tasty tortilla'd foods")
+                    Nothing
+                    [ "Tacos", "Burritos", "Enchiladas" ]
+                    |> Query.find [ tag "select" ]
+                    |> Query.findAll [ tag "option" ]
+                    |> Query.count (Expect.equal 4)
+        , test "selects the disabled default option if nothing is currently selected" <|
+            \() ->
+                viewTestV6
+                    view
+                    (Just "Tasty tortilla'd foods")
+                    Nothing
+                    [ "Tacos", "Burritos", "Enchiladas" ]
+                    |> Query.find
+                        [ tag "option"
+                        , attribute <| Attr.selected True
+                        , attribute <| Attr.disabled True
+                        ]
+                    |> Query.has [ text "Tasty tortilla'd foods" ]
+        , test "selects the current option" <|
+            \() ->
+                viewTestV6
+                    view
+                    (Just "Tasty tortilla'd foods")
+                    (Just "Burritos")
+                    [ "Tacos", "Burritos", "Enchiladas" ]
+                    |> Query.find
+                        [ tag "option"
+                        , attribute <| Attr.selected True
+                        ]
+                    |> Query.has [ text "Burritos" ]
+        ]
+    ]
+
+
+viewTestV6 :
+    ({ choices : List { label : a, value : a }, current : Maybe b, defaultDisplayText : Maybe String } -> Html.Html msg)
+    -> Maybe String
+    -> Maybe b
+    -> List a
+    -> Query.Single msg
+viewTestV6 view defaultDisplayText selected items =
+    Query.fromHtml
+        (Html.div []
+            [ view
+                { choices = List.map (\x -> { label = x, value = x }) items
+                , current = selected
+                , defaultDisplayText = defaultDisplayText
                 }
             ]
         )


### PR DESCRIPTION
### Change
Allow an initial "nothing is selected" state.

### Use case
On the interests page we have form inputs for friends & pets which takes gender. Originally we used Dropdown for this reason but turns out when we visit the form and want previously saved info to be loaded, it doesn't respect the user telling it what option to have selected! So we chose to augment the more standard Select

### How it looks
![default-select](https://user-images.githubusercontent.com/5943972/57960747-67f97880-78bf-11e9-8aa3-55478ceda9ad.gif)

### Other details
Came out of [this slack conversation](https://noredink.slack.com/archives/C0VVDLEES/p1558043241053400).

Possible weird edge cases that are being tested
* Something as default + Nothing currently selected -> the default is the currently selected value
* Something as default + Something currently selected -> The selected choice is selected
* Nothing as default + Something currently selected -> The selected choice is selected
* Nothing as default + Nothing currently selected -> The first choice is selected
(where "choice" is an item in the choice list)
