### PR TITLE
No button margin

### DIFF
--- a/src/Nri/Ui/Button/V9.elm
+++ b/src/Nri/Ui/Button/V9.elm
@@ -720,7 +720,7 @@ buttonStyle =
         , Css.property "transition" "background-color 0.2s, color 0.2s, box-shadow 0.2s, border 0.2s, border-width 0s"
         , Css.boxShadow Css.none
         , Css.border Css.zero
-        , Css.marginBottom Css.zero
+        , Css.margin Css.zero
         , Css.hover [ Css.textDecoration Css.none ]
         , Css.disabled [ Css.cursor Css.notAllowed ]
         , Css.display Css.inlineFlex


### PR DESCRIPTION
Zeroes out all margin on buttons to avoid misalignment problems like this on Safari.

<img width="1089" alt="Napkin 2 01-21-20, 11 51 03 AM" src="https://user-images.githubusercontent.com/13528834/72837979-4ddd1a80-3c44-11ea-9688-10606f6f0a15.png">