### PR TITLE
Tessa/adds sortable table

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -26,6 +26,7 @@
         "Nri.Ui.Checkbox.V5",
         "Nri.Ui.Colors.Extra",
         "Nri.Ui.Colors.V1",
+        "Nri.Ui.CssVendorPrefix.V1",
         "Nri.Ui.DisclosureIndicator.V1",
         "Nri.Ui.DisclosureIndicator.V2",
         "Nri.Ui.Divider.V2",

--- a/elm.json
+++ b/elm.json
@@ -59,6 +59,7 @@
         "Nri.Ui.Slide.V1",
         "Nri.Ui.SlideModal.V1",
         "Nri.Ui.SlideModal.V2",
+        "Nri.Ui.SortableTable.V1",
         "Nri.Ui.Table.V3",
         "Nri.Ui.Table.V4",
         "Nri.Ui.Tabs.V3",

--- a/src/Nri/Ui/CssVendorPrefix/V1.elm
+++ b/src/Nri/Ui/CssVendorPrefix/V1.elm
@@ -1,0 +1,49 @@
+module Nri.Ui.CssVendorPrefix.V1 exposing (property, value, complexProperty)
+
+{-| Vendor prefixed css properties.
+
+@docs property, value, complexProperty
+
+-}
+
+import Css
+
+
+{-| Css vendor prefixes
+-}
+prefixes : List String
+prefixes =
+    [ "-webkit-", "-moz-", "-o-", "-ms-", "" ]
+
+
+{-| Same as Css.property but vendor prefixed.
+-}
+property : String -> String -> Css.Style
+property prop value_ =
+    prefixes
+        |> List.map
+            (\prefix ->
+                Css.property (prefix ++ prop) value_
+            )
+        |> Css.batch
+
+
+{-| Same as Css.property but vendor prefixed.
+-}
+value : String -> String -> Css.Style
+value prop value_ =
+    prefixes
+        |> List.map
+            (\prefix ->
+                Css.property prop (prefix ++ value_)
+            )
+        |> Css.batch
+
+
+{-| Used to build more complex Css styles
+-}
+complexProperty : (String -> Css.Style) -> Css.Style
+complexProperty buildProp =
+    prefixes
+        |> List.map buildProp
+        |> Css.batch

--- a/src/Nri/Ui/SortableTable/V1.elm
+++ b/src/Nri/Ui/SortableTable/V1.elm
@@ -23,8 +23,8 @@ import Nri.Ui.Colors.V1
 import Nri.Ui.CssVendorPrefix.V1 as CssVendorPrefix
 import Nri.Ui.Icon.V5 as Icon
 import Nri.Ui.Table.V4
-import Svg exposing (Svg)
-import Svg.Attributes
+import Svg.Styled as Svg exposing (Svg)
+import Svg.Styled.Attributes as SvgAttributes
 
 
 type SortDirection
@@ -370,9 +370,35 @@ arrow direction =
         ]
 
 
