### PR TITLE
apply overflow hidden to segmented control buttons

### DIFF
--- a/src/Nri/Ui/SegmentedControl/V8.elm
+++ b/src/Nri/Ui/SegmentedControl/V8.elm
@@ -239,6 +239,7 @@ sharedTabStyles : List Style
 sharedTabStyles =
     [ padding2 (px 6) (px 20)
     , height (px 45)
+    , overflow hidden
     , Fonts.baseFont
     , fontSize (px 15)
     , fontWeight bold


### PR DESCRIPTION
paired with @quelledanielle 

before:
<img width="381" alt="Screen Shot 2019-11-08 at 4 17 55 PM" src="https://user-images.githubusercontent.com/60136/68487470-6c399980-0243-11ea-8269-f9eff3dc5336.png">

after:
<img width="248" alt="Screen Shot 2019-11-08 at 4 17 36 PM" src="https://user-images.githubusercontent.com/60136/68487472-6c399980-0243-11ea-9933-11c3e1b3b1a6.png">

not GREAT but ... not worse?