### PR TITLE
Zamboni/maybe default segment

### DIFF
--- a/src/Nri/Ui/SegmentedControl/V8.elm
+++ b/src/Nri/Ui/SegmentedControl/V8.elm
@@ -55,6 +55,7 @@ type alias ToggleConfig a msg =
     , width : Width
     }
 
+
 {-| Same shape as ToggleConfig but with an optional selected. This would ideally
 be the same as ToggleConfig but we as Zambonis don't have time in the ticket to
 also upgrade all existing uses of viewToggle. Katie is mentally noting this as a
@@ -121,6 +122,7 @@ viewToggle config =
             )
             config.options
         )
+
 
 {-| Creates _just the toggle_ when need the ui element itself and not a page
 control. Since this element is used for a selection and not for page navigation,
@@ -237,7 +239,7 @@ viewTab config option =
               , Role.tab
               , css sharedTabStyles
               ]
-            , if (Just option.value) == config.selected then
+            , if Just option.value == config.selected then
                 [ css focusedTabStyles
                 , config.selectedAttribute
                 ]

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -66,7 +66,7 @@ example =
             , SegmentedControl.viewOptionalSelectToggle
                 { onClick = Select
                 , options = buildOptions "Toggle-Only " options [ UiIcon.leaderboard, UiIcon.person, UiIcon.performance ]
-                , selected = Just state.selected
+                , selected = state.optionallySelected
                 , width = options.width
                 }
             ]
@@ -100,6 +100,7 @@ type ExampleOption
 {-| -}
 type alias State =
     { selected : ExampleOption
+    , optionallySelected : Maybe ExampleOption
     , optionsControl : Control Options
     }
 
@@ -108,6 +109,7 @@ type alias State =
 init : State
 init =
     { selected = A
+    , optionallySelected = Nothing
     , optionsControl = optionsControl
     }
 
@@ -148,7 +150,7 @@ update : Msg -> State -> ( State, Cmd Msg )
 update msg state =
     case msg of
         Select id ->
-            ( { state | selected = id }
+            ( { state | selected = id, optionallySelected = Just id }
             , Cmd.none
             )
 

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -48,7 +48,7 @@ example =
               in
               viewFn
                 { onClick = SelectNav
-                , options = buildOptions "" options [A,B,C] [ UiIcon.flag, UiIcon.star, Svg.withColor Colors.greenDark UiIcon.attention ]
+                , options = buildOptions "" options [ A, B, C ] [ UiIcon.flag, UiIcon.star, Svg.withColor Colors.greenDark UiIcon.attention ]
                 , selected = state.selectedNav
                 , width = options.width
                 , content = Html.text ("[Content for " ++ Debug.toString state.selectedNav ++ "]")
@@ -57,7 +57,7 @@ example =
             , Html.p [] [ Html.text "Used when you only need the ui element and not a page control." ]
             , SegmentedControl.viewToggle
                 { onClick = Select
-                , options = buildOptions "Toggle-Only " options [One, Two,Three] [ UiIcon.leaderboard, UiIcon.person, UiIcon.performance ]
+                , options = buildOptions "Toggle-Only " options [ One, Two, Three ] [ UiIcon.leaderboard, UiIcon.person, UiIcon.performance ]
                 , selected = state.selected
                 , width = options.width
                 }
@@ -65,7 +65,7 @@ example =
             , Html.p [] [ Html.text "Used when you only need the ui element and not a page control but don't want a default." ]
             , SegmentedControl.viewOptionalSelectToggle
                 { onClick = MaybeSelect
-                , options = buildOptions "Toggle-Only " options [Do, Re, Mi] [ UiIcon.leaderboard, UiIcon.person, UiIcon.performance ]
+                , options = buildOptions "Toggle-Only " options [ Do, Re, Mi ] [ UiIcon.leaderboard, UiIcon.person, UiIcon.performance ]
                 , selected = state.optionallySelected
                 , width = options.width
                 }
@@ -96,10 +96,12 @@ type ExampleOptionNav
     | B
     | C
 
+
 type ExampleOptionSelect
     = One
     | Two
     | Three
+
 
 type ExampleOptionMaybeSelect
     = Do
@@ -113,6 +115,7 @@ type alias State =
     , selected : ExampleOptionSelect
     , optionallySelected : Maybe ExampleOptionMaybeSelect
     , optionsControl : Control Options
+
     -- , optionsControlSelect
     -- , optionsControlMaybeSelect :
     }
@@ -169,10 +172,12 @@ update msg state =
             ( { state | selectedNav = id }
             , Cmd.none
             )
+
         Select id ->
             ( { state | selected = id }
             , Cmd.none
             )
+
         MaybeSelect id ->
             ( { state | optionallySelected = Just id }
             , Cmd.none

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -61,6 +61,14 @@ example =
                 , selected = state.selected
                 , width = options.width
                 }
+            , Html.h3 [] [ Html.text "Toggle only view without a default" ]
+            , Html.p [] [ Html.text "Used when you only need the ui element and not a page control but don't want a default." ]
+            , SegmentedControl.viewOptionalSelectToggle
+                { onClick = Select
+                , options = buildOptions "Toggle-Only " options [ UiIcon.leaderboard, UiIcon.person, UiIcon.performance ]
+                , selected = Just state.selected
+                , width = options.width
+                }
             ]
     , categories = [ Widgets ]
     }

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -47,25 +47,25 @@ example =
                         SegmentedControl.view
               in
               viewFn
