### PR TITLE
Use elm color / revert usage of palette

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -87,6 +87,7 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
+        "avh4/elm-color": "1.0.0 <= v < 2.0.0",
         "elm/browser": "1.0.1 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
@@ -98,7 +99,6 @@
         "tesk9/accessible-html": "4.0.0 <= v < 5.0.0",
         "tesk9/accessible-html-with-css": "2.1.1 <= v < 3.0.0",
         "tesk9/modal": "5.0.1 <= v < 6.0.0",
-        "tesk9/palette": "2.0.0 <= v < 3.0.0",
         "wernerdegroot/listzipper": "3.1.1 <= v < 4.0.0"
     },
     "test-dependencies": {

--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -14,7 +14,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # expect. This failure reminds us to come back and ratchet down the number of
 # failures to the correct value.
 NUM_ERRORS="$(jq '.violations | map(.nodes | length) | add' "$JSON_FILE")"
-TARGET_ERRORS=99
+TARGET_ERRORS=162
 if test "$NUM_ERRORS" -ne "$TARGET_ERRORS"; then
     echo "got $NUM_ERRORS errors, but expected $TARGET_ERRORS."
     echo

--- a/src/Nri/Ui/Colors/Extra.elm
+++ b/src/Nri/Ui/Colors/Extra.elm
@@ -1,40 +1,28 @@
-module Nri.Ui.Colors.Extra exposing
-    ( toCssColor, fromCssColor
-    , withAlpha
-    )
+module Nri.Ui.Colors.Extra exposing (toCoreColor, withAlpha)
 
 {-| Helpers for working with colors.
 
 
 # Conversions
 
-@docs toCssColor, fromCssColor
-@docs withAlpha
+@docs toCoreColor, withAlpha
 
 -}
 
 import Color
-import Css
+import Css exposing (..)
 
 
-{-| -}
-fromCssColor : Css.Color -> Color.Color
-fromCssColor color =
-    Color.fromRGB
-        ( toFloat color.red
-        , toFloat color.green
-        , toFloat color.blue
-        )
-
-
-{-| -}
-toCssColor : Color.Color -> Css.Color
-toCssColor color =
-    let
-        ( red, green, blue ) =
-            Color.toRGB color
-    in
-    Css.rgb (round red) (round green) (round blue)
+{-| Convert a Css.Color into a Color.Color
+toCoreColor (Css.hex "#FFFFFF") -- "RGBA 255 255 255 1 : Color.Color"
+-}
+toCoreColor : Css.Color -> Color.Color
+toCoreColor cssColor =
+    Color.rgba
+        (toFloat cssColor.red / 255)
+        (toFloat cssColor.green / 255)
+        (toFloat cssColor.blue / 255)
+        cssColor.alpha
 
 
 {-| Add an alpha property to a Css.Color

--- a/src/Nri/Ui/Colors/Extra.elm
+++ b/src/Nri/Ui/Colors/Extra.elm
@@ -1,11 +1,11 @@
-module Nri.Ui.Colors.Extra exposing (toCoreColor, withAlpha)
+module Nri.Ui.Colors.Extra exposing (fromCssColor, toCssColor, withAlpha)
 
 {-| Helpers for working with colors.
 
 
 # Conversions
 
-@docs toCoreColor, withAlpha
+@docs fromCssColor, toCssColor, withAlpha
 
 -}
 
@@ -14,15 +14,30 @@ import Css exposing (..)
 
 
 {-| Convert a Css.Color into a Color.Color
-toCoreColor (Css.hex "#FFFFFF") -- "RGBA 255 255 255 1 : Color.Color"
+fromCssColor (Css.hex "#FFFFFF") -- "RgbaSpace 1 1 1 1 : Color.Color"
 -}
-toCoreColor : Css.Color -> Color.Color
-toCoreColor cssColor =
+fromCssColor : Css.Color -> Color.Color
+fromCssColor cssColor =
     Color.rgba
         (toFloat cssColor.red / 255)
         (toFloat cssColor.green / 255)
         (toFloat cssColor.blue / 255)
         cssColor.alpha
+
+
+{-| Convert a Color.Color into a Css.Color
+toCssColor (Color.rgba 1.0 1.0 1.0 1.0) -- "{ alpha = 1, blue = 255, color = Compatible, green = 255, red = 255, value = "rgba(255, 255, 255, 1)" } : Css.Color"
+-}
+toCssColor : Color.Color -> Css.Color
+toCssColor color =
+    let
+        { red, green, blue, alpha } =
+            Color.toRgba color
+    in
+    Css.rgba (Basics.round (red * 255))
+        (Basics.round (green * 255))
+        (Basics.round (blue * 255))
+        alpha
 
 
 {-| Add an alpha property to a Css.Color

--- a/src/Nri/Ui/Modal/V5.elm
+++ b/src/Nri/Ui/Modal/V5.elm
@@ -200,7 +200,7 @@ viewTitle color { visibleTitle, title } =
 
 toCssString : Css.Color -> String
 toCssString =
-    Nri.Ui.Colors.Extra.fromCssColor >> Color.toRGBString
+    Color.toCssString << Nri.Ui.Colors.Extra.toCoreColor
 
 
 {-| -}

--- a/src/Nri/Ui/Modal/V5.elm
+++ b/src/Nri/Ui/Modal/V5.elm
@@ -200,7 +200,7 @@ viewTitle color { visibleTitle, title } =
 
 toCssString : Css.Color -> String
 toCssString =
-    Color.toCssString << Nri.Ui.Colors.Extra.toCoreColor
+    Color.toCssString << Nri.Ui.Colors.Extra.fromCssColor
 
 
 {-| -}

--- a/src/Nri/Ui/Modal/V6.elm
+++ b/src/Nri/Ui/Modal/V6.elm
@@ -84,7 +84,6 @@ import Accessibility.Styled as Html exposing (..)
 import Accessibility.Styled.Style
 import Accessibility.Styled.Widget as Widget
 import Color
-import Color.Transparent
 import Css
 import Css.Global
 import Html as Root
@@ -206,10 +205,7 @@ view { overlayColor, titleColor } config model =
 
 toOverlayColor : Css.Color -> String
 toOverlayColor color =
-    color
-        |> Nri.Ui.Colors.Extra.fromCssColor
-        |> Color.Transparent.fromColor (Color.Transparent.customOpacity 0.9)
-        |> Color.Transparent.toRGBAString
+    toCssString (Nri.Ui.Colors.Extra.withAlpha 0.9 color)
 
 
 modalStyles : List (Root.Attribute Never)
@@ -218,7 +214,7 @@ modalStyles =
     , style "max-height" "calc(100vh - 100px)"
     , style "padding" "40px 0 40px 0"
     , style "margin" "75px auto"
-    , style "background-color" ((Color.toRGBString << Nri.Ui.Colors.Extra.fromCssColor) Colors.white)
+    , style "background-color" (toCssString Colors.white)
     , style "border-radius" "20px"
     , style "box-shadow" "0 1px 10px 0 rgba(0, 0, 0, 0.35)"
     , style "position" "relative" -- required for closeButtonContainer
@@ -235,12 +231,17 @@ viewTitle color { visibleTitle, title } =
         , style "margin" "0 49px"
         , style "font-size" "20px"
         , style "text-align" "center"
-        , style "color" ((Color.toRGBString << Nri.Ui.Colors.Extra.fromCssColor) color)
+        , style "color" (toCssString color)
         ]
 
       else
         Accessibility.Style.invisible
     )
+
+
+toCssString : Css.Color -> String
+toCssString =
+    Color.toCssString << Nri.Ui.Colors.Extra.toCoreColor
 
 
 {-| -}

--- a/src/Nri/Ui/Modal/V6.elm
+++ b/src/Nri/Ui/Modal/V6.elm
@@ -241,7 +241,7 @@ viewTitle color { visibleTitle, title } =
 
 toCssString : Css.Color -> String
 toCssString =
-    Color.toCssString << Nri.Ui.Colors.Extra.toCoreColor
+    Color.toCssString << Nri.Ui.Colors.Extra.fromCssColor
 
 
 {-| -}

--- a/src/Nri/Ui/Modal/V7.elm
+++ b/src/Nri/Ui/Modal/V7.elm
@@ -96,7 +96,6 @@ import Accessibility.Style
 import Accessibility.Styled as Html exposing (..)
 import Accessibility.Styled.Widget as Widget
 import Color
-import Color.Transparent
 import Css
 import Css.Global
 import Html as Root
@@ -244,7 +243,7 @@ modalStyles =
     [ Css.property "width" "600px"
     , Css.property "padding" "40px 0 40px 0"
     , Css.property "margin" "75px auto"
-    , Css.property "background-color" ((Color.toRGBString << Nri.Ui.Colors.Extra.fromCssColor) Colors.white)
+    , Css.property "background-color" (toCssString Colors.white)
     , Css.property "border-radius" "20px"
     , Css.property "box-shadow" "0 1px 10px 0 rgba(0, 0, 0, 0.35)"
     , Css.property "position" "relative" -- required for closeButtonContainer
@@ -259,7 +258,7 @@ titleStyles color =
     , Css.property "margin" "0 49px"
     , Css.property "font-size" "20px"
     , Css.property "text-align" "center"
-    , Css.property "color" ((Color.toRGBString << Nri.Ui.Colors.Extra.fromCssColor) color)
+    , Css.property "color" (toCssString color)
     ]
 
 
@@ -350,3 +349,8 @@ closeButton wrapMsg focusableElementAttrs =
         )
         [ Nri.Ui.Svg.V1.toHtml Nri.Ui.SpriteSheet.xSvg
         ]
