### PR TITLE
Tessa/remove assets

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -66,6 +66,7 @@
         "Nri.Ui.PremiumCheckbox.V6",
         "Nri.Ui.SegmentedControl.V6",
         "Nri.Ui.SegmentedControl.V7",
+        "Nri.Ui.SegmentedControl.V8",
         "Nri.Ui.Select.V5",
         "Nri.Ui.Select.V6",
         "Nri.Ui.Slide.V1",

--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -14,7 +14,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # expect. This failure reminds us to come back and ratchet down the number of
 # failures to the correct value.
 NUM_ERRORS="$(jq '.violations | map(.nodes | length) | add' "$JSON_FILE")"
-TARGET_ERRORS=72
+TARGET_ERRORS=75
 if test "$NUM_ERRORS" -ne "$TARGET_ERRORS"; then
     echo "got $NUM_ERRORS errors, but expected $TARGET_ERRORS."
     echo

--- a/src/Nri/Ui/AssignmentIcon/V1.elm
+++ b/src/Nri/Ui/AssignmentIcon/V1.elm
@@ -12,17 +12,16 @@ module Nri.Ui.AssignmentIcon.V1 exposing
 @docs selfReview
 @docs peerReview, submitting, rating, revising
 
-    import Css
-    import Html.Styled exposing (..)
-    import Html.Styled.Attrbutes exposing (css)
+    import Html.Styled exposing (Html)
     import Nri.Ui.AssignmentIcon.V1 as AssignmentIcon
     import Nri.Ui.Colors.V1 as Colors
     import Nri.Ui.Svg.V1 as Svg
 
     view : Html msg
     view =
-        div [ css [ Css.color Colors.lichen ] ]
-            [ Svg.toHtml AssignmentIcon.diagnostic ]
+        AssignmentIcon.diagnostic
+            |> Svg.withColor Colors.lichen
+            |> Svg.toHtml
 
 -}
 

--- a/src/Nri/Ui/SegmentedControl/V8.elm
+++ b/src/Nri/Ui/SegmentedControl/V8.elm
@@ -5,8 +5,9 @@ module Nri.Ui.SegmentedControl.V8 exposing (Config, Option, Width(..), view, vie
 @docs Config, Option, Width, view, viewSpa, ToggleConfig, viewToggle
 
 Changes from V7:
-- remove dependence on Nri.Ui.Icon.V5
-- fix icons overlowing the segmented control
+
+  - remove dependence on Nri.Ui.Icon.V5
+  - fix icons overlowing the segmented control
 
 -}
 
