### PR TITLE
Text links

### DIFF
--- a/src/Nri/Ui/Text/V4.elm
+++ b/src/Nri/Ui/Text/V4.elm
@@ -54,6 +54,7 @@ API. See the Nri.Ui.Heading.V2 docs for details.
 -}
 
 import Css exposing (..)
+import Css.Global exposing (a, descendants)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Colors.V1 exposing (..)
@@ -121,6 +122,15 @@ paragraphStyles config =
         , padding zero
         , textAlign left
         , margin4 (px 0) (px 0) (px config.margin) (px 0)
+        , Css.Global.descendants
+            [ Css.Global.a
+                [ textDecoration none
+                , color azure
+                , borderBottom3 (px 1) solid azure
+                , visited
+                    [ color azure ]
+                ]
+            ]
         , lastChild
             [ margin zero
             ]

--- a/src/Nri/Ui/Text/V4.elm
+++ b/src/Nri/Ui/Text/V4.elm
@@ -4,7 +4,13 @@ module Nri.Ui.Text.V4 exposing
     , noWidow
     )
 
-{-| Changes from V3:
+ {-|
+
+Post-release patches
+
+  - adjusts link styles
+
+Changes from V3:
 
   - Removes Headings (they now live in Nri.Ui.Heading.V2)
 

--- a/src/Nri/Ui/Text/V4.elm
+++ b/src/Nri/Ui/Text/V4.elm
@@ -4,9 +4,7 @@ module Nri.Ui.Text.V4 exposing
     , noWidow
     )
 
- {-|
-
-Post-release patches
+{-| Post-release patches
 
   - adjusts link styles
 

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -21,23 +21,30 @@ example =
     , content =
         let
             longerBody =
-                [ "Be on the lookout for a new and improved assignment"
+                [ " "
+                , "Be on the lookout for a new and improved assignment"
                 , "creation form! Soon, you'll be able to easily see a summary"
                 , "of the content you're assigning, as well as an estimate for"
                 , "how long the assignment will take."
+                , " "
                 ]
                     |> String.join " "
+
+            link =
+                Html.a
+                    [ Attributes.href "http://www.noredink.com"
+                    , Attributes.target "_blank"
+                    ]
+                    [ Html.text "The quick brown fox jumps over the lazy dog." ]
         in
         [ Text.caption [ Html.text "NOTE: When using these styles, please read the documentation in the Elm module about \"Understanding spacing\"" ]
         , Heading.h2 [ Heading.style Heading.Top ] [ Html.text "Paragraph styles" ]
-        , Text.mediumBody [ Html.text <| "This is a mediumBody. " ++ longerBody ]
         , Text.mediumBody
-            [ Html.text "This is a mediumBody with with a link. "
-            , Html.a
-                [ Attributes.href "http://www.noredink.com"
-                , Attributes.target "_blank"
-                ]
-                [ Html.text longerBody ]
+            [ Html.text "This is a "
+            , Html.strong [] [ Html.text "mediumBody" ]
+            , Html.text ". "
+            , link
+            , Html.text longerBody
             ]
         , Text.smallBody [ Html.text <| "This is a smallBody. " ++ longerBody ]
         , Text.smallBodyGray [ Html.text <| "This is a smallBodyGray. " ++ longerBody ]

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -31,20 +31,19 @@ example =
         [ Text.caption [ Html.text "NOTE: When using these styles, please read the documentation in the Elm module about \"Understanding spacing\"" ]
         , Heading.h2 [ Heading.style Heading.Top ] [ Html.text "Paragraph styles" ]
         , Text.mediumBody [ Html.text <| "This is a mediumBody. " ++ longerBody ]
+        , Text.mediumBody
+            [ Html.text "This is a mediumBody with with a link. "
+            , Html.a
+                [ Attributes.href "http://www.noredink.com"
+                , Attributes.target "_blank"
+                ]
+                [ Html.text longerBody ]
+            ]
         , Text.smallBody [ Html.text <| "This is a smallBody. " ++ longerBody ]
         , Text.smallBodyGray [ Html.text <| "This is a smallBodyGray. " ++ longerBody ]
         , Text.caption [ Html.text <| "This is a caption. " ++ longerBody ]
         , Heading.h2 [ Heading.style Heading.Top ] [ Html.text "Paragraph styles for user-authored content" ]
         , Text.ugMediumBody [ Html.text <| "This is an ugMediumBody. " ++ longerBody ]
         , Text.ugSmallBody [ Html.text <| "This is an ugSmallBody. " ++ longerBody ]
-        , Text.mediumBody
-            [ Html.text "This is what text looks like with a link. "
-            , Html.a
-                [ Attributes.href "http://www.noredink.com"
-                , Attributes.target "_blank"
-                ]
-                [ Html.text "Praesent commodo cursus magna, vel scelerisque nisl consectetur \n                et. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis \n                risus eget urna mollis ornare vel eu leo." ]
-            , Html.text " Not bad, eh?"
-            ]
         ]
     }

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -20,37 +20,33 @@ example =
     , category = Text
     , content =
         let
-            longerBody =
-                [ " "
-                , "Be on the lookout for a new and improved assignment"
-                , "creation form! Soon, you'll be able to easily see a summary"
-                , "of the content you're assigning, as well as an estimate for"
-                , "how long the assignment will take."
-                , " "
-                ]
-                    |> String.join " "
-
-            link =
-                Html.a
+            exampleHtml kind =
+                [ Html.text "This is a "
+                , Html.strong [] [ Html.text kind ]
+                , Html.text ". "
+                , Html.a
                     [ Attributes.href "http://www.noredink.com"
                     , Attributes.target "_blank"
                     ]
                     [ Html.text "The quick brown fox jumps over the lazy dog." ]
+                , Html.text " Be on the lookout for a new and improved assignment creation form! Soon, you'll be able to easily see a summary of the content you're assigning, as well as an estimate for how long the assignment will take."
+                ]
+
+            exampleUGHtml kind =
+                [ Html.text "This is a "
+                , Html.strong [] [ Html.text kind ]
+                , Html.text ". The quick brown fox jumps over the lazy dog."
+                , Html.text " When I stepped out, into the bright sunlight from the darkness of the movie house, I had only two things on my mind: Paul Newman, and a ride home."
+                ]
         in
         [ Text.caption [ Html.text "NOTE: When using these styles, please read the documentation in the Elm module about \"Understanding spacing\"" ]
         , Heading.h2 [ Heading.style Heading.Top ] [ Html.text "Paragraph styles" ]
-        , Text.mediumBody
-            [ Html.text "This is a "
-            , Html.strong [] [ Html.text "mediumBody" ]
-            , Html.text ". "
-            , link
-            , Html.text longerBody
-            ]
-        , Text.smallBody [ Html.text <| "This is a smallBody. " ++ longerBody ]
-        , Text.smallBodyGray [ Html.text <| "This is a smallBodyGray. " ++ longerBody ]
-        , Text.caption [ Html.text <| "This is a caption. " ++ longerBody ]
+        , Text.mediumBody (exampleHtml "mediumBody")
+        , Text.smallBody (exampleHtml "smallBody")
+        , Text.smallBodyGray (exampleHtml "smallBodyGray")
+        , Text.caption (exampleHtml "caption")
         , Heading.h2 [ Heading.style Heading.Top ] [ Html.text "Paragraph styles for user-authored content" ]
-        , Text.ugMediumBody [ Html.text <| "This is an ugMediumBody. " ++ longerBody ]
-        , Text.ugSmallBody [ Html.text <| "This is an ugSmallBody. " ++ longerBody ]
+        , Text.ugMediumBody (exampleUGHtml "ugMediumBody")
+        , Text.ugSmallBody (exampleUGHtml "ugSmallBody")
         ]
     }

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -21,11 +21,12 @@ example =
     , content =
         let
             longerBody =
-                """Be on the lookout for a new and improved assignment
-                    creation form! Soon, you'll be able to easily see a summary
-                    of the content you're assigning, as well as an estimate for
-                    how long the assignment will take.
-                """
+                [ "Be on the lookout for a new and improved assignment"
+                , "creation form! Soon, you'll be able to easily see a summary"
+                , "of the content you're assigning, as well as an estimate for"
+                , "how long the assignment will take."
+                ]
+                    |> String.join " "
         in
         [ Text.caption [ Html.text "NOTE: When using these styles, please read the documentation in the Elm module about \"Understanding spacing\"" ]
         , Heading.h2 [ Heading.style Heading.Top ] [ Html.text "Paragraph styles" ]

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -7,6 +7,7 @@ module Examples.Text exposing (example)
 -}
 
 import Html.Styled as Html
+import Html.Styled.Attributes as Attributes
 import ModuleExample as ModuleExample exposing (Category(..), ModuleExample)
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Text.V4 as Text
@@ -35,5 +36,14 @@ example =
         , Heading.h2 [ Heading.style Heading.Top ] [ Html.text "Paragraph styles for user-authored content" ]
         , Text.ugMediumBody [ Html.text <| "This is an ugMediumBody. " ++ longerBody ]
         , Text.ugSmallBody [ Html.text <| "This is an ugSmallBody. " ++ longerBody ]
+        , Text.mediumBody
+            [ Html.text "This is what text looks like with a link. "
+            , Html.a
+                [ Attributes.href "http://www.noredink.com"
+                , Attributes.target "_blank"
+                ]
+                [ Html.text "Praesent commodo cursus magna, vel scelerisque nisl consectetur \n                et. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis \n                risus eget urna mollis ornare vel eu leo." ]
+            , Html.text " Not bad, eh?"
+            ]
         ]
     }


### PR DESCRIPTION
Improves the styling of links in text by adding an underline and making them always blue.

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/13528834/74691285-fe343500-5196-11ea-9aa2-59214b397ce7.png">