### PR TITLE
upgrade list zipper dependency

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -99,7 +99,7 @@
         "tesk9/accessible-html": "4.0.0 <= v < 5.0.0",
         "tesk9/accessible-html-with-css": "2.1.1 <= v < 3.0.0",
         "tesk9/modal": "5.0.1 <= v < 6.0.0",
-        "wernerdegroot/listzipper": "3.1.1 <= v < 4.0.0"
+        "wernerdegroot/listzipper": "3.1.1 <= v < 5.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.2.0 <= v < 2.0.0"

--- a/src/List/Zipper/Extra.elm
+++ b/src/List/Zipper/Extra.elm
@@ -1,0 +1,13 @@
+module List.Zipper.Extra exposing (from)
+
+{-| migration module from List.Zipper 3.2 -> 4. We can drop this when we drop < 3.2 support
+-}
+
+import List.Zipper
+
+
+from : List a -> a -> List a -> List.Zipper.Zipper a
+from before current after =
+    List.Zipper.singleton current
+        |> List.Zipper.mapBefore (always before)
+        |> List.Zipper.mapAfter (always after)

--- a/src/Nri/Ui/Tabs/V3.elm
+++ b/src/Nri/Ui/Tabs/V3.elm
@@ -37,7 +37,8 @@ import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Json.Decode
-import List.Zipper exposing (Zipper(..))
+import List.Zipper exposing (Zipper)
+import List.Zipper.Extra
 import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1
 import Nri.Ui.Fonts.V1
@@ -290,11 +291,11 @@ tabToBodyId tab =
 
 
 mapWithCurrent : (Bool -> a -> b) -> Zipper a -> Zipper b
-mapWithCurrent fn (Zipper before current after) =
-    Zipper
-        (List.map (fn False) before)
-        (fn True current)
-        (List.map (fn False) after)
+mapWithCurrent fn zipper =
+    List.Zipper.Extra.from
+        (List.map (fn False) (List.Zipper.before zipper))
+        (fn True (List.Zipper.current zipper))
+        (List.map (fn False) (List.Zipper.after zipper))
 
 
 

--- a/src/Nri/Ui/Tabs/V4.elm
+++ b/src/Nri/Ui/Tabs/V4.elm
@@ -38,7 +38,8 @@ import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Json.Decode
-import List.Zipper exposing (Zipper(..))
+import List.Zipper exposing (Zipper)
+import List.Zipper.Extra
 import Nri.Ui
 import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
@@ -331,11 +332,11 @@ tabToBodyId tab =
 
 
 mapWithCurrent : (Bool -> a -> b) -> Zipper a -> Zipper b
-mapWithCurrent fn (Zipper before current after) =
-    Zipper
-        (List.map (fn False) before)
-        (fn True current)
-        (List.map (fn False) after)
+mapWithCurrent fn zipper =
+    List.Zipper.Extra.from
+        (List.map (fn False) (List.Zipper.before zipper))
+        (fn True (List.Zipper.current zipper))
+        (List.map (fn False) (List.Zipper.after zipper))
 
 
 styledName : String -> String

--- a/styleguide-app/Examples/Slide.elm
+++ b/styleguide-app/Examples/Slide.elm
@@ -10,7 +10,7 @@ import Accessibility.Styled as Html
 import Css
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Keyed as Keyed
-import List.Zipper as Zipper exposing (Zipper(..))
+import List.Zipper as Zipper exposing (Zipper)
 import ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.Button.V8 as Button
 import Nri.Ui.Colors.V1 as Colors
@@ -74,7 +74,7 @@ example parentMessage state =
 init : State
 init =
     { direction = Slide.FromRTL
-    , panels = Zipper [] One [ Two, Three ]
+    , panels = Zipper.from [] One [ Two, Three ]
     , previous = Nothing
     }
 

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -31,10 +31,14 @@ example changeTab tab =
             , tabs =
                 case tab of
                     First ->
-                        List.Zipper.Zipper [] (Tabs.Tab "First tab" First) [ Tabs.Tab "Second tab" Second ]
+                        List.Zipper.from []
+                            (Tabs.Tab "First tab" First)
+                            [ Tabs.Tab "Second tab" Second ]
 
                     Second ->
-                        List.Zipper.Zipper [ Tabs.Tab "First tab" First ] (Tabs.Tab "Second tab" Second) []
+                        List.Zipper.from []
+                            (Tabs.Tab "Second tab" Second)
+                            [ Tabs.Tab "First tab" First ]
             , content =
                 \id ->
                     case id of
@@ -50,7 +54,7 @@ example changeTab tab =
             , content = Html.text "Links"
             , alignment = Tabs.Left
             , tabs =
-                List.Zipper.Zipper
+                List.Zipper.from
                     []
                     (Tabs.NormalLink { label = "Nowhere", href = Nothing })
                     [ Tabs.NormalLink { label = "Elm", href = Just "http://elm-lang.org" }

--- a/styleguide-app/elm.json
+++ b/styleguide-app/elm.json
@@ -23,7 +23,7 @@
             "tesk9/accessible-html": "4.0.0",
             "tesk9/accessible-html-with-css": "2.1.1",
             "tesk9/modal": "5.0.1",
-            "wernerdegroot/listzipper": "3.2.0"
+            "wernerdegroot/listzipper": "4.0.0"
         },
         "indirect": {
             "NoRedInk/datetimepicker-legacy": "1.0.1",

--- a/tests/Spec/List/Zipper/Extra.elm
+++ b/tests/Spec/List/Zipper/Extra.elm
@@ -1,0 +1,33 @@
+module Spec.List.Zipper.Extra exposing (fromSpec)
+
+import Expect exposing (Expectation)
+import List.Zipper
+import List.Zipper.Extra
+import Test exposing (..)
+
+
+fromSpec : Test
+fromSpec =
+    let
+        before =
+            [ 1, 2 ]
+
+        current =
+            3
+
+        after =
+            [ 4, 5 ]
+
+        zipper =
+            List.Zipper.Extra.from before current after
+    in
+    describe "List.Zipper.Extra.from before current after"
+        [ test "before" <|
+            \() ->
+                Expect.equal (List.Zipper.before zipper) before
+        , test "current" <|
+            \() ->
+                Expect.equal (List.Zipper.current zipper) current
+        , test "after" <|
+            \() -> Expect.equal (List.Zipper.after zipper) after
+        ]


### PR DESCRIPTION
just upgrading our list zipper dependency

see: 

https://github.com/wernerdegroot/listzipper/compare/3.1.1...4.0.0

major changes:

adds `from`, `fromCons` as constructors.
makes Zipper type opaque