### PR TITLE
Add nri description attribute to Tabs

### DIFF
--- a/src/Nri/Ui/Tabs/V4.elm
+++ b/src/Nri/Ui/Tabs/V4.elm
@@ -94,7 +94,7 @@ viewCustom config viewInnerTab =
                 |> List.map (viewTab config viewInnerTab selected)
     in
     Nri.Ui.styled Html.div
-        "Nri-Ui-Tabs-V4-container"
+        (styledName "container")
         []
         []
         [ Html.styled Html.div
@@ -229,7 +229,7 @@ type alias LinkConfig msg =
 links : LinkConfig msg -> Html msg
 links config =
     Nri.Ui.styled Html.div
-        "Nri-Ui-Tabs-V4-links-container"
+        (styledName "links-container")
         []
         []
         [ Html.styled Html.nav
@@ -336,6 +336,11 @@ mapWithCurrent fn (Zipper before current after) =
         (List.map (fn False) before)
         (fn True current)
         (List.map (fn False) after)
+
+
+styledName : String -> String
+styledName suffix =
+    "Nri-Ui-Tabs-V4-" ++ suffix
 
 
 

--- a/src/Nri/Ui/Tabs/V4.elm
+++ b/src/Nri/Ui/Tabs/V4.elm
@@ -229,7 +229,7 @@ type alias LinkConfig msg =
 links : LinkConfig msg -> Html msg
 links config =
     Nri.Ui.styled Html.div
-        (styledName "links-container")
+        (styledName "container")
         []
         []
         [ Html.styled Html.nav

--- a/src/Nri/Ui/Tabs/V4.elm
+++ b/src/Nri/Ui/Tabs/V4.elm
@@ -39,6 +39,7 @@ import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Json.Decode
 import List.Zipper exposing (Zipper(..))
+import Nri.Ui
 import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1
@@ -92,7 +93,9 @@ viewCustom config viewInnerTab =
             List.Zipper.toList config.tabs
                 |> List.map (viewTab config viewInnerTab selected)
     in
-    Html.div
+    Nri.Ui.styled Html.div
+        "Nri-Ui-Tabs-V4-container"
+        []
         []
         [ Html.styled Html.div
             [ Css.displayFlex
@@ -225,7 +228,10 @@ type alias LinkConfig msg =
 -}
 links : LinkConfig msg -> Html msg
 links config =
-    Html.div []
+    Nri.Ui.styled Html.div
+        "Nri-Ui-Tabs-V4-links-container"
+        []
+        []
         [ Html.styled Html.nav
             [ Css.displayFlex
             , Css.alignItems Css.flexEnd


### PR DESCRIPTION
This adds a `nri-data-description` to the container element of the Tabs module.

We are adding this because Chameleon uses DOM selectors to target nodes for it's site tour, and we need a better way to target a `Tabs`.

💭 Should both styles of `Tabs` use the same `nri-data-description`?