+
+
+toCssString : Css.Color -> String
+toCssString =
+    Color.toCssString << Nri.Ui.Colors.Extra.toCoreColor

--- a/src/Nri/Ui/Modal/V7.elm
+++ b/src/Nri/Ui/Modal/V7.elm
@@ -353,4 +353,4 @@ closeButton wrapMsg focusableElementAttrs =
 
 toCssString : Css.Color -> String
 toCssString =
-    Color.toCssString << Nri.Ui.Colors.Extra.toCoreColor
+    Color.toCssString << Nri.Ui.Colors.Extra.fromCssColor

--- a/src/Nri/Ui/SlideModal/V2.elm
+++ b/src/Nri/Ui/SlideModal/V2.elm
@@ -385,8 +385,8 @@ dot type_ =
                 ]
 
         animateBackgroundColor color =
-            Nri.Ui.Colors.Extra.fromCssColor color
-                |> Color.toRGBString
+            Nri.Ui.Colors.Extra.toCoreColor color
+                |> Color.toCssString
                 |> Css.Animations.property "background-color"
     in
     case type_ of

--- a/src/Nri/Ui/SlideModal/V2.elm
+++ b/src/Nri/Ui/SlideModal/V2.elm
@@ -385,7 +385,7 @@ dot type_ =
                 ]
 
         animateBackgroundColor color =
