### PR TITLE
Banner links

### DIFF
--- a/src/Nri/Ui/BannerAlert/V6.elm
+++ b/src/Nri/Ui/BannerAlert/V6.elm
@@ -4,6 +4,11 @@ module Nri.Ui.BannerAlert.V6 exposing (alert, error, neutral, success)
 
 @docs alert, error, neutral, success
 
+
+# Post-release patches
+
+  - adjusts link styles
+
 Changes from V5:
 
   - takes HTML rather than BannerContent

--- a/src/Nri/Ui/BannerAlert/V6.elm
+++ b/src/Nri/Ui/BannerAlert/V6.elm
@@ -341,5 +341,14 @@ notification =
         , Css.lineHeight (Css.px 27)
         , Css.maxWidth (Css.px 600)
         , Nri.Ui.Fonts.V1.baseFont
+        , Css.Global.descendants
+            [ Css.Global.a
+                [ Css.textDecoration Css.none
+                , Css.color Colors.azure
+                , Css.borderBottom3 (Css.px 1) Css.solid Colors.azure
+                , Css.visited
+                    [ Css.color Colors.azure ]
+                ]
+            ]
         ]
         []

--- a/styleguide-app/Examples/BannerAlert.elm
+++ b/styleguide-app/Examples/BannerAlert.elm
@@ -42,7 +42,7 @@ example parentMsg state =
         , BannerAlert.error
             [ Html.Styled.text "This is an error message!" ]
             Nothing
-        , h3 [] [ text "error with link" ]
+        , h3 [] [ text "with link and icon" ]
         , BannerAlert.error
             [ Html.Styled.div
                 [ Attributes.css
@@ -58,7 +58,8 @@ example parentMsg state =
                     [ Attributes.href "http://www.noredink.com"
                     , Attributes.target "_blank"
                     ]
-                    [ Html.Styled.text "here " ]
+                    [ Html.Styled.text "here" ]
+                , Html.Styled.text " "
                 , Html.Styled.div
                     [ Attributes.css
                         [ Css.display Css.inlineBlock
@@ -66,6 +67,27 @@ example parentMsg state =
                         ]
                     ]
                     [ Svg.toHtml UiIcon.gear ]
+                , Html.Styled.text " to check out NoRedInk."
+                ]
+            ]
+            Nothing
+        , h3 [] [ text "with multi-line link and" ]
+        , BannerAlert.error
+            [ Html.Styled.div
+                [ Attributes.css
+                    [ Css.fontSize (Css.px 20)
+                    , Css.fontWeight (Css.int 700)
+                    , Css.lineHeight (Css.px 25)
+                    , Css.maxWidth (Css.px 600)
+                    , Fonts.baseFont
+                    ]
+                ]
+                [ Html.Styled.text "Click "
+                , Html.Styled.a
+                    [ Attributes.href "http://www.noredink.com"
+                    , Attributes.target "_blank"
+                    ]
+                    [ Html.Styled.text "donec ullamcorper nulla non metus auctor fringilla donec ullamcorper nulla non metus auctor fringilla" ]
                 , Html.Styled.text " to check out NoRedInk."
                 ]
             ]

--- a/styleguide-app/Examples/BannerAlert.elm
+++ b/styleguide-app/Examples/BannerAlert.elm
@@ -45,14 +45,7 @@ example parentMsg state =
         , h3 [] [ text "with link and icon" ]
         , BannerAlert.error
             [ Html.Styled.div
-                [ Attributes.css
-                    [ Css.fontSize (Css.px 20)
-                    , Css.fontWeight (Css.int 700)
-                    , Css.lineHeight (Css.px 25)
-                    , Css.maxWidth (Css.px 600)
-                    , Fonts.baseFont
-                    ]
-                ]
+                []
                 [ Html.Styled.text "Click "
                 , Html.Styled.a
                     [ Attributes.href "http://www.noredink.com"
@@ -71,17 +64,10 @@ example parentMsg state =
                 ]
             ]
             Nothing
-        , h3 [] [ text "with multi-line link and" ]
+        , h3 [] [ text "with multi-line link" ]
         , BannerAlert.error
             [ Html.Styled.div
-                [ Attributes.css
-                    [ Css.fontSize (Css.px 20)
-                    , Css.fontWeight (Css.int 700)
-                    , Css.lineHeight (Css.px 25)
-                    , Css.maxWidth (Css.px 600)
-                    , Fonts.baseFont
-                    ]
-                ]
+                []
                 [ Html.Styled.text "Click "
                 , Html.Styled.a
                     [ Attributes.href "http://www.noredink.com"


### PR DESCRIPTION
Improves the styling of links in banner alerts by adding an underline and making them always blue.

<img width="843" alt="image" src="https://user-images.githubusercontent.com/13528834/74688455-72b5a680-518c-11ea-9bc8-32c342f1f4c2.png">