### PR TITLE
Release href helper for button

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "6.30.0",
+    "version": "6.31.0",
     "exposed-modules": [
         "Nri.Ui.Alert.V2",
         "Nri.Ui.Alert.V3",


### PR DESCRIPTION
Missed a needed function in the initial version of Button.V9. This adds.