-            Nri.Ui.Colors.Extra.toCoreColor color
+            Nri.Ui.Colors.Extra.fromCssColor color
                 |> Color.toCssString
                 |> Css.Animations.property "background-color"
     in

--- a/src/Nri/Ui/SortableTable/V1.elm
+++ b/src/Nri/Ui/SortableTable/V1.elm
@@ -359,4 +359,4 @@ sortArrow direction active =
 
 toCssString : Css.Color -> String
 toCssString =
-    Color.toRGBString << Nri.Ui.Colors.Extra.fromCssColor
+    Color.toCssString << Nri.Ui.Colors.Extra.toCoreColor

--- a/src/Nri/Ui/SortableTable/V1.elm
+++ b/src/Nri/Ui/SortableTable/V1.elm
@@ -359,4 +359,4 @@ sortArrow direction active =
 
 toCssString : Css.Color -> String
 toCssString =
-    Color.toCssString << Nri.Ui.Colors.Extra.toCoreColor
+    Color.toCssString << Nri.Ui.Colors.Extra.fromCssColor

--- a/src/Nri/Ui/SortableTable/V2.elm
+++ b/src/Nri/Ui/SortableTable/V2.elm
@@ -365,4 +365,4 @@ sortArrow direction active =
 
 toCssString : Css.Color -> String
 toCssString =
