### PR TITLE
Fix a11y low hanging fruit

### DIFF
--- a/script/axe-report.jq
+++ b/script/axe-report.jq
@@ -1,5 +1,5 @@
-def node: "    at \(.target | join(" ")):\n\n      \(.failureSummary | gsub("\n"; "\n      "))";
-def violation: "  \(.id): \(.impact) violation with \(.nodes | length) instances.\n\n  \(.help) (\(.helpUrl))\n\n\(.nodes | map(node) | join("\n\n"))";
+def node: "  at \(.target | join(" ")):\n\n    \(.failureSummary | gsub("\n"; "\n    "))";
+def violation: "\(.id): \(.impact) violation with \(.nodes | length) instances.\n\n\(.help) (\(.helpUrl))\n\n\(.nodes | map(node) | join("\n\n"))";
 
 "Tested \(.url) with \(.testEngine.name) \(.testEngine.version) at \(.timestamp)
 
@@ -11,5 +11,7 @@ Summary: \(.passes | length) passes | \(.violations | map(.nodes | length) | add
 
 Violations:
 
-\(.violations | map(violation) | join("\n\n"))
+----------
+
+\(.violations | map(violation) | join("\n\n----------\n\n"))
 "

--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -12,7 +12,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # Hey there! Did this script tell you to check out this file because the
 # expected error count went down? Well done! Just change this number to the new
 # value.
-TARGET_ERRORS=36
+TARGET_ERRORS=31
 
 # ideally we'd fail on any failures, but we have had a bunch build up over time!
 # So right now, we need to fail if the error count is not exactly what we

--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -12,7 +12,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # Hey there! Did this script tell you to check out this file because the
 # expected error count went down? Well done! Just change this number to the new
 # value.
-TARGET_ERRORS=48
+TARGET_ERRORS=47
 
 # ideally we'd fail on any failures, but we have had a bunch build up over time!
 # So right now, we need to fail if the error count is not exactly what we

--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -12,7 +12,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # Hey there! Did this script tell you to check out this file because the
 # expected error count went down? Well done! Just change this number to the new
 # value.
-TARGET_ERRORS=61
+TARGET_ERRORS=59
 
 # ideally we'd fail on any failures, but we have had a bunch build up over time!
 # So right now, we need to fail if the error count is not exactly what we

--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -9,12 +9,16 @@ fi
 
 jq -r -f script/axe-report.jq "$JSON_FILE"
 
+# Hey there! Did this script tell you to check out this file because the
+# expected error count went down? Well done! Just change this number to the new
+# value.
+TARGET_ERRORS=61
+
 # ideally we'd fail on any failures, but we have had a bunch build up over time!
 # So right now, we need to fail if the error count is not exactly what we
 # expect. This failure reminds us to come back and ratchet down the number of
 # failures to the correct value.
 NUM_ERRORS="$(jq '.violations | map(.nodes | length) | add' "$JSON_FILE")"
-TARGET_ERRORS=62
 if test "$NUM_ERRORS" -ne "$TARGET_ERRORS"; then
     echo "got $NUM_ERRORS errors, but expected $TARGET_ERRORS."
     echo

--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -12,7 +12,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # Hey there! Did this script tell you to check out this file because the
 # expected error count went down? Well done! Just change this number to the new
 # value.
-TARGET_ERRORS=56
+TARGET_ERRORS=55
 
 # ideally we'd fail on any failures, but we have had a bunch build up over time!
 # So right now, we need to fail if the error count is not exactly what we

--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -27,6 +27,6 @@ if test "$NUM_ERRORS" -ne "$TARGET_ERRORS"; then
     echo " 1. save this output somewhere ('make axe-report > errors.new')"
     echo " 2. undo your changes ('git stash' or 'checkout master')"
     echo " 3. regenerate the log with 'make axe-report > errors.old'"
-    echo " 4. see waht's new with 'diff -u errors.old errors.new'"
+    echo " 4. see what's new with 'diff -u errors.old errors.new'"
     exit 1
 fi

--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -12,7 +12,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # Hey there! Did this script tell you to check out this file because the
 # expected error count went down? Well done! Just change this number to the new
 # value.
-TARGET_ERRORS=59
+TARGET_ERRORS=56
 
 # ideally we'd fail on any failures, but we have had a bunch build up over time!
 # So right now, we need to fail if the error count is not exactly what we

--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -12,7 +12,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # Hey there! Did this script tell you to check out this file because the
 # expected error count went down? Well done! Just change this number to the new
 # value.
-TARGET_ERRORS=39
+TARGET_ERRORS=36
 
 # ideally we'd fail on any failures, but we have had a bunch build up over time!
 # So right now, we need to fail if the error count is not exactly what we

--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -12,7 +12,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # Hey there! Did this script tell you to check out this file because the
 # expected error count went down? Well done! Just change this number to the new
 # value.
-TARGET_ERRORS=55
+TARGET_ERRORS=48
 
 # ideally we'd fail on any failures, but we have had a bunch build up over time!
 # So right now, we need to fail if the error count is not exactly what we

--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -12,7 +12,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # Hey there! Did this script tell you to check out this file because the
 # expected error count went down? Well done! Just change this number to the new
 # value.
-TARGET_ERRORS=45
+TARGET_ERRORS=39
 
 # ideally we'd fail on any failures, but we have had a bunch build up over time!
 # So right now, we need to fail if the error count is not exactly what we

--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -12,7 +12,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # Hey there! Did this script tell you to check out this file because the
 # expected error count went down? Well done! Just change this number to the new
 # value.
-TARGET_ERRORS=46
+TARGET_ERRORS=45
 
 # ideally we'd fail on any failures, but we have had a bunch build up over time!
 # So right now, we need to fail if the error count is not exactly what we

--- a/script/format-axe-report.sh
+++ b/script/format-axe-report.sh
@@ -12,7 +12,7 @@ jq -r -f script/axe-report.jq "$JSON_FILE"
 # Hey there! Did this script tell you to check out this file because the
 # expected error count went down? Well done! Just change this number to the new
 # value.
-TARGET_ERRORS=47
+TARGET_ERRORS=46
 
 # ideally we'd fail on any failures, but we have had a bunch build up over time!
 # So right now, we need to fail if the error count is not exactly what we

--- a/src/Nri/Ui/Callout/V1.elm
+++ b/src/Nri/Ui/Callout/V1.elm
@@ -133,7 +133,7 @@ callout attrs children =
         finalAttrs =
             List.foldl customize defaultAttrs attrs
     in
-    Html.aside
+    Html.div
         (css
             ([ Css.boxSizing Css.borderBox
              , Css.backgroundColor Colors.sunshine

--- a/src/Nri/Ui/Colors/V1.elm
+++ b/src/Nri/Ui/Colors/V1.elm
@@ -558,7 +558,7 @@ purpleDark =
 -}
 red : Css.Color
 red =
-    hex "#f3336c"
+    hex "#e70d4f"
 
 
 {-|

--- a/src/Nri/Ui/Tabs/V4.elm
+++ b/src/Nri/Ui/Tabs/V4.elm
@@ -157,7 +157,6 @@ viewTab { onSelect, tabs } viewInnerTab selected tab =
         , Role.presentation
         , Attributes.id (tabToId tab)
         , Aria.controls (tabToBodyId tab)
-        , Widget.selected (selected.id == tab.id)
         , Events.on "keyup" <|
             Json.Decode.andThen
                 (\keyCode ->
@@ -191,6 +190,7 @@ viewTab { onSelect, tabs } viewInnerTab selected tab =
             ]
             [ Role.tab
             , Attributes.tabindex -1
+            , Widget.selected (selected.id == tab.id)
             ]
             [ viewInnerTab tab ]
         ]

--- a/src/Nri/Ui/Tabs/V4.elm
+++ b/src/Nri/Ui/Tabs/V4.elm
@@ -156,7 +156,6 @@ viewTab { onSelect, tabs } viewInnerTab selected tab =
         , Attributes.tabindex 0
         , Role.presentation
         , Attributes.id (tabToId tab)
-        , Aria.controls (tabToBodyId tab)
         , Events.on "keyup" <|
             Json.Decode.andThen
                 (\keyCode ->
@@ -335,12 +334,12 @@ viewTabLink config isSelected tabConfig =
 
 tabToId : { a | label : String } -> String
 tabToId tab =
-    tab.label
+    String.replace " " "-" tab.label
 
 
 tabToBodyId : { a | label : String } -> String
 tabToBodyId tab =
-    "tab-body-" ++ tab.label
+    "tab-body-" ++ tabToId tab
 
 
 mapWithCurrent : (Bool -> a -> b) -> Zipper a -> Zipper b

--- a/src/Nri/Ui/Tooltip/V1.elm
+++ b/src/Nri/Ui/Tooltip/V1.elm
@@ -56,6 +56,7 @@ import Css.Global as Global
 import EventExtras.Styled as EventExtras
 import Html.Styled.Attributes as Attributes exposing (css)
 import Html.Styled.Events as Events
+import Json.Encode as Encode
 import Nri.Ui
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
@@ -305,12 +306,20 @@ viewTooltip_ purpose { trigger, triggerHtml, onTrigger, isOpen, id, extraButtonA
         tooltipContainerStyles
         []
         [ Html.button
-            ([ case purpose of
-                PrimaryLabel ->
-                    Aria.labeledBy id
+            ([ if isOpen then
+                case purpose of
+                    PrimaryLabel ->
+                        Aria.labeledBy id
 
-                AuxillaryDescription ->
-                    Aria.describedBy [ id ]
+                    AuxillaryDescription ->
+                        Aria.describedBy [ id ]
+
+               else
+                -- when our tooltips are closed, they're not rendered in the
+                -- DOM. This means that the ID references above would be
+                -- invalid and jumping to a reference would not work, so we
+                -- skip labels and descriptions if the tooltip is closed.
+                Attributes.property "data-closed-tooltip" Encode.null
              , css buttonStyleOverrides
              ]
                 ++ eventsForTrigger trigger onTrigger

--- a/styleguide-app/Examples/Accordion.elm
+++ b/styleguide-app/Examples/Accordion.elm
@@ -27,7 +27,7 @@ example parentMessage model =
     { name = "Nri.Ui.Accordion.V1"
     , category = Layout
     , content =
-        [ Heading.h5 [] [ Html.text "Accordion.view with default styles" ]
+        [ Heading.h3 [] [ Html.text "Accordion.view with default styles" ]
         , Accordion.view
             { entries =
                 [ { id = 1, title = "Entry 1", content = "Content for the first accordion" }
@@ -44,7 +44,7 @@ example parentMessage model =
             , toggle = \entry toExpand -> Toggle entry.id toExpand
             , caret = Accordion.DefaultCaret
             }
-        , Heading.h5 [] [ Html.text "Accordion.view with custom styles from peer reviews" ]
+        , Heading.h3 [] [ Html.text "Accordion.view with custom styles from peer reviews" ]
         , Accordion.view
             { entries =
                 [ { id = 4

--- a/styleguide-app/Examples/Alert.elm
+++ b/styleguide-app/Examples/Alert.elm
@@ -9,6 +9,7 @@ module Examples.Alert exposing (example)
 import Html.Styled as Html
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.Alert.V4 as Alert
+import Nri.Ui.Heading.V2 as Heading
 
 
 example : ModuleExample msg
@@ -16,13 +17,13 @@ example =
     { name = "Nri.Ui.Alert.V4"
     , category = Messaging
     , content =
-        [ Html.h4 [] [ Html.text "Markdown-supporting:" ]
+        [ Heading.h3 [] [ Html.text "Markdown-supporting:" ]
         , Alert.error "This is an **error**"
         , Alert.warning "This is a **warning**"
         , Alert.tip "This is a **tip**"
         , Alert.success "This is a **success**"
         , Html.hr [] []
-        , Html.h4 [] [ Html.text "Stacktraces-supporting:" ]
+        , Heading.h3 [] [ Html.text "Stacktraces-supporting:" ]
         , Alert.somethingWentWrong exampleRailsError
         ]
     }

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -130,15 +130,15 @@ viewMultilineCheckboxes =
         [ css [ Css.width (Css.px 500) ] ]
         [ Html.h3 [] [ Html.text "Multiline Text in Checkboxes" ]
         , Checkbox.viewWithLabel
-            { identifier = "fake"
+            { identifier = "fake-not-selected"
             , label = "Ut nobis et vel. Nulla rerum sit eos accusamus placeat. Iure sunt earum voluptatibus autem ratione soluta sint.\n\nIste perferendis eum corporis ullam magnam incidunt eos."
-            , setterMsg = ToggleCheck "fake"
+            , setterMsg = ToggleCheck "fake-not-selected"
             , selected = Checkbox.NotSelected
             , disabled = False
             , theme = Checkbox.Square
             }
         , Checkbox.viewWithLabel
-            { identifier = "fake"
+            { identifier = "fake-partially-selected"
             , label = "Ut nobis et vel. Nulla rerum sit eos accusamus placeat. Iure sunt earum voluptatibus autem ratione soluta sint.\n\nIste perferendis eum corporis ullam magnam incidunt eos."
             , setterMsg = ToggleCheck "fake"
             , selected = Checkbox.PartiallySelected
@@ -146,7 +146,7 @@ viewMultilineCheckboxes =
             , theme = Checkbox.Square
             }
         , Checkbox.viewWithLabel
-            { identifier = "fake"
+            { identifier = "fake-not-selected-locked"
             , label = "Ut nobis et vel. Nulla rerum sit eos accusamus placeat. Iure sunt earum voluptatibus autem ratione soluta sint.\n\nIste perferendis eum corporis ullam magnam incidunt eos."
             , setterMsg = ToggleCheck "fake"
             , selected = Checkbox.NotSelected
@@ -154,7 +154,7 @@ viewMultilineCheckboxes =
             , theme = Checkbox.Locked
             }
         , Checkbox.viewWithLabel
-            { identifier = "fake"
+            { identifier = "fake-not-selected-square"
             , label = "Ut nobis et vel. Nulla rerum sit eos accusamus placeat. Iure sunt earum voluptatibus autem ratione soluta sint.\n\nIste perferendis eum corporis ullam magnam incidunt eos."
             , setterMsg = ToggleCheck "fake"
             , selected = Checkbox.NotSelected

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -167,10 +167,13 @@ viewMultilineCheckboxes =
 viewPremiumCheckboxes : State -> Html Msg
 viewPremiumCheckboxes state =
     let
+        safeId =
+            String.replace " " "-"
+
         checkbox config =
             PremiumCheckbox.view
                 { label = config.label
-                , id = "premium-checkbox-" ++ config.label
+                , id = "premium-checkbox-" ++ safeId config.label
                 , selected =
                     if Set.member config.label state.isChecked then
                         Checkbox.Selected

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -26,17 +26,17 @@ example noOp =
                 , Css.flexWrap Css.wrap
                 ]
             ]
-        , Heading.h4 [] [ Html.text "Page: Not Found, recovery text: ReturnTo" ]
+        , Heading.h3 [] [ Html.text "Page: Not Found, recovery text: ReturnTo" ]
         , Page.notFound
             { link = noOp
             , recoveryText = Page.ReturnTo "the main page"
             }
-        , Heading.h4 [] [ Html.text "Page: Broken, recovery text: Reload" ]
+        , Heading.h3 [] [ Html.text "Page: Broken, recovery text: Reload" ]
         , Page.broken
             { link = noOp
             , recoveryText = Page.Reload
             }
-        , Heading.h4 [] [ Html.text "Page: No Permission, recovery text: Custom" ]
+        , Heading.h3 [] [ Html.text "Page: No Permission, recovery text: Custom" ]
         , Page.noPermission
             { link = noOp
             , recoveryText = Page.Custom "Hit the road, Jack"

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -50,7 +50,7 @@ example parentMessage state =
           in
           viewFn
             { onClick = Select
-            , options = buildOptions options [ UiIcon.flag, UiIcon.star, Svg.withColor Colors.greenDark UiIcon.attention ]
+            , options = buildOptions "" options [ UiIcon.flag, UiIcon.star, Svg.withColor Colors.greenDark UiIcon.attention ]
             , selected = state.selected
             , width = options.width
             , content = Html.text ("[Content for " ++ Debug.toString state.selected ++ "]")
@@ -59,7 +59,7 @@ example parentMessage state =
         , Html.p [] [ Html.text "Used when you only need the ui element and not a page control." ]
         , SegmentedControl.viewToggle
             { onClick = Select
-            , options = buildOptions options [ UiIcon.leaderboard, UiIcon.person, UiIcon.performance ]
+            , options = buildOptions "Toggle-Only " options [ UiIcon.leaderboard, UiIcon.person, UiIcon.performance ]
             , selected = state.selected
             , width = options.width
             }
@@ -68,8 +68,8 @@ example parentMessage state =
     }
 
 
-buildOptions : Options -> List Svg -> List (SegmentedControl.Option ExampleOption)
-buildOptions options =
+buildOptions : String -> Options -> List Svg -> List (SegmentedControl.Option ExampleOption)
+buildOptions prefix options =
     let
         buildOption option icon =
             { icon =
@@ -78,7 +78,7 @@ buildOptions options =
 
                 else
                     Nothing
-            , label = "Choice " ++ Debug.toString option
+            , label = prefix ++ "Choice " ++ Debug.toString option
             , value = option
             }
     in

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -19,7 +19,9 @@ module Examples.Select exposing
 -}
 
 import Html.Styled
+import Html.Styled.Attributes
 import ModuleExample exposing (Category(..), ModuleExample)
+import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Select.V6 as Select
 
 
@@ -44,7 +46,10 @@ example parentMessage state =
     { name = "Nri.Ui.Select.V6"
     , category = Inputs
     , content =
-        [ Html.Styled.map (parentMessage << ConsoleLog) (Select.view state)
+        [ Html.Styled.label
+            [ Html.Styled.Attributes.for "tortilla-selector" ]
+            [ Heading.h3 [] [ Html.Styled.text "Tortilla Selector" ] ]
+        , Html.Styled.map (parentMessage << ConsoleLog) (Select.view state)
         ]
     }
 
@@ -58,7 +63,7 @@ init =
         , { label = "Burritos", value = "Burritos" }
         , { label = "Enchiladas", value = "Enchiladas" }
         ]
-    , id = Nothing
+    , id = Just "tortilla-selector"
     , valueToString = identity
     , defaultDisplayText = Just "Select a tasty tortilla based treat!"
     }

--- a/styleguide-app/Examples/Slide.elm
+++ b/styleguide-app/Examples/Slide.elm
@@ -117,10 +117,10 @@ viewPanel panel animation =
         ( color, text, key ) =
             case panel of
                 One ->
-                    ( Colors.red, "Panel One", "panel-1" )
+                    ( Colors.redDark, "Panel One", "panel-1" )
 
                 Two ->
-                    ( Colors.yellow, "Panel Two", "panel-2" )
+                    ( Colors.ochre, "Panel Two", "panel-2" )
 
                 Three ->
                     ( Colors.green, "Panel Three", "panel-3" )

--- a/styleguide-app/Examples/SortableTable.elm
+++ b/styleguide-app/Examples/SortableTable.elm
@@ -8,6 +8,7 @@ module Examples.SortableTable exposing (Msg, State, example, init, update)
 
 import Html.Styled as Html
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
+import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.SortableTable.V1 as SortableTable
 
 
@@ -68,9 +69,9 @@ example parentMessage { sortState } =
                 , { firstName = "First5", lastName = "Last5", coins = 5 }
                 ]
         in
-        [ Html.h4 [] [ Html.text "With sortable headers" ]
+        [ Heading.h3 [] [ Html.text "With sortable headers" ]
         , SortableTable.view config sortState data
-        , Html.h4 [] [ Html.text "Loading" ]
+        , Heading.h3 [] [ Html.text "Loading" ]
         , SortableTable.viewLoading config sortState
         ]
             |> List.map (Html.map parentMessage)

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -85,15 +85,15 @@ example parentMessage state =
                 , { firstName = "First5", lastName = "Last5", submitted = 8 }
                 ]
         in
-        [ Heading.h4 [] [ Html.text "With header" ]
+        [ Heading.h3 [] [ Html.text "With header" ]
         , Table.view columns data
-        , Heading.h4 [] [ Html.text "Without header" ]
+        , Heading.h3 [] [ Html.text "Without header" ]
         , Table.viewWithoutHeader columns data
-        , Heading.h4 [] [ Html.text "With additional cell styles" ]
+        , Heading.h3 [] [ Html.text "With additional cell styles" ]
         , Table.view columns data
-        , Heading.h4 [] [ Html.text "Loading" ]
+        , Heading.h3 [] [ Html.text "Loading" ]
         , Table.viewLoading columns
-        , Heading.h4 [] [ Html.text "Loading without header" ]
+        , Heading.h3 [] [ Html.text "Loading without header" ]
         , Table.viewLoadingWithoutHeader columns
         ]
             |> List.map (Html.map parentMessage)

--- a/styleguide-app/View.elm
+++ b/styleguide-app/View.elm
@@ -119,7 +119,7 @@ navigation route =
                 ]
                 [ element ]
     in
-    Html.styled Html.div
+    Html.styled Html.nav
         [ flexBasis (px 200)
         , backgroundColor Colors.gray96
         , marginRight (px 40)
@@ -128,7 +128,9 @@ navigation route =
         , top (px 150)
         , flexShrink zero
         ]
-        [ id "categories" ]
+        [ id "categories"
+        , attribute "aria-label" "Main Navigation"
+        ]
         [ Heading.h4 [] [ Html.text "Categories" ]
         , (categoryLink (route == Routes.All) "#" "All"
             :: List.map

--- a/styleguide-app/View.elm
+++ b/styleguide-app/View.elm
@@ -33,7 +33,7 @@ view_ model =
         ]
         []
         [ navigation model.route
-        , Html.styled Html.div
+        , Html.styled Html.main_
             [ flexGrow (int 1) ]
             []
             (case model.route of

--- a/styleguide-app/index.html
+++ b/styleguide-app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>NoRedInk style guide</title>


### PR DESCRIPTION
this gets rid of ~26~ 31 easy-ish AXE violations. There are a few left but clearing these out revealed which are hard and which are easy. (This was 50% of our Axe violations BTW!)

remaining issues after this:

- controls from avh4/elm-debug-controls are not labeled. I submitted a PR but goofed and made invalid HTML… probably a way to get around this but it turned into non-low-hanging-fruit!
- some SVG elements have duplicate IDs for filters. Unfortunately I don't see a way around this if we're going to embed those directly instead of referencing them ☹️
- ~some elements do not have sufficient color contrast. I'm gonna get together a list and ask Design about them.~ We're darkening the default red to meet AA levels (4.5:1) 💪 
- the style guide doesn't have skip links.

This also makes the axe report much easier to scan by relying less on 2-space indentation for hierarchy.