-sortArrow : Svg msg
-sortArrow =
-    Svg.svg
-        [ Svg.Attributes.viewBox "0 0 8 6" ]
-        [ Svg.polygon [ Svg.Attributes.points "0 6 4 0 8 6 0 6" ] []
+sortArrow : Direction -> Bool -> Html msg
+sortArrow direction active =
+    Html.div
+        [ css
+            [ width (px 8)
+            , height (px 6)
+            , position relative
+            , margin2 (px 1) zero
+            , if active then
+                color Nri.Ui.Colors.V1.azure
+
+              else
+                color Nri.Ui.Colors.V1.gray75
+            ]
+        ]
+        [ Svg.svg
+            [ SvgAttributes.viewBox "0 0 8 6"
+            , css
+                [ position absolute
+                , top zero
+                , left zero
+                , case direction of
+                    Up ->
+                        Css.batch []
+
+                    Down ->
+                        Css.batch [ transform <| rotate (deg 180) ]
+                ]
+            ]
+            [ Svg.polygon [ SvgAttributes.points "0 6 4 0 8 6 0 6" ] []
+            ]
         ]

--- a/src/Nri/Ui/SortableTable/V1.elm
+++ b/src/Nri/Ui/SortableTable/V1.elm
@@ -1,10 +1,308 @@
-module Nri.Ui.SortableTable.V1 exposing (Direction(..), arrow, arrowActive, arrows, downArrow, sortActive, sortButton, sortHeader, sortInactive, upArrow)
+module Nri.Ui.SortableTable.V1 exposing
+    ( Column, Config, Sorter, State
+    , init, initDescending
+    , custom, string, view, viewLoading
+    , invariantSort, simpleSort, combineSorters
+    )
+
+{-|
+
+@docs Column, Config, Sorter, State
+@docs init, initDescending
+@docs custom, string, view, viewLoading
+@docs invariantSort, simpleSort, combineSorters
+
+-}
 
 import Css exposing (..)
-import Css.File exposing (Stylesheet, UniqueClass, stylesheet, uniqueClass)
 import Css.Global exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import Html exposing (Html)
+import Html.Events
+import Html.Styled
+import List.Extra
+import Nri.IconDEPRECATED
 import Nri.Ui.Colors.V1
 import Nri.Ui.CssVendorPrefix.V1 as CssVendorPrefix
+import Nri.Ui.Table.V4
+
+
+type SortDirection
+    = Ascending
+    | Descending
+
+
+{-| -}
+type alias Sorter a =
+    SortDirection -> a -> a -> Order
+
+
+{-| -}
+type Column id entry msg
+    = Column
+        { id : id
+        , header : Html msg
+        , view : entry -> Html msg
+        , sorter : Sorter entry
+        , width : Int
+        }
+
+
+{-| -}
+type alias State id =
+    { column : id
+    , sortDirection : SortDirection
+    }
+
+
+{-| -}
+type alias Config id entry msg =
+    { updateMsg : State id -> msg
+    , columns : List (Column id entry msg)
+    }
+
+
+{-| -}
+init : id -> State id
+init initialSort =
+    { column = initialSort
+    , sortDirection = Ascending
+    }
+
+
+{-| -}
+initDescending : id -> State id
+initDescending initialSort =
+    { column = initialSort
+    , sortDirection = Descending
+    }
+
+
+{-| -}
+string :
+    { id : id
+    , header : String
+    , value : entry -> String
+    , width : Int
+    }
+    -> Column id entry msg
+string { id, header, value, width } =
+    Column
+        { id = id
+        , header = Html.text header
+        , view = value >> Html.text
+        , sorter = simpleSort value
+        , width = width
+        }
+
+
+{-| -}
+custom :
+    { id : id
+    , header : Html msg
+    , view : entry -> Html msg
+    , sorter : Sorter entry
+    , width : Int
+    }
+    -> Column id entry msg
+custom config =
+    Column
+        { id = config.id
+        , header = config.header
+        , view = config.view
+        , sorter = config.sorter
+        , width = config.width
+        }
+
+
+{-| Create a sorter function that always orders the entries in the same order.
+For example, this is useful when we want to resolve ties and sort the tied
+entries by name, no matter of the sort direction set on the table.
+-}
+invariantSort : (entry -> comparable) -> Sorter entry
+invariantSort mapper =
+    \sortDirection elem1 elem2 ->
+        compare (mapper elem1) (mapper elem2)
+
+
+{-| Create a simple sorter function that orders entries by mapping a function
+over the collection. It will also reverse it when the sort direction is descending.
+-}
+simpleSort : (entry -> comparable) -> Sorter entry
+simpleSort mapper =
+    \sortDirection elem1 elem2 ->
+        let
+            result =
+                compare (mapper elem1) (mapper elem2)
+        in
+        case sortDirection of
+            Ascending ->
+                result
+
+            Descending ->
+                flipOrder result
+
+
+flipOrder : Order -> Order
+flipOrder order =
+    case order of
+        LT ->
+            GT
+
+        EQ ->
+            EQ
+
+        GT ->
+            LT
+
+
+{-| -}
+combineSorters : List (Sorter entry) -> Sorter entry
+combineSorters sorters =
+    \sortDirection elem1 elem2 ->
+        let
+            folder =
+                \sorter acc ->
+                    case acc of
+                        EQ ->
+                            sorter sortDirection elem1 elem2
+
+                        _ ->
+                            acc
+        in
+        List.foldl folder EQ sorters
+
+
+{-| -}
+viewLoading : Config id entry msg -> State id -> Html msg
+viewLoading config state =
+    let
+        tableColumns =
+            List.map (buildTableColumn config.updateMsg state) config.columns
+    in
+    Nri.Ui.Table.V4.viewLoading
+        tableColumns
+        |> Html.Styled.toUnstyled
+
+
+{-| -}
+view : Config id entry msg -> State id -> List entry -> Html msg
+view config state entries =
+    let
+        tableColumns =
+            List.map (buildTableColumn config.updateMsg state) config.columns
+
+        sorter =
+            findSorter config.columns state.column
+    in
+    Nri.Ui.Table.V4.view
+        tableColumns
+        (List.sortWith (sorter state.sortDirection) entries)
+        |> Html.Styled.toUnstyled
+
+
+findSorter : List (Column id entry msg) -> id -> Sorter entry
+findSorter columns columnId =
+    columns
+        |> List.Extra.find (\(Column column) -> column.id == columnId)
+        |> Maybe.map (\(Column column) -> column.sorter)
+        |> Maybe.withDefault identitySorter
+
+
+identitySorter : Sorter a
+identitySorter =
+    \sortDirection item1 item2 ->
+        EQ
+
+
+buildTableColumn : (State id -> msg) -> State id -> Column id entry msg -> Nri.Ui.Table.V4.Column entry msg
+buildTableColumn updateMsg state (Column column) =
+    Nri.Ui.Table.V4.custom
+        { header = Html.Styled.fromUnstyled (viewSortHeader column.header updateMsg state column.id)
+        , view = column.view >> Html.Styled.fromUnstyled
+        , width = Css.px (toFloat column.width)
+        }
+
+
+viewSortHeader : Html msg -> (State id -> msg) -> State id -> id -> Html msg
+viewSortHeader header updateMsg state id =
+    let
+        nextState =
+            nextTableState state id
+
+        headerStyle =
+            if state.column == id then
+                Styles.sortActive
+
+            else
+                Styles.sortInactive
+    in
+    Html.div
+        [ Styles.sortHeader
+        , headerStyle
+        , Html.Events.onClick (updateMsg nextState)
+        ]
+        [ Html.div [] [ header ]
+        , viewSortButton updateMsg state id
+        ]
+
+
+viewSortButton : (State id -> msg) -> State id -> id -> Html msg
+viewSortButton updateMsg state id =
+    let
+        ifActive bool =
+            if bool then
+                [ Styles.arrowActive ]
+
+            else
+                []
+
+        arrows upHighlighted downHighlighted =
+            Html.div [ Styles.arrows ]
+                [ Html.div
+                    (Styles.upArrow :: ifActive upHighlighted)
+                    [ Nri.IconDEPRECATED.decorativeIcon Nri.IconDEPRECATED.SortArrow ]
+                , Html.div
+                    (Styles.downArrow :: ifActive downHighlighted)
+                    [ Nri.IconDEPRECATED.decorativeIcon Nri.IconDEPRECATED.SortArrow ]
+                ]
+
+        buttonContent =
+            case ( state.column == id, state.sortDirection ) of
+                ( True, Ascending ) ->
+                    arrows True False
+
+                ( True, Descending ) ->
+                    arrows False True
+
+                ( False, _ ) ->
+                    arrows False False
+    in
+    Html.div
+        [ Styles.sortButton ]
+        [ buttonContent ]
+
+
+nextTableState : State id -> id -> State id
+nextTableState state id =
+    if state.column == id then
+        { column = id
+        , sortDirection = flipSortDirection state.sortDirection
+        }
+
+    else
+        { column = id
+        , sortDirection = Ascending
+        }
+
+
+flipSortDirection : SortDirection -> SortDirection
+flipSortDirection order =
+    case order of
+        Ascending ->
+            Descending
+
+        Descending ->
+            Ascending
 
 
 sortHeader : UniqueClass

--- a/src/Nri/Ui/SortableTable/V1.elm
+++ b/src/Nri/Ui/SortableTable/V1.elm
@@ -23,6 +23,8 @@ import Nri.Ui.Colors.V1
 import Nri.Ui.CssVendorPrefix.V1 as CssVendorPrefix
 import Nri.Ui.Icon.V5 as Icon
 import Nri.Ui.Table.V4
+import Svg exposing (Svg)
+import Svg.Attributes
 
 
 type SortDirection
@@ -365,4 +367,12 @@ arrow direction =
                     ++ result
                 )
             ]
