### PR TITLE
Remove P+ in Checkbox V3

### DIFF
--- a/src/Nri/Ui/PremiumCheckbox/V3.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V3.elm
@@ -87,7 +87,7 @@ premium assets config =
                                     assets.iconPremiumFlag_svg
 
                                 PremiumWithWriting ->
-                                    assets.iconPremiumWithWritingFlag_svg
+                                    assets.iconPremiumFlag_svg
                             )
                         , backgroundRepeat noRepeat
                         , backgroundPosition center
@@ -109,7 +109,6 @@ type alias Assets r =
         , checkboxCheckedPartially_svg : Asset
         , checkboxLockOnInside_svg : Asset
         , iconPremiumFlag_svg : Asset
-        , iconPremiumWithWritingFlag_svg : Asset
     }
 
 


### PR DESCRIPTION
Designed to make these checkboxes in Peer Review on the assignment form stop saying P+

<img width="644" alt="Screen Shot 2019-07-12 at 9 13 18 AM" src="https://user-images.githubusercontent.com/13528834/61144132-e40bd900-a488-11e9-8366-9b9ca83a5998.png">