### PR TITLE
go back from elm-color to palette for better styleguide

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -87,7 +87,6 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "avh4/elm-color": "1.0.0 <= v < 2.0.0",
         "elm/browser": "1.0.1 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
@@ -99,6 +98,7 @@
         "tesk9/accessible-html": "4.0.0 <= v < 5.0.0",
         "tesk9/accessible-html-with-css": "2.1.1 <= v < 3.0.0",
         "tesk9/modal": "5.0.1 <= v < 6.0.0",
+        "tesk9/palette": "2.0.0 <= v < 3.0.0",
         "wernerdegroot/listzipper": "3.1.1 <= v < 4.0.0"
     },
     "test-dependencies": {

--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -14,7 +14,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # expect. This failure reminds us to come back and ratchet down the number of
 # failures to the correct value.
 NUM_ERRORS="$(jq '.violations | map(.nodes | length) | add' "$JSON_FILE")"
-TARGET_ERRORS=162
+TARGET_ERRORS=99
 if test "$NUM_ERRORS" -ne "$TARGET_ERRORS"; then
     echo "got $NUM_ERRORS errors, but expected $TARGET_ERRORS."
     echo

--- a/src/Nri/Ui/Colors/Extra.elm
+++ b/src/Nri/Ui/Colors/Extra.elm
@@ -1,43 +1,40 @@
-module Nri.Ui.Colors.Extra exposing (fromCssColor, toCssColor, withAlpha)
+module Nri.Ui.Colors.Extra exposing
+    ( toCssColor, fromCssColor
+    , withAlpha
+    )
 
 {-| Helpers for working with colors.
 
 
 # Conversions
 
-@docs fromCssColor, toCssColor, withAlpha
+@docs toCssColor, fromCssColor
+@docs withAlpha
 
 -}
 
 import Color
-import Css exposing (..)
+import Css
 
 
-{-| Convert a Css.Color into a Color.Color
-fromCssColor (Css.hex "#FFFFFF") -- "RgbaSpace 1 1 1 1 : Color.Color"
--}
+{-| -}
 fromCssColor : Css.Color -> Color.Color
-fromCssColor cssColor =
-    Color.rgba
-        (toFloat cssColor.red / 255)
-        (toFloat cssColor.green / 255)
-        (toFloat cssColor.blue / 255)
-        cssColor.alpha
+fromCssColor color =
+    Color.fromRGB
+        ( toFloat color.red
+        , toFloat color.green
+        , toFloat color.blue
+        )
 
 
-{-| Convert a Color.Color into a Css.Color
-toCssColor (Color.rgba 1.0 1.0 1.0 1.0) -- "{ alpha = 1, blue = 255, color = Compatible, green = 255, red = 255, value = "rgba(255, 255, 255, 1)" } : Css.Color"
--}
+{-| -}
 toCssColor : Color.Color -> Css.Color
 toCssColor color =
     let
-        { red, green, blue, alpha } =
-            Color.toRgba color
+        ( red, green, blue ) =
+            Color.toRGB color
     in
-    Css.rgba (Basics.round (red * 255))
-        (Basics.round (green * 255))
-        (Basics.round (blue * 255))
-        alpha
+    Css.rgb (round red) (round green) (round blue)
 
 
 {-| Add an alpha property to a Css.Color

--- a/src/Nri/Ui/Modal/V5.elm
+++ b/src/Nri/Ui/Modal/V5.elm
@@ -200,7 +200,7 @@ viewTitle color { visibleTitle, title } =
 
 toCssString : Css.Color -> String
 toCssString =
-    Color.toCssString << Nri.Ui.Colors.Extra.fromCssColor
+    Nri.Ui.Colors.Extra.fromCssColor >> Color.toRGBString
 
 
 {-| -}

--- a/src/Nri/Ui/Modal/V6.elm
+++ b/src/Nri/Ui/Modal/V6.elm
@@ -84,6 +84,7 @@ import Accessibility.Styled as Html exposing (..)
 import Accessibility.Styled.Style
 import Accessibility.Styled.Widget as Widget
 import Color
+import Color.Transparent
 import Css
 import Css.Global
 import Html as Root
@@ -205,7 +206,10 @@ view { overlayColor, titleColor } config model =
 
 toOverlayColor : Css.Color -> String
 toOverlayColor color =
-    toCssString (Nri.Ui.Colors.Extra.withAlpha 0.9 color)
+    color
+        |> Nri.Ui.Colors.Extra.fromCssColor
+        |> Color.Transparent.fromColor (Color.Transparent.customOpacity 0.9)
+        |> Color.Transparent.toRGBAString
 
 
 modalStyles : List (Root.Attribute Never)
@@ -214,7 +218,7 @@ modalStyles =
     , style "max-height" "calc(100vh - 100px)"
     , style "padding" "40px 0 40px 0"
     , style "margin" "75px auto"
-    , style "background-color" (toCssString Colors.white)
+    , style "background-color" ((Color.toRGBString << Nri.Ui.Colors.Extra.fromCssColor) Colors.white)
     , style "border-radius" "20px"
     , style "box-shadow" "0 1px 10px 0 rgba(0, 0, 0, 0.35)"
     , style "position" "relative" -- required for closeButtonContainer
@@ -231,17 +235,12 @@ viewTitle color { visibleTitle, title } =
         , style "margin" "0 49px"
         , style "font-size" "20px"
         , style "text-align" "center"
-        , style "color" (toCssString color)
+        , style "color" ((Color.toRGBString << Nri.Ui.Colors.Extra.fromCssColor) color)
         ]
 
       else
         Accessibility.Style.invisible
     )