+        ]
+
+
+sortArrow : Svg msg
+sortArrow =
+    Svg.svg
+        [ Svg.Attributes.viewBox "0 0 8 6" ]
+        [ Svg.polygon [ Svg.Attributes.points "0 6 4 0 8 6 0 6" ] []
         ]

--- a/src/Nri/Ui/SortableTable/V1.elm
+++ b/src/Nri/Ui/SortableTable/V1.elm
@@ -3,19 +3,18 @@ module Nri.Ui.SortableTable.V1 exposing (Direction(..), arrow, arrowActive, arro
 import Css exposing (..)
 import Css.File exposing (Stylesheet, UniqueClass, stylesheet, uniqueClass)
 import Css.Global exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
-import Css.VendorPrefixed
-import FlexBoxWithVendorPrefix as FlexBox
 import Nri.Ui.Colors.V1
+import Nri.Ui.CssVendorPrefix.V1 as CssVendorPrefix
 
 
 sortHeader : UniqueClass
 sortHeader =
     uniqueClass
-        [ FlexBox.displayFlex
-        , FlexBox.alignItems FlexBox.center
-        , FlexBox.justifyContent FlexBox.spaceBetween
+        [ Css.displayFlex
+        , Css.alignItems Css.center
+        , Css.justifyContent Css.spaceBetween
         , cursor pointer
-        , Css.VendorPrefixed.property "user-select" "none"
+        , CssVendorPrefix.property "user-select" "none"
         ]
 
 
@@ -42,10 +41,10 @@ sortActive =
 arrows : UniqueClass
 arrows =
     uniqueClass
-        [ FlexBox.displayFlex
-        , FlexBox.flexDirection FlexBox.column
-        , FlexBox.alignItems FlexBox.center
-        , FlexBox.justifyContent FlexBox.center
+        [ Css.displayFlex
+        , Css.flexDirection Css.column
+        , Css.alignItems Css.center
+        , Css.justifyContent Css.center
         ]
 
 

--- a/src/Nri/Ui/SortableTable/V1.elm
+++ b/src/Nri/Ui/SortableTable/V1.elm
@@ -14,14 +14,15 @@ module Nri.Ui.SortableTable.V1 exposing
 
 -}
 
+import Color
 import Css exposing (..)
 import Css.Global exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events
+import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1
 import Nri.Ui.CssVendorPrefix.V1 as CssVendorPrefix
-import Nri.Ui.Icon.V5 as Icon
 import Nri.Ui.Table.V4
 import Svg.Styled as Svg exposing (Svg)
 import Svg.Styled.Attributes as SvgAttributes
@@ -243,13 +244,6 @@ viewSortHeader header updateMsg state id =
     let
         nextState =
             nextTableState state id
-
-        headerStyle =
-            if state.column == id then
-                [ fontWeight bold ]
-
-            else
-                [ fontWeight normal ]
     in
     Html.div
         [ css
@@ -258,8 +252,12 @@ viewSortHeader header updateMsg state id =
             , Css.justifyContent Css.spaceBetween
             , cursor pointer
             , CssVendorPrefix.property "user-select" "none"
+            , if state.column == id then
+                fontWeight bold
+
+              else
+                fontWeight normal
             ]
-        , css headerStyle
         , Html.Styled.Events.onClick (updateMsg nextState)
         ]
         [ Html.div [] [ header ]
@@ -270,13 +268,6 @@ viewSortHeader header updateMsg state id =
 viewSortButton : (State id -> msg) -> State id -> id -> Html msg
 viewSortButton updateMsg state id =
     let
-        ifActive bool =
-            if bool then
-                [ css [ color Nri.Ui.Colors.V1.azure ] ]
-
-            else
-                []
-
         arrows upHighlighted downHighlighted =
             Html.div
                 [ css
@@ -286,12 +277,8 @@ viewSortButton updateMsg state id =
                     , Css.justifyContent Css.center
                     ]
                 ]
-                [ Html.div
-                    (css [ arrow Up ] :: ifActive upHighlighted)
-                    [ Icon.decorativeIcon (Icon.sortArrow { sortArrow = "sort_arrow" }) ]
-                , Html.div
-                    (css [ arrow Down ] :: ifActive downHighlighted)
-                    [ Icon.decorativeIcon (Icon.sortArrow { sortArrow = "sort_arrow" }) ]
+                [ sortArrow Up upHighlighted
+                , sortArrow Down downHighlighted
                 ]
 
         buttonContent =
@@ -305,13 +292,7 @@ viewSortButton updateMsg state id =
                 ( False, _ ) ->
                     arrows False False
     in
-    Html.div
-        [ css
-            [ padding (px 2)
-            , color Nri.Ui.Colors.V1.gray75
-            ]
-        ]
-        [ buttonContent ]
+    Html.div [ css [ padding (px 2) ] ] [ buttonContent ]
 
 
 nextTableState : State id -> id -> State id
@@ -342,34 +323,6 @@ type Direction
     | Down
 
 
-arrow : Direction -> Css.Style
-arrow direction =
-    let
-        result =
-            case direction of
-                Up ->
-                    []
-
-                Down ->
-                    [ transform <| rotate (deg 180) ]
-    in
-    Css.batch
-        [ width (px 8)
-        , height (px 6)
-        , position relative
-        , margin2 (px 1) zero
-        , children
-            [ selector "svg"
-                ([ position absolute
-                 , top zero
-                 , left zero
-                 ]
-                    ++ result
-                )
-            ]
-        ]
-
-
 sortArrow : Direction -> Bool -> Html msg
 sortArrow direction active =
     Html.div
@@ -378,16 +331,11 @@ sortArrow direction active =
             , height (px 6)
             , position relative
             , margin2 (px 1) zero
-            , if active then
-                color Nri.Ui.Colors.V1.azure
-
-              else
-                color Nri.Ui.Colors.V1.gray75
             ]
         ]
         [ Svg.svg
             [ SvgAttributes.viewBox "0 0 8 6"
-            , css
+            , SvgAttributes.css
                 [ position absolute
                 , top zero
                 , left zero
@@ -398,7 +346,17 @@ sortArrow direction active =
                     Down ->
                         Css.batch [ transform <| rotate (deg 180) ]
                 ]
+            , if active then
+                SvgAttributes.fill (toCssString Nri.Ui.Colors.V1.azure)
+
+              else
+                SvgAttributes.fill (toCssString Nri.Ui.Colors.V1.gray75)
             ]
             [ Svg.polygon [ SvgAttributes.points "0 6 4 0 8 6 0 6" ] []
             ]
         ]
