### PR TITLE
Tessa/adds missing clickable helpers

### DIFF
--- a/src/ClickableAttributes.elm
+++ b/src/ClickableAttributes.elm
@@ -1,0 +1,166 @@
+module ClickableAttributes exposing
+    ( ClickableAttributes
+    , href
+    , init
+    , linkExternal
+    , linkExternalWithTracking
+    , linkSpa
+    , linkWithMethod
+    , linkWithTracking
+    , onClick
+    , toButtonAttributes
+    , toLinkAttributes
+    )
+
+{-| -}
+
+import AttributeExtras exposing (targetBlank)
+import EventExtras.Styled as EventExtras
+import Html.Styled exposing (Attribute)
+import Html.Styled.Attributes as Attributes
+import Html.Styled.Events as Events
+import Json.Decode
+
+
+{-| -}
+type alias ClickableAttributes msg =
+    { linkType : Link
+    , url : String
+    , onClick : Maybe msg
+    }
+
+
+type Link
+    = Default
+    | WithTracking
+    | SinglePageApp
+    | WithMethod String
+    | External
+    | ExternalWithTracking
+
+
+{-| -}
+init : ClickableAttributes msg
+init =
+    { linkType = Default
+    , url = "#"
+    , onClick = Nothing
+    }
+
+
+{-| -}
+onClick : msg -> ClickableAttributes msg -> ClickableAttributes msg
+onClick msg clickableAttributes =
+    { clickableAttributes | onClick = Just msg }
+
+
+{-| -}
+href : String -> ClickableAttributes msg -> ClickableAttributes msg
+href url clickableAttributes =
+    { clickableAttributes | url = url }
+
+
+{-| -}
+linkSpa : String -> ClickableAttributes msg -> ClickableAttributes msg
+linkSpa url clickableAttributes =
+    { clickableAttributes | linkType = SinglePageApp, url = url }
+
+
+{-| -}
+linkWithMethod : { method : String, url : String } -> ClickableAttributes msg -> ClickableAttributes msg
+linkWithMethod { method, url } clickableAttributes =
+    { clickableAttributes | linkType = WithMethod method, url = url }
+
+
+{-| -}
+linkWithTracking : { track : msg, url : String } -> ClickableAttributes msg -> ClickableAttributes msg
+linkWithTracking { track, url } _ =
+    { linkType = WithTracking, url = url, onClick = Just track }
+
+
+{-| -}
+linkExternal : String -> ClickableAttributes msg -> ClickableAttributes msg
+linkExternal url clickableAttributes =
+    { clickableAttributes | linkType = External, url = url }
+
+
+{-| -}
+linkExternalWithTracking : { track : msg, url : String } -> ClickableAttributes msg -> ClickableAttributes msg
+linkExternalWithTracking { track, url } _ =
+    { linkType = ExternalWithTracking, url = url, onClick = Just track }
+
+
+{-| -}
+toButtonAttributes : ClickableAttributes msg -> List (Attribute msg)
+toButtonAttributes clickableAttributes =
+    case clickableAttributes.onClick of
+        Just handler ->
+            [ Events.onClick handler ]
+
+        Nothing ->
+            []
+
+
+{-| -}
+toLinkAttributes : ClickableAttributes msg -> ( String, List (Attribute msg) )
+toLinkAttributes clickableAttributes =
+    case clickableAttributes.linkType of
+        Default ->
+            ( "link"
+            , [ Attributes.href clickableAttributes.url
+              , Attributes.target "_self"
+              ]
+            )
+
+        SinglePageApp ->
+            ( "linkSpa"
+            , case clickableAttributes.onClick of
+                Just handler ->
+                    [ Attributes.href clickableAttributes.url
+                    , EventExtras.onClickPreventDefaultForLinkWithHref handler
+                    ]
+
+                Nothing ->
+                    [ Attributes.href clickableAttributes.url ]
+            )
+
+        WithMethod method ->
+            ( "linkWithMethod"
+            , [ Attributes.href clickableAttributes.url
+              , Attributes.attribute "data-method" method
+              ]
+            )
+
+        WithTracking ->
+            ( "linkWithTracking"
+            , case clickableAttributes.onClick of
+                Just track ->
+                    [ Attributes.href clickableAttributes.url
+                    , Events.preventDefaultOn "click"
+                        (Json.Decode.succeed ( track, True ))
+                    ]
+
+                Nothing ->
+                    [ Attributes.href clickableAttributes.url ]
+            )
+
+        External ->
+            ( "linkExternal"
+            , Attributes.href clickableAttributes.url
+                :: targetBlank
+            )
+
+        ExternalWithTracking ->
+            ( "linkExternalWithTracking"
+            , case clickableAttributes.onClick of
+                Just handler ->
+                    [ Attributes.href clickableAttributes.url
+                    , Events.onClick handler
+                    , Events.on "auxclick" (Json.Decode.succeed handler)
+                    ]
+                        ++ targetBlank
+
+                Nothing ->
+                    Attributes.href clickableAttributes.url
+                        :: targetBlank
+            )

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -65,23 +65,18 @@ module Nri.Ui.Button.V10 exposing
 import Accessibility.Styled as Html exposing (Html)
 import Accessibility.Styled.Role as Role
 import Accessibility.Styled.Widget as Widget