-
-
-toCssString : Css.Color -> String
-toCssString =
-    Color.toCssString << Nri.Ui.Colors.Extra.fromCssColor
 
 
 {-| -}

--- a/src/Nri/Ui/Modal/V7.elm
+++ b/src/Nri/Ui/Modal/V7.elm
@@ -96,6 +96,7 @@ import Accessibility.Style
 import Accessibility.Styled as Html exposing (..)
 import Accessibility.Styled.Widget as Widget
 import Color
+import Color.Transparent
 import Css
 import Css.Global
 import Html as Root
@@ -243,7 +244,7 @@ modalStyles =
     [ Css.property "width" "600px"
     , Css.property "padding" "40px 0 40px 0"
     , Css.property "margin" "75px auto"
-    , Css.property "background-color" (toCssString Colors.white)
+    , Css.property "background-color" ((Color.toRGBString << Nri.Ui.Colors.Extra.fromCssColor) Colors.white)
     , Css.property "border-radius" "20px"
     , Css.property "box-shadow" "0 1px 10px 0 rgba(0, 0, 0, 0.35)"
     , Css.property "position" "relative" -- required for closeButtonContainer
@@ -258,7 +259,7 @@ titleStyles color =
     , Css.property "margin" "0 49px"
     , Css.property "font-size" "20px"
     , Css.property "text-align" "center"
-    , Css.property "color" (toCssString color)
+    , Css.property "color" ((Color.toRGBString << Nri.Ui.Colors.Extra.fromCssColor) color)
     ]
 
 
@@ -349,8 +350,3 @@ closeButton wrapMsg focusableElementAttrs =
         )
         [ Nri.Ui.Svg.V1.toHtml Nri.Ui.SpriteSheet.xSvg
         ]
-
-
-toCssString : Css.Color -> String
-toCssString =
-    Color.toCssString << Nri.Ui.Colors.Extra.fromCssColor

--- a/src/Nri/Ui/SlideModal/V2.elm
+++ b/src/Nri/Ui/SlideModal/V2.elm
@@ -386,7 +386,7 @@ dot type_ =
 
         animateBackgroundColor color =
             Nri.Ui.Colors.Extra.fromCssColor color
-                |> Color.toCssString
+                |> Color.toRGBString
                 |> Css.Animations.property "background-color"
     in
     case type_ of

--- a/src/Nri/Ui/SortableTable/V1.elm
+++ b/src/Nri/Ui/SortableTable/V1.elm
@@ -359,4 +359,4 @@ sortArrow direction active =
 
 toCssString : Css.Color -> String
 toCssString =
-    Color.toCssString << Nri.Ui.Colors.Extra.fromCssColor
+    Color.toRGBString << Nri.Ui.Colors.Extra.fromCssColor

--- a/src/Nri/Ui/SortableTable/V2.elm
+++ b/src/Nri/Ui/SortableTable/V2.elm
@@ -365,4 +365,4 @@ sortArrow direction active =
 
 toCssString : Css.Color -> String
 toCssString =
-    Color.toCssString << Nri.Ui.Colors.Extra.fromCssColor
+    Color.toRGBString << Nri.Ui.Colors.Extra.fromCssColor

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -6,10 +6,12 @@ module Examples.Colors exposing (example)
 
 -}
 
+import Color exposing (highContrast)
 import Css
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes exposing (css)
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
+import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
 
 
@@ -103,8 +105,10 @@ viewColor ( name, color, description ) =
 
             -- Colors
             , Css.backgroundColor color
-            , Css.color Colors.gray20
-            , Css.textShadow4 Css.zero Css.zero (Css.px 6) Colors.white
+            , Nri.Ui.Colors.Extra.fromCssColor color
+                |> highContrast
+                |> Nri.Ui.Colors.Extra.toCssColor
+                |> Css.color
             ]
         ]
         [ Html.div

--- a/styleguide-app/elm.json
+++ b/styleguide-app/elm.json
@@ -7,9 +7,7 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "avh4/elm-color": "1.0.0",
             "avh4/elm-debug-controls": "2.0.0",
-            "elm-community/string-extra": "4.0.1",
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",
@@ -18,11 +16,13 @@
             "elm/regex": "1.0.0",
             "elm/svg": "1.0.1",
             "elm/url": "1.0.0",
+            "elm-community/string-extra": "4.0.1",
             "pablohirafuji/elm-markdown": "2.0.5",
             "rtfeldman/elm-css": "16.0.0",
             "tesk9/accessible-html": "4.0.0",
             "tesk9/accessible-html-with-css": "2.1.1",
             "tesk9/modal": "5.0.1",
+            "tesk9/palette": "2.0.0",
             "wernerdegroot/listzipper": "3.2.0"
         },
         "indirect": {


### PR DESCRIPTION
# do not merge until we fix a bug in elm-doc

fixed! https://github.com/NoRedInk/NoRedInk/pull/24900

This reverts commit 8b6f993fb312355375a635e8e2aaf05901f673c4, reversing
changes made to d8fcbc58f85742ac2442c48198c5a465dc5691b1.