+
+
+toCssString : Css.Color -> String
+toCssString =
+    Color.toCssString << Nri.Ui.Colors.Extra.toCoreColor

--- a/src/Nri/Ui/SortableTable/V1.elm
+++ b/src/Nri/Ui/SortableTable/V1.elm
@@ -1,0 +1,99 @@
+module Nri.Ui.SortableTable.V1 exposing (Direction(..), arrow, arrowActive, arrows, downArrow, sortActive, sortButton, sortHeader, sortInactive, upArrow)
+
+import Css exposing (..)
+import Css.File exposing (Stylesheet, UniqueClass, stylesheet, uniqueClass)
+import Css.Global exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import Css.VendorPrefixed
+import FlexBoxWithVendorPrefix as FlexBox
+import Nri.Ui.Colors.V1
+
+
+sortHeader : UniqueClass
+sortHeader =
+    uniqueClass
+        [ FlexBox.displayFlex
+        , FlexBox.alignItems FlexBox.center
+        , FlexBox.justifyContent FlexBox.spaceBetween
+        , cursor pointer
+        , Css.VendorPrefixed.property "user-select" "none"
+        ]
+
+
+sortButton : UniqueClass
+sortButton =
+    uniqueClass
+        [ padding (px 2)
+        , color Nri.Ui.Colors.V1.gray75
+        ]
+
+
+sortInactive : UniqueClass
+sortInactive =
+    uniqueClass
+        [ fontWeight normal ]
+
+
+sortActive : UniqueClass
+sortActive =
+    uniqueClass
+        [ fontWeight bold ]
+
+
+arrows : UniqueClass
+arrows =
+    uniqueClass
+        [ FlexBox.displayFlex
+        , FlexBox.flexDirection FlexBox.column
+        , FlexBox.alignItems FlexBox.center
+        , FlexBox.justifyContent FlexBox.center
+        ]
+
+
+type Direction
+    = Up
+    | Down
+
+
+arrow : Direction -> UniqueClass
+arrow direction =
+    let
+        result =
+            case direction of
+                Up ->
+                    []
+
+                Down ->
+                    [ transform <| rotate (deg 180) ]
+    in
+    uniqueClass
+        [ width (px 8)
+        , height (px 6)
+        , position relative
+        , margin2 (px 1) zero
+        , children
+            [ selector "svg"
+                ([ position absolute
+                 , top zero
+                 , left zero
+                 ]
+                    ++ result
+                )
+            ]
+        ]
+
+
+upArrow : UniqueClass
+upArrow =
+    arrow Up
+
+
+downArrow : UniqueClass
+downArrow =
+    arrow Down
+
+
+arrowActive : UniqueClass
+arrowActive =
+    uniqueClass
+        [ color Nri.Ui.Colors.V1.azure
+        ]

