### PR TITLE
SegementedControl as toggle

### DIFF
--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -14,7 +14,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # expect. This failure reminds us to come back and ratchet down the number of
 # failures to the correct value.
 NUM_ERRORS="$(jq '.violations | map(.nodes | length) | add' "$JSON_FILE")"
-TARGET_ERRORS=99
+TARGET_ERRORS=97
 if test "$NUM_ERRORS" -ne "$TARGET_ERRORS"; then
     echo "got $NUM_ERRORS errors, but expected $TARGET_ERRORS."
     echo

--- a/src/Nri/Ui/SegmentedControl/V7.elm
+++ b/src/Nri/Ui/SegmentedControl/V7.elm
@@ -100,7 +100,17 @@ viewToggle config =
             , cursor pointer
             ]
         ]
-        (List.map (viewTab Nothing (Widget.selected True) config) config.options)
+        (List.map
+            (viewTab
+                { onClick = config.onClick
+                , selected = config.selected
+                , width = config.width
+                , selectedAttribute = Widget.selected True
+                , maybeToUrl = Nothing
+                }
+            )
+            config.options
+        )
 
 
 viewHelper : Maybe (a -> String) -> Config a msg -> Html msg
@@ -118,7 +128,17 @@ viewHelper maybeToUrl config =
                 , cursor pointer
                 ]
             ]
-            (List.map (viewTab maybeToUrl Aria.currentPage config) config.options)
+            (List.map
+                (viewTab
+                    { onClick = config.onClick
+                    , selected = config.selected
+                    , width = config.width
+                    , selectedAttribute = Aria.currentPage
+                    , maybeToUrl = maybeToUrl
+                    }
+                )
+                config.options
+            )
         , tabPanel
             (List.filterMap identity
                 [ Maybe.map (Aria.labelledBy << tabIdFor) selected
@@ -141,23 +161,21 @@ panelIdFor option =
 
 
 viewTab :
-    Maybe (a -> String)
-    -> Html.Attribute msg
-    ->
-        { x
-            | onClick : a -> msg
-            , selected : a
-            , width : Width
-        }
+    { onClick : a -> msg
+    , selected : a
+    , width : Width
+    , selectedAttribute : Html.Attribute msg
+    , maybeToUrl : Maybe (a -> String)
+    }
     -> Option a
     -> Html.Html msg
-viewTab maybeToUrl selectedAttribute config option =
+viewTab config option =
     let
         idValue =
             tabIdFor option
 
         element attrs children =
-            case maybeToUrl of
+            case config.maybeToUrl of
                 Nothing ->
                     -- This is for a non-SPA view
                     Html.button
@@ -184,7 +202,7 @@ viewTab maybeToUrl selectedAttribute config option =
               ]
             , if option.value == config.selected then
                 [ css focusedTabStyles
-                , selectedAttribute
+                , config.selectedAttribute
                 ]
 
               else

--- a/src/Nri/Ui/SegmentedControl/V7.elm
+++ b/src/Nri/Ui/SegmentedControl/V7.elm
@@ -100,7 +100,7 @@ viewToggle config =
             , cursor pointer
             ]
         ]
-        (List.map (viewTab Nothing False config) config.options)
+        (List.map (viewTab Nothing (Widget.selected True) config) config.options)
 
 
 viewHelper : Maybe (a -> String) -> Config a msg -> Html msg
@@ -118,7 +118,7 @@ viewHelper maybeToUrl config =
                 , cursor pointer
                 ]
             ]