@@ -220,6 +221,7 @@ viewTab config option =
                 span
                     [ css
                         [ maxWidth (px 18)
+                        , maxHeight (px 18)
                         , display inlineBlock
                         , verticalAlign middle
                         , lineHeight (px 15)

--- a/src/Nri/Ui/SegmentedControl/V8.elm
+++ b/src/Nri/Ui/SegmentedControl/V8.elm
@@ -221,9 +221,11 @@ viewTab config option =
                 span
                     [ css
                         [ maxWidth (px 18)
+                        , width (px 18)
                         , maxHeight (px 18)
+                        , height (px 18)
                         , display inlineBlock
-                        , verticalAlign middle
+                        , verticalAlign textTop
                         , lineHeight (px 15)
                         , marginRight (px 8)
                         ]

--- a/src/Nri/Ui/SegmentedControl/V8.elm
+++ b/src/Nri/Ui/SegmentedControl/V8.elm
@@ -1,0 +1,289 @@
+module Nri.Ui.SegmentedControl.V8 exposing (Config, Option, Width(..), view, viewSpa, ToggleConfig, viewToggle)
+
+{-|
+
+@docs Config, Option, Width, view, viewSpa, ToggleConfig, viewToggle
+
+Changes from V7:
+- remove dependence on Nri.Ui.Icon.V5
+- fix icons overlowing the segmented control
+
+-}
+
+import Accessibility.Styled exposing (..)
+import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Role as Role
+import Accessibility.Styled.Widget as Widget
+import Css exposing (..)
+import EventExtras.Styled as EventExtras
+import Html.Styled
+import Html.Styled.Attributes as Attr exposing (css, href)
+import Html.Styled.Events as Events
+import Nri.Ui
+import Nri.Ui.Colors.Extra exposing (withAlpha)
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Svg.V1 as Svg exposing (Svg)
+import Nri.Ui.Util exposing (dashify)
+
+
+{-|
+
+  - `onClick` : the message to produce when an option is selected (clicked) by the user
+  - `options`: the list of options available
+  - `selected`: the value of the currently-selected option
+  - `width`: how to size the segmented control
+  - `content`: the panel content for the selected option
+
+-}
+type alias Config a msg =
+    { onClick : a -> msg
+    , options : List (Option a)
+    , selected : a
+    , width : Width
+    , content : Html msg
+    }
+
+
+{-| Same shape as Config but without the content
+-}
+type alias ToggleConfig a msg =
+    { onClick : a -> msg
+    , options : List (Option a)
+    , selected : a
+    , width : Width
+    }
+
+
+{-| -}
+type alias Option a =
+    { value : a
+    , icon : Maybe Svg
+    , label : String
+    }
+
+
+{-| -}
+type Width
+    = FitContent
+    | FillContainer
+
+
+{-| -}
+view : Config a msg -> Html msg
+view config =
+    viewHelper Nothing config
+
+
+{-| Creates a segmented control that supports SPA navigation.
+You should always use this instead of `view` when building a SPA
+and the segmented control options correspond to routes in the SPA.
+
+The first parameter is a function that takes a `route` and returns the URL of that route.
+
+-}
+viewSpa : (route -> String) -> Config route msg -> Html msg
+viewSpa toUrl config =
+    viewHelper (Just toUrl) config
+
+
+{-| Creates _just the toggle_ when need the ui element itself and not a page control
+-}
+viewToggle : ToggleConfig a msg -> Html msg
+viewToggle config =
+    tabList
+        [ css
+            [ displayFlex
+            , cursor pointer
+            ]
+        ]
+        (List.map
+            (viewTab
+                { onClick = config.onClick
+                , selected = config.selected
+                , width = config.width
+                , selectedAttribute = Widget.selected True
+                , maybeToUrl = Nothing
+                }
+            )
+            config.options
+        )
+
+
+viewHelper : Maybe (a -> String) -> Config a msg -> Html msg
+viewHelper maybeToUrl config =
+    let
+        selected =
+            config.options
+                |> List.filter (\o -> o.value == config.selected)
+                |> List.head
+    in
+    div []
+        [ tabList
+            [ css
+                [ displayFlex
+                , cursor pointer
+                ]
+            ]
+            (List.map
+                (viewTab
+                    { onClick = config.onClick
+                    , selected = config.selected
+                    , width = config.width
+                    , selectedAttribute = Aria.currentPage
+                    , maybeToUrl = maybeToUrl
+                    }
+                )
+                config.options
+            )
+        , tabPanel
+            (List.filterMap identity
+                [ Maybe.map (Aria.labelledBy << tabIdFor) selected
+                , Just <| css [ paddingTop (px 10) ]
+                ]
+            )
+            [ config.content
+            ]
+        ]
+
+
+tabIdFor : Option a -> String
+tabIdFor option =
+    "Nri-Ui-SegmentedControl-Tab-" ++ dashify option.label
+
+
+panelIdFor : Option a -> String
+panelIdFor option =
+    "Nri-Ui-SegmentedControl-Panel-" ++ dashify option.label
+
+
+viewTab :
+    { onClick : a -> msg
+    , selected : a
+    , width : Width
+    , selectedAttribute : Attribute msg
+    , maybeToUrl : Maybe (a -> String)
+    }
+    -> Option a
+    -> Html msg
+viewTab config option =
+    let
+        idValue =
+            tabIdFor option
+
+        element attrs children =
+            case config.maybeToUrl of
+                Nothing ->
+                    -- This is for a non-SPA view
+                    button
+                        (Events.onClick (config.onClick option.value)
+                            :: attrs
+                        )
+                        children
+
+                Just toUrl ->
+                    -- This is a for a SPA view
+                    Html.Styled.a
+                        (href (toUrl option.value)
+                            :: EventExtras.onClickPreventDefaultForLinkWithHref
+                                (config.onClick option.value)
+                            :: attrs
+                        )
+                        children
+    in
+    element
+        (List.concat
+            [ [ Attr.id idValue
+              , Role.tab
+              , css sharedTabStyles
+              ]
+            , if option.value == config.selected then
+                [ css focusedTabStyles
+                , config.selectedAttribute
+                ]
+
+              else
+                [ css unFocusedTabStyles ]
+            , case config.width of
+                FitContent ->
+                    []
+
+                FillContainer ->
+                    [ css expandingTabStyles ]
+            ]
+        )
+        [ case option.icon of
+            Nothing ->
+                text ""
+
+            Just svg ->
+                span
+                    [ css
+                        [ maxWidth (px 18)
+                        , display inlineBlock
+                        , verticalAlign middle
+                        , lineHeight (px 15)
+                        , marginRight (px 8)
+                        ]
+                    ]
+                    [ Svg.toHtml svg ]
+        , text option.label
+        ]
+
+
+sharedTabStyles : List Style
+sharedTabStyles =
+    [ padding2 (px 6) (px 20)
+    , height (px 45)
+    , Fonts.baseFont
+    , fontSize (px 15)
+    , fontWeight bold
+    , lineHeight (px 30)
+    , firstOfType
+        [ borderTopLeftRadius (px 8)
+        , borderBottomLeftRadius (px 8)
+        , borderLeft3 (px 1) solid Colors.azure
+        ]
+    , lastOfType
+        [ borderTopRightRadius (px 8)
+        , borderBottomRightRadius (px 8)
+        ]
+    , border3 (px 1) solid Colors.azure
+    , borderLeft (px 0)
+    , boxSizing borderBox
+    , cursor pointer
+    , property "transition" "background-color 0.2s, color 0.2s, box-shadow 0.2s, border 0.2s, border-width 0s"
+    , textDecoration none
+    , hover
+        [ textDecoration none
+        ]
+    , focus
+        [ textDecoration none
+        ]
+    ]
+
+
+focusedTabStyles : List Style
+focusedTabStyles =
+    [ backgroundColor Colors.glacier
+    , boxShadow5 inset zero (px 3) zero (withAlpha 0.2 Colors.gray20)
+    , color Colors.navy
+    ]
+
+
+unFocusedTabStyles : List Style
+unFocusedTabStyles =
+    [ backgroundColor Colors.white
+    , boxShadow5 inset zero (px -2) zero Colors.azure
+    , color Colors.azure
+    , hover
+        [ backgroundColor Colors.frost
+        ]
+    ]
+
+
+expandingTabStyles : List Style
+expandingTabStyles =
+    [ flexGrow (int 1)
+    , textAlign center
+    ]

--- a/src/Nri/Ui/Svg/V1.elm
+++ b/src/Nri/Ui/Svg/V1.elm
@@ -1,22 +1,31 @@
 module Nri.Ui.Svg.V1 exposing
     ( Svg
+    , withColor
     , fromHtml, toHtml
     )
 
 {-|
 
 @docs Svg
+@docs withColor
 @docs fromHtml, toHtml
 
 -}
 
+import Css exposing (Color)
 import Html.Styled as Html exposing (Html)
-import Svg
+import Html.Styled.Attributes as Attributes
 
 
 {-| -}
 type Svg
     = Svg (Html Never)
+
+
+{-| -}
+withColor : Color -> Svg -> Svg
+withColor color (Svg svg) =
+    Svg (Html.span [ Attributes.css [ Css.color color ] ] [ svg ])
 
 
 {-| Tag html as being an svg.

--- a/src/Nri/Ui/UiIcon/V1.elm
+++ b/src/Nri/Ui/UiIcon/V1.elm
@@ -8,7 +8,7 @@ module Nri.Ui.UiIcon.V1 exposing
     , arrowDown
     , checkmark, x
     , attention, exclamation
-    , flag
+    , flag, star
     )
 
 {-|
@@ -54,7 +54,7 @@ module Nri.Ui.UiIcon.V1 exposing
 
 ### Notifs
 
-@docs flag
+@docs flag, star
 
 -}
 
@@ -502,7 +502,7 @@ flag =
     Svg.svg
         [ Attributes.width "100%"
         , Attributes.height "100%"
-        , Attributes.fill "currentcolor"
+        , Attributes.fill "#F3336C"
         , Attributes.viewBox "0 0 25 25"
         ]
         [ Svg.path
@@ -510,5 +510,77 @@ flag =
             , Attributes.d "M21.36 1.25C20.064.414 17.107-.368 13.036.324 9.688.894 6.155.308 5 .081a.965.965 0 0 0-1.36.895v23.051c0 .538.427.973.967.973.542 0 .98-.437.98-.973V12.933c1.242.414 3.589.931 6.564.35 4.043-.794 7.36.229 7.36.229 1.02-1.017 1.808-3.482 1.435-6.203-.407-2.958.414-6.06.414-6.06z"
             ]
             []
+        ]
+        |> Nri.Ui.Svg.V1.fromHtml
+
+
+{-| -}
+star : Nri.Ui.Svg.V1.Svg
+star =
+    Svg.svg
+        [ Attributes.width "100%"
+        , Attributes.height "100%"
+        , Attributes.viewBox "0 0 25 24"
+        ]
+        [ Svg.defs []
+            [ Svg.path
+                [ Attributes.id "stara"
+                , Attributes.d "M13.396.554l3.121 6.259a1 1 0 0 0 .744.542l6.89 1.054a1 1 0 0 1 .554 1.698l-4.966 4.937a1 1 0 0 0-.282.87l1.132 6.924a1 1 0 0 1-1.448 1.049l-6.18-3.216a1 1 0 0 0-.923 0L5.86 23.887a1 1 0 0 1-1.448-1.049l1.132-6.924a1 1 0 0 0-.282-.87L.295 10.107A1 1 0 0 1 .849 8.41l6.89-1.054a1 1 0 0 0 .744-.542l3.123-6.26a1 1 0 0 1 1.79.001z"
+                ]
+                []
+            , Svg.filter
+                [ Attributes.id "starb"
+                , Attributes.x "-8%"
+                , Attributes.y "-8.3%"
+                , Attributes.width "116%"
+                , Attributes.height "116.7%"
+                ]
+                [ Svg.feGaussianBlur
+                    [ Attributes.in_ "SourceAlpha"
+                    , Attributes.result "shadowBlurInner1"
+                    , Attributes.stdDeviation "1.5"
+                    ]
+                    []
+                , Svg.feOffset
+                    [ Attributes.dy "1"
+                    , Attributes.in_ "shadowBlurInner1"
+                    , Attributes.result "shadowOffsetInner1"
+                    ]
+                    []
+                , Svg.feComposite
+                    [ Attributes.in_ "shadowOffsetInner1"
+                    , Attributes.in2 "SourceAlpha"
+                    , Attributes.k2 "-1"
+                    , Attributes.k3 "1"
+                    , Attributes.operator "arithmetic"
+                    , Attributes.result "shadowInnerInner1"
+                    ]
+                    []
+                , Svg.feColorMatrix
+                    [ Attributes.in_ "shadowInnerInner1"
+                    , Attributes.values
+                        """
+                        0 0 0 0 1
+                        0 0 0 0 0.3
+                        0 0 0 0 0
+                        0 0 0 1 0
+                        """
+                    ]
+                    []
+                ]
+            ]
+        , Svg.g [ Attributes.fillRule "evenodd" ]
+            [ Svg.use
+                [ Attributes.fill "#FEC709"
+                , Attributes.xlinkHref "#stara"
+                ]
+                []
+            , Svg.use
+                [ Attributes.fill "#000"
+                , Attributes.filter "url(#starb)"
+                , Attributes.xlinkHref "#stara"
+                ]
+                []
+            ]
         ]
         |> Nri.Ui.Svg.V1.fromHtml

--- a/src/Nri/Ui/UiIcon/V1.elm
+++ b/src/Nri/Ui/UiIcon/V1.elm
@@ -8,6 +8,7 @@ module Nri.Ui.UiIcon.V1 exposing
     , arrowDown
     , checkmark, x
     , attention, exclamation
+    , flag
     )
 
 {-|
@@ -41,17 +42,19 @@ module Nri.Ui.UiIcon.V1 exposing
 @docs checkmark, x
 @docs attention, exclamation
 
-    import Css
     import Html.Styled exposing (..)
-    import Html.Styled.Attrbutes exposing (css)
     import Nri.Ui.Colors.V1 as Colors
     import Nri.Ui.Svg.V1 as Svg
     import Nri.Ui.UiIcon.V1 as UiIcon
 
     view : Html msg
     view =
-        div [ css [ Css.color Colors.lichen ] ]
-            [ Svg.toHtml UiIcon.unarchive ]
+        Svg.toHtml (Svg.withColor Colors.lichen UiIcon.unarchive)
+
+
+### Notifs
+
+@docs flag
 
 -}
 
@@ -487,6 +490,24 @@ attention =
             []
         , Svg.path
             [ Attributes.d "M2.57,0H2.48A2.46,2.46,0,0,0,0,2.36c0,.56,1.1,7.08,1.1,7.08a1.4,1.4,0,0,0,1.4,1.16h.06a1.4,1.4,0,0,0,1.4-1.16S5,2.93,5,2.36A2.46,2.46,0,0,0,2.57,0Z"
+            ]
+            []
+        ]
+        |> Nri.Ui.Svg.V1.fromHtml
+
+
+{-| -}
+flag : Nri.Ui.Svg.V1.Svg
+flag =
+    Svg.svg
+        [ Attributes.width "100%"
+        , Attributes.height "100%"
+        , Attributes.fill "currentcolor"
+        , Attributes.viewBox "0 0 25 25"
+        ]
+        [ Svg.path
+            [ Attributes.fillRule "evenodd"
+            , Attributes.d "M21.36 1.25C20.064.414 17.107-.368 13.036.324 9.688.894 6.155.308 5 .081a.965.965 0 0 0-1.36.895v23.051c0 .538.427.973.967.973.542 0 .98-.437.98-.973V12.933c1.242.414 3.589.931 6.564.35 4.043-.794 7.36.229 7.36.229 1.02-1.017 1.808-3.482 1.435-6.203-.407-2.958.414-6.06.414-6.06z"
             ]
             []
         ]

