### PR TITLE
Tessa/fix styleguide link

### DIFF
--- a/src/Nri/Ui/Divider/V2.elm
+++ b/src/Nri/Ui/Divider/V2.elm
@@ -1,6 +1,8 @@
 module Nri.Ui.Divider.V2 exposing (view)
 
-{-|
+{-| Patch changes:
+
+  - Title is navy, Muli, fontWeight 600
 
 @docs view
 
@@ -9,6 +11,7 @@ module Nri.Ui.Divider.V2 exposing (view)
 import Css exposing (..)
 import Html.Styled as Html exposing (..)
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
 
 
 {-| -}
@@ -57,5 +60,7 @@ titleStyles =
     batch
         [ margin2 zero (px 5)
         , fontSize (px 12)
-        , color Colors.gray45
+        , color Colors.navy
+        , Fonts.baseFont
+        , fontWeight (int 600)
         ]

--- a/src/Nri/Ui/Divider/V2.elm
+++ b/src/Nri/Ui/Divider/V2.elm
@@ -1,6 +1,6 @@
 module Nri.Ui.Divider.V2 exposing (view)
 
-{-| <https://staging.noredink.com/style_guide#ui/src/Nri/Divider.elm>
+{-|
 
 @docs view
 
@@ -9,12 +9,6 @@ module Nri.Ui.Divider.V2 exposing (view)
 import Css exposing (..)
 import Html.Styled as Html exposing (..)
 import Nri.Ui.Colors.V1 as Colors
-
-
-type alias Config =
-    { lineColor : Css.Color
-    , textColor : Css.Color
-    }
 
 
 {-| -}

--- a/styleguide-app/Examples.elm
+++ b/styleguide-app/Examples.elm
@@ -12,6 +12,7 @@ import Examples.ClickableSvg as ClickableSvg
 import Examples.ClickableText as ClickableText
 import Examples.Colors as Colors
 import Examples.DisclosureIndicator as DisclosureIndicator
+import Examples.Divider as Divider
 import Examples.Dropdown as Dropdown
 import Examples.Fonts as Fonts
 import Examples.Heading as Heading
@@ -244,6 +245,25 @@ all =
             (\msg ->
                 case msg of
                     DisclosureIndicatorState childState ->
+                        Just childState
+
+                    _ ->
+                        Nothing
+            )
+    , Divider.example
+        |> Example.wrapMsg DividerMsg
+            (\msg ->
+                case msg of
+                    DividerMsg childMsg ->
+                        Just childMsg
+
+                    _ ->
+                        Nothing
+            )
+        |> Example.wrapState DividerState
+            (\msg ->
+                case msg of
+                    DividerState childState ->
                         Just childState
 
                     _ ->
@@ -720,6 +740,7 @@ type State
     | ClickableTextState ClickableText.State
     | ColorsState Colors.State
     | DisclosureIndicatorState DisclosureIndicator.State
+    | DividerState Divider.State
     | DropdownState Dropdown.State
     | FontsState Fonts.State
     | HeadingState Heading.State
@@ -758,6 +779,7 @@ type Msg
     | ClickableTextMsg ClickableText.Msg
     | ColorsMsg Colors.Msg
     | DisclosureIndicatorMsg DisclosureIndicator.Msg
+    | DividerMsg Divider.Msg
     | DropdownMsg Dropdown.Msg
     | FontsMsg Fonts.Msg
     | HeadingMsg Heading.Msg

--- a/styleguide-app/Examples/Divider.elm
+++ b/styleguide-app/Examples/Divider.elm
@@ -1,0 +1,36 @@
+module Examples.Divider exposing (Msg, State, example)
+
+{-|
+
+@docs Msg, State, example
+
+-}
+
+import Category exposing (Category(..))
+import Css
+import Example exposing (Example)
+import Html.Styled as Html
+import Html.Styled.Attributes exposing (css)
+import Nri.Ui.Divider.V2 as Divider
+
+
+{-| -}
+type alias State =
+    {}
+
+
+{-| -}
+type alias Msg =
+    ()
+
+
+{-| -}
+example : Example State Msg
+example =
+    { name = "Nri.Ui.Divider.V2"
+    , categories = [ Layout ]
+    , state = {}
+    , update = \_ state -> ( state, Cmd.none )
+    , subscriptions = \_ -> Sub.none
+    , view = \state -> [ Divider.view "Dividing Line" ]
+    }


### PR DESCRIPTION
I'm removing the old divider component from the old styleguide (https://staging.noredink.com/style_guide#doodad/Nri%2FDivider.elm) and putting it into the netlify one.

I'm noticing that some of the styles differ: the netlify version has a gray45 title without a set font, and the /styleguide version has a navy title using baseFont (Multi).

Not sure whether to make changes or not -- is one of these behaviors right? cc @NoRedInk/design 

### /styleguide
<img width="812" alt="Screen Shot 2020-04-08 at 3 14 20 PM" src="https://user-images.githubusercontent.com/8811312/78838858-efeee200-79ab-11ea-9423-60bb022dfb33.png">

### New netlify addition
<img width="713" alt="Screen Shot 2020-04-08 at 3 14 29 PM" src="https://user-images.githubusercontent.com/8811312/78838855-eebdb500-79ab-11ea-9e00-715d71c6ccec.png">