--- a/styleguide-app/Examples/SortableTable.elm
+++ b/styleguide-app/Examples/SortableTable.elm
@@ -1,0 +1,94 @@
+module Examples.SortableTable exposing (Msg, State, example, init, update)
+
+{-|
+
+    @docs Msg, State, example, init, update
+
+-}
+
+import Html
+import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
+import Nri.Ui.SortableTable.V1 as SortableTable
+
+
+type Column
+    = FirstName
+    | LastName
+    | Coins
+
+
+{-| -}
+type Msg
+    = NoOp
+    | SetSortState (SortableTable.State Column)
+
+
+{-| -}
+type alias State =
+    { sortState : SortableTable.State Column }
+
+
+{-| -}
+example : (Msg -> msg) -> State -> ModuleExample msg
+example parentMessage { sortState } =
+    { filename = "Nri.Ui.SortableTable.V1"
+    , category = Layout
+    , content =
+        let
+            config =
+                { updateMsg = SetSortState
+                , columns =
+                    [ SortableTable.string
+                        { id = FirstName
+                        , header = "First name"
+                        , value = .firstName
+                        , width = 125
+                        }
+                    , SortableTable.string
+                        { id = LastName
+                        , header = "Last name"
+                        , value = .lastName
+                        , width = 125
+                        }
+                    , SortableTable.custom
+                        { id = Coins
+                        , header = Html.text "Coins"
+                        , view = .coins >> String.fromInt >> Html.text
+                        , sorter = SortableTable.simpleSort .coins
+                        , width = 125
+                        }
+                    ]
+                }
+
+            data =
+                [ { firstName = "First1", lastName = "Last1", coins = 1 }
+                , { firstName = "First2", lastName = "Last2", coins = 2 }
+                , { firstName = "First3", lastName = "Last3", coins = 3 }
+                , { firstName = "First4", lastName = "Last4", coins = 4 }
+                , { firstName = "First5", lastName = "Last5", coins = 5 }
+                ]
+        in
+        [ Html.h4 [] [ Html.text "With sortable headers" ]
+        , SortableTable.view config sortState data
+        , Html.h4 [] [ Html.text "Loading" ]
+        , SortableTable.viewLoading config sortState
+        ]
+            |> List.map (Html.map parentMessage)
+    }
+
+
+{-| -}
+init : State
+init =
+    { sortState = SortableTable.init FirstName }
+
+
+{-| -}
+update : Msg -> State -> ( State, Cmd Msg )
+update msg state =
+    case msg of
+        NoOp ->
+            ( state, Cmd.none )
+
+        SetSortState sortState ->
+            ( { state | sortState = sortState }, Cmd.none )

