### PR TITLE
Add SPA Support for Tabs

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -56,6 +56,7 @@
         "Nri.Ui.Table.V3",
         "Nri.Ui.Table.V4",
         "Nri.Ui.Tabs.V3",
+        "Nri.Ui.Tabs.V4",
         "Nri.Ui.Text.V2",
         "Nri.Ui.Text.Writing.V1",
         "Nri.Ui.TextArea.V3",

--- a/src/Nri/Ui/Tabs/V4.elm
+++ b/src/Nri/Ui/Tabs/V4.elm
@@ -1,0 +1,367 @@
+module Nri.Ui.Tabs.V4 exposing
+    ( Alignment(..)
+    , Config
+    , LinkConfig
+    , Tab
+    , TabLink
+    , links
+    , view
+    , viewCustom
+    , viewTabDefault
+    )
+
+{-|
+
+@docs Alignment
+@docs Config
+@docs LinkConfig
+@docs Tab
+@docs TabLink
+@docs links
+@docs view
+@docs viewCustom
+
+
+## Defaults
+
+@docs viewTabDefault
+
+-}
+
+import Accessibility.Aria
+import Accessibility.Key
+import Accessibility.Role
+import Accessibility.Widget
+import Css exposing (Style)
+import Html.Styled as Html exposing (Attribute, Html)
+import Html.Styled.Attributes as Attributes
+import Html.Styled.Events as Events
+import Json.Decode
+import List.Zipper exposing (Zipper(..))
+import Nri.Ui.Colors.Extra
+import Nri.Ui.Colors.V1
+import Nri.Ui.Fonts.V1
+
+
+{-| -}
+type alias Config id msg =
+    { title : Maybe String
+    , onSelect : id -> msg
+    , tabs : Zipper (Tab id)
+    , content : id -> Html msg
+    , alignment : Alignment
+    }
+
+
+{-| Determines whether tabs are centered or floating to the left or right.
+-}
+type Alignment
+    = Left
+    | Center
+    | Right
+
+
+{-| -}
+type alias Tab id =
+    { label : String
+    , id : id
+    }
+
+
+{-| -}
+view : Config id msg -> Html msg
+view config =
+    viewCustom config viewTabDefault
+
+
+{-| -}
+viewTabDefault : Tab id -> Html msg
+viewTabDefault tab =
+    Html.text tab.label
+
+
+{-| -}
+viewCustom : Config id msg -> (Tab id -> Html msg) -> Html msg
+viewCustom config viewInnerTab =
+    let
+        selected =
+            List.Zipper.current config.tabs
+
+        viewTabs =
+            List.Zipper.toList config.tabs
+                |> List.map (viewTab config viewInnerTab selected)
+    in
+    Html.div
+        []
+        [ Html.styled Html.div
+            [ Css.displayFlex
+            , Css.alignItems Css.flexEnd
+            , Css.borderBottom (Css.px 1)
+            , Css.borderBottomStyle Css.solid
+            , Css.borderBottomColor Nri.Ui.Colors.V1.navy
+            , Nri.Ui.Fonts.V1.baseFont
+            ]
+            []
+            [ config.title
+                |> Maybe.map viewTitle
+                |> Maybe.withDefault (Html.text "")
+            , Html.styled Html.ul
+                (stylesTabsAligned config.alignment)
+                [ Attributes.fromUnstyled <| Accessibility.Role.tabList
+                ]
+                viewTabs
+            ]
+        , Html.div
+            [ Attributes.fromUnstyled <| Accessibility.Role.tabPanel
+            , Attributes.fromUnstyled <| Accessibility.Aria.labelledBy (tabToId selected)
+            , Attributes.fromUnstyled <| Accessibility.Widget.hidden False
+            , Attributes.id (tabToBodyId selected)
+            ]
+            [ config.content selected.id ]
+        ]
+
+
+viewTitle : String -> Html msg
+viewTitle title =
+    Html.styled Html.h1
+        [ Css.flexGrow (Css.int 2)
+        , Css.fontSize (Css.px 30)
+        , Css.fontWeight Css.bold
+        , Css.margin Css.zero
+        , Css.marginTop (Css.px 5)
+        , Css.marginBottom (Css.px 10)
+        , Css.color Nri.Ui.Colors.V1.navy
+        , Css.width (Css.px 430)
+        ]
+        []
+        [ Html.text title ]
+
+
+viewTab : Config id msg -> (Tab id -> Html msg) -> Tab id -> Tab id -> Html msg
+viewTab { onSelect, tabs } viewInnerTab selected tab =
+    let
+        isSelected =
+            selected.id == tab.id
+    in
+    Html.styled Html.li
+        (stylesTabSelectable isSelected)
+        [ Events.onClick (onSelect tab.id)
+        , Attributes.fromUnstyled <| Accessibility.Key.onKeyDown [ Accessibility.Key.enter (onSelect tab.id) ]
+        , Events.onFocus (onSelect tab.id)
+        , Attributes.tabindex 0
+        , Attributes.fromUnstyled <| Accessibility.Role.presentation
+        , Attributes.id (tabToId tab)
+        , Attributes.fromUnstyled <| Accessibility.Aria.controls (tabToBodyId tab)
+        , Attributes.fromUnstyled <| Accessibility.Widget.selected (selected.id == tab.id)
+        , Events.on "keyup" <|
+            Json.Decode.andThen
+                (\keyCode ->
+                    if keyCode == 39 then
+                        tabs
+                            |> List.Zipper.next
+                            |> Maybe.map (List.Zipper.current >> .id >> onSelect >> Json.Decode.succeed)
+                            |> Maybe.withDefault (Json.Decode.fail "No next tab")
+
+                    else if keyCode == 37 then
+                        tabs
+                            |> List.Zipper.previous
+                            |> Maybe.map (List.Zipper.current >> .id >> onSelect >> Json.Decode.succeed)
+                            |> Maybe.withDefault (Json.Decode.fail "No previous tab")
+
+                    else
+                        Json.Decode.fail "Wrong key code"
+                )
+                Events.keyCode
+        ]
+        [ Html.styled Html.div
+            [ Css.color Nri.Ui.Colors.V1.navy
+            , Css.hover [ Css.textDecoration Css.none ]
+            , Css.focus [ Css.textDecoration Css.none ]
+            , Css.display Css.inlineBlock
+            , Css.padding4 (Css.px 14) (Css.px 20) (Css.px 12) (Css.px 20)
+            , Css.position Css.relative
+            , Css.textDecoration Css.none
+            , Css.property "background" "none"
+            , Css.fontFamily Css.inherit
+            , Css.fontSize Css.inherit
+            , Css.cursor Css.pointer
+            ]
+            [ Attributes.fromUnstyled <| Accessibility.Role.tab
+            , Attributes.tabindex -1
+            ]
+            [ viewInnerTab tab ]
+        ]
+
+
+{-| Describe a tab that is meant to link to another page
+-}
+type alias TabLink =
+    { label : String
+    , href : Maybe String
+    }
+
+
+{-| Configure a set a tab links
+-}
+type alias LinkConfig msg =
+    { title : Maybe String
+    , tabs : Zipper TabLink
+    , content : Html msg
+    , alignment : Alignment
+    }
+
+
+{-| View a set of tab links
+-}
+links : LinkConfig msg -> Html msg
+links config =
+    Html.div []
+        [ Html.styled Html.nav
+            [ Css.displayFlex
+            , Css.alignItems Css.flexEnd
+            , Css.borderBottom (Css.px 1)
+            , Css.borderBottomStyle Css.solid
+            , Css.borderBottomColor Nri.Ui.Colors.V1.navy
+            , Nri.Ui.Fonts.V1.baseFont
+            ]
+            []
+            [ config.title
+                |> Maybe.map viewTitle
+                |> Maybe.withDefault (Html.text "")
+            , Html.styled Html.ul
+                (stylesTabsAligned config.alignment)
+                []
+                (config.tabs
+                    |> mapWithCurrent (viewTabLink config)
+                    |> List.Zipper.toList
+                )
+            ]
+        , Html.div [] [ config.content ]
+        ]
+
+
+viewTabLink : LinkConfig msg -> Bool -> TabLink -> Html msg
+viewTabLink config isSelected tabLink =
+    Html.styled Html.li
+        (stylesTabSelectable isSelected)
+        [ Attributes.fromUnstyled <| Accessibility.Role.presentation
+        , Attributes.id (tabToId tabLink)
+        ]
+        [ case tabLink.href of
+            Just href ->
+                Html.styled Html.a
+                    [ Css.color Nri.Ui.Colors.V1.navy
+                    , Css.display Css.inlineBlock
+                    , Css.padding4 (Css.px 14) (Css.px 20) (Css.px 12) (Css.px 20)
+                    , Css.textDecoration Css.none
+                    ]
+                    [ Attributes.href href ]
+                    [ Html.text tabLink.label ]
+
+            Nothing ->
+                Html.styled Html.button
+                    [ Css.color Nri.Ui.Colors.V1.navy
+                    , Css.display Css.inlineBlock
+                    , Css.padding4 (Css.px 14) (Css.px 20) (Css.px 12) (Css.px 20)
+                    , Css.textDecoration Css.none
+                    , Css.fontFamily Css.inherit
+                    , Css.fontSize Css.inherit
+                    , Css.border Css.zero
+                    , Css.property "background" "none"
+                    , Css.lineHeight (Css.num 1)
+                    ]
+                    []
+                    [ Html.text tabLink.label ]
+        ]
+
+
+
+-- HELP
+
+
+tabToId : { a | label : String } -> String
+tabToId tab =
+    tab.label
+
+
+tabToBodyId : { a | label : String } -> String
+tabToBodyId tab =
+    "tab-body-" ++ tab.label
+
+
+mapWithCurrent : (Bool -> a -> b) -> Zipper a -> Zipper b
+mapWithCurrent fn (Zipper before current after) =
+    Zipper
+        (List.map (fn False) before)
+        (fn True current)
+        (List.map (fn False) after)
+
+
+
+-- STYLES
+
+
+stylesTabsAligned : Alignment -> List Style
+stylesTabsAligned alignment =
+    let
+        alignmentStyles =
+            case alignment of
+                Left ->
+                    [ Css.justifyContent Css.flexStart ]
+
+                Center ->
+                    [ Css.justifyContent Css.center ]
+
+                Right ->
+                    [ Css.justifyContent Css.flexEnd ]
+    in
+    stylesTabs ++ alignmentStyles
+
+
+stylesTabs : List Style
+stylesTabs =
+    [ Css.listStyle Css.none
+    , Css.margin Css.zero
+    , Css.fontSize (Css.px 19)
+    , Css.displayFlex
+    , Css.flexGrow (Css.int 1)
+    , Css.marginRight (Css.px 10)
+    ]
+
+
+stylesTabSelectable : Bool -> List Style
+stylesTabSelectable isSelected =
+    let
+        stylesDynamic =
+            if isSelected then
+                [ Css.backgroundColor Nri.Ui.Colors.V1.white
+                , Css.borderBottom (Css.px 1)
+                , Css.borderBottomStyle Css.solid
+                , Css.borderBottomColor Nri.Ui.Colors.V1.white
+                ]
+
+            else
+                [ Css.backgroundColor Nri.Ui.Colors.V1.frost
+                , Css.backgroundImage <|
+                    Css.linearGradient2 Css.toTop
+                        (Css.stop2 (Nri.Ui.Colors.Extra.withAlpha 0.25 Nri.Ui.Colors.V1.azure) (Css.pct 0))
+                        (Css.stop2 (Nri.Ui.Colors.Extra.withAlpha 0 Nri.Ui.Colors.V1.azure) (Css.pct 25))
+                        [ Css.stop2 (Nri.Ui.Colors.Extra.withAlpha 0 Nri.Ui.Colors.V1.azure) (Css.pct 100) ]
+                ]
+    in
+    stylesTab ++ stylesDynamic
+
+
+stylesTab : List Style
+stylesTab =
+    [ Css.display Css.inlineBlock
+    , Css.borderTopLeftRadius (Css.px 10)
+    , Css.borderTopRightRadius (Css.px 10)
+    , Css.border3 (Css.px 1) Css.solid Nri.Ui.Colors.V1.navy
+    , Css.marginBottom (Css.px -1)
+    , Css.marginLeft (Css.px 10)
+    , Css.cursor Css.pointer
+    , Css.firstChild
+        [ Css.marginLeft Css.zero
+        ]
+    ]

