### PR TITLE
constructor now reverses before

### DIFF
--- a/src/Nri/Ui/Tabs/V3.elm
+++ b/src/Nri/Ui/Tabs/V3.elm
@@ -293,7 +293,7 @@ tabToBodyId tab =
 mapWithCurrent : (Bool -> a -> b) -> Zipper a -> Zipper b
 mapWithCurrent fn zipper =
     List.Zipper.Extra.from
-        (List.map (fn False) (List.Zipper.before zipper))
+        (List.reverse (List.map (fn False) (List.Zipper.before zipper)))
         (fn True (List.Zipper.current zipper))
         (List.map (fn False) (List.Zipper.after zipper))
 

--- a/src/Nri/Ui/Tabs/V4.elm
+++ b/src/Nri/Ui/Tabs/V4.elm
@@ -334,7 +334,7 @@ tabToBodyId tab =
 mapWithCurrent : (Bool -> a -> b) -> Zipper a -> Zipper b
 mapWithCurrent fn zipper =
     List.Zipper.Extra.from
-        (List.map (fn False) (List.Zipper.before zipper))
+        (List.reverse (List.map (fn False) (List.Zipper.before zipper)))
         (fn True (List.Zipper.current zipper))
         (List.map (fn False) (List.Zipper.after zipper))
 


### PR DESCRIPTION
missed a functionality change from list-zipper 3.1.1 to 4.0.0 (#359).  This includes it.