### PR TITLE
Zero margin on accordion

### DIFF
--- a/src/Nri/Ui/Accordion/V1.elm
+++ b/src/Nri/Ui/Accordion/V1.elm
@@ -67,6 +67,7 @@ defaultStyleOptions =
         -- button resets
         , cursor pointer
         , borderWidth Css.zero
+        , margin zero
 
         -- fonts & text
         , textAlign left


### PR DESCRIPTION
Zeroes out the margin on accordions to address this problem in 
Safari

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/13528834/70946323-d9dba100-200b-11ea-85c9-b5de9f9f34cc.png">

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/13528834/70946340-df38eb80-200b-11ea-8ed2-8c32397ffced.png">