--- a/styleguide-app/Examples/SortableTable.elm
+++ b/styleguide-app/Examples/SortableTable.elm
@@ -6,7 +6,7 @@ module Examples.SortableTable exposing (Msg, State, example, init, update)
 
 -}
 
-import Html
+import Html.Styled as Html
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.SortableTable.V1 as SortableTable
 
@@ -31,8 +31,8 @@ type alias State =
 {-| -}
 example : (Msg -> msg) -> State -> ModuleExample msg
 example parentMessage { sortState } =
-    { filename = "Nri.Ui.SortableTable.V1"
-    , category = Layout
+    { name = "Nri.Ui.SortableTable.V1"
+    , category = Tables
     , content =
         let
             config =

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -17,6 +17,7 @@ import Examples.SegmentedControl
 import Examples.Select
 import Examples.Slide
 import Examples.SlideModal
+import Examples.SortableTable
 import Examples.Table
 import Examples.Tabs
 import Examples.Text
@@ -44,6 +45,7 @@ type alias ModuleStates =
     , modalExampleState : Examples.Modal.State
     , slideModalExampleState : Examples.SlideModal.State
     , slideExampleState : Examples.Slide.State
+    , sortableTableState : Examples.SortableTable.State
     , tabsExampleState : Examples.Tabs.Tab
     }
 
@@ -64,6 +66,7 @@ init =
     , modalExampleState = Examples.Modal.init
     , slideModalExampleState = Examples.SlideModal.init
     , slideExampleState = Examples.Slide.init
+    , sortableTableState = Examples.SortableTable.init
     , tabsExampleState = Examples.Tabs.First
     }
 
