### PR TITLE
Toggle tip triggers "on hover"

### DIFF
--- a/src/Nri/Ui/Tooltip/V1.elm
+++ b/src/Nri/Ui/Tooltip/V1.elm
@@ -352,6 +352,7 @@ viewIf viewFn condition =
 viewTooltip : Maybe String -> Tooltip msg -> Html msg
 viewTooltip maybeTooltipId (Tooltip config) =
     Html.div (containerPositioningForArrowPosition config.position)
+    Html.div [ css <| containerPositioningForArrowPosition config.position ]
         [ Html.div
             ([ css
                 ([ Css.borderRadius (Css.px 8)
@@ -426,33 +427,32 @@ tooltipColor =
 
 {-| This returns an absolute positioning style attribute for the popout container for a given arrow position.
 -}
-containerPositioningForArrowPosition : Position -> List (Attribute msg)
+containerPositioningForArrowPosition : Position -> List Style
 containerPositioningForArrowPosition arrowPosition =
-    List.map (\( k, v ) -> Attributes.style k v) <|
-        case arrowPosition of
-            OnTop ->
-                [ ( "left", "50%" )
-                , ( "top", "calc(-" ++ String.fromFloat arrowSize ++ "px - 2px)" )
-                , ( "position", "absolute" )
-                ]
+    case arrowPosition of
+        OnTop ->
+            [ Css.left (Css.pct 50)
+            , Css.top (Css.calc (Css.px (negate arrowSize)) Css.minus (Css.px 2))
+            , Css.position Css.absolute
+            ]
 
-            OnBottom ->
-                [ ( "left", "50%" )
-                , ( "bottom", "calc(-" ++ String.fromFloat arrowSize ++ "px - 2px)" )
-                , ( "position", "absolute" )
-                ]
+        OnBottom ->
+            [ Css.left (Css.pct 50)
+            , Css.bottom (Css.calc (Css.px (negate arrowSize)) Css.minus (Css.px 2))
+            , Css.position Css.absolute
+            ]
 
-            OnLeft ->
-                [ ( "top", "50%" )
-                , ( "left", "calc(-" ++ String.fromFloat arrowSize ++ "px - 2px)" )
-                , ( "position", "absolute" )
-                ]
+        OnLeft ->
+            [ Css.top (Css.pct 50)
+            , Css.left (Css.calc (Css.px (negate arrowSize)) Css.minus (Css.px 2))
+            , Css.position Css.absolute
+            ]
 
-            OnRight ->
-                [ ( "top", "50%" )
-                , ( "right", "calc(-" ++ String.fromFloat arrowSize ++ "px - 2px)" )
-                , ( "position", "absolute" )
-                ]
+        OnRight ->
+            [ Css.top (Css.pct 50)
+            , Css.right (Css.calc (Css.px (negate arrowSize)) Css.minus (Css.px 2))
+            , Css.position Css.absolute
+            ]
 
 
 pointerBox : Position -> Attribute msg

--- a/src/Nri/Ui/Tooltip/V1.elm
+++ b/src/Nri/Ui/Tooltip/V1.elm
@@ -243,38 +243,71 @@ toggleTip :
     -> Tooltip msg
     -> Html msg
 toggleTip { isOpen, onTrigger, extraButtonAttrs, label } tooltip_ =
+    let
+        contentSize =
+            20
+    in
     Nri.Ui.styled Html.div
         "Nri-Ui-Tooltip-V1-ToggleTip"
-        tooltipContainerStyles
+        (tooltipContainerStyles
+            ++ [ -- Take up enough room within the document flow
+                 Css.width (Css.px contentSize)
+               , Css.height (Css.px contentSize)
+               , Css.margin (Css.px 5)
+               ]
+        )
         []
         [ Html.button
             ([ Widget.label label
-             , css
-                (buttonStyleOverrides
-                    ++ [ Css.padding (Css.px 10) -- This is needed to provide a "hover bridge", so the tooltip won't close when trying to click a link
-                       ]
-                )
+             , css buttonStyleOverrides
              ]
                 ++ eventsForTrigger OnHover onTrigger
                 ++ extraButtonAttrs
             )
-            [ Html.div
-                [ css
-                    [ Css.position Css.relative
-                    , Css.width (Css.px 20)
-                    , Css.height (Css.px 20)
-                    , Css.color Colors.azure
+            [ hoverBridge contentSize
+                [ Html.div
+                    [ css
+                        [ Css.position Css.relative
+                        , Css.width (Css.px contentSize)
+                        , Css.height (Css.px contentSize)
+                        , Css.color Colors.azure
+                        ]
                     ]
-                ]
-                [ iconHelp
-                , Html.span
-                    [ -- This adds aria-live polite & also aria-live atomic, so our screen readers are alerted when content appears
-                      Role.status
+                    [ iconHelp
+                    , Html.span
+                        [ -- This adds aria-live polite & also aria-live atomic, so our screen readers are alerted when content appears
+                          Role.status
+                        ]
+                        [ viewIf (\_ -> viewTooltip Nothing OnHover tooltip_) isOpen ]
                     ]
-                    [ viewIf (\_ -> viewTooltip Nothing OnHover tooltip_) isOpen ]
                 ]
             ]
         ]
+
+
+{-| Provides a "bridge" for the cursor to move from trigger content to tooltip, so the user can click on links, etc.
+
+Works by being larger than the trigger content & overlaying it, but is removed from the flow of the page (position: absolute), so that it looks ok visually.
+
+-}
+hoverBridge : Float -> List (Html msg) -> Html msg
+hoverBridge contentSize =
+    let
+        padding =
+            -- enough to cover the empty gap between tooltip and trigger content
+            10
+    in
+    Nri.Ui.styled Html.div
+        "tooltip-hover-bridge"
+        [ Css.boxSizing Css.borderBox
+        , Css.padding (Css.px padding)
+        , Css.width (Css.px <| contentSize + padding * 2)
+        , Css.height (Css.px <| contentSize + padding * 2)
+        , Css.position Css.absolute
+        , Css.top (Css.px <| negate padding)
+        , Css.left (Css.px <| negate padding)
+        ]
+        []
 
 
 {-| Made with <https://levelteams.com/svg-to-elm>

--- a/src/Nri/Ui/Tooltip/V1.elm
+++ b/src/Nri/Ui/Tooltip/V1.elm
@@ -26,6 +26,14 @@ Example usage:
         }
 
 
+## Suggested Improvements for V2
+
+  - The toggle tip does not currently manage focus correctly for keyboard users - if a
+    user tries to click on a link in the toggle tip, the tip will disappear as focus moves
+    to the next item in the page. This should be improved in the next release.
+  - Currently, only toggle tip supports links on hover - generalize this to all tooltips
+
+
 ## Tooltip Construction
 
 @docs Tooltip, tooltip

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -11,7 +11,7 @@ import Css
 import Html.Styled.Attributes exposing (css, href)
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.Heading.V2 as Heading
-import Nri.Ui.Text.V3 as Text
+import Nri.Ui.Text.V4 as Text
 import Nri.Ui.Tooltip.V1 as Tooltip
 
 
@@ -100,56 +100,40 @@ example msg model =
         , Html.br [ css [ Css.marginBottom (Css.px 20) ] ]
         , Heading.h3 [] [ Html.text "toggleTip" ]
         , Text.smallBody [ Html.text "A Toggle Tip is triggered by the \"?\" icon and provides supplemental information for the page." ]
-        , Tooltip.tooltip
-            [ Html.text "Tooltip On Top! "
-            , Html.a
-                [ href "/" ]
-                [ Html.text "Links work!" ]
+        , Html.div [ css [ Css.displayFlex, Css.alignItems Css.center ] ]
+            [ Tooltip.tooltip
+                [ Html.text "Tooltip On Top! "
+                , Html.a
+                    [ href "/" ]
+                    [ Html.text "Links work!" ]
+                ]
+                |> Tooltip.toggleTip
+                    { onTrigger = ToggleTooltip ToggleTipTop >> msg
+                    , isOpen = model.openTooltip == Just ToggleTipTop
+                    , label = "More info"
+                    , extraButtonAttrs = []
+                    }
+            , Text.mediumBody
+                [ Html.text "This toggletip will open on top"
+                ]
             ]
-            |> Tooltip.toggleTip
-                { onTrigger = ToggleTooltip ToggleTipTop >> msg
-                , isOpen = model.openTooltip == Just ToggleTipTop
-                , label = "More info"
-                , extraButtonAttrs = []
-                }
-        , Tooltip.tooltip
-            [ Html.text "Tooltip On Left! "
-            , Html.a
-                [ href "/" ]
-                [ Html.text "Links work!" ]
+        , Html.div [ css [ Css.displayFlex, Css.alignItems Css.center ] ]
+            [ Tooltip.tooltip
+                [ Html.text "Tooltip On Left! "
+                , Html.a
+                    [ href "/" ]
+                    [ Html.text "Links work!" ]
+                ]
+                |> Tooltip.withPosition Tooltip.OnLeft
+                |> Tooltip.toggleTip
+                    { onTrigger = ToggleTooltip ToggleTipLeft >> msg
+                    , isOpen = model.openTooltip == Just ToggleTipLeft
+                    , label = "More info"
+                    , extraButtonAttrs = []
+                    }
+            , Text.mediumBody
+                [ Html.text "This toggletip will open on the left"
+                ]
             ]
-            |> Tooltip.withPosition Tooltip.OnLeft
-            |> Tooltip.toggleTip
-                { onTrigger = ToggleTooltip ToggleTipLeft >> msg
-                , isOpen = model.openTooltip == Just ToggleTipLeft
-                , label = "More info"
-                , extraButtonAttrs = []
-                }
-        , Tooltip.tooltip
-            [ Html.text "Tooltip On Right! "
-            , Html.a
-                [ href "/" ]
-                [ Html.text "Links work!" ]
-            ]
-            |> Tooltip.withPosition Tooltip.OnRight
-            |> Tooltip.toggleTip
-                { onTrigger = ToggleTooltip ToggleTipRight >> msg
-                , isOpen = model.openTooltip == Just ToggleTipRight
-                , label = "More info"
-                , extraButtonAttrs = []
-                }
-        , Tooltip.tooltip
-            [ Html.text "Tooltip On Bottom! "
-            , Html.a
-                [ href "/" ]
-                [ Html.text "Links work!" ]
-            ]
-            |> Tooltip.withPosition Tooltip.OnBottom
-            |> Tooltip.toggleTip
-                { onTrigger = ToggleTooltip ToggleTipBottom >> msg
-                , isOpen = model.openTooltip == Just ToggleTipBottom
-                , label = "More info"
-                , extraButtonAttrs = []
-                }
         ]
     }

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -8,7 +8,7 @@ module Examples.Tooltip exposing (example, init, update, State, Msg)
 
 import Accessibility.Styled as Html
 import Css
-import Html.Styled.Attributes exposing (css)
+import Html.Styled.Attributes exposing (css, href)
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Text.V3 as Text
@@ -100,14 +100,24 @@ example msg model =
         , Html.br [ css [ Css.marginBottom (Css.px 20) ] ]
         , Heading.h3 [] [ Html.text "toggleTip" ]
         , Text.smallBody [ Html.text "A Toggle Tip is triggered by the \"?\" icon and provides supplemental information for the page." ]
-        , Tooltip.tooltip [ Html.text "Tooltip On Top" ]
+        , Tooltip.tooltip
+            [ Html.text "Tooltip On Top! "
+            , Html.a
+                [ href "/" ]
+                [ Html.text "Links work!" ]
+            ]
             |> Tooltip.toggleTip
                 { onTrigger = ToggleTooltip ToggleTipTop >> msg
                 , isOpen = model.openTooltip == Just ToggleTipTop
                 , label = "More info"
                 , extraButtonAttrs = []
                 }
-        , Tooltip.tooltip [ Html.text "Tooltip On Left" ]
+        , Tooltip.tooltip
+            [ Html.text "Tooltip On Left! "
+            , Html.a
+                [ href "/" ]
+                [ Html.text "Links work!" ]
+            ]
             |> Tooltip.withPosition Tooltip.OnLeft
             |> Tooltip.toggleTip
                 { onTrigger = ToggleTooltip ToggleTipLeft >> msg
@@ -115,7 +125,12 @@ example msg model =
                 , label = "More info"
                 , extraButtonAttrs = []
                 }
-        , Tooltip.tooltip [ Html.text "Tooltip On Right" ]
+        , Tooltip.tooltip
+            [ Html.text "Tooltip On Right! "
+            , Html.a
+                [ href "/" ]
+                [ Html.text "Links work!" ]
+            ]
             |> Tooltip.withPosition Tooltip.OnRight
             |> Tooltip.toggleTip
                 { onTrigger = ToggleTooltip ToggleTipRight >> msg
@@ -123,7 +138,12 @@ example msg model =
                 , label = "More info"
                 , extraButtonAttrs = []
                 }
-        , Tooltip.tooltip [ Html.text "Tooltip On Bottom" ]
+        , Tooltip.tooltip
+            [ Html.text "Tooltip On Bottom! "
+            , Html.a
+                [ href "/" ]
+                [ Html.text "Links work!" ]
+            ]
             |> Tooltip.withPosition Tooltip.OnBottom
             |> Tooltip.toggleTip
                 { onTrigger = ToggleTooltip ToggleTipBottom >> msg

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -19,7 +19,10 @@ type TooltipType
     = PrimaryLabelOnClick
     | PrimaryLabelOnHover
     | AuxillaryDescription
-    | ToggleTip
+    | ToggleTipTop
+    | ToggleTipRight
+    | ToggleTipBottom
+    | ToggleTipLeft
 
 
 type alias State =
@@ -97,10 +100,34 @@ example msg model =
         , Html.br [ css [ Css.marginBottom (Css.px 20) ] ]
         , Heading.h3 [] [ Html.text "toggleTip" ]
         , Text.smallBody [ Html.text "A Toggle Tip is triggered by the \"?\" icon and provides supplemental information for the page." ]
-        , Tooltip.tooltip [ Html.text "Tooltip" ]
+        , Tooltip.tooltip [ Html.text "Tooltip On Top" ]
             |> Tooltip.toggleTip
-                { onTrigger = ToggleTooltip ToggleTip >> msg
-                , isOpen = model.openTooltip == Just ToggleTip
+                { onTrigger = ToggleTooltip ToggleTipTop >> msg
+                , isOpen = model.openTooltip == Just ToggleTipTop
+                , label = "More info"
+                , extraButtonAttrs = []
+                }
+        , Tooltip.tooltip [ Html.text "Tooltip On Left" ]
+            |> Tooltip.withPosition Tooltip.OnLeft
+            |> Tooltip.toggleTip
+                { onTrigger = ToggleTooltip ToggleTipLeft >> msg
+                , isOpen = model.openTooltip == Just ToggleTipLeft
+                , label = "More info"
+                , extraButtonAttrs = []
+                }
+        , Tooltip.tooltip [ Html.text "Tooltip On Right" ]
+            |> Tooltip.withPosition Tooltip.OnRight
+            |> Tooltip.toggleTip
+                { onTrigger = ToggleTooltip ToggleTipRight >> msg
+                , isOpen = model.openTooltip == Just ToggleTipRight
+                , label = "More info"
+                , extraButtonAttrs = []
+                }
+        , Tooltip.tooltip [ Html.text "Tooltip On Bottom" ]
+            |> Tooltip.withPosition Tooltip.OnBottom
+            |> Tooltip.toggleTip
+                { onTrigger = ToggleTooltip ToggleTipBottom >> msg
+                , isOpen = model.openTooltip == Just ToggleTipBottom
                 , label = "More info"
                 , extraButtonAttrs = []
                 }

--- a/tests/Spec/Nri/Ui/Tooltip/V1.elm
+++ b/tests/Spec/Nri/Ui/Tooltip/V1.elm
@@ -37,7 +37,7 @@ spec : Test
 spec =
     describe "Nri.Ui.Tooltip.V1"
         [ describe "toggleTip"
-            [ test "Toggletip is available on click and hides on blur" <|
+            [ test "Toggletip is available on hover and hides on blur" <|
                 \() ->
                     ProgramTest.createSandbox
                         { init = init
@@ -52,7 +52,7 @@ spec =
                                     (Widget.label "More info")
                                 ]
                             )
-                            Event.click
+                            Event.mouseEnter
                         |> ProgramTest.ensureViewHas
                             [ Selector.text "Toggly"
                             ]


### PR DESCRIPTION
Previously, this triggered "on click", but design has requested it to be "on hover" instead. This was blocked on not being able to click links in "hover" tooltips - this PR fixes the problem by adding a "bridge" for the mouse to traverse while the tooltip stays open.

![Dec-03-2019 10-44-10](https://user-images.githubusercontent.com/13489089/70079595-e4cd1500-15b9-11ea-9ebb-f6460c823df1.gif)


Because this was blocked from usage in the monolith, it's safe to change this

Part of https://www.pivotaltracker.com/story/show/169905620

## Eng QA
- script/develop.sh -> localhost:8000 & see the tooltip section
- Ensure that toggle tips trigger on hover, and that you can click on links