### PR TITLE
Bump to 7.17.1

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "7.17.0",
+    "version": "7.17.1",
     "exposed-modules": [
         "Nri.Ui",
         "Nri.Ui.Accordion.V1",


### PR DESCRIPTION
Publishing a new version to release the changes in #440.

Here's the `elm-diff` output:

```
Based on your new API, this should be a PATCH change (7.17.0 => 7.17.1)
```