-            (List.map (viewTab maybeToUrl True config) config.options)
+            (List.map (viewTab maybeToUrl Aria.currentPage config) config.options)
         , tabPanel
             (List.filterMap identity
                 [ Maybe.map (Aria.labelledBy << tabIdFor) selected
@@ -142,7 +142,7 @@ panelIdFor option =
 
 viewTab :
     Maybe (a -> String)
-    -> Bool
+    -> Html.Attribute msg
     ->
         { x
             | onClick : a -> msg
@@ -151,7 +151,7 @@ viewTab :
         }
     -> Option a
     -> Html.Html msg
-viewTab maybeToUrl forPage config option =
+viewTab maybeToUrl selectedAttribute config option =
     let
         idValue =
             tabIdFor option
@@ -175,13 +175,6 @@ viewTab maybeToUrl forPage config option =
                             :: attrs
                         )
                         children
-
-        ariaCurrent =
-            if forPage then
-                Aria.currentPage
-
-            else
-                Widget.selected True
     in
     element
         (List.concat
@@ -191,7 +184,7 @@ viewTab maybeToUrl forPage config option =
               ]
             , if option.value == config.selected then
                 [ css focusedTabStyles
-                , ariaCurrent
+                , selectedAttribute
                 ]
 
               else

--- a/src/Nri/Ui/SegmentedControl/V7.elm
+++ b/src/Nri/Ui/SegmentedControl/V7.elm
@@ -9,6 +9,7 @@ module Nri.Ui.SegmentedControl.V7 exposing (Config, Icon, Option, Width(..), vie
 import Accessibility.Styled exposing (..)
 import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Role as Role
+import Accessibility.Styled.Widget as Widget
 import Css exposing (..)
 import EventExtras.Styled as EventExtras
 import Html.Styled as Html exposing (Html)
@@ -181,7 +182,7 @@ viewTab maybeToUrl forPage config option =
                 Aria.currentPage
 
             else
-                Aria.currentItem True
+                Widget.selected True
     in
     element
         (List.concat

--- a/src/Nri/Ui/SegmentedControl/V7.elm
+++ b/src/Nri/Ui/SegmentedControl/V7.elm
@@ -121,8 +121,7 @@ viewHelper maybeToUrl config =
             (List.map (viewTab maybeToUrl True config) config.options)
         , tabPanel
             (List.filterMap identity
-                [ Maybe.map (Attr.id << panelIdFor) selected
-                , Maybe.map (Aria.labelledBy << tabIdFor) selected
+                [ Maybe.map (Aria.labelledBy << tabIdFor) selected
                 , Just <| css [ paddingTop (px 10) ]
                 ]
             )
@@ -188,7 +187,6 @@ viewTab maybeToUrl forPage config option =
         (List.concat
             [ [ Attr.id idValue
               , Role.tab
-              , Aria.controls (panelIdFor option)
               , css sharedTabStyles
               ]
             , if option.value == config.selected then

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -55,15 +55,16 @@ type alias Options =
 {-| -}
 example : (Msg -> msg) -> State -> ModuleExample msg
 example parentMessage state =
+    let
+        options =
+            Control.currentValue state.optionsControl
+    in
     { name = "Nri.Ui.SegmentedControl.V7"
     , category = Widgets
     , content =
         [ Control.view ChangeOptions state.optionsControl
             |> Html.fromUnstyled
         , let
-            options =
-                Control.currentValue state.optionsControl
-
             viewFn =
                 if options.useSpa then
                     SegmentedControl.viewSpa Debug.toString
@@ -85,6 +86,22 @@ example parentMessage state =
             , selected = state.selected
             , width = options.width
             , content = Html.text ("[Content for " ++ Debug.toString state.selected ++ "]")
+            }
+        , Html.h3 [] [ Html.text "Toggle only view" ]
+        , Html.p [] [ Html.text "Used when you only need the ui element and not a page control." ]
+        , SegmentedControl.viewToggle
+            { onClick = Select
+            , options =
+                [ A, B, C ]
+                    |> List.map
+                        (\i ->
+                            { icon = options.icon
+                            , label = "Option " ++ Debug.toString i
+                            , value = i
+                            }
+                        )
+            , selected = state.selected
+            , width = options.width
             }
         ]
             |> List.map (Html.map parentMessage)

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -96,7 +96,7 @@ example parentMessage state =
                     |> List.map
                         (\i ->
                             { icon = options.icon
-                            , label = "Option " ++ Debug.toString i
+                            , label = "Choice " ++ Debug.toString i
                             , value = i
                             }
                         )

--- a/tests/Spec/Nri/Ui/SegmentedControl/V7.elm
+++ b/tests/Spec/Nri/Ui/SegmentedControl/V7.elm
@@ -1,6 +1,7 @@
 module Spec.Nri.Ui.SegmentedControl.V7 exposing (spec)
 
 import Accessibility.Aria as Aria
+import Accessibility.Widget as Widget
 import Expect
 import Html.Attributes
 import Html.Styled
@@ -45,14 +46,14 @@ spec =
                         }
                         |> Query.findAll [ Selector.attribute (Aria.controls "Nri-Ui-SegmentedControl-Panel-a-label") ]
                         |> Query.index 1
-                        |> Query.has [ Selector.attribute (Aria.currentItem True) ]
+                        |> Query.has [ Selector.attribute (Widget.selected True) ]
             , test "always has one item selected" <|
                 \() ->
                     toggleView
                         { options = [ 1, 2, 3 ]
                         , selected = 2
                         }
-                        |> Query.findAll [ Selector.attribute (Aria.currentItem True) ]
+                        |> Query.findAll [ Selector.attribute (Widget.selected True) ]
                         |> Query.count (Expect.equal 1)
             ]
         ]

--- a/tests/Spec/Nri/Ui/SegmentedControl/V7.elm
+++ b/tests/Spec/Nri/Ui/SegmentedControl/V7.elm
@@ -1,0 +1,58 @@
+module Spec.Nri.Ui.SegmentedControl.V7 exposing (spec)
+
+import Accessibility.Aria as Aria
+import Expect
+import Html.Attributes
+import Html.Styled
+import Nri.Ui.AssetPath exposing (Asset(..))
+import Nri.Ui.SegmentedControl.V7 as SegmentedControl
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+
+
+toggleView : { options : List a, selected : a } -> Query.Single ()
+toggleView config =
+    SegmentedControl.viewToggle
+        { onClick = \_ -> ()
+        , options =
+            config.options
+                |> List.map (\o -> { value = o, icon = Nothing, label = "a label" })
+        , selected = config.selected
+        , width = SegmentedControl.FitContent
+        }
+        |> Html.Styled.toUnstyled
+        |> Query.fromHtml
+
+
+spec : Test
+spec =
+    describe "Nri.Ui.SegmentedControl.V7"
+        [ describe "viewToggle"
+            [ test "displays the correct amount of options" <|
+                \() ->
+                    toggleView
+                        { options = [ 1, 2, 3 ]
+                        , selected = 1
+                        }
+                        |> Query.findAll [ Selector.text "a label" ]
+                        |> Query.count (Expect.equal 3)
+            , test "shows the correct item as selected" <|
+                \() ->
+                    toggleView
+                        { options = [ 1, 2, 3 ]
+                        , selected = 2
+                        }
+                        |> Query.findAll [ Selector.attribute (Aria.controls "Nri-Ui-SegmentedControl-Panel-a-label") ]
+                        |> Query.index 1
+                        |> Query.has [ Selector.attribute (Aria.currentItem True) ]
+            , test "always has one item selected" <|
+                \() ->
+                    toggleView
+                        { options = [ 1, 2, 3 ]
+                        , selected = 2
+                        }
+                        |> Query.findAll [ Selector.attribute (Aria.currentItem True) ]
+                        |> Query.count (Expect.equal 1)
+            ]
+        ]

--- a/tests/Spec/Nri/Ui/SegmentedControl/V7.elm
+++ b/tests/Spec/Nri/Ui/SegmentedControl/V7.elm
@@ -8,14 +8,19 @@ import Html.Styled
 import Nri.Ui.AssetPath exposing (Asset(..))
 import Nri.Ui.SegmentedControl.V7 as SegmentedControl
 import Test exposing (..)
+import Test.Html.Event as Event
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector
 
 
-toggleView : { options : List a, selected : a } -> Query.Single ()
+type Msg a
+    = Selected a
+
+
+toggleView : { options : List a, selected : a } -> Query.Single (Msg a)
 toggleView config =
     SegmentedControl.viewToggle
-        { onClick = \_ -> ()
+        { onClick = \new -> Selected new
         , options =
             config.options
                 |> List.map (\o -> { value = o, icon = Nothing, label = "a label" })
@@ -55,5 +60,15 @@ spec =
                         }
                         |> Query.findAll [ Selector.attribute (Widget.selected True) ]
                         |> Query.count (Expect.equal 1)
+            , test "shows the correct item as selected when the button was clicked" <|
+                \() ->
+                    toggleView
+                        { options = [ 1, 2, 3 ]
+                        , selected = 1
+                        }
+                        |> Query.findAll [ Selector.id "Nri-Ui-SegmentedControl-Tab-a-label" ]
+                        |> Query.index 1
+                        |> Event.simulate Event.click
+                        |> Event.expect (Selected 2)
             ]
         ]

--- a/tests/Spec/Nri/Ui/SegmentedControl/V7.elm
+++ b/tests/Spec/Nri/Ui/SegmentedControl/V7.elm
@@ -44,7 +44,7 @@ spec =
                         { options = [ 1, 2, 3 ]
                         , selected = 2
                         }
-                        |> Query.findAll [ Selector.attribute (Aria.controls "Nri-Ui-SegmentedControl-Panel-a-label") ]
+                        |> Query.findAll [ Selector.id "Nri-Ui-SegmentedControl-Tab-a-label" ]
                         |> Query.index 1
                         |> Query.has [ Selector.attribute (Widget.selected True) ]
             , test "always has one item selected" <|


### PR DESCRIPTION
### Background
The district report needs a segmented control but in the mock (https://at0hwb.axshare.com/#id=sbgn8r&p=district_report click the `skills tab`) it is used as an input element as opposed to a page control so this adds a version of the segmented control view called `viewToggle` that takes all the same stuff except `content`.

Allows for progress on https://www.pivotaltracker.com/story/show/167167857

### 🖼 Style Guide screenshot
![image](https://user-images.githubusercontent.com/5943972/64993367-c09b4b00-d88a-11e9-8150-6b85f890cc8c.png)
cc @bendansby making this change for the pathways toggle