-import AttributeExtras exposing (targetBlank)
 import ClickableAttributes exposing (ClickableAttributes)
 import Css exposing (Style)
 import Css.Global
-import EventExtras.Styled as EventExtras
 import Html.Styled as Styled
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
-import Json.Decode
 import Markdown.Block
 import Markdown.Inline
 import Nri.Ui
-import Nri.Ui.AssetPath as AssetPath exposing (Asset)
 import Nri.Ui.Colors.Extra as ColorsExtra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1
-import Nri.Ui.Html.Attributes.V2 as AttributesExtra
 import Nri.Ui.Svg.V1 as NriSvg exposing (Svg)
 import Svg
 import Svg.Attributes

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -170,6 +170,16 @@ css styles =
 -- LINKING, CLICKING, and TRACKING BEHAVIOR
 
 
+setClickableAttributes :
+    (ClickableAttributes msg -> ClickableAttributes msg)
+    -> Attribute msg
+setClickableAttributes apply =
+    set
+        (\attributes ->
+            { attributes | clickableAttributes = apply attributes.clickableAttributes }
+        )
+
+
 {-| -}
 onClick : msg -> Attribute msg
 onClick msg =
@@ -402,16 +412,6 @@ set :
     -> Attribute msg
 set with =
     Attribute (\(ButtonOrLink config) -> ButtonOrLink (with config))
-
-
-setClickableAttributes :
-    (ClickableAttributes msg -> ClickableAttributes msg)
-    -> Attribute msg
-setClickableAttributes apply =
-    set
-        (\attributes ->
-            { attributes | clickableAttributes = apply attributes.clickableAttributes }
-        )
 
 
 build : ButtonOrLink msg

--- a/src/Nri/Ui/ClickableSvg/V1.elm
+++ b/src/Nri/Ui/ClickableSvg/V1.elm
@@ -41,6 +41,7 @@ module Nri.Ui.ClickableSvg.V1 exposing
 
 import Accessibility.Styled.Widget as Widget
 import AttributeExtras exposing (targetBlank)
+import ClickableAttributes exposing (ClickableAttributes)
 import Css exposing (Style)
 import EventExtras.Styled as EventExtras
 import Html.Styled as Html exposing (Html)
@@ -77,16 +78,26 @@ link name icon attributes =
 -- LINKING, CLICKING, and TRACKING BEHAVIOR
 
 
+setClickableAttributes :
+    (ClickableAttributes msg -> ClickableAttributes msg)
+    -> Attribute msg
+setClickableAttributes apply =
+    set
+        (\attributes ->
+            { attributes | clickableAttributes = apply attributes.clickableAttributes }
+        )
+
+
 {-| -}
 onClick : msg -> Attribute msg
 onClick msg =
-    set (\attributes -> { attributes | onClick = Just msg })
+    setClickableAttributes (ClickableAttributes.onClick msg)
 
 
 {-| -}
 href : String -> Attribute msg
 href url =
-    set (\attributes -> { attributes | url = url })
+    setClickableAttributes (ClickableAttributes.href url)
 
 
 {-| Use this link for routing within a single page app.
@@ -98,71 +109,31 @@ See <https://github.com/elm-lang/html/issues/110> for details on this implementa
 -}
 linkSpa : String -> Attribute msg
 linkSpa url =
-    set
-        (\attributes ->
-            { attributes
-                | linkType = SinglePageApp
-                , url = url
-            }
-        )
+    setClickableAttributes (ClickableAttributes.linkSpa url)
 
 
-{-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to
-some url, and it's an HTTP request (Rails includes JS to make this use the given HTTP method)
--}
+{-| -}
 linkWithMethod : { method : String, url : String } -> Attribute msg
