### PR TITLE
Fix percy flakes

### DIFF
--- a/script/percy-tests.js
+++ b/script/percy-tests.js
@@ -1,36 +1,32 @@
 const PercyScript = require('@percy/script')
 
 PercyScript.run(async (page, percySnapshot) => {
-  await page.goto('http://localhost:8000/')
-  // ensure the page has loaded before capturing a snapshot
-  await page.waitFor('#categories')
-
   await page.goto('http://localhost:8000/#category/Animations')
-  await page.waitFor('.Animations')
+  await page.waitFor('#animations')
   await percySnapshot('Animations')
 
   await page.goto('http://localhost:8000/#category/Buttons')
-  await page.waitFor('.Buttons')
+  await page.waitFor('#buttons-and-links')
   await percySnapshot('Buttons')
 
   await page.goto('http://localhost:8000/#category/Colors')
-  await page.waitFor('.Colors')
+  await page.waitFor('#colors')
   await percySnapshot('Colors')
 
   await page.goto('http://localhost:8000/#category/Icons')
-  await page.waitFor('.Icons')
+  await page.waitFor('#icons')
   await percySnapshot('Icons')
 
   await page.goto('http://localhost:8000/#category/Inputs')
-  await page.waitFor('.Inputs')
+  await page.waitFor('#inputs')
   await percySnapshot('Inputs')
 
   await page.goto('http://localhost:8000/#category/Layout')
-  await page.waitFor('.Layout')
+  await page.waitFor('#layout')
   await percySnapshot('Layout')
 
   await page.goto('http://localhost:8000/#category/Modals')
-  await page.waitFor('.Modals')
+  await page.waitFor('#modals')
   await percySnapshot('Modals')
   await page.click('#launch-info-modal')
   await page.waitFor('[role="dialog"]')
@@ -42,22 +38,22 @@ PercyScript.run(async (page, percySnapshot) => {
   await page.click('[aria-label="Close modal"]')
 
   await page.goto('http://localhost:8000/#category/Pages')
-  await page.waitFor('.Error')
+  await page.waitFor('#error-pages')
   await percySnapshot('Pages')
 
   await page.goto('http://localhost:8000/#category/Tables')
-  await page.waitFor('.Tables')
+  await page.waitFor('#tables')
   await percySnapshot('Tables')
 
   await page.goto('http://localhost:8000/#category/Text')
-  await page.waitFor('.Text')
+  await page.waitFor('#text-and-fonts')
   await percySnapshot('Text')
 
   await page.goto('http://localhost:8000/#category/Widgets')
-  await page.waitFor('.Widgets')
+  await page.waitFor('#widgets')
   await percySnapshot('Widgets')
 
   await page.goto('http://localhost:8000/#category/Messaging')
-  await page.waitFor('.Alerts')
+  await page.waitFor('#alerts-and-messages')
   await percySnapshot('Messaging')
 })

--- a/script/percy-tests.js
+++ b/script/percy-tests.js
@@ -33,9 +33,11 @@ PercyScript.run(async (page, percySnapshot) => {
   await page.waitFor('.Modals')
   await percySnapshot('Modals')
   await page.click('#launch-info-modal')
+  await page.waitFor('[role="dialog"]')
   await percySnapshot('Full Info Modal')
   await page.click('[aria-label="Close modal"]')
   await page.click('#launch-warning-modal')
+  await page.waitFor('[role="dialog"]')
   await percySnapshot('Full Warning Modal')
   await page.click('[aria-label="Close modal"]')
 

--- a/script/percy-tests.js
+++ b/script/percy-tests.js
@@ -6,24 +6,31 @@ PercyScript.run(async (page, percySnapshot) => {
   await page.waitFor('#categories')
 
   await page.goto('http://localhost:8000/#category/Animations')
+  await page.waitFor('.Animations')
   await percySnapshot('Animations')
 
   await page.goto('http://localhost:8000/#category/Buttons')
+  await page.waitFor('.Buttons')
   await percySnapshot('Buttons')
 
   await page.goto('http://localhost:8000/#category/Colors')
+  await page.waitFor('.Colors')
   await percySnapshot('Colors')
 
   await page.goto('http://localhost:8000/#category/Icons')
+  await page.waitFor('.Icons')
   await percySnapshot('Icons')
 
   await page.goto('http://localhost:8000/#category/Inputs')
+  await page.waitFor('.Inputs')
   await percySnapshot('Inputs')
 
   await page.goto('http://localhost:8000/#category/Layout')
+  await page.waitFor('.Layout')
   await percySnapshot('Layout')
 
   await page.goto('http://localhost:8000/#category/Modals')
+  await page.waitFor('.Modals')
   await percySnapshot('Modals')
   await page.click('#launch-info-modal')
   await percySnapshot('Full Info Modal')
@@ -33,17 +40,22 @@ PercyScript.run(async (page, percySnapshot) => {
   await page.click('[aria-label="Close modal"]')
 
   await page.goto('http://localhost:8000/#category/Pages')
+  await page.waitFor('.Error')
   await percySnapshot('Pages')
 
   await page.goto('http://localhost:8000/#category/Tables')
+  await page.waitFor('.Tables')
   await percySnapshot('Tables')
 
   await page.goto('http://localhost:8000/#category/Text')
+  await page.waitFor('.Text')
   await percySnapshot('Text')
 
   await page.goto('http://localhost:8000/#category/Widgets')
+  await page.waitFor('.Widgets')
   await percySnapshot('Widgets')
 
   await page.goto('http://localhost:8000/#category/Messaging')
+  await page.waitFor('.Alerts')
   await percySnapshot('Messaging')
 })

--- a/styleguide-app/ModuleExample.elm
+++ b/styleguide-app/ModuleExample.elm
@@ -128,6 +128,7 @@ categoryForDisplay category =
         Animations ->
             "Animations"
 
+
 categoryForId : Category -> String
 categoryForId category =
     case category of

--- a/styleguide-app/ModuleExample.elm
+++ b/styleguide-app/ModuleExample.elm
@@ -3,6 +3,7 @@ module ModuleExample exposing
     , ModuleExample
     , ModuleMessages
     , categoryForDisplay
+    , categoryForId
     , categoryFromString
     , view
     )
@@ -126,6 +127,45 @@ categoryForDisplay category =
 
         Animations ->
             "Animations"
+
+categoryForId : Category -> String
+categoryForId category =
+    case category of
+        Tables ->
+            "tables"
+
+        Inputs ->
+            "inputs"
+
+        Widgets ->
+            "widgets"
+
+        Layout ->
+            "layout"
+
+        Buttons ->
+            "buttons-and-links"
+
+        Icons ->
+            "icons"
+
+        Messaging ->
+            "alerts-and-messages"
+
+        Modals ->
+            "modals"
+
+        Colors ->
+            "colors"
+
+        Text ->
+            "text-and-fonts"
+
+        Pages ->
+            "error-pages"
+
+        Animations ->
+            "animations"
 
 
 view : Bool -> ModuleExample msg -> Html msg

--- a/styleguide-app/View.elm
+++ b/styleguide-app/View.elm
@@ -7,7 +7,7 @@ import Html.Attributes
 import Html.Styled as Html exposing (Html, img)
 import Html.Styled.Attributes as Attributes exposing (..)
 import Model exposing (..)
-import ModuleExample as ModuleExample exposing (Category(..), ModuleExample, categoryForDisplay)
+import ModuleExample as ModuleExample exposing (Category(..), ModuleExample, categoryForDisplay, categoryForId)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Css.VendorPrefixed as VendorPrefixed
 import Nri.Ui.Fonts.V1 as Fonts
@@ -58,7 +58,7 @@ view_ model =
                         , nriThemedModules model.moduleStates
                             |> List.filter (\doodad -> category == doodad.category)
                             |> List.map (ModuleExample.view True)
-                            |> Html.div [ class (categoryForDisplay category) ]
+                            |> Html.div [ id (categoryForId category) ]
                             |> Html.map UpdateModuleStates
                         ]
                     ]

--- a/styleguide-app/View.elm
+++ b/styleguide-app/View.elm
@@ -58,7 +58,7 @@ view_ model =
                         , nriThemedModules model.moduleStates
                             |> List.filter (\doodad -> category == doodad.category)
                             |> List.map (ModuleExample.view True)
-                            |> Html.div []
+                            |> Html.div [ class (categoryForDisplay category) ]
                             |> Html.map UpdateModuleStates
                         ]
                     ]


### PR DESCRIPTION
Percy's been flaking a bit since it was introduced, most likely it's that it's firing too early before pages have loaded (it appeared to be capturing the same page twice or not capturing modals), this adds in a load of waits so that the right pages is definitely there before Percy tries to capture it (🤞). It does the same for the modals, making sure they're open before capturing.

For the main pages, I added a Class - ID would have been better but my Elm knowledge ran out at trying to remove the spaces in the string I was using and IDs aren't supposed to have spaces in (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id), using a Class means I can just use the first word as the thing to check - feel free to change if there is a better way of doing this.

For the modals I used the `role="dialog"` attribute they have.

This seems to now show the correct things in Percy - the three diffs are ones where it had flaked in the past and this branch is showing the correct snapshot.