### PR TITLE
Fix tab links roles

### DIFF
--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -14,7 +14,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # expect. This failure reminds us to come back and ratchet down the number of
 # failures to the correct value.
 NUM_ERRORS="$(jq '.violations | map(.nodes | length) | add' "$JSON_FILE")"
-TARGET_ERRORS=70
+TARGET_ERRORS=69
 if test "$NUM_ERRORS" -ne "$TARGET_ERRORS"; then
     echo "got $NUM_ERRORS errors, but expected $TARGET_ERRORS."
     echo

--- a/src/Nri/Ui/Tabs/V4.elm
+++ b/src/Nri/Ui/Tabs/V4.elm
@@ -28,10 +28,10 @@ module Nri.Ui.Tabs.V4 exposing
 
 -}
 
-import Accessibility.Aria
-import Accessibility.Key
-import Accessibility.Role
-import Accessibility.Widget
+import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Key as Key
+import Accessibility.Styled.Role as Role
+import Accessibility.Styled.Widget as Widget
 import Css exposing (..)
 import EventExtras
 import Html.Styled as Html exposing (Attribute, Html)
@@ -112,14 +112,14 @@ viewCustom config viewInnerTab =
                 |> Maybe.withDefault (Html.text "")
             , Html.styled Html.ul
                 (stylesTabsAligned config.alignment)
-                [ Attributes.fromUnstyled <| Accessibility.Role.tabList
+                [ Role.tabList
                 ]
                 viewTabs
             ]
         , Html.div
-            [ Attributes.fromUnstyled <| Accessibility.Role.tabPanel
-            , Attributes.fromUnstyled <| Accessibility.Aria.labelledBy (tabToId selected)
-            , Attributes.fromUnstyled <| Accessibility.Widget.hidden False
+            [ Role.tabPanel
+            , Aria.labelledBy (tabToId selected)
+            , Widget.hidden False
             , Attributes.id (tabToBodyId selected)
             ]
             [ config.content selected.id ]
@@ -151,13 +151,13 @@ viewTab { onSelect, tabs } viewInnerTab selected tab =
     Html.styled Html.li
         (stylesTabSelectable isSelected)
         [ Events.onClick (onSelect tab.id)
-        , Attributes.fromUnstyled <| Accessibility.Key.onKeyDown [ Accessibility.Key.enter (onSelect tab.id) ]
+        , Key.onKeyDown [ Key.enter (onSelect tab.id) ]
         , Events.onFocus (onSelect tab.id)
         , Attributes.tabindex 0
-        , Attributes.fromUnstyled <| Accessibility.Role.presentation
+        , Role.presentation
         , Attributes.id (tabToId tab)
-        , Attributes.fromUnstyled <| Accessibility.Aria.controls (tabToBodyId tab)
-        , Attributes.fromUnstyled <| Accessibility.Widget.selected (selected.id == tab.id)
+        , Aria.controls (tabToBodyId tab)
+        , Widget.selected (selected.id == tab.id)
         , Events.on "keyup" <|
             Json.Decode.andThen
                 (\keyCode ->
@@ -189,7 +189,7 @@ viewTab { onSelect, tabs } viewInnerTab selected tab =
             , Css.fontSize Css.inherit
             , Css.cursor Css.pointer
             ]
-            [ Attributes.fromUnstyled <| Accessibility.Role.tab
+            [ Role.tab
             , Attributes.tabindex -1
             ]
             [ viewInnerTab tab ]
@@ -247,7 +247,7 @@ links config =
                 |> Maybe.withDefault (Html.text "")
             , Html.styled Html.ul
                 (stylesTabsAligned config.alignment)
-                [ Attributes.fromUnstyled <| Accessibility.Role.tabList
+                [ Role.tabList
                 ]
                 (config.tabs
                     |> mapWithCurrent (viewTabLink config)
@@ -274,14 +274,14 @@ viewTabLink config isSelected tabConfig =
 
         currentPage =
             if isSelected then
-                [ Attributes.fromUnstyled <| Accessibility.Aria.currentPage ]
+                [ Aria.currentPage ]
 
             else
                 []
     in
     Html.styled Html.li
         (stylesTabSelectable isSelected)
-        [ Attributes.fromUnstyled <| Accessibility.Role.presentation
+        [ Role.presentation
         , Attributes.id (tabToId { label = tabLabel })
         ]
         [ case tabHref of
@@ -300,7 +300,7 @@ viewTabLink config isSelected tabConfig =
                     ]
                     (List.concat
                         [ [ Attributes.href href
-                          , Attributes.fromUnstyled <| Accessibility.Role.tab
+                          , Role.tab
                           ]
                         , preventDefault
                         , currentPage
@@ -321,7 +321,7 @@ viewTabLink config isSelected tabConfig =
                     , Css.lineHeight (Css.num 1)
                     ]
                     (List.concat
-                        [ [ Attributes.fromUnstyled <| Accessibility.Role.tab ]
+                        [ [ Role.tab ]
                         , currentPage
                         ]
                     )

--- a/src/Nri/Ui/Tabs/V4.elm
+++ b/src/Nri/Ui/Tabs/V4.elm
@@ -247,7 +247,8 @@ links config =
                 |> Maybe.withDefault (Html.text "")
             , Html.styled Html.ul
                 (stylesTabsAligned config.alignment)
-                []
+                [ Attributes.fromUnstyled <| Accessibility.Role.tabList
+                ]
                 (config.tabs
                     |> mapWithCurrent (viewTabLink config)
                     |> List.Zipper.toList
@@ -297,7 +298,14 @@ viewTabLink config isSelected tabConfig =
                         [ textDecoration none
                         ]
                     ]
-                    ([ Attributes.href href ] ++ preventDefault ++ currentPage)
+                    (List.concat
+                        [ [ Attributes.href href
+                          , Attributes.fromUnstyled <| Accessibility.Role.tab
+                          ]
+                        , preventDefault
+                        , currentPage
+                        ]
+                    )
                     [ Html.text tabLabel ]
 
             Nothing ->
@@ -312,7 +320,11 @@ viewTabLink config isSelected tabConfig =
                     , Css.property "background" "none"
                     , Css.lineHeight (Css.num 1)
                     ]
-                    currentPage
+                    (List.concat
+                        [ [ Attributes.fromUnstyled <| Accessibility.Role.tab ]
+                        , currentPage
+                        ]
+                    )
                     [ Html.text tabLabel ]
         ]
 


### PR DESCRIPTION
I noticed axe complaining about list elements over in the monolith, and realized that `Tabs.links` was missing a few `role` attributes. This adds them!
