### PR TITLE
small fixes for shared input transitions

### DIFF
--- a/src/Nri/Ui/InputStyles/V2.elm
+++ b/src/Nri/Ui/InputStyles/V2.elm
@@ -98,7 +98,6 @@ input theme isInError =
                 [ border3 (px 1) solid gray75
                 , width (pct 100)
                 , borderRadius (px 8)
-                , property "transition" "all 0.1s ease"
                 , pseudoClass "placeholder"
                     [ color gray45
                     ]

--- a/src/Nri/Ui/InputStyles/V2.elm
+++ b/src/Nri/Ui/InputStyles/V2.elm
@@ -109,7 +109,7 @@ input theme isInError =
                 , marginBottom zero
                 , marginTop (px 9)
                 , boxShadow6 inset zero (px 3) zero zero gray92
-                , property "transition" "all 0.4s ease"
+                , property "transition" "border-color 0.4s ease"
                 , boxSizing borderBox
                 , focus
                     [ borderColor azure


### PR DESCRIPTION
the shared input styles were animating too much. In particular, they were animating border width, shadow size, etc, and making the text input jump around when it entered the page when they overrode sass styles in the monorepo.

This applies the fixes I patched in in the monorepo to the upstream library. Once this is in, I'll upgrade downstream and remove my `!important`.