### PR TITLE
Tabs tweak

### DIFF
--- a/src/Nri/Ui/Tabs/V4.elm
+++ b/src/Nri/Ui/Tabs/V4.elm
@@ -389,7 +389,7 @@ stylesTabs =
     , Css.fontSize (Css.px 19)
     , Css.displayFlex
     , Css.flexGrow (Css.int 1)
-    , Css.marginRight (Css.px 10)
+    , Css.padding Css.zero
     ]
 
 


### PR DESCRIPTION
Adjusts tab styles to partially outfox: https://www.pivotaltracker.com/story/show/172591130

Shouldn't have a deleterious effect on other tab instances.

<img width="645" alt="image" src="https://user-images.githubusercontent.com/13528834/80821111-ff1d1600-8b8c-11ea-8e3b-cc425dcbc194.png">