--- a/src/Nri/Ui/Tabs/V4.elm
+++ b/src/Nri/Ui/Tabs/V4.elm
@@ -265,6 +265,13 @@ viewTabLink config isSelected tabConfig =
                     , Just href
                     , [ Attributes.fromUnstyled <| EventExtras.onClickPreventDefaultForLinkWithHref msg ]
                     )
+
+        currentPage =
+            if isSelected then
+                [ Attributes.fromUnstyled <| Accessibility.Aria.currentPage ]
+
+            else
+                []
     in
     Html.styled Html.li
         (stylesTabSelectable isSelected)
@@ -279,7 +286,7 @@ viewTabLink config isSelected tabConfig =
                     , Css.padding4 (Css.px 14) (Css.px 20) (Css.px 12) (Css.px 20)
                     , Css.textDecoration Css.none
                     ]
-                    ([ Attributes.href href ] ++ preventDefault)
+                    ([ Attributes.href href ] ++ preventDefault ++ currentPage)
                     [ Html.text tabLabel ]
 
             Nothing ->
@@ -294,7 +301,7 @@ viewTabLink config isSelected tabConfig =
                     , Css.property "background" "none"
                     , Css.lineHeight (Css.num 1)
                     ]
-                    []
+                    currentPage
                     [ Html.text tabLabel ]
         ]
 

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -12,7 +12,7 @@ module Examples.Tabs exposing
 import Html.Styled as Html
 import List.Zipper
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
-import Nri.Ui.Tabs.V3 as Tabs
+import Nri.Ui.Tabs.V4 as Tabs
 
 
 type Tab
