### PR TITLE
Icon in Alert module doesn't shrink

### DIFF
--- a/src/Nri/Ui/Alert/V4.elm
+++ b/src/Nri/Ui/Alert/V4.elm
@@ -167,6 +167,7 @@ iconContainer styles icon =
                , Css.justifyContent Css.center
                , Css.marginRight (Css.px 5)
                , Css.lineHeight (Css.px 13)
+               , Css.flexShrink Css.zero
 
                -- Size
                , Css.borderRadius (Css.px 13)


### PR DESCRIPTION
Add `flex-shrink 0` so that the icon doesn't shrink when using `Alert.tip` and similar views.

I need it to turn this...

![Screen Shot 2019-07-08 at 11 48 42](https://user-images.githubusercontent.com/753421/60819903-c67ffc00-a176-11e9-8c6e-64e886472a18.png)


into this...

![Screen Shot 2019-07-08 at 11 48 54](https://user-images.githubusercontent.com/753421/60819914-cc75dd00-a176-11e9-80f8-07c7e16f3a33.png)


I didn't find any other imports of `Nri.Ui.Alert.V4` in the monolith yet, so changing the style should be pretty safe I guess.