### PR TITLE
Fix overflow in selectors

### DIFF
--- a/src/Nri/Ui/Select/V7.elm
+++ b/src/Nri/Ui/Select/V7.elm
@@ -103,8 +103,9 @@ view config =
 
             -- Size and spacing
             , Css.height (Css.px 45)
-            , Css.width (Css.pct 100)
+            , Css.width (Css.calc (Css.pct 100) Css.minus (Css.px 30))
             , Css.paddingLeft (Css.px 20)
+            , Css.paddingRight (Css.px 30)
 
             -- Icons
             , selectArrowsCss
@@ -161,7 +162,7 @@ selectArrowsCss =
         -- "appearance: none" removes the default dropdown arrows
         , VendorPrefixed.property "appearance" "none"
         , Css.backgroundRepeat Css.noRepeat
-        , Css.property "background-position" "center right 10px"
+        , Css.property "background-position" "center right -20px"
         , Css.backgroundOrigin Css.contentBox
         ]
 

--- a/src/Nri/Ui/Select/V7.elm
+++ b/src/Nri/Ui/Select/V7.elm
@@ -97,13 +97,16 @@ view config =
             , Css.color Colors.gray20
             , Fonts.baseFont
             , Css.fontSize (Css.px 15)
+            , Css.textOverflow Css.ellipsis
+            , Css.overflow Css.hidden
+            , Css.whiteSpace Css.noWrap
 
             -- Interaction
             , Css.cursor Css.pointer
 
             -- Size and spacing
             , Css.height (Css.px 45)
-            , Css.width (Css.calc (Css.pct 100) Css.minus (Css.px 30))
+            , Css.width (Css.pct 100)
             , Css.paddingLeft (Css.px 20)
             , Css.paddingRight (Css.px 30)
 

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -16,6 +16,7 @@ module Examples.Select exposing
 
 -}
 
+import Css
 import Html.Styled
 import Html.Styled.Attributes
 import ModuleExample exposing (Category(..), ModuleExample)
@@ -57,6 +58,21 @@ example parentMessage state =
             , isInError = True
             }
             |> Html.Styled.map (parentMessage << ConsoleLog)
+        , Html.Styled.label
+            [ Html.Styled.Attributes.for "overflowed-selector" ]
+            [ Heading.h3 [] [ Html.Styled.text "Selector with Overflowed Text" ] ]
+        , Html.Styled.div
+            [ Html.Styled.Attributes.css [ Css.maxWidth (Css.px 400) ] ]
+            [ Select.view
+                { current = Nothing
+                , choices = []
+                , id = "overflowed-selector"
+                , valueToString = identity
+                , defaultDisplayText = Just "Look at me, I design coastlines, I got an award for Norway. Where's the sense in that?"
+                , isInError = False
+                }
+                |> Html.Styled.map (parentMessage << ConsoleLog)
+            ]
         ]
     }
 


### PR DESCRIPTION
Selectors currently look a little funny if the text would be long enough to go under the arrows.

![](https://user-images.githubusercontent.com/355401/73190380-87ea6880-40eb-11ea-8cfa-cdb766e2e3d9.png)

This fixes selectors to truncate instead:

![image](https://user-images.githubusercontent.com/355401/73193123-b0746180-40ef-11ea-8870-0e07faa4de7c.png)