-                { onClick = Select
-                , options = buildOptions "" options [ UiIcon.flag, UiIcon.star, Svg.withColor Colors.greenDark UiIcon.attention ]
-                , selected = state.selected
+                { onClick = SelectNav
+                , options = buildOptions "" options [A,B,C] [ UiIcon.flag, UiIcon.star, Svg.withColor Colors.greenDark UiIcon.attention ]
+                , selected = state.selectedNav
                 , width = options.width
-                , content = Html.text ("[Content for " ++ Debug.toString state.selected ++ "]")
+                , content = Html.text ("[Content for " ++ Debug.toString state.selectedNav ++ "]")
                 }
             , Html.h3 [] [ Html.text "Toggle only view" ]
             , Html.p [] [ Html.text "Used when you only need the ui element and not a page control." ]
             , SegmentedControl.viewToggle
                 { onClick = Select
-                , options = buildOptions "Toggle-Only " options [ UiIcon.leaderboard, UiIcon.person, UiIcon.performance ]
+                , options = buildOptions "Toggle-Only " options [One, Two,Three] [ UiIcon.leaderboard, UiIcon.person, UiIcon.performance ]
                 , selected = state.selected
                 , width = options.width
                 }
             , Html.h3 [] [ Html.text "Toggle only view without a default" ]
             , Html.p [] [ Html.text "Used when you only need the ui element and not a page control but don't want a default." ]
             , SegmentedControl.viewOptionalSelectToggle
-                { onClick = Select
-                , options = buildOptions "Toggle-Only " options [ UiIcon.leaderboard, UiIcon.person, UiIcon.performance ]
+                { onClick = MaybeSelect
+                , options = buildOptions "Toggle-Only " options [Do, Re, Mi] [ UiIcon.leaderboard, UiIcon.person, UiIcon.performance ]
                 , selected = state.optionallySelected
                 , width = options.width
                 }
@@ -74,8 +74,8 @@ example =
     }
 
 
-buildOptions : String -> Options -> List Svg -> List (SegmentedControl.Option ExampleOption)
-buildOptions prefix options =
+buildOptions : String -> Options -> List a -> List Svg -> List (SegmentedControl.Option a)
+buildOptions prefix options selections =
     let
         buildOption option icon =
             { icon =
@@ -88,27 +88,41 @@ buildOptions prefix options =
             , value = option
             }
     in
-    List.map2 buildOption [ A, B, C ]
+    List.map2 buildOption selections
 
 
-type ExampleOption
+type ExampleOptionNav
     = A
     | B
     | C
 
+type ExampleOptionSelect
+    = One
+    | Two
+    | Three
+
+type ExampleOptionMaybeSelect
+    = Do
+    | Re
+    | Mi
+
 
 {-| -}
 type alias State =
-    { selected : ExampleOption
-    , optionallySelected : Maybe ExampleOption
+    { selectedNav : ExampleOptionNav
+    , selected : ExampleOptionSelect
+    , optionallySelected : Maybe ExampleOptionMaybeSelect
     , optionsControl : Control Options
+    -- , optionsControlSelect
+    -- , optionsControlMaybeSelect :
     }
 
 
 {-| -}
 init : State
 init =
-    { selected = A
+    { selectedNav = A
+    , selected = One
     , optionallySelected = Nothing
     , optionsControl = optionsControl
     }
@@ -141,7 +155,9 @@ optionsControl =
 
 {-| -}
 type Msg
-    = Select ExampleOption
+    = SelectNav ExampleOptionNav
+    | Select ExampleOptionSelect
+    | MaybeSelect ExampleOptionMaybeSelect
     | ChangeOptions (Control Options)
 
 
@@ -149,8 +165,16 @@ type Msg
 update : Msg -> State -> ( State, Cmd Msg )
 update msg state =
     case msg of
+        SelectNav id ->
+            ( { state | selectedNav = id }
+            , Cmd.none
+            )
         Select id ->
-            ( { state | selected = id, optionallySelected = Just id }
+            ( { state | selected = id }
+            , Cmd.none
+            )
+        MaybeSelect id ->
+            ( { state | optionallySelected = Just id }
             , Cmd.none
             )
 


### PR DESCRIPTION
This adds the ability to not have a default selection in a quick and dirty way so zamboni can wrap up https://www.pivotaltracker.com/story/show/172845604 faster. I'll be going back and doing clean up in my TCR with the intention of DRYing things up. Also broke out the example states so they'll all work uniquely.

- [x] Fix build
- [ ] Get approval
- [ ] merge
- [ ] bump
- [ ] publish
then we can use!

### No Default
![image](https://user-images.githubusercontent.com/5943972/82487577-65fa6480-9a93-11ea-9f15-d68250bc523b.png)

### Each in unique states 🙌 
![image](https://user-images.githubusercontent.com/5943972/82487439-3186a880-9a93-11ea-9b0e-c92f983efd72.png)

cc @bendansby 