--- a/src/Nri/Ui/UiIcon/V1.elm
+++ b/src/Nri/Ui/UiIcon/V1.elm
@@ -8,7 +8,7 @@ module Nri.Ui.UiIcon.V1 exposing
     , arrowDown
     , checkmark, x
     , attention, exclamation
-    , flag, star
+    , flag, star, starOutline
     )
 
 {-|
@@ -54,7 +54,7 @@ module Nri.Ui.UiIcon.V1 exposing
 
 ### Notifs
 
-@docs flag, star
+@docs flag, star, starOutline
 
 -}
 
@@ -582,5 +582,25 @@ star =
                 ]
                 []
             ]
+        ]
+        |> Nri.Ui.Svg.V1.fromHtml
+
+
+{-| -}
+starOutline : Nri.Ui.Svg.V1.Svg
+starOutline =
+    Svg.svg
+        [ Attributes.width "100%"
+        , Attributes.height "100%"
+        , Attributes.viewBox "0 0 25 24"
+        ]
+        [ Svg.path
+            [ Attributes.fill "none"
+            , Attributes.fillRule "evenodd"
+            , Attributes.stroke "currentcolor"
+            , Attributes.strokeWidth "2"
+            , Attributes.d "M12.501 1L9.378 7.26A2 2 0 0 1 7.89 8.344L1 9.398l4.966 4.936a2 2 0 0 1 .564 1.742L5.397 23l6.18-3.216a2 2 0 0 1 1.846 0L19.603 23l-1.133-6.924a2 2 0 0 1 .564-1.742L24 9.398l-6.89-1.054a2 2 0 0 1-1.488-1.085L12.502 1z"
+            ]
+            []
         ]
         |> Nri.Ui.Svg.V1.fromHtml

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -11,11 +11,10 @@ import Debug.Control as Control exposing (Control)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css, id)
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample, ModuleMessages)
-import Nri.Ui.AssetPath exposing (Asset)
 import Nri.Ui.Button.V9 as Button
 import Nri.Ui.Heading.V2 as Heading
