### PR TITLE
re-enable major version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,7 @@ checks:
 
 .PHONY: diff
 diff: node_modules
-	true
-#if (npx elm diff | tee /dev/stderr | grep -q MAJOR); then echo "MAJOR changes are not allowed!"; exit 1; fi
+	if (npx elm diff | tee /dev/stderr | grep -q MAJOR); then echo "MAJOR changes are not allowed!"; exit 1; fi
 
 .PHONY: format
 format: node_modules


### PR DESCRIPTION
I disabled this to publish 8.0.0 in #486, reenabling now.