### PR TITLE
Zero margin on segments

### DIFF
--- a/src/Nri/Ui/SegmentedControl/V8.elm
+++ b/src/Nri/Ui/SegmentedControl/V8.elm
@@ -243,6 +243,7 @@ sharedTabStyles =
     , fontSize (px 15)
     , fontWeight bold
     , lineHeight (px 30)
+    , margin zero
     , firstOfType
         [ borderTopLeftRadius (px 8)
         , borderBottomLeftRadius (px 8)


### PR DESCRIPTION
Zero out margin on segmented control segments to address this on Safari:

<img width="317" alt="image" src="https://user-images.githubusercontent.com/13528834/70945489-31790d00-200a-11ea-816f-1e9da44254c1.png">