-import Nri.Ui.Icon.V5 as Icon
-import Nri.Ui.Svg.V1 as NriSvg exposing (Svg)
+import Nri.Ui.Svg.V1 as Svg exposing (Svg)
+import Nri.Ui.UiIcon.V1 as UiIcon
 
 
 {-| -}
@@ -76,11 +75,11 @@ type alias Model msg =
 
 
 {-| -}
-init : { r | performance : String, lock : String } -> State msg
-init assets =
+init : State msg
+init =
     Control.record Model
         |> Control.field "label" (Control.string "Label")
-        |> Control.field "icon" (iconChoice assets)
+        |> Control.field "icon" iconChoice
         |> Control.field "button type"
             (Control.choice
                 [ ( "button", Control.value Button )
@@ -108,26 +107,13 @@ init assets =
         |> State
 
 
-iconChoice : { r | performance : String, lock : String } -> Control.Control (Maybe Svg)
-iconChoice assets =
+iconChoice : Control.Control (Maybe Svg)
+iconChoice =
     Control.choice
-        [ ( "Nothing"
-          , Control.value Nothing
-          )
-        , ( "Just Performance"
-          , Icon.performance assets
-                |> Icon.decorativeIcon
-                |> NriSvg.fromHtml
-                |> Just
-                |> Control.value
-          )
-        , ( "Just Lock"
-          , Icon.lock assets
-                |> Icon.decorativeIcon
-                |> NriSvg.fromHtml
-                |> Just
-                |> Control.value
-          )
+        [ ( "Nothing", Control.value Nothing )
+        , ( "Just Performance", Control.value (Just UiIcon.performance) )
+        , ( "Just Share", Control.value (Just UiIcon.share) )
+        , ( "Just Download", Control.value (Just UiIcon.download) )
         ]
 
 

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -12,9 +12,9 @@ import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css, id)
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample, ModuleMessages)
 import Nri.Ui.ClickableText.V3 as ClickableText
-import Nri.Ui.Icon.V5 as Icon
-import Nri.Ui.Svg.V1 as NriSvg exposing (Svg)
+import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Text.V4 as Text
+import Nri.Ui.UiIcon.V1 as UiIcon
 
 
 {-| -}
@@ -45,31 +45,16 @@ example unnamedMessages state =
 
 
 {-| -}
-init : { r | performance : String, lock : String, help : String } -> State
-init assets =
+init : State
+init =
     Control.record Model
         |> Control.field "label" (Control.string "Clickable Text")
         |> Control.field "icon"
             (Control.maybe True <|
                 Control.choice
-                    [ ( "Help"
-                      , Icon.helpSvg assets
-                            |> Icon.decorativeIcon
-                            |> NriSvg.fromHtml
-                            |> Control.value
-                      )
-                    , ( "Performance"
-                      , Icon.performance assets
-                            |> Icon.decorativeIcon
-                            |> NriSvg.fromHtml
-                            |> Control.value
-                      )
-                    , ( "Lock"
-                      , Icon.lock assets
-                            |> Icon.decorativeIcon
-                            |> NriSvg.fromHtml
-                            |> Control.value
-                      )
+                    [ ( "Preview", Control.value UiIcon.preview )
+                    , ( "Performance", Control.value UiIcon.performance )
+                    , ( "Edit", Control.value UiIcon.edit )
                     ]
             )
         |> State

--- a/styleguide-app/Examples/Icon.elm
+++ b/styleguide-app/Examples/Icon.elm
@@ -31,9 +31,7 @@ example =
             , deprecatedIcon { icon = Icon.masteryBadge, background = Colors.frost, alt = "Badge " }
             ]
         , IconExamples.view "Stars and Flags"
-            [ deprecatedIcon { icon = Icon.starred, background = Colors.frost, alt = "Starred" }
-            , deprecatedIcon { icon = Icon.notStarred, background = Colors.frost, alt = "NotStarred" }
-            , deprecatedIcon { icon = Icon.flag, background = Colors.frost, alt = "Flag" }
+            [ deprecatedIcon { icon = Icon.notStarred, background = Colors.frost, alt = "NotStarred" }
             ]
         , IconExamples.view "Student Assignment Actions"
             [ deprecatedIcon { icon = Icon.assignmentStartButtonPrimary, background = Colors.frost, alt = "Start primary" }

--- a/styleguide-app/Examples/Icon.elm
+++ b/styleguide-app/Examples/Icon.elm
@@ -30,9 +30,6 @@ example =
             , deprecatedIcon { icon = Icon.thumbsUp, background = Colors.blue, alt = "ThumbsUp" }
             , deprecatedIcon { icon = Icon.masteryBadge, background = Colors.frost, alt = "Badge " }
             ]
-        , IconExamples.view "Stars and Flags"
-            [ deprecatedIcon { icon = Icon.notStarred, background = Colors.frost, alt = "NotStarred" }
-            ]
         , IconExamples.view "Student Assignment Actions"
             [ deprecatedIcon { icon = Icon.assignmentStartButtonPrimary, background = Colors.frost, alt = "Start primary" }
             , deprecatedIcon { icon = Icon.assignmentStartButtonSecondary, background = Colors.frost, alt = "Start secondary" }

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -24,34 +24,8 @@ import Html.Styled.Events as Events
 import ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.SegmentedControl.V8 as SegmentedControl
-import Nri.Ui.Svg.V1 as Svg exposing (Svg)
+import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.UiIcon.V1 as UiIcon
-
-
-{-| -}
-type Msg
-    = Select ExampleOption
-    | ChangeOptions (Control Options)
-
-
-type ExampleOption
-    = A
-    | B
-    | C
-
-
-{-| -}
-type alias State =
-    { selected : ExampleOption
-    , optionsControl : Control Options
-    }
-
-
-type alias Options =
-    { width : SegmentedControl.Width
-    , icon : Maybe Svg
-    , useSpa : Bool
-    }
 
 
 {-| -}
@@ -76,15 +50,7 @@ example parentMessage state =
           in
           viewFn
             { onClick = Select
-            , options =
-                [ A, B, C ]
-                    |> List.map
-                        (\i ->
-                            { icon = options.icon
-                            , label = "Option " ++ Debug.toString i
-                            , value = i
-                            }
-                        )
+            , options = buildOptions options
             , selected = state.selected
             , width = options.width
             , content = Html.text ("[Content for " ++ Debug.toString state.selected ++ "]")
@@ -93,15 +59,7 @@ example parentMessage state =
         , Html.p [] [ Html.text "Used when you only need the ui element and not a page control." ]
         , SegmentedControl.viewToggle
             { onClick = Select
-            , options =
-                [ A, B, C ]
-                    |> List.map
-                        (\i ->
-                            { icon = options.icon
-                            , label = "Choice " ++ Debug.toString i
-                            , value = i
-                            }
-                        )
+            , options = buildOptions options
             , selected = state.selected
             , width = options.width
             }
@@ -110,31 +68,77 @@ example parentMessage state =
     }
 
 
+buildOptions : Options -> List (SegmentedControl.Option ExampleOption)
+buildOptions options =
+    let
+        buildOption ( icon, option ) =
+            { icon =
+                if options.icon then
+                    Just icon
+
+                else
+                    Nothing
+            , label = "Choice " ++ Debug.toString option
+            , value = option
+            }
+    in
+    List.map buildOption
+        [ ( UiIcon.flag, A )
+        , ( UiIcon.star, B )
+        , ( Svg.withColor Colors.greenDark UiIcon.attention, C )
+        ]
+
+
+type ExampleOption
+    = A
+    | B
+    | C
+
+
+{-| -}
+type alias State =
+    { selected : ExampleOption
+    , optionsControl : Control Options
+    }
+
+
 {-| -}
 init : State
 init =
     { selected = A
-    , optionsControl =
-        Control.record Options
-            |> Control.field "width"
-                (Control.choice
-                    [ ( "FitContent", Control.value SegmentedControl.FitContent )
-                    , ( "FillContainer", Control.value SegmentedControl.FillContainer )
-                    ]
-                )
-            |> Control.field "icon" (Control.maybe False redFlagControl)
-            |> Control.field "which view function"
-                (Control.choice
-                    [ ( "view", Control.value False )
-                    , ( "viewSpa", Control.value True )
-                    ]
-                )
+    , optionsControl = optionsControl
     }
 
 
-redFlagControl : Control Svg
-redFlagControl =
-    Control.value (Svg.withColor Colors.red UiIcon.flag)
+type alias Options =
+    { width : SegmentedControl.Width
+    , icon : Bool
+    , useSpa : Bool
+    }
+
+
+optionsControl : Control Options
+optionsControl =
+    Control.record Options
+        |> Control.field "width"
+            (Control.choice
+                [ ( "FitContent", Control.value SegmentedControl.FitContent )
+                , ( "FillContainer", Control.value SegmentedControl.FillContainer )
+                ]
+            )
+        |> Control.field "icon" (Control.bool False)
+        |> Control.field "which view function"
+            (Control.choice
+                [ ( "view", Control.value False )
+                , ( "viewSpa", Control.value True )
+                ]
+            )
+
+
+{-| -}
+type Msg
+    = Select ExampleOption
+    | ChangeOptions (Control Options)
 
 
 {-| -}

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -22,8 +22,9 @@ import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attr
 import Html.Styled.Events as Events
 import ModuleExample exposing (Category(..), ModuleExample)
-import Nri.Ui.Icon.V5 as Icon
-import Nri.Ui.SegmentedControl.V7 as SegmentedControl
+import Nri.Ui.SegmentedControl.V8 as SegmentedControl
+import Nri.Ui.Svg.V1 as Svg exposing (Svg)
+import Nri.Ui.UiIcon.V1 as UiIcon
 
 
 {-| -}
@@ -47,7 +48,7 @@ type alias State =
 
 type alias Options =
     { width : SegmentedControl.Width
-    , icon : Maybe SegmentedControl.Icon
+    , icon : Maybe Svg
     , useSpa : Bool
     }
 
@@ -59,7 +60,7 @@ example parentMessage state =
         options =
             Control.currentValue state.optionsControl
     in
-    { name = "Nri.Ui.SegmentedControl.V7"
+    { name = "Nri.Ui.SegmentedControl.V8"
     , category = Widgets
     , content =
         [ Control.view ChangeOptions state.optionsControl
@@ -109,8 +110,8 @@ example parentMessage state =
 
 
 {-| -}
-init : { r | help : String } -> State
-init assets =
+init : State
+init =
     { selected = A
     , optionsControl =
         Control.record Options
@@ -120,8 +121,7 @@ init assets =
                     , ( "FillContainer", Control.value SegmentedControl.FillContainer )
                     ]
                 )
-            |> Control.field "icon"
-                (Control.maybe False (Control.value { alt = "Help", icon = Icon.helpSvg assets }))
+            |> Control.field "icon" (Control.maybe False (Control.value UiIcon.performance))
             |> Control.field "which view function"
                 (Control.choice
                     [ ( "view", Control.value False )

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -22,6 +22,7 @@ import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attr
 import Html.Styled.Events as Events
 import ModuleExample exposing (Category(..), ModuleExample)
+import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.SegmentedControl.V8 as SegmentedControl
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -121,7 +122,7 @@ init =
                     , ( "FillContainer", Control.value SegmentedControl.FillContainer )
                     ]
                 )
-            |> Control.field "icon" (Control.maybe False (Control.value UiIcon.performance))
+            |> Control.field "icon" (Control.maybe False redFlagControl)
             |> Control.field "which view function"
                 (Control.choice
                     [ ( "view", Control.value False )
@@ -129,6 +130,11 @@ init =
                     ]
                 )
     }
+
+
+redFlagControl : Control Svg
+redFlagControl =
+    Control.value (Svg.withColor Colors.red UiIcon.flag)
 
 
 {-| -}

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -24,7 +24,7 @@ import Html.Styled.Events as Events
 import ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.SegmentedControl.V8 as SegmentedControl
-import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.UiIcon.V1 as UiIcon
 
 
@@ -50,7 +50,7 @@ example parentMessage state =
           in
           viewFn
             { onClick = Select
-            , options = buildOptions options
+            , options = buildOptions options [ UiIcon.flag, UiIcon.star, Svg.withColor Colors.greenDark UiIcon.attention ]
             , selected = state.selected
             , width = options.width
             , content = Html.text ("[Content for " ++ Debug.toString state.selected ++ "]")
@@ -59,7 +59,7 @@ example parentMessage state =
         , Html.p [] [ Html.text "Used when you only need the ui element and not a page control." ]
         , SegmentedControl.viewToggle
             { onClick = Select
-            , options = buildOptions options
+            , options = buildOptions options [ UiIcon.leaderboard, UiIcon.person, UiIcon.performance ]
             , selected = state.selected
             , width = options.width
             }
@@ -68,10 +68,10 @@ example parentMessage state =
     }
 
 
-buildOptions : Options -> List (SegmentedControl.Option ExampleOption)
+buildOptions : Options -> List Svg -> List (SegmentedControl.Option ExampleOption)
 buildOptions options =
     let
-        buildOption ( icon, option ) =
+        buildOption option icon =
             { icon =
                 if options.icon then
                     Just icon
@@ -82,11 +82,7 @@ buildOptions options =
             , value = option
             }
     in
-    List.map buildOption
-        [ ( UiIcon.flag, A )
-        , ( UiIcon.star, B )
-        , ( Svg.withColor Colors.greenDark UiIcon.attention, C )
-        ]
+    List.map2 buildOption [ A, B, C ]
 
 
 type ExampleOption

--- a/styleguide-app/Examples/SlideModal.elm
+++ b/styleguide-app/Examples/SlideModal.elm
@@ -7,7 +7,6 @@ module Examples.SlideModal exposing (Msg, State, example, init, update)
 -}
 
 import Accessibility.Styled as Html exposing (Html, div, h3, p, text)
-import Assets
 import Css
 import Html.Styled exposing (fromUnstyled)
 import Html.Styled.Attributes exposing (css)

--- a/styleguide-app/Examples/UiIcon.elm
+++ b/styleguide-app/Examples/UiIcon.elm
@@ -60,6 +60,7 @@ example =
             ]
         , (IconExamples.view "Notifs" << List.map (Tuple.mapSecond Svg.toHtml))
             [ ( "flag", UiIcon.flag )
+            , ( "star", UiIcon.star )
             ]
         ]
     }