@@ -84,6 +87,7 @@ type Msg
     | ModalExampleMsg Examples.Modal.Msg
     | SlideModalExampleMsg Examples.SlideModal.Msg
     | SlideExampleMsg Examples.Slide.Msg
+    | SortableTableMsg Examples.SortableTable.Msg
     | TabsExampleMsg Examples.Tabs.Tab
     | NoOp
 
@@ -221,6 +225,15 @@ update outsideMsg moduleStates =
             , Cmd.map SlideExampleMsg cmd
             )
 
+        SortableTableMsg msg ->
+            let
+                ( sortableTableState, cmd ) =
+                    Examples.SortableTable.update msg moduleStates.sortableTableState
+            in
+            ( { moduleStates | sortableTableState = sortableTableState }
+            , Cmd.map SortableTableMsg cmd
+            )
+
         TabsExampleMsg tab ->
             ( { moduleStates | tabsExampleState = tab }
             , Cmd.none
@@ -272,6 +285,7 @@ nriThemedModules model =
     , Examples.Modal.example ModalExampleMsg model.modalExampleState
     , Examples.SlideModal.example SlideModalExampleMsg model.slideModalExampleState
     , Examples.Slide.example SlideExampleMsg model.slideExampleState
+    , Examples.SortableTable.example SortableTableMsg model.sortableTableState
     , Examples.Tabs.example TabsExampleMsg model.tabsExampleState
     ]
 

