### PR TITLE
remove x bottom padding

### DIFF
--- a/src/Nri/Ui/Modal/V8.elm
+++ b/src/Nri/Ui/Modal/V8.elm
@@ -441,7 +441,7 @@ closeButton wrapMsg focusableElementAttrs =
                 -- make the hitspace extend all the way to the corner
                 , Css.width (Css.px 40)
                 , Css.height (Css.px 40)
-                , Css.padding4 (Css.px 20) (Css.px 20) (Css.px 2) Css.zero
+                , Css.padding4 (Css.px 20) (Css.px 20) Css.zero Css.zero
 
                 -- apply button styles
                 , Css.borderWidth Css.zero


### PR DESCRIPTION
The close x on the modal is clipped in Safari. This fixes it.
![Untitled 2020-01-21 14_53_06](https://user-images.githubusercontent.com/13528834/72850454-006da700-3c5e-11ea-9565-967b63580747.gif)
