### PR TITLE
remove bottom padding from modal content in slide modal

### DIFF
--- a/src/Nri/Ui/SlideModal/V2.elm
+++ b/src/Nri/Ui/SlideModal/V2.elm
@@ -260,7 +260,13 @@ viewContent content =
         "modal-content"
         [ Css.overflowY Css.auto
         , Css.margin2 Css.zero (Css.px 21)
-        , Css.padding2 (Css.px 30) (Css.px 40)
+        , Css.paddingTop (Css.px 30)
+        , Css.paddingRight (Css.px 40)
+        , Css.paddingLeft (Css.px 40)
+
+        -- , Css.paddingBottom Css.zero
+        -- padding bottom used to be 30px. We removed it because it caused
+        -- scrolling where we didn't want any
         , Css.width (Css.pct 100)
         , Css.height (Css.pct 100)
         , Css.marginBottom Css.auto


### PR DESCRIPTION
paired with @tesk9 

remove padding-bottom to stop scrollbar from appearing when it's unnecessary
before
<img width="688" alt="Screen Shot 2019-09-19 at 5 27 07 PM" src="https://user-images.githubusercontent.com/60136/65258233-d74bd700-db02-11e9-961f-b09c3946d050.png">
after
<img width="688" alt="Screen Shot 2019-09-19 at 5 27 22 PM" src="https://user-images.githubusercontent.com/60136/65258240-d9ae3100-db02-11e9-90ac-68240895a38b.png">