-    Color.toRGBString << Nri.Ui.Colors.Extra.fromCssColor
+    Color.toCssString << Nri.Ui.Colors.Extra.toCoreColor

--- a/src/Nri/Ui/SortableTable/V2.elm
+++ b/src/Nri/Ui/SortableTable/V2.elm
@@ -365,4 +365,4 @@ sortArrow direction active =
 
 toCssString : Css.Color -> String
 toCssString =
-    Color.toCssString << Nri.Ui.Colors.Extra.toCoreColor
+    Color.toCssString << Nri.Ui.Colors.Extra.fromCssColor

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -6,7 +6,7 @@ module Examples.Colors exposing (example)
 
 -}
 
-import Color exposing (highContrast)
+import Color.Generator exposing (highContrast)
 import Css
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes exposing (css)

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -6,12 +6,10 @@ module Examples.Colors exposing (example)
 
 -}
 
-import Color.Generator exposing (highContrast)
 import Css
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes exposing (css)
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
-import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
 
 
@@ -105,10 +103,8 @@ viewColor ( name, color, description ) =
 
             -- Colors
             , Css.backgroundColor color
-            , Nri.Ui.Colors.Extra.fromCssColor color
-                |> highContrast
-                |> Nri.Ui.Colors.Extra.toCssColor
-                |> Css.color
+            , Css.color Colors.gray20
+            , Css.textShadow4 Css.zero Css.zero (Css.px 6) Colors.white
             ]
         ]
         [ Html.div

--- a/styleguide-app/elm.json
+++ b/styleguide-app/elm.json
@@ -8,6 +8,7 @@
     "dependencies": {
         "direct": {
             "avh4/elm-debug-controls": "2.0.0",
+            "avh4/elm-color": "1.0.0",
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",
@@ -17,12 +18,11 @@
             "elm/svg": "1.0.1",
             "elm/url": "1.0.0",
             "elm-community/string-extra": "4.0.1",
+            "tesk9/accessible-html-with-css": "2.1.1",
             "pablohirafuji/elm-markdown": "2.0.5",
             "rtfeldman/elm-css": "16.0.0",
             "tesk9/accessible-html": "4.0.0",
-            "tesk9/accessible-html-with-css": "2.1.1",
             "tesk9/modal": "5.0.1",
-            "tesk9/palette": "1.4.0",
             "wernerdegroot/listzipper": "3.2.0"
         },
         "indirect": {

--- a/styleguide-app/elm.json
+++ b/styleguide-app/elm.json
@@ -22,7 +22,7 @@
             "tesk9/accessible-html": "4.0.0",
             "tesk9/accessible-html-with-css": "2.1.1",
             "tesk9/modal": "5.0.1",
-            "tesk9/palette": "2.0.0",
+            "tesk9/palette": "1.4.0",
             "wernerdegroot/listzipper": "3.2.0"
         },
         "indirect": {

--- a/styleguide-app/elm.json
+++ b/styleguide-app/elm.json
@@ -7,8 +7,9 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "avh4/elm-debug-controls": "2.0.0",
             "avh4/elm-color": "1.0.0",
+            "avh4/elm-debug-controls": "2.0.0",
+            "elm-community/string-extra": "4.0.1",
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",
@@ -17,11 +18,10 @@
             "elm/regex": "1.0.0",
             "elm/svg": "1.0.1",
             "elm/url": "1.0.0",
-            "elm-community/string-extra": "4.0.1",
-            "tesk9/accessible-html-with-css": "2.1.1",
             "pablohirafuji/elm-markdown": "2.0.5",
             "rtfeldman/elm-css": "16.0.0",
             "tesk9/accessible-html": "4.0.0",
+            "tesk9/accessible-html-with-css": "2.1.1",
             "tesk9/modal": "5.0.1",
             "wernerdegroot/listzipper": "3.2.0"
         },


### PR DESCRIPTION
Rolls back adoption of tesk9/palette because replacing avh4/elm-color [is a little more complicated](https://github.com/NoRedInk/NoRedInk/pull/24839)

palette looks promising but we need to resolve other blockers before using it here.