### PR TITLE
Tessa/nri loading

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -36,6 +36,7 @@
         "Nri.Ui.Icon.V4",
         "Nri.Ui.Icon.V5",
         "Nri.Ui.InputStyles.V2",
+        "Nri.Ui.Loading.V1",
         "Nri.Ui.Logo.V1",
         "Nri.Ui.MasteryIcon.V1",
         "Nri.Ui.Modal.V8",

--- a/src/Nri/Ui/Loading/V1.elm
+++ b/src/Nri/Ui/Loading/V1.elm
@@ -1,12 +1,12 @@
 module Nri.Ui.Loading.V1 exposing
     ( fadeInPage, page
-    , spinner
+    , spinningPencil, spinningDots
     )
 
 {-| Loading behaviors
 
 @docs fadeInPage, page
-@docs spinner
+@docs spinningPencil, spinningDots
 
 -}
 
@@ -15,8 +15,10 @@ import Css.Animations
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.Svg.V1 as Svg exposing (Svg)
+import Nri.Ui.Svg.V1
 import Nri.Ui.UiIcon.V1 as UiIcon
+import Svg.Styled as Svg exposing (Svg)
+import Svg.Styled.Attributes as SvgAttributes
 
 
 {-| View a full-screen loading page that fades into view.
@@ -58,24 +60,51 @@ loading_ withCss =
                 ++ withCss
             )
         ]
