### PR TITLE
Set `rel` on external links

### DIFF
--- a/src/AttributeExtras.elm
+++ b/src/AttributeExtras.elm
@@ -1,0 +1,20 @@
+module AttributeExtras exposing (targetBlank)
+
+import Html.Styled exposing (Attribute)
+import Html.Styled.Attributes as Attributes
+
+
+{-| Use this list of attributes instead of applying `Attributes.target "_blank"`
+directly. This prevents an exploits like "tabnabbing", among other things.
+
+See these resources:
+
+  - <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Security_and_privacy_concerns>
+  - <https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever>
+
+-}
+targetBlank : List (Attribute msg)
+targetBlank =
+    [ Attributes.target "_blank"
+    , Attributes.rel "noopener noreferrer"
+    ]

--- a/src/Nri/Ui/Button/V9.elm
+++ b/src/Nri/Ui/Button/V9.elm
@@ -56,7 +56,7 @@ module Nri.Ui.Button.V9 exposing
 
 -}
 
-import Accessibility.Styled as Html exposing (Attribute, Html)
+import Accessibility.Styled as Html exposing (Html)
 import Accessibility.Styled.Role as Role
 import Accessibility.Styled.Widget as Widget
 import Css exposing (Style)
@@ -550,17 +550,34 @@ renderLink ((ButtonOrLink config) as link_) =
 
         External ->
             linkBase "linkExternal"
-                (Attributes.target "_blank" :: config.customAttributes)
+                (targetBlankAttributes ++ config.customAttributes)
 
         ExternalWithTracking ->
             linkBase "linkExternalWithTracking"
-                (List.append
-                    [ Attributes.target "_blank"
-                    , Maybe.map EventExtras.onClickForLinkWithHref config.onClick
-                        |> Maybe.withDefault AttributesExtra.none
+                (List.concat
+                    [ targetBlankAttributes
+                    , [ Maybe.map EventExtras.onClickForLinkWithHref config.onClick
+                            |> Maybe.withDefault AttributesExtra.none
+                      ]
+                    , config.customAttributes
                     ]
-                    config.customAttributes
                 )
+
+
+{-| Use this list of attributes instead of applying `Attributes.target "_blank"`
+directly. This prevents an exploits like "tabnabbing", among other things.
+
+See these resources:
+
+  - <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Security_and_privacy_concerns>
+  - <https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever>
+
+-}
+targetBlankAttributes : List (Html.Attribute msg)
+targetBlankAttributes =
+    [ Attributes.target "_blank"
+    , Attributes.rel "noopener noreferrer"
+    ]
 
 
 

--- a/src/Nri/Ui/Button/V9.elm
+++ b/src/Nri/Ui/Button/V9.elm
@@ -59,6 +59,7 @@ module Nri.Ui.Button.V9 exposing
 import Accessibility.Styled as Html exposing (Html)
 import Accessibility.Styled.Role as Role
 import Accessibility.Styled.Widget as Widget
+import AttributeExtras exposing (targetBlank)
 import Css exposing (Style)
 import Css.Global
 import EventExtras.Styled as EventExtras
@@ -550,34 +551,18 @@ renderLink ((ButtonOrLink config) as link_) =
 
         External ->
             linkBase "linkExternal"
-                (targetBlankAttributes ++ config.customAttributes)
+                (targetBlank ++ config.customAttributes)
 
         ExternalWithTracking ->
             linkBase "linkExternalWithTracking"
                 (List.concat
-                    [ targetBlankAttributes
+                    [ targetBlank
                     , [ Maybe.map EventExtras.onClickForLinkWithHref config.onClick
                             |> Maybe.withDefault AttributesExtra.none
                       ]
                     , config.customAttributes
                     ]
                 )
-
-
-{-| Use this list of attributes instead of applying `Attributes.target "_blank"`
-directly. This prevents an exploits like "tabnabbing", among other things.
-
-See these resources:
-
-  - <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Security_and_privacy_concerns>
-  - <https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever>
-
--}
-targetBlankAttributes : List (Html.Attribute msg)
-targetBlankAttributes =
-    [ Attributes.target "_blank"
-    , Attributes.rel "noopener noreferrer"
-    ]
 
 
 

--- a/src/Nri/Ui/Icon/V5.elm
+++ b/src/Nri/Ui/Icon/V5.elm
@@ -139,6 +139,7 @@ module Nri.Ui.Icon.V5 exposing
 
 import Accessibility.Role as Role
 import Accessibility.Styled exposing (..)
+import AttributeExtras
 import Css exposing (..)
 import EventExtras
 import Html as RootHtml
@@ -293,7 +294,7 @@ Uses our default icon styles (25 x 25 px, azure)
 -}
 linkExternal : IconLinkModel -> Html msg
 linkExternal =
-    linkBase [ Attributes.target "_blank" ]
+    linkBase AttributeExtras.targetBlank
 
 
 linkBase : List (Attribute msg) -> IconLinkModel -> Html msg


### PR DESCRIPTION
Adds `rel="noopener noreferrer` on buttons that use `Button.linkExternal` and `Button.linkExternalWithTracking`.

This is a reasonable default to set for any link using `target="_blank"`. It prevent security exploits like ["tabnabbing"](https://en.wikipedia.org/wiki/Tabnabbing), and also can improve performance. For more info, check out these links:

* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Security_and_privacy_concerns
* https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/

Its possible that this could break fancy cross-window communication that we had in one of our apps, but I'm pretty sure we don't do anything like that. I checked both the rails monolith and Haskell monorepo for references to `window.opener` or `window.postMessage`, but didn't find anything.
