### PR TITLE
Restore previous behavior: Message.banner centers the content when it…

### DIFF
--- a/src/Nri/Ui/Message/V1.elm
+++ b/src/Nri/Ui/Message/V1.elm
@@ -413,6 +413,10 @@ banner theme content attr =
                 [ width (px 50)
                 , height (px 50)
                 , marginRight (px 20)
+                , -- NOTE: I think it's normally best to avoid relying on flexShrink (and use flexGrow/flexBasis) instead,
+                  -- But using shrink here and on the next div lets us have the text content be centered rather than
+                  -- left-aligned when the content is shorter than one line
+                  flexShrink zero
                 ]
                 []
                 [ config.icon ]
@@ -423,8 +427,7 @@ banner theme content attr =
                 , lineHeight (px 27)
                 , maxWidth (px 600)
                 , minWidth (px 100)
-                , flexBasis (px 100)
-                , flexGrow (int 1)
+                , flexShrink (int 1)
                 , Fonts.baseFont
                 , Css.Global.descendants
                     [ Css.Global.a

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -86,6 +86,15 @@ init =
                                 ]
                             )
                       )
+                    , ( "HTML (short)"
+                      , Control.value
+                            (Message.Html
+                                [ code [] [ text "git status" ]
+                                , text " ⇄ "
+                                , Html.em [] [ text "tries again" ]
+                                ]
+                            )
+                      )
                     ]
                 )
     }


### PR DESCRIPTION
… is shorter than one line

<img width="419" alt="Screen Shot 2020-04-30 at 10 14 29 AM" src="https://user-images.githubusercontent.com/1222/80739962-3a0b4500-8acc-11ea-9585-126a69b24101.png">
<img width="908" alt="Screen Shot 2020-04-30 at 10 14 34 AM" src="https://user-images.githubusercontent.com/1222/80739972-3d063580-8acc-11ea-91b2-320a63ed3bfc.png">



> Hello there, wonderful author of widgets!
> This is `Nri.Ui.Friendly.AI.V1` speaking to you!
> Are you looking to get this awesome work reviewed as quickly as possible, so you can start putting it to use?
> Then feel free to ask Teambot to assign a reviewer to your PR
>
> https://nri-teambot.herokuapp.com
>
> It's best if we have separate pull requests for code changes and package version bumps. If you're just changing code, great! If you're just bumping the version, check out https://github.com/NoRedInk/noredink-ui#deploying.
