### PR TITLE
Fix duped ids

### DIFF
--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -14,7 +14,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # expect. This failure reminds us to come back and ratchet down the number of
 # failures to the correct value.
 NUM_ERRORS="$(jq '.violations | map(.nodes | length) | add' "$JSON_FILE")"
-TARGET_ERRORS=66
+TARGET_ERRORS=62
 if test "$NUM_ERRORS" -ne "$TARGET_ERRORS"; then
     echo "got $NUM_ERRORS errors, but expected $TARGET_ERRORS."
     echo

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -85,7 +85,7 @@ example parentMessage state =
                     }
                 , Heading.h3 [] [ Html.text "invisible label" ]
                 , TextInput.view
-                    { label = "Criterion"
+                    { label = "Invisible label text input"
                     , isInError = False
                     , placeholder = "For example, \"Something!!\""
                     , value = Maybe.withDefault "" <| Dict.get 2 state.textInputValues
@@ -97,7 +97,7 @@ example parentMessage state =
                     }
                 , Html.br [] []
                 , TextInput.view
-                    { label = "Criterion"
+                    { label = "Invisible label text input with error"
                     , placeholder = "Everything you type is wrong!"
                     , value = Maybe.withDefault "" <| Dict.get 3 state.textInputValues
                     , onInput = SetTextInput 3


### PR DESCRIPTION
<img width="1061" alt="Screen Shot 2019-11-08 at 12 28 29 PM" src="https://user-images.githubusercontent.com/8811312/68508652-c75b9400-0223-11ea-889e-630cb6db80b2.png">

Text input ids were duplicated in the styleguide. This resolves.