--- a/tests/Spec/Nri/Ui/SortableTable/V1.elm
+++ b/tests/Spec/Nri/Ui/SortableTable/V1.elm
@@ -1,0 +1,176 @@
+module Spec.Nri.Ui.SortableTable.V1 exposing (spec)
+
+import Expect exposing (Expectation)
+import Html.Styled
+import Nri.Ui.SortableTable.V1 as SortableTable
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+
+
+type Column
+    = FirstName
+    | LastName
+    | Coins
+
+
+type alias Person =
+    { firstName : String
+    , lastName : String
+    }
+
+
+type Msg
+    = NoOp
+
+
+config : SortableTable.Config Column Person Msg
+config =
+    { updateMsg = \_ -> NoOp
+    , columns =
+        [ SortableTable.string
+            { id = FirstName
+            , header = "First name"
+            , value = .firstName
+            , width = 125
+            }
+        , SortableTable.string
+            { id = LastName
+            , header = "Last name"
+            , value = .lastName
+            , width = 125
+            }
+        ]
+    }
+
+
+entries : List Person
+entries =
+    [ { firstName = "Bob", lastName = "Stevenson" }
+    , { firstName = "Alice", lastName = "Vonnegut" }
+    , { firstName = "Charlie", lastName = "Dickens" }
+    ]
+
+
+tableView : SortableTable.State Column -> Query.Single Msg
+tableView sortState =
+    SortableTable.view config sortState entries
+        |> Html.Styled.toUnstyled
+        |> Query.fromHtml
+
+
+sortBy : Column -> SortableTable.State Column
+sortBy field =
+    SortableTable.init field
+
+
+sortByDescending : Column -> SortableTable.State Column
+sortByDescending field =
+    SortableTable.initDescending field
+
+
+ascending =
+    sortBy FirstName |> .sortDirection
+
+
+descending =
+    sortByDescending FirstName |> .sortDirection
+
+
+spec : Test
+spec =
+    describe "Nri.SortableTable"
+        [ describe "invariantSort"
+            [ test "sorts in the same way independently of sort direction" <|
+                \() ->
+                    let
+                        sorter =
+                            SortableTable.invariantSort .firstName
+                    in
+                    List.sortWith (sorter ascending) entries
+                        |> Expect.equal (List.sortWith (sorter descending) entries)
+            ]
+        , describe "simpleSort"
+            [ test "sorts ascending" <|
+                \() ->
+                    let
+                        sorter =
+                            SortableTable.simpleSort .firstName
+                    in
+                    List.sortWith (sorter ascending) entries
+                        |> List.map .firstName
+                        |> Expect.equal [ "Alice", "Bob", "Charlie" ]
+            , test "sorts descending" <|
+                \() ->
+                    let
+                        sorter =
+                            SortableTable.simpleSort .firstName
+                    in
+                    List.sortWith (sorter descending) entries
+                        |> List.map .firstName
+                        |> Expect.equal [ "Charlie", "Bob", "Alice" ]
+            ]
+        , describe "combineSorters"
+            [ test "combines multiple sorters" <|
+                \() ->
+                    let
+                        newEntries =
+                            { firstName = "Alice", lastName = "InChains" } :: entries
+
+                        sortByFirstName =
+                            SortableTable.simpleSort .firstName
+
+                        sortByLastName =
+                            SortableTable.simpleSort .lastName
+
+                        sorter =
+                            SortableTable.combineSorters [ sortByFirstName, sortByLastName ]
+                    in
+                    List.sortWith (sorter ascending) newEntries
+                        |> List.map (\elem -> elem.firstName ++ " " ++ elem.lastName)
+                        |> Expect.equal
+                            [ "Alice InChains"
+                            , "Alice Vonnegut"
+                            , "Bob Stevenson"
+                            , "Charlie Dickens"
+                            ]
+            ]
+        , describe "view"
+            [ test "displays one row for each entry" <|
+                \() ->
+                    tableView (sortBy FirstName)
+                        |> Query.find [ Selector.tag "tbody" ]
+                        |> Query.findAll [ Selector.tag "tr" ]
+                        |> Query.count (Expect.equal 3)
+            , test "displays entries sorted by first name" <|
+                \() ->
+                    tableView (sortBy FirstName)
+                        |> Query.find [ Selector.tag "tbody" ]
+                        |> Query.findAll [ Selector.tag "tr" ]
+                        |> Expect.all
+                            [ Query.index 0 >> Query.has [ Selector.text "Alice" ]
+                            , Query.index 1 >> Query.has [ Selector.text "Bob" ]
+                            , Query.index 2 >> Query.has [ Selector.text "Charlie" ]
+                            ]
+            , test "displays entries sorted by last name" <|
+                \() ->
+                    tableView (sortBy LastName)
+                        |> Query.find [ Selector.tag "tbody" ]
+                        |> Query.findAll [ Selector.tag "tr" ]
+                        |> Expect.all
+                            [ Query.index 0 >> Query.has [ Selector.text "Dickens" ]
+                            , Query.index 1 >> Query.has [ Selector.text "Stevenson" ]
+                            , Query.index 2 >> Query.has [ Selector.text "Vonnegut" ]
+                            ]
+            , test "displays entries sorted by descending first name" <|
+                \() ->
+                    tableView (sortByDescending FirstName)
+                        |> Query.find [ Selector.tag "tbody" ]
+                        |> Query.findAll [ Selector.tag "tr" ]
+                        |> Expect.all
+                            [ Query.index 0 >> Query.has [ Selector.text "Charlie" ]
+                            , Query.index 1 >> Query.has [ Selector.text "Bob" ]
+                            , Query.index 2 >> Query.has [ Selector.text "Alice" ]
+                            ]
+            ]
+        ]


### PR DESCRIPTION
Adds SortableTable to the styleguide.

Changes from the monolith version:
- Uses Svg directly for the sort arrows
- Uses Styled approach rather than a separate stylesheet

<img width="1304" alt="Screen Shot 2019-07-11 at 1 54 33 PM" src="https://user-images.githubusercontent.com/8811312/61084813-b3259880-a3e3-11e9-9ede-5538f4c586e9.png">

cc @NoRedInk/design 