--- a/styleguide-app/Examples/UiIcon.elm
+++ b/styleguide-app/Examples/UiIcon.elm
@@ -58,5 +58,8 @@ example =
             , ( "attention", UiIcon.attention )
             , ( "exclamation", UiIcon.exclamation )
             ]
+        , (IconExamples.view "Notifs" << List.map (Tuple.mapSecond Svg.toHtml))
+            [ ( "flag", UiIcon.flag )
+            ]
         ]
     }

--- a/styleguide-app/Examples/UiIcon.elm
+++ b/styleguide-app/Examples/UiIcon.elm
@@ -61,6 +61,7 @@ example =
         , (IconExamples.view "Notifs" << List.map (Tuple.mapSecond Svg.toHtml))
             [ ( "flag", UiIcon.flag )
             , ( "star", UiIcon.star )
+            , ( "starOutline", UiIcon.starOutline )
             ]
         ]
     }

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -1,6 +1,5 @@
 module NriModules exposing (ModuleStates, Msg, init, nriThemedModules, subscriptions, update)
 
-import Assets exposing (assets)
 import Examples.Alert
 import Examples.AssignmentIcon
 import Examples.BannerAlert
@@ -63,7 +62,7 @@ init =
     , clickableTextExampleState = Examples.ClickableText.init
     , checkboxExampleState = Examples.Checkbox.init
     , dropdownState = Examples.Dropdown.init
