### PR TITLE
bump to 7.0.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "6.31.0",
+    "version": "7.0.0",
     "exposed-modules": [
         "Nri.Ui.Alert.V2",
         "Nri.Ui.Alert.V3",


### PR DESCRIPTION
This releases 3 changes that cause a major version bump:
- https://github.com/NoRedInk/noredink-ui/pull/297
- https://github.com/NoRedInk/noredink-ui/pull/278
- https://github.com/NoRedInk/noredink-ui/pull/344

After: revert commit that allowed this until next time - https://github.com/NoRedInk/noredink-ui/pull/297/commits/05841e9b2fb7c42151267054ccba034e9253f353
