### PR TITLE
add an input type that handles floats

### DIFF
--- a/src/Nri/Ui/TextInput/V5.elm
+++ b/src/Nri/Ui/TextInput/V5.elm
@@ -2,7 +2,7 @@ module Nri.Ui.TextInput.V5 exposing
     ( Model
     , view, writing
     , generateId
-    , number, text, password
+    , number, float, text, password
     )
 
 {-|
@@ -19,7 +19,7 @@ module Nri.Ui.TextInput.V5 exposing
 
 ## Input types
 
-@docs number, text, password
+@docs number, float, text, password
 
 -}
 
@@ -68,13 +68,24 @@ text =
         }
 
 
-{-| An input that allows number entry
+{-| An input that allows integer entry
 -}
 number : InputType (Maybe Int)
 number =
     InputType
         { toString = Maybe.map String.fromInt >> Maybe.withDefault ""
         , fromString = String.toInt
+        , fieldType = "number"
+        }
+
+
+{-| An input that allows float entry
+-}
+float : InputType (Maybe Float)
+float =
+    InputType
+        { toString = Maybe.map String.fromFloat >> Maybe.withDefault ""
+        , fromString = String.toFloat
         , fieldType = "number"
         }
 
@@ -110,39 +121,48 @@ view_ theme model =
 
         (InputType inputType) =
             model.type_
+
+        maybeStep =
+            if inputType.fieldType == "number" then
+                [ step "any" ]
+
+            else
+                []
     in
     div
         [ Attributes.css [ position relative ]
         ]
         [ input
-            [ Attributes.id idValue
-            , css
-                [ InputStyles.input theme model.isInError
-                , if theme == InputStyles.Writing then
-                    Css.Global.withClass "override-sass-styles"
-                        [ textAlign center
-                        , Css.height Css.auto
-                        ]
+            (maybeStep
+                ++ [ Attributes.id idValue
+                   , css
+                        [ InputStyles.input theme model.isInError
+                        , if theme == InputStyles.Writing then
+                            Css.Global.withClass "override-sass-styles"
+                                [ textAlign center
+                                , Css.height Css.auto
+                                ]
 
-                  else
-                    Css.Global.withClass "override-sass-styles"
-                        [ Css.height (px 45)
+                          else
+                            Css.Global.withClass "override-sass-styles"
+                                [ Css.height (px 45)
+                                ]
                         ]
-                ]
-            , placeholder model.placeholder
-            , value (inputType.toString model.value)
-            , onInput (inputType.fromString >> model.onInput)
-            , Maybe.withDefault Extra.none (Maybe.map Events.onBlur model.onBlur)
-            , autofocus model.autofocus
-            , type_ inputType.fieldType
-            , class "override-sass-styles"
-            , Attributes.attribute "aria-invalid" <|
-                if model.isInError then
-                    "true"
+                   , placeholder model.placeholder
+                   , value (inputType.toString model.value)
+                   , onInput (inputType.fromString >> model.onInput)
+                   , Maybe.withDefault Extra.none (Maybe.map Events.onBlur model.onBlur)
+                   , autofocus model.autofocus
+                   , type_ inputType.fieldType
+                   , class "override-sass-styles"
+                   , Attributes.attribute "aria-invalid" <|
+                        if model.isInError then
+                            "true"
 
-                else
-                    "false"
-            ]
+                        else
+                            "false"
+                   ]
+            )
             []
         , if model.showLabel then
             Html.label

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -33,7 +33,7 @@ type alias State =
 {-| -}
 example : (Msg -> msg) -> State -> ModuleExample msg
 example parentMessage state =
-    { name = "Nri.Ui.TextInput.V4"
+    { name = "Nri.Ui.TextInput.V5"
     , category = Inputs
     , content =
         [ Html.map parentMessage <|

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -17,12 +17,14 @@ import Nri.Ui.TextInput.V5 as TextInput
 type Msg
     = SetTextInput Id String
     | SetNumberInput (Maybe Int)
+    | SetFloatInput (Maybe Float)
     | SetPassword String
 
 
 {-| -}
 type alias State =
     { numberInputValue : Maybe Int
+    , floatInputValue : Maybe Float
     , textInputValues : Dict Id String
     , passwordInputValue : String
     }
@@ -57,6 +59,18 @@ example parentMessage state =
                     , onBlur = Nothing
                     , autofocus = False
                     , type_ = TextInput.number
+                    , showLabel = True
+                    }
+                , Html.br [] []
+                , TextInput.view
+                    { label = "Points (decimal)"
+                    , isInError = False
+                    , placeholder = "enter a decimal"
+                    , value = state.floatInputValue
+                    , onInput = SetFloatInput
+                    , onBlur = Nothing
+                    , autofocus = False
+                    , type_ = TextInput.float
                     , showLabel = True
                     }
                 , Html.br [] []
@@ -164,6 +178,7 @@ example parentMessage state =
 init : State
 init =
     { numberInputValue = Nothing
+    , floatInputValue = Nothing
     , textInputValues = Dict.empty
     , passwordInputValue = ""
     }
@@ -178,6 +193,9 @@ update msg state =
 
         SetNumberInput numberInputValue ->
             ( { state | numberInputValue = numberInputValue }, Cmd.none )
+
+        SetFloatInput floatInputValue ->
+            ( { state | floatInputValue = floatInputValue }, Cmd.none )
 
         SetPassword password ->
             ( { state | passwordInputValue = password }, Cmd.none )


### PR DESCRIPTION
Adds the ability to handle text-input floats so we can input averages in the admin page https://www.pivotaltracker.com/story/show/169453952

To review
- [x] checkout this branch locally
- [x] run `script/develop.sh`
- [x] hit http://localhost:8000/#doodad/Nri.Ui.TextInput.V5
- [x] Play around with the various inputs on the page and confirm that the "Points" field only takes integers and the "Points (decimal)" field accepts floats