### PR TITLE
Tessa/modal scrolling

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -48,6 +48,7 @@
         "Nri.Ui.Modal.V4",
         "Nri.Ui.Modal.V5",
         "Nri.Ui.Modal.V6",
+        "Nri.Ui.Modal.V7",
         "Nri.Ui.Outline.V2",
         "Nri.Ui.Page.V2",
         "Nri.Ui.Page.V3",

--- a/elm.json
+++ b/elm.json
@@ -95,7 +95,7 @@
         "rtfeldman/elm-css": "16.0.0 <= v < 17.0.0",
         "tesk9/accessible-html": "4.0.0 <= v < 5.0.0",
         "tesk9/accessible-html-with-css": "2.1.1 <= v < 3.0.0",
-        "tesk9/modal": "5.0.1 <= v < 6.0.0",
+        "tesk9/modal": "6.0.0 <= v < 7.0.0",
         "tesk9/palette": "2.0.0 <= v < 3.0.0",
         "wernerdegroot/listzipper": "3.1.1 <= v < 4.0.0"
     },

--- a/elm.json
+++ b/elm.json
@@ -96,7 +96,7 @@
         "rtfeldman/elm-css": "16.0.0 <= v < 17.0.0",
         "tesk9/accessible-html": "4.0.0 <= v < 5.0.0",
         "tesk9/accessible-html-with-css": "2.1.1 <= v < 3.0.0",
-        "tesk9/modal": "6.0.0 <= v < 7.0.0",
+        "tesk9/modal": "5.0.1 <= v < 6.0.0",
         "tesk9/palette": "2.0.0 <= v < 3.0.0",
         "wernerdegroot/listzipper": "3.1.1 <= v < 4.0.0"
     },

--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -14,7 +14,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # expect. This failure reminds us to come back and ratchet down the number of
 # failures to the correct value.
 NUM_ERRORS="$(jq '.violations | map(.nodes | length) | add' "$JSON_FILE")"
-TARGET_ERRORS=98
+TARGET_ERRORS=99
 if test "$NUM_ERRORS" -ne "$TARGET_ERRORS"; then
     echo "got $NUM_ERRORS errors, but expected $TARGET_ERRORS."
     echo

--- a/src/Accessibility/Modal/Copy.elm
+++ b/src/Accessibility/Modal/Copy.elm
@@ -1,0 +1,381 @@
+module Accessibility.Modal.Copy exposing
+    ( Model, init, subscriptions
+    , update, Msg, close, open
+    , view
+    , Attribute
+    , multipleFocusableElementView, onlyFocusableElementView
+    , autofocusOnLastElement
+    , overlayColor, custom, titleStyles
+    )
+
+{-| COPIED from <https://package.elm-lang.org/packages/tesk9/modal/latest/> for
+clean monolith upgrades. Remove this and go back to using tesk9/modal when possible!
+
+    import Accessibility.Modal as Modal
+    import Html.Styled exposing (..)
+    import Html.Styled.Events exposing (onClick)
+
+    view : Html Modal.Msg
+    view =
+        Modal.view identity
+            "Example modal"
+            [ Modal.onlyFocusableElementView
+                (\onlyFocusableElementAttributes ->
+                    div []
+                        [ text "Welcome to this modal! I'm so happy to have you here with me."
+                        , button
+                            (onClick Modal.close :: onlyFocusableElementAttributes)
+                            [ text "Close Modal" ]
+                        ]
+                )
+            ]
+            modal
+
+@docs Model, init, subscriptions
+@docs update, Msg, close, open
+@docs view
+
+@docs Attribute
+@docs multipleFocusableElementView, onlyFocusableElementView
+@docs autofocusOnLastElement
+@docs overlayColor, custom, titleStyles
+
+-}
+
+import Accessibility.Styled exposing (..)
+import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Key as Key
+import Accessibility.Styled.Role as Role
+import Browser
+import Browser.Dom as Dom
+import Browser.Events
+import Css exposing (..)
+import Html.Styled as Root
+import Html.Styled.Attributes as Attributes exposing (css, id)
+import Html.Styled.Events exposing (onClick)
+import Task
+
+
+{-| -}
+type Model
+    = Opened String
+    | Closed
+
+
+{-| -}
+init : Model
+init =
+    Closed
+
+
+type By
+    = EscapeKey
+    | OverlayClick
+    | Other
+
+
+{-| -}
+type Msg
+    = OpenModal String
+    | CloseModal By
+    | Focus String
+    | Focused (Result Dom.Error ())
+
+
+{-| -}
+update : { dismissOnEscAndOverlayClick : Bool } -> Msg -> Model -> ( Model, Cmd Msg )
+update { dismissOnEscAndOverlayClick } msg model =
+    case msg of
+        OpenModal returnFocusTo ->
+            ( Opened returnFocusTo
+            , Dom.focus autofocusId
+                |> Task.onError (\_ -> Dom.focus firstId)
+                |> Task.attempt Focused
+            )
+
+        CloseModal by ->
+            let
+                closeModal returnFocusTo =
+                    ( Closed, Task.attempt Focused (Dom.focus returnFocusTo) )
+            in
+            case ( model, by, dismissOnEscAndOverlayClick ) of
+                ( Opened returnFocusTo, _, True ) ->
+                    closeModal returnFocusTo
+
+                ( Opened returnFocusTo, Other, False ) ->
+                    closeModal returnFocusTo
+
+                _ ->
+                    ( model, Cmd.none )
+
+        Focus id ->
+            ( model, Task.attempt Focused (Dom.focus id) )
+
+        Focused _ ->
+            ( model, Cmd.none )
+
+
+type Autofocus
+    = Default
+    | Last
+
+
+type alias Config msg =
+    { overlayColor : Color
+    , wrapMsg : Msg -> msg
+    , modalStyle : Style
+    , titleString : String
+    , titleStyles : List Style
+    , autofocusOn : Autofocus
+    , content :
+        { onlyFocusableElement : List (Accessibility.Styled.Attribute msg)
+        , firstFocusableElement : List (Accessibility.Styled.Attribute msg)
+        , lastFocusableElement : List (Accessibility.Styled.Attribute msg)
+        , autofocusOn : Accessibility.Styled.Attribute msg
+        }
+        -> Html msg
+    }
+
+
+defaults : (Msg -> msg) -> String -> Config msg
+defaults wrapMsg t =
+    { overlayColor = rgba 128 0 70 0.7
+    , wrapMsg = wrapMsg
+    , modalStyle =
+        batch
+            [ backgroundColor (rgb 255 255 255)
+            , borderRadius (px 8)
+            , border3 (px 2) solid (rgb 127 0 127)
+            , margin2 (px 80) auto
+            , padding (px 20)
+            , maxWidth (px 600)
+            , minHeight (vh 40)
+            ]
+    , titleString = t
+    , titleStyles = []
+    , autofocusOn = Default
+    , content = \_ -> text ""
+    }
+
+
+{-| -}
+type Attribute msg
+    = Attribute (Config msg -> Config msg)
+
+
+{-| -}
+overlayColor : Color -> Attribute msg
+overlayColor color =
+    Attribute (\config -> { config | overlayColor = color })
+
+
+{-| -}
+title : String -> Attribute msg
+title t =
+    Attribute (\config -> { config | titleString = t })
+
+
+{-| -}
+titleStyles : List Style -> Attribute msg
+titleStyles styles =
+    Attribute (\config -> { config | titleStyles = styles })
+
+
+{-| -}
+custom : List Style -> Attribute msg
+custom styles =
+    Attribute (\config -> { config | modalStyle = batch styles })
+
+
+{-| -}
+autofocusOnLastElement : Attribute msg
+autofocusOnLastElement =
+    Attribute (\config -> { config | autofocusOn = Last })
+
+
+{-| -}
+onlyFocusableElementView : (List (Accessibility.Styled.Attribute msg) -> Html msg) -> Attribute msg
+onlyFocusableElementView v =
+    Attribute (\config -> { config | content = \{ onlyFocusableElement } -> v onlyFocusableElement })
+
+
+{-| -}
+multipleFocusableElementView :
+    ({ firstFocusableElement : List (Accessibility.Styled.Attribute msg)
+     , lastFocusableElement : List (Accessibility.Styled.Attribute msg)
+     , autofocusElement : Accessibility.Styled.Attribute msg
+     }
+     -> Html msg
+    )
+    -> Attribute msg
+multipleFocusableElementView v =
+    Attribute
+        (\config ->
+            { config
+                | content =
+                    \{ firstFocusableElement, lastFocusableElement, autofocusOn } ->
+                        v
+                            { firstFocusableElement = firstFocusableElement
+                            , lastFocusableElement = lastFocusableElement
+                            , autofocusElement = autofocusOn
+                            }
+            }
+        )
+
+
+{-| -}
+view :
+    (Msg -> msg)
+    -> String
+    -> List (Attribute msg)
+    -> Model
+    -> Html msg
+view wrapMsg ti attributes model =
+    let
+        config =
+            List.foldl (\(Attribute f) acc -> f acc) (defaults wrapMsg ti) attributes
+    in
+    case model of
+        Opened _ ->
+            div
+                [ css
+                    [ position fixed
+                    , top zero
+                    , left zero
+                    , width (pct 100)
+                    , height (pct 100)
+                    ]
+                ]
+                [ viewBackdrop config
+                , div
+                    [ css [ position relative, config.modalStyle ] ]
+                    [ viewModal config ]
+                , Root.node "style" [] [ Root.text "body {overflow: hidden;} " ]
+                ]
+
+        Closed ->
+            text ""
+
+
+viewBackdrop :
+    { a | wrapMsg : Msg -> msg, overlayColor : Color }
+    -> Html msg
+viewBackdrop config =
+    Root.div
+        -- We use Root html here in order to allow clicking to exit out of
+        -- the overlay. This behavior is available to non-mouse users as
+        -- well via the ESC key, so imo it's fine to have this div
+        -- be clickable but not focusable.
+        [ css
+            [ position absolute
+            , width (pct 100)
+            , height (pct 100)
+            , backgroundColor config.overlayColor
+            ]
+        , onClick (config.wrapMsg (CloseModal OverlayClick))
+        ]
+        []
+
+
+viewModal : Config msg -> Html msg
+viewModal config =
+    section
+        [ Role.dialog
+        , Aria.labeledBy modalTitleId
+        ]
+        [ h1 [ id modalTitleId, css config.titleStyles ] [ text config.titleString ]
+        , config.content
+            (case config.autofocusOn of
+                Last ->
+                    { onlyFocusableElement =
+                        [ Key.onKeyDown
+                            [ Key.tabBack (Focus firstId)
+                            , Key.tab (Focus firstId)
+                            ]
+                        , id firstId
+                        ]
+                            |> List.map (Attributes.map config.wrapMsg)
+                    , firstFocusableElement =
+                        [ Key.onKeyDown [ Key.tabBack (Focus autofocusId) ]
+                        , id firstId
+                        ]
+                            |> List.map (Attributes.map config.wrapMsg)
+                    , lastFocusableElement =
+                        [ Key.onKeyDown [ Key.tab (Focus firstId) ]
+                        , id autofocusId
+                        ]
+                            |> List.map (Attributes.map config.wrapMsg)
+                    , autofocusOn =
+                        id autofocusId
+                            |> Attributes.map config.wrapMsg
+                    }
+
+                _ ->
+                    { onlyFocusableElement =
+                        [ Key.onKeyDown
+                            [ Key.tabBack (Focus firstId)
+                            , Key.tab (Focus firstId)
+                            ]
+                        , id firstId
+                        ]
+                            |> List.map (Attributes.map config.wrapMsg)
+                    , firstFocusableElement =
+                        [ Key.onKeyDown [ Key.tabBack (Focus lastId) ]
+                        , id firstId
+                        ]
+                            |> List.map (Attributes.map config.wrapMsg)
+                    , lastFocusableElement =
+                        [ Key.onKeyDown [ Key.tab (Focus firstId) ]
+                        , id lastId
+                        ]
+                            |> List.map (Attributes.map config.wrapMsg)
+                    , autofocusOn =
+                        id autofocusId
+                            |> Attributes.map config.wrapMsg
+                    }
+            )
+        ]
+
+
+modalTitleId : String
+modalTitleId =
+    "modal__title"
+
+
+firstId : String
+firstId =
+    "modal__first-focusable-element"
+
+
+lastId : String
+lastId =
+    "modal__last-focusable-element"
+
+
+autofocusId : String
+autofocusId =
+    "modal__autofocus-element"
+
+
+{-| Pass the id of the element that should receive focus when the modal closes.
+-}
+open : String -> Msg
+open =
+    OpenModal
+
+
+{-| -}
+close : Msg
+close =
+    CloseModal Other
+
+
+{-| -}
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    case model of
+        Opened _ ->
+            Browser.Events.onKeyDown (Key.escape (CloseModal EscapeKey))
+
+        Closed ->
+            Sub.none