-        [ Svg.toHtml spinner
+        [ Nri.Ui.Svg.V1.toHtml spinningPencil
         ]
 
 
 {-| -}
-spinner : Svg
-spinner =
+spinningPencil : Nri.Ui.Svg.V1.Svg
+spinningPencil =
     UiIcon.edit
-        |> Svg.withLabel "Loading..."
-        |> Svg.withColor Colors.white
-        |> Svg.withWidth (Css.px 100)
-        |> Svg.withHeight (Css.px 100)
-        |> Svg.withCss
-            [ Css.property "animation-duration" "1s"
-            , Css.property "animation-iteration-count" "infinite"
-            , Css.animationName rotateKeyframes
-            , Css.property "animation-timing-function" "linear"
-            ]
+        |> Nri.Ui.Svg.V1.withLabel "Loading..."
+        |> Nri.Ui.Svg.V1.withColor Colors.white
+        |> Nri.Ui.Svg.V1.withWidth (Css.px 100)
+        |> Nri.Ui.Svg.V1.withHeight (Css.px 100)
+        |> Nri.Ui.Svg.V1.withCss circlingCss
+
+
+{-| -}
+spinningDots : Nri.Ui.Svg.V1.Svg
+spinningDots =
+    Svg.svg
+        [ SvgAttributes.width "100%"
+        , SvgAttributes.height "100%"
+        , SvgAttributes.viewBox "0 0 12.54 12.54"
+        ]
+        [ Svg.circle [ SvgAttributes.fill "#004e95", SvgAttributes.cx "6.13", SvgAttributes.cy "0.98", SvgAttributes.r "0.98" ] []
+        , Svg.circle [ SvgAttributes.fill "#004cc9", SvgAttributes.cx "9.95", SvgAttributes.cy "2.47", SvgAttributes.r "0.98", SvgAttributes.transform "translate(1.12 7.67) rotate(-44.43)" ] []
+        , Svg.circle [ SvgAttributes.fill "#146aff", SvgAttributes.x "11.56", SvgAttributes.cy "6.24", SvgAttributes.r "0.98", SvgAttributes.transform "translate(5.09 17.67) rotate(-88.86)" ] []
+        , Svg.circle [ SvgAttributes.fill "#0af", SvgAttributes.cx "10", SvgAttributes.cy "10.02", SvgAttributes.r "0.98", SvgAttributes.transform "translate(-4.15 9.58) rotate(-43.29)" ] []
+        , Svg.circle [ SvgAttributes.fill "#d4f0ff", SvgAttributes.cx "6.2", SvgAttributes.cy "11.56", SvgAttributes.r "0.98", SvgAttributes.transform "translate(-5.6 17.29) rotate(-87.71)" ] []
+        , Svg.circle [ SvgAttributes.fill "#eef9ff", SvgAttributes.cx "2.44", SvgAttributes.cy "9.92", SvgAttributes.r "0.98", SvgAttributes.transform "translate(-6.03 4.21) rotate(-42.14)" ] []
+        , Svg.circle [ SvgAttributes.fill "#f5f5f5", SvgAttributes.cx "0.98", SvgAttributes.cy "6.1", SvgAttributes.r "0.98", SvgAttributes.transform "translate(-5.16 6.71) rotate(-86.57)" ] []
+        , Svg.circle [ SvgAttributes.fill "#fff", SvgAttributes.cx "2.69", SvgAttributes.cy "2.37", SvgAttributes.r "0.98", SvgAttributes.transform "translate(-0.9 2.35) rotate(-41)" ] []
+        ]
+        |> Nri.Ui.Svg.V1.fromHtml
+        |> Nri.Ui.Svg.V1.withWidth (Css.px 100)
+        |> Nri.Ui.Svg.V1.withHeight (Css.px 100)
+        |> Nri.Ui.Svg.V1.withCss circlingCss
+
+
+circlingCss : List Css.Style
+circlingCss =
+    [ Css.property "animation-duration" "1s"
+    , Css.property "animation-iteration-count" "infinite"
+    , Css.animationName rotateKeyframes
+    , Css.property "animation-timing-function" "linear"
+    ]
 
 
 rotateKeyframes : Css.Animations.Keyframes {}

--- a/src/Nri/Ui/Loading/V1.elm
+++ b/src/Nri/Ui/Loading/V1.elm
@@ -1,0 +1,93 @@
+module Nri.Ui.Loading.V1 exposing
+    ( fadeInPage, page
+    , spinner
+    )
+
+{-| Loading behaviors
+
+@docs fadeInPage, page
+@docs spinner
+
+-}
+
+import Css exposing (..)
+import Css.Animations
+import Html.Styled as Html exposing (Html)
+import Html.Styled.Attributes as Attributes
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Svg.V1 as Svg exposing (Svg)
+import Nri.Ui.UiIcon.V1 as UiIcon
+
+
+{-| View a full-screen loading page that fades into view.
+-}
+fadeInPage : Html msg
+fadeInPage =
+    loading_
+        [ Css.property "animation-delay" "1s"
+        , Css.property "animation-duration" "1.5s"
+        , Css.property "animation-fill-mode" "forwards"
+        , Css.animationName fadeInKeyframes
+        , Css.property "animation-timing-function" "linear"
+        , Css.opacity Css.zero
+        ]
+
+
+{-| View a full-screen loading page.
+-}
+page : Html msg
+page =
+    loading_ []
+
+
+loading_ : List Css.Style -> Html msg
+loading_ withCss =
+    Html.div
+        [ Attributes.css
+            ([ Css.backgroundColor Colors.blueDeep
+             , Css.position Css.fixed
+             , Css.displayFlex
+             , Css.alignItems Css.center
+             , Css.justifyContent Css.center
+             , Css.width (Css.vw 100)
+             , Css.height (Css.vh 100)
+             , Css.top Css.zero
+             , Css.left Css.zero
+             , Css.zIndex (Css.int 10000)
+             ]
+                ++ withCss
+            )
+        ]
+        [ Svg.toHtml spinner
+        ]
+
+
+{-| -}
+spinner : Svg
+spinner =
+    UiIcon.edit
+        |> Svg.withLabel "Loading..."
+        |> Svg.withColor Colors.white
+        |> Svg.withWidth (Css.px 100)
+        |> Svg.withHeight (Css.px 100)
+        |> Svg.withCss
+            [ Css.property "animation-duration" "1s"
+            , Css.property "animation-iteration-count" "infinite"
+            , Css.animationName rotateKeyframes
+            , Css.property "animation-timing-function" "linear"
+            ]
+
+
+rotateKeyframes : Css.Animations.Keyframes {}
+rotateKeyframes =
+    Css.Animations.keyframes
+        [ ( 0, [ Css.Animations.transform [ Css.rotate (Css.deg -360) ] ] )
+        ]
+
+
+fadeInKeyframes : Css.Animations.Keyframes {}
+fadeInKeyframes =
+    Css.Animations.keyframes
+        [ ( 0, [ Css.Animations.opacity Css.zero ] )
+        , ( 100, [ Css.Animations.opacity (Css.num 1) ] )
+        ]

--- a/src/Nri/Ui/Page/V3.elm
+++ b/src/Nri/Ui/Page/V3.elm
@@ -1,20 +1,26 @@
 module Nri.Ui.Page.V3 exposing
     ( DefaultPage, broken, blocked, notFound, noPermission
     , RecoveryText(..)
+    , loadingFadeIn
     )
 
-{-| A styled NRI issue page!
+{-| A styled NRI page!
 
 @docs DefaultPage, broken, blocked, notFound, noPermission
 @docs RecoveryText
+@docs loadingFadeIn
 
 -}
 
 import Css exposing (..)
+import Css.Animations
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Nri.Ui.Button.V5 as Button
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Text.V2 as Text
+import Nri.Ui.UiIcon.V1 as UiIcon
 
 
 {-| The default page information is for the button
@@ -88,6 +94,58 @@ noPermission defaultPage =
         , defaultPage = Just defaultPage
         , details = Nothing
         }
+
+
+{-| View a full-screen loading page.
+-}
+loadingFadeIn : Html msg
+loadingFadeIn =
+    Html.div
+        [ Attributes.css
+            [ Css.backgroundColor Colors.blueDeep
+            , Css.position Css.fixed
+            , Css.displayFlex
+            , Css.alignItems Css.center
+            , Css.justifyContent Css.center
+            , Css.width (Css.vw 100)
+            , Css.height (Css.vh 100)
+            , Css.top Css.zero
+            , Css.left Css.zero
+            , Css.zIndex (Css.int 10000)
+            , Css.opacity Css.zero
+            , Css.property "animation-delay" "1s"
+            , Css.property "animation-duration" "1.5s"
+            , Css.property "animation-fill-mode" "forwards"
+            , Css.animationName fadeInKeyframes
+            , Css.property "animation-timing-function" "linear"
+            ]
+        ]
+        [ UiIcon.edit
+            |> Svg.withLabel "Loading..."
+            |> Svg.withColor Colors.white
+            |> Svg.withCss
+                [ Css.property "animation-duration" "1s"
+                , Css.property "animation-iteration-count" "infinite"
+                , Css.animationName rotateKeyframes
+                , Css.property "animation-timing-function" "linear"
+                ]
+            |> Svg.toHtml
+        ]
+
+
+rotateKeyframes : Css.Animations.Keyframes {}
+rotateKeyframes =
+    Css.Animations.keyframes
+        [ ( 0, [ Css.Animations.transform [ Css.rotate (Css.deg -360) ] ] )
+        ]
+
+
+fadeInKeyframes : Css.Animations.Keyframes {}
+fadeInKeyframes =
+    Css.Animations.keyframes
+        [ ( 0, [ Css.Animations.opacity Css.zero ] )
+        , ( 100, [ Css.Animations.opacity (Css.num 1) ] )
+        ]
 
 
 

--- a/src/Nri/Ui/Page/V3.elm
+++ b/src/Nri/Ui/Page/V3.elm
@@ -1,14 +1,14 @@
 module Nri.Ui.Page.V3 exposing
     ( DefaultPage, broken, blocked, notFound, noPermission
     , RecoveryText(..)
-    , loadingFadeIn
+    , loadingFadeIn, loading
     )
 
 {-| A styled NRI page!
 
 @docs DefaultPage, broken, blocked, notFound, noPermission
 @docs RecoveryText
-@docs loadingFadeIn
+@docs loadingFadeIn, loading
 
 -}
 
@@ -96,29 +96,44 @@ noPermission defaultPage =
         }
 
 
-{-| View a full-screen loading page.
+{-| View a full-screen loading page that fades into view.
 -}
 loadingFadeIn : Html msg
 loadingFadeIn =
+    loading_
+        [ Css.property "animation-delay" "1s"
+        , Css.property "animation-duration" "1.5s"
+        , Css.property "animation-fill-mode" "forwards"
+        , Css.animationName fadeInKeyframes
+        , Css.property "animation-timing-function" "linear"
+        , Css.opacity Css.zero
+        ]
+
+
+{-| View a full-screen loading page.
+-}
+loading : Html msg
+loading =
+    loading_ []
+
+
+loading_ : List Css.Style -> Html msg
+loading_ withCss =
     Html.div
         [ Attributes.css
-            [ Css.backgroundColor Colors.blueDeep
-            , Css.position Css.fixed
-            , Css.displayFlex
-            , Css.alignItems Css.center
-            , Css.justifyContent Css.center
-            , Css.width (Css.vw 100)
-            , Css.height (Css.vh 100)
-            , Css.top Css.zero
-            , Css.left Css.zero
-            , Css.zIndex (Css.int 10000)
-            , Css.opacity Css.zero
-            , Css.property "animation-delay" "1s"
-            , Css.property "animation-duration" "1.5s"
-            , Css.property "animation-fill-mode" "forwards"
-            , Css.animationName fadeInKeyframes
-            , Css.property "animation-timing-function" "linear"
-            ]
+            ([ Css.backgroundColor Colors.blueDeep
+             , Css.position Css.fixed
+             , Css.displayFlex
+             , Css.alignItems Css.center
+             , Css.justifyContent Css.center
+             , Css.width (Css.vw 100)
+             , Css.height (Css.vh 100)
+             , Css.top Css.zero
+             , Css.left Css.zero
+             , Css.zIndex (Css.int 10000)
+             ]
+                ++ withCss
+            )
         ]
         [ UiIcon.edit
             |> Svg.withLabel "Loading..."

--- a/src/Nri/Ui/Page/V3.elm
+++ b/src/Nri/Ui/Page/V3.elm
@@ -1,26 +1,20 @@
 module Nri.Ui.Page.V3 exposing
     ( DefaultPage, broken, blocked, notFound, noPermission
     , RecoveryText(..)
-    , loadingFadeIn, loading
     )
 
 {-| A styled NRI page!
 
 @docs DefaultPage, broken, blocked, notFound, noPermission
 @docs RecoveryText
-@docs loadingFadeIn, loading
 
 -}
 
 import Css exposing (..)
-import Css.Animations
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Nri.Ui.Button.V5 as Button
-import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Text.V2 as Text
-import Nri.Ui.UiIcon.V1 as UiIcon
 
 
 {-| The default page information is for the button
@@ -94,75 +88,6 @@ noPermission defaultPage =
         , defaultPage = Just defaultPage
         , details = Nothing
         }
-
-
-{-| View a full-screen loading page that fades into view.
--}
-loadingFadeIn : Html msg
-loadingFadeIn =
-    loading_
-        [ Css.property "animation-delay" "1s"
-        , Css.property "animation-duration" "1.5s"
-        , Css.property "animation-fill-mode" "forwards"
-        , Css.animationName fadeInKeyframes
-        , Css.property "animation-timing-function" "linear"
-        , Css.opacity Css.zero
-        ]
-
-
-{-| View a full-screen loading page.
--}
-loading : Html msg
-loading =
-    loading_ []
-
-
-loading_ : List Css.Style -> Html msg
-loading_ withCss =
-    Html.div
-        [ Attributes.css
-            ([ Css.backgroundColor Colors.blueDeep
-             , Css.position Css.fixed
-             , Css.displayFlex
-             , Css.alignItems Css.center
-             , Css.justifyContent Css.center
-             , Css.width (Css.vw 100)
-             , Css.height (Css.vh 100)
-             , Css.top Css.zero
-             , Css.left Css.zero
-             , Css.zIndex (Css.int 10000)
-             ]
-                ++ withCss
-            )
-        ]
-        [ UiIcon.edit
-            |> Svg.withLabel "Loading..."
-            |> Svg.withColor Colors.white
-            |> Svg.withWidth (Css.px 100)
-            |> Svg.withHeight (Css.px 100)
-            |> Svg.withCss
-                [ Css.property "animation-duration" "1s"
-                , Css.property "animation-iteration-count" "infinite"
-                , Css.animationName rotateKeyframes
-                , Css.property "animation-timing-function" "linear"
-                ]
-            |> Svg.toHtml
-        ]
-
-
-rotateKeyframes : Css.Animations.Keyframes {}
-rotateKeyframes =
-    Css.Animations.keyframes
-        [ ( 0, [ Css.Animations.transform [ Css.rotate (Css.deg -360) ] ] )
-        ]
-
-
-fadeInKeyframes : Css.Animations.Keyframes {}
-fadeInKeyframes =
-    Css.Animations.keyframes
-        [ ( 0, [ Css.Animations.opacity Css.zero ] )
-        , ( 100, [ Css.Animations.opacity (Css.num 1) ] )
-        ]
 
 
 

--- a/src/Nri/Ui/Page/V3.elm
+++ b/src/Nri/Ui/Page/V3.elm
@@ -138,6 +138,8 @@ loading_ withCss =
         [ UiIcon.edit
             |> Svg.withLabel "Loading..."
             |> Svg.withColor Colors.white
+            |> Svg.withWidth (Css.px 100)
+            |> Svg.withHeight (Css.px 100)
             |> Svg.withCss
                 [ Css.property "animation-duration" "1s"
                 , Css.property "animation-iteration-count" "infinite"

--- a/styleguide-app/Category.elm
+++ b/styleguide-app/Category.elm
@@ -180,7 +180,7 @@ forId category =
             "text-and-fonts"
 
         Pages ->
-            "error-pages"
+            "pages"
 
         Animations ->
             "animations"

--- a/styleguide-app/Category.elm
+++ b/styleguide-app/Category.elm
@@ -133,7 +133,7 @@ forDisplay category =
             "Text and Fonts"
 
         Pages ->
-            "Error Pages"
+            "Pages"
 
         Animations ->
             "Animations"

--- a/styleguide-app/Examples.elm
+++ b/styleguide-app/Examples.elm
@@ -16,6 +16,7 @@ import Examples.Dropdown as Dropdown
 import Examples.Fonts as Fonts
 import Examples.Heading as Heading
 import Examples.Icon as Icon
+import Examples.Loading as Loading
 import Examples.Logo as Logo
 import Examples.MasteryIcon as MasteryIcon
 import Examples.Modal as Modal
@@ -319,6 +320,25 @@ all =
             (\msg ->
                 case msg of
                     IconState childState ->
+                        Just childState
+
+                    _ ->
+                        Nothing
+            )
+    , Loading.example
+        |> Example.wrapMsg LoadingMsg
+            (\msg ->
+                case msg of
+                    LoadingMsg childMsg ->
+                        Just childMsg
+
+                    _ ->
+                        Nothing
+            )
+        |> Example.wrapState LoadingState
+            (\msg ->
+                case msg of
+                    LoadingState childState ->
                         Just childState
 
                     _ ->
@@ -704,6 +724,7 @@ type State
     | FontsState Fonts.State
     | HeadingState Heading.State
     | IconState Icon.State
+    | LoadingState Loading.State
     | LogoState Logo.State
     | MasteryIconState MasteryIcon.State
     | ModalState Modal.State
@@ -741,6 +762,7 @@ type Msg
     | FontsMsg Fonts.Msg
     | HeadingMsg Heading.Msg
     | IconMsg Icon.Msg
+    | LoadingMsg Loading.Msg
     | LogoMsg Logo.Msg
     | MasteryIconMsg MasteryIcon.Msg
     | ModalMsg Modal.Msg

--- a/styleguide-app/Examples/Loading.elm
+++ b/styleguide-app/Examples/Loading.elm
@@ -26,7 +26,7 @@ import Nri.Ui.Text.V4 as Text
 type alias State =
     { showLoadingFadeIn : Bool
     , showLoading : Bool
-    , showSpinner : Bool
+    , showSpinners : Bool
     }
 
 
@@ -34,7 +34,7 @@ init : State
 init =
     { showLoadingFadeIn = False
     , showLoading = False
-    , showSpinner = False
+    , showSpinners = False
     }
 
 
@@ -42,7 +42,7 @@ init =
 type Msg
     = ShowLoadingFadeIn
     | ShowLoading
-    | ShowSpinner
+    | ShowSpinners
     | Close
 
 
@@ -59,8 +59,8 @@ update msg model =
             , Cmd.none
             )
 
-        ShowSpinner ->
-            ( { model | showSpinner = True }
+        ShowSpinners ->
+            ( { model | showSpinners = True }
             , Cmd.none
             )
 
@@ -68,15 +68,15 @@ update msg model =
             ( { model
                 | showLoadingFadeIn = False
                 , showLoading = False
-                , showSpinner = False
+                , showSpinners = False
               }
             , Cmd.none
             )
 
 
 subscriptions : State -> Sub Msg
-subscriptions { showLoadingFadeIn, showLoading, showSpinner } =
-    if showLoadingFadeIn || showLoading || showSpinner then
+subscriptions { showLoadingFadeIn, showLoading, showSpinners } =
+    if showLoadingFadeIn || showLoading || showSpinners then
         Browser.Events.onClick (Json.Decode.succeed Close)
 
     else
@@ -92,7 +92,7 @@ example =
     , update = update
     , subscriptions = subscriptions
     , view =
-        \{ showLoadingFadeIn, showLoading, showSpinner } ->
+        \{ showLoadingFadeIn, showLoading, showSpinners } ->
             [ if showLoading then
                 Loading.page
 
@@ -105,16 +105,18 @@ example =
               else
                 Html.text ""
             , button "Loading.fadeInPage" ShowLoadingFadeIn showLoadingFadeIn
-            , if showSpinner then
+            , if showSpinners then
                 Html.div []
-                    [ Loading.spinner
+                    [ Loading.spinningPencil
                         |> Svg.withColor Colors.blue
                         |> Svg.toHtml
-                    , Text.caption [ Html.text "By default, the spinner is white. Showing as blue for visibility." ]
+                    , Text.caption [ Html.text "By default, the spinningPencil is white. Showing as blue for visibility." ]
+                    , Loading.spinningDots
+                        |> Svg.toHtml
                     ]
 
               else
-                button "Loading.spinner" ShowSpinner showLoadingFadeIn
+                button "Loading.spinningPencil, Loading.spinningDots" ShowSpinners showLoadingFadeIn
             ]
     }
 

--- a/styleguide-app/Examples/Loading.elm
+++ b/styleguide-app/Examples/Loading.elm
@@ -1,0 +1,122 @@
+module Examples.Loading exposing (example, State, Msg)
+
+{-|
+
+@docs example, State, Msg
+
+-}
+
+import Browser.Events
+import Category exposing (Category(..))
+import Css
+import Css.Global exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
+import Example exposing (Example)
+import Html.Styled as Html exposing (Html)
+import Html.Styled.Events as Events
+import Json.Decode
+import Nri.Ui.Button.V10 as Button
+import Nri.Ui.Heading.V2 as Heading
+import Nri.Ui.Loading.V1 as Loading
+
+
+{-| -}
+type alias State =
+    { showLoadingFadeIn : Bool
+    , showLoading : Bool
+    }
+
+
+init : State
+init =
+    { showLoadingFadeIn = False
+    , showLoading = False
+    }
+
+
+{-| -}
+type Msg
+    = ShowLoadingFadeIn
+    | ShowLoading
+    | CloseFullScreenPage
+
+
+update : Msg -> State -> ( State, Cmd Msg )
+update msg model =
+    case msg of
+        ShowLoadingFadeIn ->
+            ( { model | showLoadingFadeIn = True }
+            , Cmd.none
+            )
+
+        ShowLoading ->
+            ( { model | showLoading = True }
+            , Cmd.none
+            )
+
+        CloseFullScreenPage ->
+            ( { model
+                | showLoadingFadeIn = False
+                , showLoading = False
+              }
+            , Cmd.none
+            )
+
+
+subscriptions : State -> Sub Msg
+subscriptions { showLoadingFadeIn, showLoading } =
+    if showLoadingFadeIn || showLoading then
+        Browser.Events.onClick (Json.Decode.succeed CloseFullScreenPage)
+
+    else
+        Sub.none
+
+
+{-| -}
+example : Example State Msg
+example =
+    { name = "Nri.Ui.Loading.V1"
+    , categories = [ Pages ]
+    , state = init
+    , update = update
+    , subscriptions = subscriptions
+    , view =
+        \{ showLoadingFadeIn, showLoading } ->
+            [ if showLoading then
+                Loading.page
+
+              else
+                Html.text ""
+            , Button.button "Loading.page"
+                [ Button.custom
+                    [ Events.stopPropagationOn "click"
+                        (Json.Decode.map (\m -> ( m, True ))
+                            (Json.Decode.succeed ShowLoading)
+                        )
+                    ]
+                , if showLoadingFadeIn then
+                    Button.disabled
+
+                  else
+                    Button.secondary
+                , Button.css [ Css.marginRight (Css.px 20) ]
+                ]
+            , if showLoadingFadeIn then
+                Loading.fadeInPage
+
+              else
+                Html.text ""
+            , Button.button "Loading.fadeInPage"
+                [ Button.custom
+                    [ Events.stopPropagationOn "click"
+                        (Json.Decode.map (\m -> ( m, True ))
+                            (Json.Decode.succeed ShowLoadingFadeIn)
+                        )
+                    ]
+                , if showLoadingFadeIn then
+                    Button.loading
+
+                  else
+                    Button.secondary
+                ]
+            ]
+    }

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -21,47 +21,22 @@ import Nri.Ui.Page.V3 as Page
 
 {-| -}
 type alias State =
-    { showLoadingFadeIn : Bool
-    , showLoading : Bool
-    }
+    {}
 
 
 init : State
 init =
-    { showLoadingFadeIn = False
-    , showLoading = False
-    }
+    {}
 
 
 {-| -}
 type Msg
-    = ShowLoadingFadeIn
-    | ShowLoading
-    | CloseFullScreenPage
-    | LinkClick String
+    = LinkClick String
 
 
 update : Msg -> State -> ( State, Cmd Msg )
 update msg model =
     case msg of
-        ShowLoadingFadeIn ->
-            ( { model | showLoadingFadeIn = True }
-            , Cmd.none
-            )
-
-        ShowLoading ->
-            ( { model | showLoading = True }
-            , Cmd.none
-            )
-
-        CloseFullScreenPage ->
-            ( { model
-                | showLoadingFadeIn = False
-                , showLoading = False
-              }
-            , Cmd.none
-            )
-
         LinkClick message ->
             let
                 _ =
@@ -71,12 +46,8 @@ update msg model =
 
 
 subscriptions : State -> Sub Msg
-subscriptions { showLoadingFadeIn, showLoading } =
-    if showLoadingFadeIn || showLoading then
-        Browser.Events.onClick (Json.Decode.succeed CloseFullScreenPage)
-
-    else
-        Sub.none
+subscriptions {} =
+    Sub.none
 
 
 {-| -}
@@ -88,7 +59,7 @@ example =
     , update = update
     , subscriptions = subscriptions
     , view =
-        \{ showLoadingFadeIn, showLoading } ->
+        \{} ->
             [ Css.Global.global
                 [ Css.Global.selector "[data-page-container]"
                     [ Css.displayFlex
@@ -110,43 +81,5 @@ example =
                 { link = LinkClick "Custom"
                 , recoveryText = Page.Custom "Hit the road, Jack"
                 }
-            , Heading.h3 [] [ Html.text "Page.loadingFadeIn" ]
-            , if showLoadingFadeIn then
-                Page.loadingFadeIn
-
-              else
-                Html.text ""
-            , Button.button "Open loadingFadeIn"
-                [ Button.custom
-                    [ Events.stopPropagationOn "click"
-                        (Json.Decode.map (\m -> ( m, True ))
-                            (Json.Decode.succeed ShowLoadingFadeIn)
-                        )
-                    ]
-                , if showLoadingFadeIn then
-                    Button.loading
-
-                  else
-                    Button.primary
-                ]
-            , Heading.h3 [] [ Html.text "Page.loading" ]
-            , if showLoading then
-                Page.loading
-
-              else
-                Html.text ""
-            , Button.button "Open loading"
-                [ Button.custom
-                    [ Events.stopPropagationOn "click"
-                        (Json.Decode.map (\m -> ( m, True ))
-                            (Json.Decode.succeed ShowLoading)
-                        )
-                    ]
-                , if showLoadingFadeIn then
-                    Button.disabled
-
-                  else
-                    Button.primary
-                ]
             ]
     }

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -6,48 +6,23 @@ module Examples.Page exposing (example, State, Msg)
 
 -}
 
-import Browser.Events
 import Category exposing (Category(..))
 import Css
 import Css.Global exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
-import Html.Styled.Events as Events
-import Json.Decode
-import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Page.V3 as Page
 
 
 {-| -}
 type alias State =
-    {}
-
-
-init : State
-init =
-    {}
+    ()
 
 
 {-| -}
-type Msg
-    = LinkClick String
-
-
-update : Msg -> State -> ( State, Cmd Msg )
-update msg model =
-    case msg of
-        LinkClick message ->
-            let
-                _ =
-                    Debug.log "Clicked: " message
-            in
-            ( model, Cmd.none )
-
-
-subscriptions : State -> Sub Msg
-subscriptions {} =
-    Sub.none
+type alias Msg =
+    String
 
 
 {-| -}
@@ -55,11 +30,17 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Page.V3"
     , categories = List.singleton Pages
-    , state = init
-    , update = update
-    , subscriptions = subscriptions
+    , state = ()
+    , update =
+        \msg model ->
+            let
+                _ =
+                    Debug.log "Clicked: " msg
+            in
+            ( model, Cmd.none )
+    , subscriptions = \_ -> Sub.none
     , view =
-        \{} ->
+        \_ ->
             [ Css.Global.global
                 [ Css.Global.selector "[data-page-container]"
                     [ Css.displayFlex
@@ -68,17 +49,17 @@ example =
                 ]
             , Heading.h3 [] [ Html.text "Page: Not Found, recovery text: ReturnTo" ]
             , Page.notFound
-                { link = LinkClick "ReturnTo"
+                { link = "Page.notFound ReturnTo"
                 , recoveryText = Page.ReturnTo "the main page"
                 }
             , Heading.h3 [] [ Html.text "Page: Broken, recovery text: Reload" ]
             , Page.broken
-                { link = LinkClick "Reload"
+                { link = "Page.broken Reload"
                 , recoveryText = Page.Reload
                 }
             , Heading.h3 [] [ Html.text "Page: No Permission, recovery text: Custom" ]
             , Page.noPermission
-                { link = LinkClick "Custom"
+                { link = "Page.noPermission Custom"
                 , recoveryText = Page.Custom "Hit the road, Jack"
                 }
             ]

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -6,23 +6,65 @@ module Examples.Page exposing (example, State, Msg)
 
 -}
 
+import Browser.Events
 import Category exposing (Category(..))
 import Css
 import Css.Global exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
+import Html.Styled.Events as Events
+import Json.Decode
+import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Page.V3 as Page
 
 
 {-| -}
 type alias State =
-    ()
+    { showLoadingFadeIn : Bool
+    }
+
+
+init : State
+init =
+    { showLoadingFadeIn = False }
 
 
 {-| -}
-type alias Msg =
-    ()
+type Msg
+    = ShowLoadingFadeIn
+    | CloseFullScreenPage
+    | LinkClick String
+
+
+update : Msg -> State -> ( State, Cmd Msg )
+update msg model =
+    case msg of
+        ShowLoadingFadeIn ->
+            ( { model | showLoadingFadeIn = True }, Cmd.none )
+
+        CloseFullScreenPage ->
+            ( { model
+                | showLoadingFadeIn = False
+              }
+            , Cmd.none
+            )
+
+        LinkClick message ->
+            let
+                _ =
+                    Debug.log "Clicked: " message
+            in
+            ( model, Cmd.none )
+
+
+subscriptions : State -> Sub Msg
+subscriptions { showLoadingFadeIn } =
+    if showLoadingFadeIn then
+        Browser.Events.onClick (Json.Decode.succeed CloseFullScreenPage)
+
+    else
+        Sub.none
 
 
 {-| -}
@@ -30,11 +72,11 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Page.V3"
     , categories = List.singleton Pages
-    , state = ()
-    , update = \_ state -> ( state, Cmd.none )
-    , subscriptions = \_ -> Sub.none
+    , state = init
+    , update = update
+    , subscriptions = subscriptions
     , view =
-        \_ ->
+        \{ showLoadingFadeIn } ->
             [ Css.Global.global
                 [ Css.Global.selector "[data-page-container]"
                     [ Css.displayFlex
@@ -43,18 +85,37 @@ example =
                 ]
             , Heading.h3 [] [ Html.text "Page: Not Found, recovery text: ReturnTo" ]
             , Page.notFound
-                { link = ()
+                { link = LinkClick "ReturnTo"
                 , recoveryText = Page.ReturnTo "the main page"
                 }
             , Heading.h3 [] [ Html.text "Page: Broken, recovery text: Reload" ]
             , Page.broken
-                { link = ()
+                { link = LinkClick "Reload"
                 , recoveryText = Page.Reload
                 }
             , Heading.h3 [] [ Html.text "Page: No Permission, recovery text: Custom" ]
             , Page.noPermission
-                { link = ()
+                { link = LinkClick "Custom"
                 , recoveryText = Page.Custom "Hit the road, Jack"
                 }
+            , Heading.h3 [] [ Html.text "Page.loadingFadeIn" ]
+            , if showLoadingFadeIn then
+                Page.loadingFadeIn
+
+              else
+                Html.text ""
+            , Button.button "Open loadingFadeIn"
+                [ Button.custom
+                    [ Events.stopPropagationOn "click"
+                        (Json.Decode.map (\m -> ( m, True ))
+                            (Json.Decode.succeed ShowLoadingFadeIn)
+                        )
+                    ]
+                , if showLoadingFadeIn then
+                    Button.loading
+
+                  else
+                    Button.primary
+                ]
             ]
     }

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -22,17 +22,21 @@ import Nri.Ui.Page.V3 as Page
 {-| -}
 type alias State =
     { showLoadingFadeIn : Bool
+    , showLoading : Bool
     }
 
 
 init : State
 init =
-    { showLoadingFadeIn = False }
+    { showLoadingFadeIn = False
+    , showLoading = False
+    }
 
 
 {-| -}
 type Msg
     = ShowLoadingFadeIn
+    | ShowLoading
     | CloseFullScreenPage
     | LinkClick String
 
@@ -41,11 +45,19 @@ update : Msg -> State -> ( State, Cmd Msg )
 update msg model =
     case msg of
         ShowLoadingFadeIn ->
-            ( { model | showLoadingFadeIn = True }, Cmd.none )
+            ( { model | showLoadingFadeIn = True }
+            , Cmd.none
+            )
+
+        ShowLoading ->
+            ( { model | showLoading = True }
+            , Cmd.none
+            )
 
         CloseFullScreenPage ->
             ( { model
                 | showLoadingFadeIn = False
+                , showLoading = False
               }
             , Cmd.none
             )
@@ -59,8 +71,8 @@ update msg model =
 
 
 subscriptions : State -> Sub Msg
-subscriptions { showLoadingFadeIn } =
-    if showLoadingFadeIn then
+subscriptions { showLoadingFadeIn, showLoading } =
+    if showLoadingFadeIn || showLoading then
         Browser.Events.onClick (Json.Decode.succeed CloseFullScreenPage)
 
     else
@@ -76,7 +88,7 @@ example =
     , update = update
     , subscriptions = subscriptions
     , view =
-        \{ showLoadingFadeIn } ->
+        \{ showLoadingFadeIn, showLoading } ->
             [ Css.Global.global
                 [ Css.Global.selector "[data-page-container]"
                     [ Css.displayFlex
@@ -113,6 +125,25 @@ example =
                     ]
                 , if showLoadingFadeIn then
                     Button.loading
+
+                  else
+                    Button.primary
+                ]
+            , Heading.h3 [] [ Html.text "Page.loading" ]
+            , if showLoading then
+                Page.loading
+
+              else
+                Html.text ""
+            , Button.button "Open loading"
+                [ Button.custom
+                    [ Events.stopPropagationOn "click"
+                        (Json.Decode.map (\m -> ( m, True ))
+                            (Json.Decode.succeed ShowLoading)
+                        )
+                    ]
+                , if showLoadingFadeIn then
+                    Button.disabled
 
                   else
                     Button.primary

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -32,6 +32,7 @@
         "Nri.Ui.Icon.V4",
         "Nri.Ui.Icon.V5",
         "Nri.Ui.InputStyles.V2",
+        "Nri.Ui.Loading.V1",
         "Nri.Ui.Logo.V1",
         "Nri.Ui.MasteryIcon.V1",
         "Nri.Ui.Modal.V8",


### PR DESCRIPTION
Nri/Loading and Nri/Loading in the monolith and content creation code are practically identical. This PR extracts to a place that both applications can reference.

![loading](https://user-images.githubusercontent.com/8811312/78315126-f34c1e80-7510-11ea-8777-bc9d9d76e5dc.gif)

cc @NoRedInk/design 
Sorry for the jerky gif. Should be easier to see what it looks like once it's published to Netlify. (IMO, these spinners are a bit fast)
