### PR TITLE
Bump npm package to 1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@noredink/ui",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noredink/ui",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "UI widgets we use.",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Releases the fix in the TextArea custom element from #483 

Also, I didn't actually need to bump the elm package in #484 since it didn't actually change any Elm code! Woops! I kinda went on autopilot there, since I rarely make changes to our js code here.