### PR TITLE
Fix Firefox banner alert alignment

### DIFF
--- a/src/Nri/Ui/BannerAlert/V6.elm
+++ b/src/Nri/Ui/BannerAlert/V6.elm
@@ -230,6 +230,7 @@ inCircle config =
             , Css.backgroundColor config.backgroundColor
             , Css.displayFlex
             , Css.alignItems Css.center
+            , Css.justifyContent Css.center
             ]
         ]
         [ config.icon


### PR DESCRIPTION
Fix styles for banner alert in Firefox.

## Before

<img width="955" alt="Screen Shot 2020-03-18 at 1 51 22 PM" src="https://user-images.githubusercontent.com/8811312/77006402-9f8de280-691f-11ea-8e28-771af4757f6c.png">

## After

<img width="1087" alt="Screen Shot 2020-03-18 at 1 50 49 PM" src="https://user-images.githubusercontent.com/8811312/77006412-a1f03c80-691f-11ea-98d6-7564242eb044.png">