--- a/src/Nri/Ui/Modal/V7.elm
+++ b/src/Nri/Ui/Modal/V7.elm
@@ -10,6 +10,7 @@ module Nri.Ui.Modal.V7 exposing
 {-| Changes from V6:
 
   - Modal starts a new stacking context, to prevent non-normal-flow elements from showing through the backdrop
+  - Scrollable content shows a shadow
 
 ```
     import Html.Styled exposing (..)
@@ -261,12 +262,12 @@ viewContent =
             """
             /* TOP shadow */
 
-            top linear-gradient(to top, rgb(255, 0, 0), rgb(255, 0, 0)) local,
+            top linear-gradient(to top, rgb(255, 255, 255), rgb(255, 255, 255)) local,
             top linear-gradient(to top, rgba(255, 255, 255, 0), rgba(0, 0, 0, 0.15)) scroll,
 
             /* BOTTOM shadow */
 
-            bottom linear-gradient(to bottom, rgb(255, 0, 0), rgb(255, 0, 0)) local,
+            bottom linear-gradient(to bottom, rgb(255, 255, 255), rgb(255, 255, 255)) local,
             bottom linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(0, 0, 0, 0.15)) scroll
             """
         , Css.backgroundSize2 (Css.pct 100) (Css.px 10)

--- a/src/Nri/Ui/Modal/V7.elm
+++ b/src/Nri/Ui/Modal/V7.elm
@@ -147,6 +147,7 @@ type alias FocusableElementAttrs msg =
     { onlyFocusableElement : List (Attribute msg)
     , firstFocusableElement : List (Attribute msg)
     , lastFocusableElement : List (Attribute msg)
+    , autofocusOn : Attribute msg
     }
 
 
@@ -154,12 +155,14 @@ fromUnstyledFocusableElementAttrs :
     { onlyFocusableElement : List (Root.Attribute msg)
     , firstFocusableElement : List (Root.Attribute msg)
     , lastFocusableElement : List (Root.Attribute msg)
+    , autofocusOn : Root.Attribute msg
     }
     -> FocusableElementAttrs msg
-fromUnstyledFocusableElementAttrs { onlyFocusableElement, firstFocusableElement, lastFocusableElement } =
-    { onlyFocusableElement = List.map Attributes.fromUnstyled onlyFocusableElement
-    , firstFocusableElement = List.map Attributes.fromUnstyled firstFocusableElement
-    , lastFocusableElement = List.map Attributes.fromUnstyled lastFocusableElement
+fromUnstyledFocusableElementAttrs elements =
+    { onlyFocusableElement = List.map Attributes.fromUnstyled elements.onlyFocusableElement
+    , firstFocusableElement = List.map Attributes.fromUnstyled elements.firstFocusableElement
+    , lastFocusableElement = List.map Attributes.fromUnstyled elements.lastFocusableElement
+    , autofocusOn = Attributes.fromUnstyled elements.autofocusOn
     }
 
 

--- a/src/Nri/Ui/Modal/V7.elm
+++ b/src/Nri/Ui/Modal/V7.elm
@@ -280,7 +280,7 @@ viewContent =
         "modal-content"
         [ Css.overflowY Css.auto
         , Css.minHeight (Css.px 150)
-        , Css.maxHeight (Css.calc (Css.vh 100) Css.minus (Css.px 300))
+        , Css.maxHeight (Css.calc (Css.vh 100) Css.minus (Css.px 360))
         , Css.padding2 (Css.px 30) (Css.px 40)
         , Css.width (Css.pct 100)
         , Css.boxSizing Css.borderBox

--- a/src/Nri/Ui/Modal/V7.elm
+++ b/src/Nri/Ui/Modal/V7.elm
@@ -90,7 +90,7 @@ import Css
 import Css.Global
 import Html as Root
 import Html.Attributes exposing (style)
-import Html.Styled.Attributes exposing (css)
+import Html.Styled.Attributes as Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
 import Nri.Ui
 import Nri.Ui.Colors.Extra
@@ -150,6 +150,19 @@ type alias FocusableElementAttrs msg =
     }
 
 
+fromUnstyledFocusableElementAttrs :
+    { onlyFocusableElement : List (Root.Attribute msg)
+    , firstFocusableElement : List (Root.Attribute msg)
+    , lastFocusableElement : List (Root.Attribute msg)
+    }
+    -> FocusableElementAttrs msg
+fromUnstyledFocusableElementAttrs { onlyFocusableElement, firstFocusableElement, lastFocusableElement } =
+    { onlyFocusableElement = List.map Attributes.fromUnstyled onlyFocusableElement
+    , firstFocusableElement = List.map Attributes.fromUnstyled firstFocusableElement
+    , lastFocusableElement = List.map Attributes.fromUnstyled lastFocusableElement
+    }
+
+
 {-| -}
 info :
     { visibleTitle : Bool
@@ -193,11 +206,8 @@ view { overlayColor, titleColor } config model =
         , modalAttributes = modalStyles
         , title = viewTitle titleColor { title = config.title, visibleTitle = config.visibleTitle }
         , content =
-            \{ onlyFocusableElement, firstFocusableElement, lastFocusableElement } ->
-                { onlyFocusableElement = List.map Html.Styled.Attributes.fromUnstyled onlyFocusableElement
-                , firstFocusableElement = List.map Html.Styled.Attributes.fromUnstyled firstFocusableElement
-                , lastFocusableElement = List.map Html.Styled.Attributes.fromUnstyled lastFocusableElement
-                }
+            \focusableElementAttrs ->
+                fromUnstyledFocusableElementAttrs focusableElementAttrs
                     |> config.content
                     |> toUnstyled
         }
@@ -314,7 +324,7 @@ closeButton wrapMsg focusableElementAttrs =
         , Css.property "transition" "color 0.1s"
         ]
         (Widget.label "Close modal"
-            :: Html.Styled.Attributes.map wrapMsg (onClick Modal.close)
+            :: Attributes.map wrapMsg (onClick Modal.close)
             :: focusableElementAttrs
         )
         [ Nri.Ui.Svg.V1.toHtml Nri.Ui.SpriteSheet.xSvg

--- a/src/Nri/Ui/Modal/V7.elm
+++ b/src/Nri/Ui/Modal/V7.elm
@@ -30,8 +30,9 @@ module Nri.Ui.Modal.V7 exposing
             { title = "Modal Header"
             , visibleTitle = True
             , wrapMsg = ModalMsg
-            , content =
-                \{ onlyFocusableElement } ->
+            }
+            [ Modal.onlyFocusableElementView
+                (\{ onlyFocusableElement } ->
                     div []
                         [ Modal.viewContent [ text "Content goes here!" ]
                         , Modal.viewFooter
@@ -43,7 +44,8 @@ module Nri.Ui.Modal.V7 exposing
                             , text "`onlyFocusableElement` will trap the focus on the 'Continue' button."
                             ]
                         ]
-            }
+                )
+            ]
             state
 
     subscriptions : Modal.Model -> Sub Msg

--- a/src/Nri/Ui/Modal/V7.elm
+++ b/src/Nri/Ui/Modal/V7.elm
@@ -217,7 +217,6 @@ toOverlayColor color =
 modalStyles : List (Root.Attribute Never)
 modalStyles =
     [ style "width" "600px"
-    , style "max-height" "calc(100vh - 100px)"
     , style "padding" "40px 0 40px 0"
     , style "margin" "75px auto"
     , style "background-color" ((Color.toRGBString << Nri.Ui.Colors.Extra.fromCssColor) Colors.white)
@@ -252,6 +251,7 @@ viewContent =
         "modal-content"
         [ Css.overflowY Css.auto
         , Css.minHeight (Css.px 150)
+        , Css.maxHeight (Css.calc (Css.vh 100) Css.minus (Css.px 300))
         , Css.padding2 (Css.px 30) (Css.px 40)
         , Css.width (Css.pct 100)
         , Css.boxSizing Css.borderBox

--- a/src/Nri/Ui/Modal/V7.elm
+++ b/src/Nri/Ui/Modal/V7.elm
@@ -261,11 +261,13 @@ viewContent =
             """
             /* TOP shadow */
 
-            top linear-gradient(to top, rgba(255, 255, 255, 0), rgba(0, 0, 0, 0.15)) local,
+            top linear-gradient(to top, rgb(255, 0, 0), rgb(255, 0, 0)) local,
+            top linear-gradient(to top, rgba(255, 255, 255, 0), rgba(0, 0, 0, 0.15)) scroll,
 
             /* BOTTOM shadow */
 
-            bottom linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(0, 0, 0, 0.15)) local
+            bottom linear-gradient(to bottom, rgb(255, 0, 0), rgb(255, 0, 0)) local,
+            bottom linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(0, 0, 0, 0.15)) scroll
             """
         , Css.backgroundSize2 (Css.pct 100) (Css.px 10)
         , Css.backgroundRepeat Css.noRepeat

--- a/src/Nri/Ui/Modal/V7.elm
+++ b/src/Nri/Ui/Modal/V7.elm
@@ -1,0 +1,302 @@
+module Nri.Ui.Modal.V7 exposing
+    ( Model, init
+    , Msg, update, subscriptions
+    , open, close
+    , info, warning, FocusableElementAttrs
+    , viewContent, viewFooter
+    , closeButton
+    )
+
+{-| Changes from V5:
+
+  - Removes button helpers, now that we can use Nri.Ui.Button.V9 directly
+
+These changes have required major API changes. Be sure to wire up subscriptions!
+
+    import Html.Styled exposing (..)
+    import Nri.Ui.Button.V9 as Button
+    import Nri.Ui.Modal.V7 as Modal
+
+    type Msg
+        = ModalMsg Modal.Msg
+        | DoSomthing
+
+    view : Modal.Model -> Html Msg
+    view state =
+        Modal.info
+            { title = "Modal Header"
+            , visibleTitle = True
+            , wrapMsg = ModalMsg
+            , content =
+                \{ onlyFocusableElement } ->
+                    div []
+                        [ Modal.viewContent [ text "Content goes here!" ]
+                        , Modal.viewFooter
+                            [ Button.button "Continue"
+                                [ Button.primary
+                                , Button.onClick DoSomthing
+                                , Button.custom onlyFocusableElement
+                                ]
+                            , text "`onlyFocusableElement` will trap the focus on the 'Continue' button."
+                            ]
+                        ]
+            }
+            state
+
+    subscriptions : Modal.Model -> Sub Msg
+    subscriptions state =
+        Modal.subscriptions state
+
+    view init
+    --> text ""  -- a closed modal
+
+
+## State and updates
+
+@docs Model, init
+@docs Msg, update, subscriptions
+
+@docs open, close
+
+
+## Views
+
+
+### Modals
+
+@docs info, warning, FocusableElementAttrs
+
+
+### View containers
+
+@docs viewContent, viewFooter
+
+
+## X icon
+
+@docs closeButton
+
+-}
+
+import Accessibility.Modal as Modal
+import Accessibility.Style
+import Accessibility.Styled as Html exposing (..)
+import Accessibility.Styled.Style
+import Accessibility.Styled.Widget as Widget
+import Color
+import Color.Transparent
+import Css
+import Css.Global
+import Html as Root
+import Html.Attributes exposing (style)
+import Html.Styled.Attributes exposing (css)
+import Html.Styled.Events exposing (onClick)
+import Nri.Ui
+import Nri.Ui.Colors.Extra
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.SpriteSheet
+import Nri.Ui.Svg.V1
+
+
+{-| -}
+type alias Model =
+    Modal.Model
+
+
+{-| -}
+init : Model
+init =
+    Modal.init
+
+
+{-| -}
+type alias Msg =
+    Modal.Msg
+
+
+{-| Include the subscription if you want the modal to dismiss on `Esc`.
+-}
+subscriptions : Model -> Sub Msg
+subscriptions =
+    Modal.subscriptions
+
+
+{-| -}
+update : { dismissOnEscAndOverlayClick : Bool } -> Msg -> Model -> ( Model, Cmd Msg )
+update config msg model =
+    Modal.update config msg model
+
+
+{-| -}
+close : Msg
+close =
+    Modal.close
+
+
+{-| Pass the id of the element that focus should return to when the modal closes.
+-}
+open : String -> Msg
+open =
+    Modal.open
+
+
+{-| -}
+type alias FocusableElementAttrs msg =
+    { onlyFocusableElement : List (Attribute msg)
+    , firstFocusableElement : List (Attribute msg)
+    , lastFocusableElement : List (Attribute msg)
+    }
+
+
+{-| -}
+info :
+    { visibleTitle : Bool
+    , title : String
+    , content : FocusableElementAttrs msg -> Html msg
+    , wrapMsg : Msg -> msg
+    }
+    -> Model
+    -> Html msg
+info config model =
+    view { overlayColor = Colors.navy, titleColor = Colors.navy } config model
+
+
+{-| -}
+warning :
+    { visibleTitle : Bool
+    , title : String
+    , content : FocusableElementAttrs msg -> Html msg
+    , wrapMsg : Msg -> msg
+    }
+    -> Model
+    -> Html msg
+warning config model =
+    view { overlayColor = Colors.gray20, titleColor = Colors.red } config model
+
+
+view :
+    { overlayColor : Css.Color, titleColor : Css.Color }
+    ->
+        { visibleTitle : Bool
+        , title : String
+        , content : FocusableElementAttrs msg -> Html msg
+        , wrapMsg : Msg -> msg
+        }
+    -> Model
+    -> Html msg
+view { overlayColor, titleColor } config model =
+    Modal.view
+        { overlayColor = toOverlayColor overlayColor
+        , wrapMsg = config.wrapMsg
+        , modalAttributes = modalStyles
+        , title = viewTitle titleColor { title = config.title, visibleTitle = config.visibleTitle }
+        , content =
+            \{ onlyFocusableElement, firstFocusableElement, lastFocusableElement } ->
+                { onlyFocusableElement = List.map Html.Styled.Attributes.fromUnstyled onlyFocusableElement
+                , firstFocusableElement = List.map Html.Styled.Attributes.fromUnstyled firstFocusableElement
+                , lastFocusableElement = List.map Html.Styled.Attributes.fromUnstyled lastFocusableElement
+                }
+                    |> config.content
+                    |> toUnstyled
+        }
+        model
+        |> fromUnstyled
+
+
+toOverlayColor : Css.Color -> String
+toOverlayColor color =
+    color
+        |> Nri.Ui.Colors.Extra.fromCssColor
+        |> Color.Transparent.fromColor (Color.Transparent.customOpacity 0.9)
+        |> Color.Transparent.toRGBAString
+
+
+modalStyles : List (Root.Attribute Never)
+modalStyles =
+    [ style "width" "600px"
+    , style "max-height" "calc(100vh - 100px)"
+    , style "padding" "40px 0 40px 0"
+    , style "margin" "75px auto"
+    , style "background-color" ((Color.toRGBString << Nri.Ui.Colors.Extra.fromCssColor) Colors.white)
+    , style "border-radius" "20px"
+    , style "box-shadow" "0 1px 10px 0 rgba(0, 0, 0, 0.35)"
+    , style "position" "relative" -- required for closeButtonContainer
+    ]
+
+
+{-| -}
+viewTitle : Css.Color -> { visibleTitle : Bool, title : String } -> ( String, List (Root.Attribute Never) )
+viewTitle color { visibleTitle, title } =
+    ( title
+    , if visibleTitle then
+        [ style "font-weight" "700"
+        , style "line-height" "27px"
+        , style "margin" "0 49px"
+        , style "font-size" "20px"
+        , style "text-align" "center"
+        , style "color" ((Color.toRGBString << Nri.Ui.Colors.Extra.fromCssColor) color)
+        ]
+
+      else
+        Accessibility.Style.invisible
+    )
+
+
+{-| -}
+viewContent : List (Html msg) -> Html msg
+viewContent =
+    Nri.Ui.styled div
+        "modal-content"
+        [ Css.overflowY Css.auto
+        , Css.minHeight (Css.px 150)
+        , Css.padding2 (Css.px 30) (Css.px 40)
+        , Css.width (Css.pct 100)
+        , Css.boxSizing Css.borderBox
+        ]
+        []
+
+
+{-| -}
+viewFooter : List (Html msg) -> Html msg
+viewFooter =
+    Nri.Ui.styled div
+        "modal-footer"
+        [ Css.alignItems Css.center
+        , Css.displayFlex
+        , Css.flexDirection Css.column
+        , Css.flexGrow (Css.int 2)
+        , Css.flexWrap Css.noWrap
+        , Css.margin4 (Css.px 20) Css.zero Css.zero Css.zero
+        , Css.width (Css.pct 100)
+        ]
+        []
+
+
+
+--BUTTONS
+
+
+{-| -}
+closeButton : (Msg -> msg) -> List (Attribute msg) -> Html msg
+closeButton wrapMsg focusableElementAttrs =
+    Nri.Ui.styled button
+        "close-button-container"
+        [ Css.position Css.absolute
+        , Css.top Css.zero
+        , Css.right Css.zero
+        , Css.padding (Css.px 25)
+        , Css.borderWidth Css.zero
+        , Css.width (Css.px 75)
+        , Css.backgroundColor Css.transparent
+        , Css.cursor Css.pointer
+        , Css.color Colors.azure
+        , Css.hover [ Css.color Colors.azureDark ]
+        , Css.property "transition" "color 0.1s"
+        ]
+        (Widget.label "Close modal"
+            :: Html.Styled.Attributes.map wrapMsg (onClick Modal.close)
+            :: focusableElementAttrs
+        )
+        [ Nri.Ui.Svg.V1.toHtml Nri.Ui.SpriteSheet.xSvg
+        ]

--- a/src/Nri/Ui/Modal/V7.elm
+++ b/src/Nri/Ui/Modal/V7.elm
@@ -253,7 +253,8 @@ modalStyles =
 
 titleStyles : Css.Color -> List Css.Style
 titleStyles color =
-    [ Css.property "font-weight" "700"
+    [ Fonts.baseFont
+    , Css.property "font-weight" "700"
     , Css.property "line-height" "27px"
     , Css.property "margin" "0 49px"
     , Css.property "font-size" "20px"

--- a/src/Nri/Ui/Modal/V7.elm
+++ b/src/Nri/Ui/Modal/V7.elm
@@ -7,12 +7,11 @@ module Nri.Ui.Modal.V7 exposing
     , closeButton
     )
 
-{-| Changes from V5:
+{-| Changes from V6:
 
-  - Removes button helpers, now that we can use Nri.Ui.Button.V9 directly
+  - Modal starts a new stacking context, to prevent non-normal-flow elements from showing through the backdrop
 
-These changes have required major API changes. Be sure to wire up subscriptions!
-
+```
     import Html.Styled exposing (..)
     import Nri.Ui.Button.V9 as Button
     import Nri.Ui.Modal.V7 as Modal
@@ -49,6 +48,7 @@ These changes have required major API changes. Be sure to wire up subscriptions!
 
     view init
     --> text ""  -- a closed modal
+```
 
 
 ## State and updates
@@ -202,6 +202,8 @@ view { overlayColor, titleColor } config model =
         }
         model
         |> fromUnstyled
+        |> List.singleton
+        |> div [ css [ Css.position Css.relative, Css.zIndex (Css.int 1) ] ]
 
 
 toOverlayColor : Css.Color -> String

--- a/src/Nri/Ui/Modal/V7.elm
+++ b/src/Nri/Ui/Modal/V7.elm
@@ -255,6 +255,20 @@ viewContent =
         , Css.padding2 (Css.px 30) (Css.px 40)
         , Css.width (Css.pct 100)
         , Css.boxSizing Css.borderBox
+
+        -- Shadows for indicating that the content is scrollable
+        , Css.property "background"
+            """
+            /* TOP shadow */
+
+            top linear-gradient(to top, rgba(255, 255, 255, 0), rgba(0, 0, 0, 0.15)) local,
+
+            /* BOTTOM shadow */
+
+            bottom linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(0, 0, 0, 0.15)) local
+            """
+        , Css.backgroundSize2 (Css.pct 100) (Css.px 10)
+        , Css.backgroundRepeat Css.noRepeat
         ]
         []
 

--- a/src/Nri/Ui/Modal/V7.elm
+++ b/src/Nri/Ui/Modal/V7.elm
@@ -70,7 +70,7 @@ module Nri.Ui.Modal.V7 exposing
 
 ### Modals
 
-@docs info, warning, FocusableElementAttrs
+@docs info, warning
 
 
 ### View containers

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -15,7 +15,7 @@ import ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.Button.V9 as Button
 import Nri.Ui.Checkbox.V5 as Checkbox
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.Modal.V6 as Modal
+import Nri.Ui.Modal.V7 as Modal
 
 
 {-| -}
@@ -46,7 +46,7 @@ init =
 {-| -}
 example : (Msg -> msg) -> State -> ModuleExample msg
 example parentMessage state =
-    { name = "Nri.Ui.Modal.V6"
+    { name = "Nri.Ui.Modal.V7"
     , category = Modals
     , content =
         [ Button.button "Launch Info Modal"

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -29,6 +29,7 @@ type alias State =
     , showContinue : Bool
     , showSecondary : Bool
     , dismissOnEscAndOverlayClick : Bool
+    , longContent : Bool
     }
 
 
@@ -40,8 +41,9 @@ init =
     , visibleTitle = True
     , showX = True
     , showContinue = True
-    , showSecondary = False
+    , showSecondary = True
     , dismissOnEscAndOverlayClick = True
+    , longContent = True
     }
 
 
@@ -98,7 +100,7 @@ viewContent state wrapMsg firstButtonStyle =
                 (\focusableElementAttrs ->
                     div []
                         [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
-                        , Modal.viewContent [ viewModalContent ]
+                        , Modal.viewContent [ viewModalContent state.longContent ]
                         , Modal.viewFooter
                             [ Button.button "Continue"
                                 [ firstButtonStyle
@@ -124,7 +126,7 @@ viewContent state wrapMsg firstButtonStyle =
                 (\focusableElementAttrs ->
                     div []
                         [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
-                        , Modal.viewContent [ viewModalContent ]
+                        , Modal.viewContent [ viewModalContent state.longContent ]
                         , Modal.viewFooter
                             [ ClickableText.button "Close"
                                 [ ClickableText.onClick ForceClose
@@ -144,7 +146,7 @@ viewContent state wrapMsg firstButtonStyle =
                 (\focusableElementAttrs ->
                     div []
                         [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
-                        , Modal.viewContent [ viewModalContent ]
+                        , Modal.viewContent [ viewModalContent state.longContent ]
                         ]
                 )
             ]
@@ -155,7 +157,7 @@ viewContent state wrapMsg firstButtonStyle =
                 (\focusableElementAttrs ->
                     div []
                         [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
-                        , Modal.viewContent [ viewModalContent ]
+                        , Modal.viewContent [ viewModalContent state.longContent ]
                         , Modal.viewFooter
                             [ Button.button "Continue"
                                 [ firstButtonStyle
@@ -172,7 +174,7 @@ viewContent state wrapMsg firstButtonStyle =
             [ Modal.multipleFocusableElementView
                 (\focusableElementAttrs ->
                     div []
-                        [ Modal.viewContent [ viewModalContent ]
+                        [ Modal.viewContent [ viewModalContent state.longContent ]
                         , Modal.viewFooter
                             [ Button.button "Continue"
                                 [ firstButtonStyle
@@ -198,7 +200,7 @@ viewContent state wrapMsg firstButtonStyle =
             , Modal.multipleFocusableElementView
                 (\focusableElementAttrs ->
                     div []
-                        [ Modal.viewContent [ viewModalContent ]
+                        [ Modal.viewContent [ viewModalContent state.longContent ]
                         , Modal.viewFooter
                             [ ClickableText.button "Close"
                                 [ ClickableText.onClick ForceClose
@@ -221,7 +223,7 @@ viewContent state wrapMsg firstButtonStyle =
             , Modal.multipleFocusableElementView
                 (\focusableElementAttrs ->
                     div []
-                        [ Modal.viewContent [ viewModalContent ]
+                        [ Modal.viewContent [ viewModalContent state.longContent ]
                         , Modal.viewFooter
                             [ Button.button "Continue"
                                 [ firstButtonStyle
@@ -238,17 +240,17 @@ viewContent state wrapMsg firstButtonStyle =
             [ Modal.multipleFocusableElementView
                 (\focusableElementAttrs ->
                     div []
-                        [ Modal.viewContent [ viewModalContent ]
+                        [ Modal.viewContent [ viewModalContent state.longContent ]
                         ]
                 )
             ]
 
 
-viewModalContent : Html msg
-viewModalContent =
+viewModalContent : Bool -> Html msg
+viewModalContent longContent =
     Text.mediumBody
         [ span [ css [ whiteSpace preLine ] ]
-            [ text
+            [ if longContent then
                 """
                 Soufflé pastry chocolate cake danish muffin. Candy wafer pastry ice cream cheesecake toffee cookie cake carrot cake. Macaroon pie jujubes gummies cookie pie. Gummi bears brownie pastry carrot cake cotton candy. Jelly-o sweet roll biscuit cake soufflé lemon drops tiramisu marshmallow macaroon. Chocolate jelly halvah marzipan macaroon cupcake sweet cheesecake carrot cake.
 
@@ -256,6 +258,11 @@ viewModalContent =
 
                 Tootsie roll icing jelly danish ice cream tiramisu sweet roll. Fruitcake ice cream dragée. Bear claw sugar plum sweet jelly beans bonbon dragée tart. Gingerbread chocolate sweet. Apple pie danish toffee sugar plum jelly beans donut. Chocolate cake croissant caramels chocolate bar. Jelly beans caramels toffee chocolate cake liquorice. Toffee pie sugar plum cookie toffee muffin. Marzipan marshmallow marzipan liquorice tiramisu.
                 """
+                    |> text
+
+              else
+                "Ice cream tootsie roll donut sweet cookie liquorice sweet donut. Sugar plum danish apple pie sesame snaps chocolate bar biscuit. Caramels macaroon jelly gummies sweet tootsie roll tiramisu apple pie. Dessert chocolate bar lemon drops dragée jelly powder cheesecake chocolate."
+                    |> text
             ]
         ]
 
@@ -303,6 +310,14 @@ viewSettings state =
             , disabled = False
             , theme = Checkbox.Square
             }
+        , Checkbox.viewWithLabel
+            { identifier = "long-content"
+            , label = "Display longer content"
+            , selected = Checkbox.selectedFromBool state.longContent
+            , setterMsg = SetLongContent
+            , disabled = False
+            , theme = Checkbox.Square
+            }
         ]
 
 
@@ -316,6 +331,7 @@ type Msg
     | SetShowContinue Bool
     | SetShowSecondary Bool
     | SetDismissOnEscAndOverlayClick Bool
+    | SetLongContent Bool
 
 
 {-| -}
@@ -362,6 +378,9 @@ update msg state =
 
         SetDismissOnEscAndOverlayClick value ->
             ( { state | dismissOnEscAndOverlayClick = value }, Cmd.none )
+
+        SetLongContent value ->
+            ( { state | longContent = value }, Cmd.none )
 
 
 {-| -}

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -148,7 +148,8 @@ viewContent state wrapMsg firstButtonStyle =
             ]
 
         ( True, True, False ) ->
-            [ Modal.multipleFocusableElementView
+            [ Modal.autofocusOnLastElement
+            , Modal.multipleFocusableElementView
                 (\focusableElementAttrs ->
                     div []
                         [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
@@ -157,10 +158,7 @@ viewContent state wrapMsg firstButtonStyle =
                             [ Button.button "Continue"
                                 [ firstButtonStyle
                                 , Button.onClick ForceClose
-                                , Button.custom
-                                    (focusableElementAttrs.autofocusElement
-                                        :: focusableElementAttrs.lastFocusableElement
-                                    )
+                                , Button.custom focusableElementAttrs.lastFocusableElement
                                 , Button.large
                                 ]
                             ]
@@ -194,7 +192,8 @@ viewContent state wrapMsg firstButtonStyle =
             ]
 
         ( False, False, True ) ->
-            [ Modal.multipleFocusableElementView
+            [ Modal.autofocusOnLastElement
+            , Modal.multipleFocusableElementView
                 (\focusableElementAttrs ->
                     div []
                         [ Modal.viewContent [ viewSettings state ]
@@ -216,7 +215,8 @@ viewContent state wrapMsg firstButtonStyle =
             ]
 
         ( False, True, False ) ->
-            [ Modal.multipleFocusableElementView
+            [ Modal.autofocusOnLastElement
+            , Modal.multipleFocusableElementView
                 (\focusableElementAttrs ->
                     div []
                         [ Modal.viewContent [ viewSettings state ]
@@ -224,10 +224,7 @@ viewContent state wrapMsg firstButtonStyle =
                             [ Button.button "Continue"
                                 [ firstButtonStyle
                                 , Button.onClick ForceClose
-                                , Button.custom
-                                    (focusableElementAttrs.autofocusElement
-                                        :: focusableElementAttrs.lastFocusableElement
-                                    )
+                                , Button.custom [ focusableElementAttrs.autofocusElement ]
                                 , Button.large
                                 ]
                             ]

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -69,15 +69,15 @@ example parentMessage state =
             { title = "Modal.info"
             , visibleTitle = state.visibleTitle
             , wrapMsg = InfoModalMsg
-            , content = viewContent state InfoModalMsg Button.primary
             }
+            (viewContent state InfoModalMsg Button.danger)
             state.infoModal
         , Modal.warning
             { title = "Modal.warning"
             , visibleTitle = state.visibleTitle
             , wrapMsg = WarningModalMsg
-            , content = viewContent state WarningModalMsg Button.danger
             }
+            (viewContent state WarningModalMsg Button.danger)
             state.warningModal
         ]
             |> List.map (Html.map parentMessage)
@@ -88,130 +88,161 @@ viewContent :
     State
     -> (Modal.Msg -> Msg)
     -> Button.Attribute Msg
-    -> Modal.FocusableElementAttrs Msg
-    -> Html Msg
-viewContent state wrapMsg firstButtonStyle focusableElementAttrs =
+    -> List (Modal.Attribute Msg)
+viewContent state wrapMsg firstButtonStyle =
     case ( state.showX, state.showContinue, state.showSecondary ) of
         ( True, True, True ) ->
-            div []
-                [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
-                , Modal.viewContent [ viewSettings state ]
-                , Modal.viewFooter
-                    [ Button.button "Continue"
-                        [ firstButtonStyle
-                        , Button.onClick ForceClose
-                        , Button.large
-                        , Button.custom [ focusableElementAttrs.autofocusOn ]
+            [ Modal.multipleFocusableElementView
+                (\focusableElementAttrs ->
+                    div []
+                        [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
+                        , Modal.viewContent [ viewSettings state ]
+                        , Modal.viewFooter
+                            [ Button.button "Continue"
+                                [ firstButtonStyle
+                                , Button.onClick ForceClose
+                                , Button.large
+                                , Button.custom [ focusableElementAttrs.autofocusElement ]
+                                ]
+                            , ClickableText.button "Close"
+                                [ ClickableText.onClick ForceClose
+                                , ClickableText.large
+                                , ClickableText.custom
+                                    (css [ Css.marginTop (Css.px 20) ]
+                                        :: focusableElementAttrs.lastFocusableElement
+                                    )
+                                ]
+                            ]
                         ]
-                    , ClickableText.button "Close"
-                        [ ClickableText.onClick ForceClose
-                        , ClickableText.large
-                        , ClickableText.custom
-                            (css [ Css.marginTop (Css.px 20) ]
-                                :: focusableElementAttrs.lastFocusableElement
-                            )
-                        ]
-                    ]
-                ]
+                )
+            ]
 
         ( True, False, True ) ->
-            div []
-                [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
-                , Modal.viewContent [ viewSettings state ]
-                , Modal.viewFooter
-                    [ ClickableText.button "Close"
-                        [ ClickableText.onClick ForceClose
-                        , ClickableText.large
-                        , ClickableText.custom
-                            (css [ Css.marginTop (Css.px 20) ]
-                                :: focusableElementAttrs.lastFocusableElement
-                            )
+            [ Modal.multipleFocusableElementView
+                (\focusableElementAttrs ->
+                    div []
+                        [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
+                        , Modal.viewContent [ viewSettings state ]
+                        , Modal.viewFooter
+                            [ ClickableText.button "Close"
+                                [ ClickableText.onClick ForceClose
+                                , ClickableText.large
+                                , ClickableText.custom
+                                    (css [ Css.marginTop (Css.px 20) ]
+                                        :: focusableElementAttrs.lastFocusableElement
+                                    )
+                                ]
+                            ]
                         ]
-                    ]
-                ]
+                )
+            ]
 
         ( True, False, False ) ->
-            div []
-                [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
-                , Modal.viewContent [ viewSettings state ]
-                ]
+            [ Modal.multipleFocusableElementView
+                (\focusableElementAttrs ->
+                    div []
+                        [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
+                        , Modal.viewContent [ viewSettings state ]
+                        ]
+                )
+            ]
 
         ( True, True, False ) ->
-            div []
-                [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
-                , Modal.viewContent [ viewSettings state ]
-                , Modal.viewFooter
-                    [ Button.button "Continue"
-                        [ firstButtonStyle
-                        , Button.onClick ForceClose
-                        , Button.custom
-                            (focusableElementAttrs.autofocusOn
-                                :: focusableElementAttrs.lastFocusableElement
-                            )
-                        , Button.large
+            [ Modal.multipleFocusableElementView
+                (\focusableElementAttrs ->
+                    div []
+                        [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
+                        , Modal.viewContent [ viewSettings state ]
+                        , Modal.viewFooter
+                            [ Button.button "Continue"
+                                [ firstButtonStyle
+                                , Button.onClick ForceClose
+                                , Button.custom
+                                    (focusableElementAttrs.autofocusElement
+                                        :: focusableElementAttrs.lastFocusableElement
+                                    )
+                                , Button.large
+                                ]
+                            ]
                         ]
-                    ]
-                ]
+                )
+            ]
 
         ( False, True, True ) ->
-            div []
-                [ Modal.viewContent [ viewSettings state ]
-                , Modal.viewFooter
-                    [ Button.button "Continue"
-                        [ firstButtonStyle
-                        , Button.onClick ForceClose
-                        , Button.custom focusableElementAttrs.firstFocusableElement
-                        , Button.large
+            [ Modal.multipleFocusableElementView
+                (\focusableElementAttrs ->
+                    div []
+                        [ Modal.viewContent [ viewSettings state ]
+                        , Modal.viewFooter
+                            [ Button.button "Continue"
+                                [ firstButtonStyle
+                                , Button.onClick ForceClose
+                                , Button.custom focusableElementAttrs.firstFocusableElement
+                                , Button.large
+                                ]
+                            , ClickableText.button "Close"
+                                [ ClickableText.onClick ForceClose
+                                , ClickableText.large
+                                , ClickableText.custom
+                                    (css [ Css.marginTop (Css.px 20) ]
+                                        :: focusableElementAttrs.lastFocusableElement
+                                    )
+                                ]
+                            ]
                         ]
-                    , ClickableText.button "Close"
-                        [ ClickableText.onClick ForceClose
-                        , ClickableText.large
-                        , ClickableText.custom
-                            (css [ Css.marginTop (Css.px 20) ]
-                                :: focusableElementAttrs.lastFocusableElement
-                            )
-                        ]
-                    ]
-                ]
+                )
+            ]
 
         ( False, False, True ) ->
-            div []
-                [ Modal.viewContent [ viewSettings state ]
-                , Modal.viewFooter
-                    [ ClickableText.button "Close"
-                        [ ClickableText.onClick ForceClose
-                        , ClickableText.large
-                        , ClickableText.custom
-                            (css
-                                [ Css.marginTop
-                                    (Css.px 20)
+            [ Modal.multipleFocusableElementView
+                (\focusableElementAttrs ->
+                    div []
+                        [ Modal.viewContent [ viewSettings state ]
+                        , Modal.viewFooter
+                            [ ClickableText.button "Close"
+                                [ ClickableText.onClick ForceClose
+                                , ClickableText.large
+                                , ClickableText.custom
+                                    (css
+                                        [ Css.marginTop
+                                            (Css.px 20)
+                                        ]
+                                        :: focusableElementAttrs.lastFocusableElement
+                                    )
                                 ]
-                                :: focusableElementAttrs.lastFocusableElement
-                            )
+                            ]
                         ]
-                    ]
-                ]
+                )
+            ]
 
         ( False, True, False ) ->
-            div []
-                [ Modal.viewContent [ viewSettings state ]
-                , Modal.viewFooter
-                    [ Button.button "Continue"
-                        [ firstButtonStyle
-                        , Button.onClick ForceClose
-                        , Button.custom
-                            (focusableElementAttrs.autofocusOn
-                                :: focusableElementAttrs.lastFocusableElement
-                            )
-                        , Button.large
+            [ Modal.multipleFocusableElementView
+                (\focusableElementAttrs ->
+                    div []
+                        [ Modal.viewContent [ viewSettings state ]
+                        , Modal.viewFooter
+                            [ Button.button "Continue"
+                                [ firstButtonStyle
+                                , Button.onClick ForceClose
+                                , Button.custom
+                                    (focusableElementAttrs.autofocusElement
+                                        :: focusableElementAttrs.lastFocusableElement
+                                    )
+                                , Button.large
+                                ]
+                            ]
                         ]
-                    ]
-                ]
+                )
+            ]
 
         ( False, False, False ) ->
-            div []
-                [ Modal.viewContent [ viewSettings state ]
-                ]
+            [ Modal.multipleFocusableElementView
+                (\focusableElementAttrs ->
+                    div []
+                        [ Modal.viewContent [ viewSettings state ]
+                        ]
+                )
+            ]
 
 
 viewSettings : State -> Html Msg

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -108,6 +108,7 @@ viewContent state wrapMsg firstButtonStyle secondButtonStyle focusableElementAtt
                     [ Button.button "Continue"
                         [ firstButtonStyle
                         , Button.onClick ForceClose
+                        , Button.large
                         ]
                     , Button.button "Close"
                         [ secondButtonStyle
@@ -145,6 +146,7 @@ viewContent state wrapMsg firstButtonStyle secondButtonStyle focusableElementAtt
                         [ firstButtonStyle
                         , Button.onClick ForceClose
                         , Button.custom focusableElementAttrs.lastFocusableElement
+                        , Button.large
                         ]
                     ]
                 ]
@@ -157,6 +159,7 @@ viewContent state wrapMsg firstButtonStyle secondButtonStyle focusableElementAtt
                         [ firstButtonStyle
                         , Button.onClick ForceClose
                         , Button.custom focusableElementAttrs.firstFocusableElement
+                        , Button.large
                         ]
                     , Button.button "Close"
                         [ secondButtonStyle
@@ -186,6 +189,7 @@ viewContent state wrapMsg firstButtonStyle secondButtonStyle focusableElementAtt
                         [ firstButtonStyle
                         , Button.onClick ForceClose
                         , Button.custom focusableElementAttrs.lastFocusableElement
+                        , Button.large
                         ]
                     ]
                 ]

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -6,7 +6,7 @@ module Examples.Modal exposing (Msg, State, example, init, update, subscriptions
 
 -}
 
-import Accessibility.Styled as Html exposing (Html, div, h3, h4, p, text)
+import Accessibility.Styled as Html exposing (Html, div, h3, h4, p, span, text)
 import Css exposing (..)
 import Css.Global
 import Html as Root
@@ -17,6 +17,7 @@ import Nri.Ui.Checkbox.V5 as Checkbox
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Modal.V7 as Modal
+import Nri.Ui.Text.V4 as Text
 
 
 {-| -}
@@ -50,7 +51,8 @@ example parentMessage state =
     { name = "Nri.Ui.Modal.V7"
     , category = Modals
     , content =
-        [ Button.button "Launch Info Modal"
+        [ viewSettings state
+        , Button.button "Launch Info Modal"
             [ Button.onClick (InfoModalMsg (Modal.open "launch-info-modal"))
             , Button.custom
                 [ Html.Styled.Attributes.id "launch-info-modal"
@@ -96,7 +98,7 @@ viewContent state wrapMsg firstButtonStyle =
                 (\focusableElementAttrs ->
                     div []
                         [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
-                        , Modal.viewContent [ viewSettings state ]
+                        , Modal.viewContent [ viewModalContent ]
                         , Modal.viewFooter
                             [ Button.button "Continue"
                                 [ firstButtonStyle
@@ -122,7 +124,7 @@ viewContent state wrapMsg firstButtonStyle =
                 (\focusableElementAttrs ->
                     div []
                         [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
-                        , Modal.viewContent [ viewSettings state ]
+                        , Modal.viewContent [ viewModalContent ]
                         , Modal.viewFooter
                             [ ClickableText.button "Close"
                                 [ ClickableText.onClick ForceClose
@@ -142,7 +144,7 @@ viewContent state wrapMsg firstButtonStyle =
                 (\focusableElementAttrs ->
                     div []
                         [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
-                        , Modal.viewContent [ viewSettings state ]
+                        , Modal.viewContent [ viewModalContent ]
                         ]
                 )
             ]
@@ -153,7 +155,7 @@ viewContent state wrapMsg firstButtonStyle =
                 (\focusableElementAttrs ->
                     div []
                         [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
-                        , Modal.viewContent [ viewSettings state ]
+                        , Modal.viewContent [ viewModalContent ]
                         , Modal.viewFooter
                             [ Button.button "Continue"
                                 [ firstButtonStyle
@@ -170,7 +172,7 @@ viewContent state wrapMsg firstButtonStyle =
             [ Modal.multipleFocusableElementView
                 (\focusableElementAttrs ->
                     div []
-                        [ Modal.viewContent [ viewSettings state ]
+                        [ Modal.viewContent [ viewModalContent ]
                         , Modal.viewFooter
                             [ Button.button "Continue"
                                 [ firstButtonStyle
@@ -196,7 +198,7 @@ viewContent state wrapMsg firstButtonStyle =
             , Modal.multipleFocusableElementView
                 (\focusableElementAttrs ->
                     div []
-                        [ Modal.viewContent [ viewSettings state ]
+                        [ Modal.viewContent [ viewModalContent ]
                         , Modal.viewFooter
                             [ ClickableText.button "Close"
                                 [ ClickableText.onClick ForceClose
@@ -219,7 +221,7 @@ viewContent state wrapMsg firstButtonStyle =
             , Modal.multipleFocusableElementView
                 (\focusableElementAttrs ->
                     div []
-                        [ Modal.viewContent [ viewSettings state ]
+                        [ Modal.viewContent [ viewModalContent ]
                         , Modal.viewFooter
                             [ Button.button "Continue"
                                 [ firstButtonStyle
@@ -236,10 +238,26 @@ viewContent state wrapMsg firstButtonStyle =
             [ Modal.multipleFocusableElementView
                 (\focusableElementAttrs ->
                     div []
-                        [ Modal.viewContent [ viewSettings state ]
+                        [ Modal.viewContent [ viewModalContent ]
                         ]
                 )
             ]
+
+
+viewModalContent : Html msg
+viewModalContent =
+    Text.mediumBody
+        [ span [ css [ whiteSpace preLine ] ]
+            [ text
+                """
+                Soufflé pastry chocolate cake danish muffin. Candy wafer pastry ice cream cheesecake toffee cookie cake carrot cake. Macaroon pie jujubes gummies cookie pie. Gummi bears brownie pastry carrot cake cotton candy. Jelly-o sweet roll biscuit cake soufflé lemon drops tiramisu marshmallow macaroon. Chocolate jelly halvah marzipan macaroon cupcake sweet cheesecake carrot cake.
+
+                Sesame snaps pastry muffin cookie. Powder powder sweet roll toffee cake icing. Chocolate cake sweet roll gingerbread icing chupa chups sweet roll sesame snaps. Chocolate croissant chupa chups jelly beans toffee. Jujubes sweet wafer marshmallow halvah jelly. Liquorice sesame snaps sweet.
+
+                Tootsie roll icing jelly danish ice cream tiramisu sweet roll. Fruitcake ice cream dragée. Bear claw sugar plum sweet jelly beans bonbon dragée tart. Gingerbread chocolate sweet. Apple pie danish toffee sugar plum jelly beans donut. Chocolate cake croissant caramels chocolate bar. Jelly beans caramels toffee chocolate cake liquorice. Toffee pie sugar plum cookie toffee muffin. Marzipan marshmallow marzipan liquorice tiramisu.
+                """
+            ]
+        ]
 
 
 viewSettings : State -> Html Msg

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -74,7 +74,7 @@ example parentMessage state =
             , visibleTitle = state.visibleTitle
             , wrapMsg = InfoModalMsg
             }
-            (viewContent state InfoModalMsg Button.danger)
+            (viewContent state InfoModalMsg Button.primary)
             state.infoModal
         , Modal.warning
             { title = "Modal.warning"

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -101,6 +101,7 @@ viewContent state wrapMsg firstButtonStyle focusableElementAttrs =
                         [ firstButtonStyle
                         , Button.onClick ForceClose
                         , Button.large
+                        , Button.custom [ focusableElementAttrs.autofocusOn ]
                         ]
                     , ClickableText.button "Close"
                         [ ClickableText.onClick ForceClose
@@ -143,7 +144,10 @@ viewContent state wrapMsg firstButtonStyle focusableElementAttrs =
                     [ Button.button "Continue"
                         [ firstButtonStyle
                         , Button.onClick ForceClose
-                        , Button.custom focusableElementAttrs.lastFocusableElement
+                        , Button.custom
+                            (focusableElementAttrs.autofocusOn
+                                :: focusableElementAttrs.lastFocusableElement
+                            )
                         , Button.large
                         ]
                     ]
@@ -195,7 +199,10 @@ viewContent state wrapMsg firstButtonStyle focusableElementAttrs =
                     [ Button.button "Continue"
                         [ firstButtonStyle
                         , Button.onClick ForceClose
-                        , Button.custom focusableElementAttrs.lastFocusableElement
+                        , Button.custom
+                            (focusableElementAttrs.autofocusOn
+                                :: focusableElementAttrs.lastFocusableElement
+                            )
                         , Button.large
                         ]
                     ]

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -14,6 +14,7 @@ import Html.Styled.Attributes exposing (css)
 import ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.Button.V9 as Button
 import Nri.Ui.Checkbox.V5 as Checkbox
+import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Modal.V7 as Modal
 
@@ -68,22 +69,14 @@ example parentMessage state =
             { title = "Modal.info"
             , visibleTitle = state.visibleTitle
             , wrapMsg = InfoModalMsg
-            , content =
-                viewContent state
-                    InfoModalMsg
-                    Button.primary
-                    Button.secondary
+            , content = viewContent state InfoModalMsg Button.primary
             }
             state.infoModal
         , Modal.warning
             { title = "Modal.warning"
             , visibleTitle = state.visibleTitle
             , wrapMsg = WarningModalMsg
-            , content =
-                viewContent state
-                    WarningModalMsg
-                    Button.danger
-                    Button.secondary
+            , content = viewContent state WarningModalMsg Button.danger
             }
             state.warningModal
         ]
@@ -95,10 +88,9 @@ viewContent :
     State
     -> (Modal.Msg -> Msg)
     -> Button.Attribute Msg
-    -> Button.Attribute Msg
     -> Modal.FocusableElementAttrs Msg
     -> Html Msg
-viewContent state wrapMsg firstButtonStyle secondButtonStyle focusableElementAttrs =
+viewContent state wrapMsg firstButtonStyle focusableElementAttrs =
     case ( state.showX, state.showContinue, state.showSecondary ) of
         ( True, True, True ) ->
             div []
@@ -110,10 +102,13 @@ viewContent state wrapMsg firstButtonStyle secondButtonStyle focusableElementAtt
                         , Button.onClick ForceClose
                         , Button.large
                         ]
-                    , Button.button "Close"
-                        [ secondButtonStyle
-                        , Button.onClick ForceClose
-                        , Button.custom focusableElementAttrs.lastFocusableElement
+                    , ClickableText.button "Close"
+                        [ ClickableText.onClick ForceClose
+                        , ClickableText.large
+                        , ClickableText.custom
+                            (css [ Css.marginTop (Css.px 20) ]
+                                :: focusableElementAttrs.lastFocusableElement
+                            )
                         ]
                     ]
                 ]
@@ -123,10 +118,13 @@ viewContent state wrapMsg firstButtonStyle secondButtonStyle focusableElementAtt
                 [ Modal.closeButton wrapMsg focusableElementAttrs.firstFocusableElement
                 , Modal.viewContent [ viewSettings state ]
                 , Modal.viewFooter
-                    [ Button.button "Close"
-                        [ secondButtonStyle
-                        , Button.onClick ForceClose
-                        , Button.custom focusableElementAttrs.lastFocusableElement
+                    [ ClickableText.button "Close"
+                        [ ClickableText.onClick ForceClose
+                        , ClickableText.large
+                        , ClickableText.custom
+                            (css [ Css.marginTop (Css.px 20) ]
+                                :: focusableElementAttrs.lastFocusableElement
+                            )
                         ]
                     ]
                 ]
@@ -161,10 +159,13 @@ viewContent state wrapMsg firstButtonStyle secondButtonStyle focusableElementAtt
                         , Button.custom focusableElementAttrs.firstFocusableElement
                         , Button.large
                         ]
-                    , Button.button "Close"
-                        [ secondButtonStyle
-                        , Button.onClick ForceClose
-                        , Button.custom focusableElementAttrs.lastFocusableElement
+                    , ClickableText.button "Close"
+                        [ ClickableText.onClick ForceClose
+                        , ClickableText.large
+                        , ClickableText.custom
+                            (css [ Css.marginTop (Css.px 20) ]
+                                :: focusableElementAttrs.lastFocusableElement
+                            )
                         ]
                     ]
                 ]
@@ -173,10 +174,16 @@ viewContent state wrapMsg firstButtonStyle secondButtonStyle focusableElementAtt
             div []
                 [ Modal.viewContent [ viewSettings state ]
                 , Modal.viewFooter
-                    [ Button.button "Close"
-                        [ secondButtonStyle
-                        , Button.onClick ForceClose
-                        , Button.custom focusableElementAttrs.lastFocusableElement
+                    [ ClickableText.button "Close"
+                        [ ClickableText.onClick ForceClose
+                        , ClickableText.large
+                        , ClickableText.custom
+                            (css
+                                [ Css.marginTop
+                                    (Css.px 20)
+                                ]
+                                :: focusableElementAttrs.lastFocusableElement
+                            )
                         ]
                     ]
                 ]

--- a/styleguide-app/elm.json
+++ b/styleguide-app/elm.json
@@ -21,7 +21,7 @@
             "rtfeldman/elm-css": "16.0.0",
             "tesk9/accessible-html": "4.0.0",
             "tesk9/accessible-html-with-css": "2.1.1",
-            "tesk9/modal": "6.0.0",
+            "tesk9/modal": "5.0.1",
             "tesk9/palette": "2.0.0",
             "wernerdegroot/listzipper": "3.2.0"
         },

--- a/styleguide-app/elm.json
+++ b/styleguide-app/elm.json
@@ -21,7 +21,7 @@
             "rtfeldman/elm-css": "16.0.0",
             "tesk9/accessible-html": "4.0.0",
             "tesk9/accessible-html-with-css": "2.1.1",
-            "tesk9/modal": "5.0.1",
+            "tesk9/modal": "6.0.0",
             "tesk9/palette": "2.0.0",
             "wernerdegroot/listzipper": "3.2.0"
         },


### PR DESCRIPTION
![modal](https://user-images.githubusercontent.com/8811312/63202462-a2012480-c03e-11e9-85a6-3b748849f2ab.gif)


### Top shadow
<img width="617" alt="Screen Shot 2019-08-16 at 3 59 00 PM" src="https://user-images.githubusercontent.com/8811312/63202507-d2e15980-c03e-11e9-9b9c-e34ca2a2cf52.png">

### Bottom shadow
<img width="645" alt="Screen Shot 2019-08-16 at 3 59 11 PM" src="https://user-images.githubusercontent.com/8811312/63202506-d2e15980-c03e-11e9-89ad-fb7566f2fe59.png">

cc @NoRedInk/design 

Adds modal shadows & adds support for autofocusing on any focusable element when the modal launches.

NOTE: this also removes ids from some svgs! This decreases the axe errors (and reduces the chances that we have multiple identical ids on the same page) but does mean there's some regression risk.