### PR TITLE
Message line height

### DIFF
--- a/src/Nri/Ui/Message/V1.elm
+++ b/src/Nri/Ui/Message/V1.elm
@@ -265,6 +265,7 @@ large theme content =
         , backgroundColor config.backgroundColor
         , Fonts.baseFont
         , fontSize (px 15)
+        , lineHeight (px 21)
         , fontWeight (int 600)
         , boxSizing borderBox
         , padding (px 20)


### PR DESCRIPTION
A small tweak.

<img width="583" alt="image" src="https://user-images.githubusercontent.com/13528834/80821429-8cf90100-8b8d-11ea-97d3-fc8a6f9391f3.png">