### PR TITLE
Prevent text area with auto resize from jumping scroll position

### DIFF
--- a/lib/TextArea/V4.js
+++ b/lib/TextArea/V4.js
@@ -47,7 +47,6 @@ CustomElement.create({
       this._textarea.style.minHeight = minHeight + 'px'
       this._textarea.style.transition = 'none'
       if (this._textarea.scrollHeight > minHeight) {
-        this._textarea.style.height = minHeight + 'px'
         this._textarea.style.height = this._textarea.scrollHeight + 'px'
       } else {
         this._textarea.style.height = minHeight + 'px'


### PR DESCRIPTION
Here's the summary from the first commit message

> The old logic looked like this:
> 
> ```
> if (this._textarea.scrollHeight > minHeight) {
>   this._textarea.style.height = minHeight + 'px'
>   this._textarea.style.height = this._textarea.scrollHeight + 'px'
> }
> ```
> 
> Imagine a case where the `minHeight` is actually less than the current
> height of the text area due to the current content. The height of the
> element would be set to a smaller value, and then later reset to the
> desired height. This causes the overall scroll height of the page to
> shrink (because the text-area did), and then expand again. Now the
> scroll position for the user on the page has changed, and this happens
> on every keystroke.
> 
> This change just skips the first assignment to `.height`. I'm not sure why it
> was initially there, but I can't see a reason for keeping it (especially
> since it seems to be the cause of this bug).

Here's the bug in action, where the scroll position on the page seemingly jumps every time I input a character:

![before](https://user-images.githubusercontent.com/2635560/77789379-23328800-7020-11ea-877d-32bdf237af54.gif)

Here's after the change. Notice no jumping as I type:

![after](https://user-images.githubusercontent.com/2635560/77789450-42311a00-7020-11ea-8efd-cec2fd1200de.gif)

You can play around with the behavior using the same test content below used in the gifs in the current netlify-deployed styleguide, and the one listen in the CI checks (which has the fix).

<details>
  <summary>Lorem Ipsum</summary>
   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus quis finibus lorem. Donec in ante est. Pellentesque velit ligula, ornare a justo sed, consequat molestie lorem. Vivamus congue, risus eu feugiat mattis, ante eros efficitur arcu, maximus imperdiet leo odio eu risus. Curabitur pellentesque justo sed pulvinar semper. Nunc mi eros, tincidunt in fermentum a, pulvinar ut libero. In dapibus justo lectus, quis consequat tellus tincidunt vel. Vivamus convallis augue eget diam suscipit malesuada. Duis convallis ante est, sit amet tempus nisi venenatis et. Nunc eleifend pretium purus non egestas. In hac habitasse platea dictumst. Morbi leo justo, pharetra sit amet arcu non, ullamcorper rutrum urna. In venenatis, magna sit amet convallis lacinia, urna justo blandit purus, ac interdum diam diam id libero. Praesent ac massa at mauris scelerisque placerat et sit amet massa.

Suspendisse accumsan auctor nibh, in tincidunt ipsum commodo at. Sed pretium, elit et rhoncus dictum, risus felis malesuada diam, quis tincidunt velit tellus vitae leo. Curabitur neque lacus, tempor eu suscipit ut, placerat et justo. In et vehicula nisl, quis luctus quam. Suspendisse eget eros quis odio maximus dapibus eget at ipsum. Nulla pellentesque vel dui at convallis. Curabitur egestas orci eget mi semper, quis cursus ex mollis. Quisque at efficitur augue, tempus bibendum neque. Nam ac gravida leo. Curabitur ultrices eget ligula id lobortis. Praesent accumsan euismod erat, quis eleifend sem facilisis vitae. Curabitur dapibus erat in lacinia condimentum. Donec commodo non tellus quis auctor. Nulla a ante velit. Donec elit orci, tincidunt sit amet dapibus vel, ultricies et nisl. Donec a odio libero.

Nunc rhoncus condimentum dui, ut aliquet justo euismod sed. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec interdum ligula et interdum blandit. Vestibulum sodales metus eget lacus rhoncus, et dictum justo efficitur. Aliquam blandit ante ut felis congue auctor. Quisque suscipit luctus augue, quis tincidunt lectus porta vitae. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Sed at vehicula dui. In et diam consectetur diam ultrices placerat sit amet a ex. Phasellus vel volutpat lectus, eget faucibus elit. Vestibulum rhoncus sed ex et facilisis. Praesent id ipsum nulla.
</details>

