### PR TITLE
Fix padding and add dismiss label to banner alert

### DIFF
--- a/src/Nri/Ui/BannerAlert/V4.elm
+++ b/src/Nri/Ui/BannerAlert/V4.elm
@@ -7,6 +7,7 @@ module Nri.Ui.BannerAlert.V4 exposing (alert, error, neutral, success)
 -}
 
 import Accessibility.Styled as Html exposing (Html)
+import Accessibility.Styled.Widget as Widget
 import Css
 import Css.Global
 import Html.Styled.Attributes as Attributes exposing (css)
@@ -144,16 +145,17 @@ dismissButton msg =
         []
         [ Html.button
             [ Html.Styled.Events.onClick msg
+            , Widget.label "Dismiss banner"
             , css
                 [ Css.borderWidth Css.zero
                 , Css.backgroundColor Css.unset
                 , Css.color Colors.azure
                 , Css.width (Css.px 30)
                 , Css.height (Css.px 30)
+                , Css.padding2 Css.zero (Css.px 7)
                 ]
             ]
-            [ -- TODO: add hidden text ("Dismiss banner") for what this is about
-              NriSvg.toHtml xSvg
+            [ NriSvg.toHtml xSvg
             ]
         ]
 

--- a/src/Nri/Ui/BannerAlert/V4.elm
+++ b/src/Nri/Ui/BannerAlert/V4.elm
@@ -153,6 +153,7 @@ dismissButton msg =
                 , Css.width (Css.px 30)
                 , Css.height (Css.px 30)
                 , Css.padding2 Css.zero (Css.px 7)
+                , Css.cursor Css.pointer
                 ]
             ]
             [ NriSvg.toHtml xSvg


### PR DESCRIPTION
Explicitly set padding for the banner alert "dismiss" button ('x').  (This was displaying strangely on the monolith due to its css resets.)

Including "Dismiss banner" aria-label