### PR TITLE
Revert "Disable the majro check"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ checks:
 
 .PHONY: diff
 diff: node_modules
-	if (npx elm diff | tee /dev/stderr | grep -q MAJORLYDISABLEDFORABIT); then echo "MAJOR changes are not allowed!"; exit 1; fi
+	if (npx elm diff | tee /dev/stderr | grep -q MAJOR); then echo "MAJOR changes are not allowed!"; exit 1; fi
 
 .PHONY: format
 format: node_modules


### PR DESCRIPTION
Reverts laxness introduced here to allow a major version bump: https://github.com/NoRedInk/noredink-ui/pull/297

Wait until we actually are able to bump the package from: https://github.com/NoRedInk/noredink-ui/pull/345