### PR TITLE
fix text alignment and propagation when links are clicked

### DIFF
--- a/src/Nri/Ui/Tooltip/V1.elm
+++ b/src/Nri/Ui/Tooltip/V1.elm
@@ -455,6 +455,7 @@ eventsForTrigger trigger msg =
             , Events.onMouseLeave (msg False)
             , Events.onFocus (msg True)
             , Events.onBlur (msg False)
+            , EventExtras.onClickStopPropagation (msg True)
             ]
 
 
@@ -552,6 +553,7 @@ buttonStyleOverrides =
     , Css.color Css.inherit
     , Css.margin Css.zero
     , Css.padding Css.zero
+    , Css.textAlign Css.left
     ]
 
 


### PR DESCRIPTION
Fixes a few bugs discovered in https://github.com/NoRedInk/NoRedInk/pull/25670
- text is now left aligned in tooltips
- clicking links in hover toggle tips will not propagate events