### PR TITLE
Bump version to 6.18.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "6.17.0",
+    "version": "6.18.0",
     "exposed-modules": [
         "Nri.Ui.Alert.V2",
         "Nri.Ui.Alert.V3",


### PR DESCRIPTION
Bumping the version to `6.18.0` to release the the new `Nri.Ui.Tabs.V4` which was added in #281.