-    , segmentedControlState = Examples.SegmentedControl.init assets
+    , segmentedControlState = Examples.SegmentedControl.init
     , selectState = Examples.Select.init
     , tableExampleState = Examples.Table.init
     , textAreaExampleState = TextAreaExample.init

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -58,7 +58,7 @@ type alias ModuleStates =
 
 init : ModuleStates
 init =
-    { buttonExampleState = Examples.Button.init assets
+    { buttonExampleState = Examples.Button.init
     , bannerAlertExampleState = Examples.BannerAlert.init
     , clickableTextExampleState = Examples.ClickableText.init assets
     , checkboxExampleState = Examples.Checkbox.init

--- a/styleguide-app/NriModules.elm
+++ b/styleguide-app/NriModules.elm
@@ -60,7 +60,7 @@ init : ModuleStates
 init =
     { buttonExampleState = Examples.Button.init
     , bannerAlertExampleState = Examples.BannerAlert.init
-    , clickableTextExampleState = Examples.ClickableText.init assets
+    , clickableTextExampleState = Examples.ClickableText.init
     , checkboxExampleState = Examples.Checkbox.init
     , dropdownState = Examples.Dropdown.init
     , segmentedControlState = Examples.SegmentedControl.init assets

--- a/styleguide-app/assets/images/attention.svg
+++ b/styleguide-app/assets/images/attention.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a62b30edd323c62dda5bc96a92331e79525ce1e3d1a2fa7038a44812e98dfbf8
-size 424

--- a/styleguide-app/assets/images/comment-notStarred.png
+++ b/styleguide-app/assets/images/comment-notStarred.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb85db21111f5a962a08bc46d5b517ca2039d944d091d15dc05a6aee101f5f08
-size 555

--- a/styleguide-app/assets/images/comment-starred.png
+++ b/styleguide-app/assets/images/comment-starred.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5f274f52cfe1b853e1e47e0f4ac16db67eaefc4e99219c714bbfc840f1a39807
-size 588

--- a/styleguide-app/assets/images/icon-flag.png
+++ b/styleguide-app/assets/images/icon-flag.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ca4fac243955fd46c714a1befb43cded71c475e15c03fb17d5c3ed6694a6906
-size 1004

--- a/styleguide-app/assets/images/pen.svg
+++ b/styleguide-app/assets/images/pen.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a2985134b44c3a9e25fea5d63f0ef5bcdf1b15de69946348c0f158de5ce08c65
-size 638

--- a/styleguide-app/assets/images/person-blue.svg
+++ b/styleguide-app/assets/images/person-blue.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a51dfa6de07beb7f708c5622bb3aebfbb83599e1cf662627174cb5da09d1df53
-size 716

--- a/styleguide-app/assets/images/unarchive-blue_2x.png
+++ b/styleguide-app/assets/images/unarchive-blue_2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94cb12d54e49a06b0aebad7cf3c636b0b616ce0b4a1cac767c9b273cff859c12
-size 1358

--- a/styleguide-app/assets/images/x-blue.svg
+++ b/styleguide-app/assets/images/x-blue.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:06683fc5e55eee3ac4e059a35ee69a3fc3874eaa775d1252393e619f30c828ae
-size 1618


### PR DESCRIPTION
While working on something else, I noticed that we were still passing an assets record to a few styleguide examples. This PR aims to fix that, so that we're only passing assets where it's unavoidable not to.

This required a new version of segmented control. As far as I can tell, SegmentedControl only uses Icons on the rate results page, so I focused on getting the segmented control example to look nice with Svg icons that correspond to the rate results view. 

<img width="717" alt="Screen Shot 2019-10-24 at 12 29 25 PM" src="https://user-images.githubusercontent.com/8811312/67519223-4618d480-f65b-11e9-8ea0-dfb8994ff8bc.png">

<details>
<summary>Rate results view, for reference
</summary>

<img width="795" alt="Screen Shot 2019-10-24 at 11 03 11 AM" src="https://user-images.githubusercontent.com/8811312/67519239-4f09a600-f65b-11e9-8b1d-7f51883586b5.png">


</details>

<details>
<summary>Styleguide showing icons prior to this change
</summary>

<img width="1163" alt="Screen Shot 2019-10-24 at 11 03 06 AM" src="https://user-images.githubusercontent.com/8811312/67519240-4f09a600-f65b-11e9-9cbe-44ec0adcb7c5.png">

</details>

I also had to convert some old icons to elm-svg to get this to work. However, it kinda seems like the svg code I exported from zeplin wasn't quite right. I had to futz with the feColorMatrix for the "star" icon to get it to look darker on the edges, and then the empty star seemed at first like the viewbox was wrong, but I think actually the path is getting cut off. @NoRedInk/design are there other icons I should use? 

<img width="595" alt="Screen Shot 2019-10-24 at 12 42 20 PM" src="https://user-images.githubusercontent.com/8811312/67519739-554c5200-f65c-11e9-8343-227a615a7ec0.png">