-linkWithMethod { method, url } =
-    set
-        (\attributes ->
-            { attributes
-                | linkType = WithMethod method
-                , url = url
-            }
-        )
+linkWithMethod config =
+    setClickableAttributes (ClickableAttributes.linkWithMethod config)
 
 
-{-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to some url.
-This should only take in messages that result in a Msg that triggers Analytics.trackAndRedirect.
-For buttons that trigger other effects on the page, please use Nri.Button.button instead.
--}
+{-| -}
 linkWithTracking : { track : msg, url : String } -> Attribute msg
-linkWithTracking { track, url } =
-    set
-        (\attributes ->
-            { attributes
-                | linkType = WithTracking
-                , url = url
-                , onClick = Just track
-            }
-        )
+linkWithTracking config =
+    setClickableAttributes (ClickableAttributes.linkWithTracking config)
 
 
-{-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to
-some url and have it open to an external site
--}
+{-| -}
 linkExternal : String -> Attribute msg
 linkExternal url =
-    set
-        (\attributes ->
-            { attributes
-                | linkType = External
-                , url = url
-            }
-        )
+    setClickableAttributes (ClickableAttributes.linkExternal url)
 
 
-{-| Wrap some text so it looks like a button, but actually is wrapped in an anchor to some url and have it open to an external site.
--}
+{-| -}
 linkExternalWithTracking : { track : msg, url : String } -> Attribute msg
-linkExternalWithTracking { track, url } =
-    set
-        (\attributes ->
-            { attributes
-                | linkType = ExternalWithTracking
-                , url = url
-                , onClick = Just track
-            }
-        )
+linkExternalWithTracking config =
+    setClickableAttributes (ClickableAttributes.linkExternalWithTracking config)
 
 
 
@@ -247,9 +218,7 @@ set with =
 build : String -> Svg -> ButtonOrLink msg
 build label icon =
     ButtonOrLink