@@ -22,7 +22,7 @@ type Tab
 
 example : (Tab -> msg) -> Tab -> ModuleExample msg
 example changeTab tab =
-    { name = "Nri.Ui.Tabs.V3"
+    { name = "Nri.Ui.Tabs.V4"
     , category = Widgets
     , content =
         [ Tabs.view

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -53,7 +53,9 @@ example changeTab tab =
                 List.Zipper.Zipper
                     []
                     (Tabs.NormalLink { label = "Nowhere", href = Nothing })
-                    [ Tabs.NormalLink { label = "Elm", href = Just "http://elm-lang.org" } ]
+                    [ Tabs.NormalLink { label = "Elm", href = Just "http://elm-lang.org" }
+                    , Tabs.SpaLink { label = "Spa", href = "/#category/Widgets", msg = changeTab Second }
+                    ]
             }
         ]
     }

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -50,7 +50,10 @@ example changeTab tab =
             , content = Html.text "Links"
             , alignment = Tabs.Left
             , tabs =
-                List.Zipper.Zipper [] (Tabs.TabLink "Nowhere" Nothing) [ Tabs.TabLink "Elm" (Just "http://elm-lang.org") ]
+                List.Zipper.Zipper
+                    []
+                    (Tabs.NormalLink { label = "Nowhere", href = Nothing })
+                    [ Tabs.NormalLink { label = "Elm", href = Just "http://elm-lang.org" } ]
             }
         ]
     }


### PR DESCRIPTION
This adds support for SPA links to the Tabs module.

The second and third commit are the most interesting, as they show two different approaches:

1. Create a new config, view function, etc. and make the SPA tabs.
2. Update the existing `links` and `LinkConfig` to support SPA links, breaking the existing API.

I decided to go with the second one, however I would love to hear thoughts!
