### PR TITLE
Docs

### DIFF
--- a/src/Nri/Ui/Page/V3.elm
+++ b/src/Nri/Ui/Page/V3.elm
@@ -5,7 +5,8 @@ module Nri.Ui.Page.V3 exposing
 
 {-| A styled NRI issue page!
 
-@docs DefaultPage, broken, blocked, notFound, noPermission, RecoveryText(..)
+@docs DefaultPage, broken, blocked, notFound, noPermission
+@docs RecoveryText
 
 -}
 


### PR DESCRIPTION
<img width="687" alt="Screen Shot 2019-09-24 at 4 07 06 PM" src="https://user-images.githubusercontent.com/8811312/65556696-5f582500-dee5-11e9-9455-71c95c6c5974.png">

There are already bugs issued with similar stuff over there. This will make the doc comment show up properly for us.