-        { onClick = Nothing
-        , url = "#"
-        , linkType = Default
+        { clickableAttributes = ClickableAttributes.init
         , label = label
         , icon = icon
         , height = Css.px 17
@@ -265,9 +234,7 @@ type ButtonOrLink msg
 
 
 type alias ButtonOrLinkAttributes msg =
-    { onClick : Maybe msg
-    , url : String
-    , linkType : Link
+    { clickableAttributes : ClickableAttributes msg
     , label : String
     , icon : Svg
     , height : Css.Px
@@ -285,10 +252,9 @@ renderButton ((ButtonOrLink config) as button_) =
          , Attributes.type_ "button"
          , Attributes.css (buttonOrLinkStyles config ++ config.customStyles)
          , Attributes.disabled config.disabled
-         , Maybe.map Events.onClick config.onClick
-            |> Maybe.withDefault AttributesExtra.none
          , Widget.label config.label
          ]
+            ++ ClickableAttributes.toButtonAttributes config.clickableAttributes
             ++ config.customAttributes
         )
         [ config.icon
@@ -310,66 +276,28 @@ type Link
 renderLink : ButtonOrLink msg -> Html msg
 renderLink ((ButtonOrLink config) as link_) =
     let
-        linkBase linkFunctionName extraAttrs =
-            Html.a
-                ([ Attributes.class ("Nri-Ui-Clickable-Svg-" ++ linkFunctionName)
-                 , if not config.disabled then
-                    Attributes.href config.url
-
-                   else
-                    AttributesExtra.none
-                 , Attributes.css (buttonOrLinkStyles config ++ config.customStyles)
-                 , Widget.disabled config.disabled
-                 , Widget.label config.label
-                 ]
-                    ++ extraAttrs
-                    ++ config.customAttributes
-                )
-                [ config.icon
-                    |> Svg.withWidth config.width
-                    |> Svg.withHeight config.height
-                    |> Svg.toHtml
-                ]
+        ( linkFunctionName, extraAttrs ) =
+            ClickableAttributes.toLinkAttributes config.clickableAttributes
     in
-    case config.linkType of
-        Default ->
-            linkBase "link" [ Attributes.target "_self" ]
+    Html.a
+        ([ Attributes.class ("Nri-Ui-Clickable-Svg-" ++ linkFunctionName)
+         , Attributes.css (buttonOrLinkStyles config ++ config.customStyles)
+         , Widget.disabled config.disabled
+         , Widget.label config.label
+         ]
+            ++ (if not config.disabled then
+                    extraAttrs
 
-        SinglePageApp ->
-            linkBase "linkSpa"
-                (config.onClick
-                    |> Maybe.map (\msg -> [ EventExtras.onClickPreventDefaultForLinkWithHref msg ])
-                    |> Maybe.withDefault []
-                )
-
-        WithMethod method ->
-            linkBase "linkWithMethod" [ Attributes.attribute "data-method" method ]
-
-        WithTracking ->
-            linkBase
-                "linkWithTracking"
-                (config.onClick
-                    |> Maybe.map (\msg -> [ Events.preventDefaultOn "click" (Json.Decode.succeed ( msg, True )) ])
-                    |> Maybe.withDefault []
-                )
-
-        External ->
-            linkBase "linkExternal" targetBlank
-
-        ExternalWithTracking ->
-            linkBase "linkExternalWithTracking"
-                (List.concat
-                    [ targetBlank
-                    , config.onClick
-                        |> Maybe.map
-                            (\onClickMsg ->
-                                [ Events.onClick onClickMsg
-                                , Events.on "auxclick" (Json.Decode.succeed onClickMsg)
-                                ]
-                            )
-                        |> Maybe.withDefault []
-                    ]
-                )
+                else
+                    []
+               )
+            ++ config.customAttributes
+        )
+        [ config.icon
+            |> Svg.withWidth config.width
+            |> Svg.withHeight config.height
+            |> Svg.toHtml
+        ]
 
 
 buttonOrLinkStyles : ButtonOrLinkAttributes msg -> List Style

--- a/src/Nri/Ui/ClickableSvg/V1.elm
+++ b/src/Nri/Ui/ClickableSvg/V1.elm
@@ -40,16 +40,11 @@ module Nri.Ui.ClickableSvg.V1 exposing
 -}
 
 import Accessibility.Styled.Widget as Widget
-import AttributeExtras exposing (targetBlank)
 import ClickableAttributes exposing (ClickableAttributes)
 import Css exposing (Style)
-import EventExtras.Styled as EventExtras
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
-import Html.Styled.Events as Events
-import Json.Decode
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.Html.Attributes.V2 as AttributesExtra
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 
 

--- a/src/Nri/Ui/ClickableSvg/V1.elm
+++ b/src/Nri/Ui/ClickableSvg/V1.elm
@@ -11,6 +11,11 @@ module Nri.Ui.ClickableSvg.V1 exposing
 {-|
 
 
+# Post-release patches
+
+  - uses ClickableAttributes
+
+
 # Create a button or link
 
 @docs button, link

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -14,6 +14,7 @@ module Nri.Ui.ClickableText.V3 exposing
 
 # Post-release patches
 
+  - uses ClickableAttributes
   - adds `css` helper
   - add bottom border on hover instead of text decoration
 

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -3,7 +3,8 @@ module Nri.Ui.ClickableText.V3 exposing
     , link
     , Attribute
     , small, medium, large
-    , href, onClick
+    , onClick
+    , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     , icon
     , custom, css
     )
@@ -46,8 +47,18 @@ HTML `<a>` elements and are created here with `*Link` functions.
 # Attributes
 
 @docs Attribute
+
+
+## Sizing
+
 @docs small, medium, large
-@docs href, onClick
+
+
+## Behavior
+
+@docs onClick
+@docs href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
+
 @docs icon
 @docs custom, css
 

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -68,11 +68,9 @@ import ClickableAttributes exposing (ClickableAttributes)
 import Css exposing (Style)
 import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes as Attributes
-import Html.Styled.Events as Events
 import Nri.Ui
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1
-import Nri.Ui.Html.Attributes.V2 as AttributesExtra
 import Nri.Ui.Svg.V1 as NriSvg exposing (Svg)
 
 


### PR DESCRIPTION
Adds missing link helpers to clickable text:

```
    Added:
        linkExternal : String.String -> Nri.Ui.ClickableText.V3.Attribute msg
        linkExternalWithTracking :
            { track : msg, url : String.String }
            -> Nri.Ui.ClickableText.V3.Attribute msg
        linkSpa : String.String -> Nri.Ui.ClickableText.V3.Attribute msg
        linkWithMethod :
            { method : String.String, url : String.String }
            -> Nri.Ui.ClickableText.V3.Attribute msg
        linkWithTracking :
            { track : msg, url : String.String }
            -> Nri.Ui.ClickableText.V3.Attribute msg
```

Also refactors so that there's less duplication between `Nri.UI.Button.V10`, `Nri.Ui.ClickableSvg.V1`, and `Nri.Ui.ClickableText.V3`.