### PR TITLE
Show keyboard shortcuts

### DIFF
--- a/styleguide-app/AtomicDesignType.elm
+++ b/styleguide-app/AtomicDesignType.elm
@@ -1,0 +1,50 @@
+module AtomicDesignType exposing
+    ( AtomicDesignType(..)
+    , sorter
+    , toString
+    )
+
+{-|
+
+@docs AtomicDesignType
+@docs sorter
+@docs toString
+
+-}
+
+import Sort exposing (Sorter)
+
+
+{-| -}
+type AtomicDesignType
+    = Atom
+    | Molecule
+    | Organism
+    | Template
+    | Page
+
+
+{-| -}
+sorter : Sorter AtomicDesignType
+sorter =
+    Sort.by toString Sort.alphabetical
+
+
+{-| -}
+toString : AtomicDesignType -> String
+toString atomicDesignType =
+    case atomicDesignType of
+        Atom ->
+            "Atom"
+
+        Molecule ->
+            "Molecule"
+
+        Organism ->
+            "Organism"
+
+        Template ->
+            "Template"
+
+        Page ->
+            "Page"

--- a/styleguide-app/AtomicDesignType.elm
+++ b/styleguide-app/AtomicDesignType.elm
@@ -36,7 +36,25 @@ all =
 {-| -}
 sorter : Sorter AtomicDesignType
 sorter =
-    Sort.by toString Sort.alphabetical
+    Sort.by
+        (\v ->
+            case v of
+                Atom ->
+                    0
+
+                Molecule ->
+                    1
+
+                Organism ->
+                    2
+
+                Template ->
+                    3
+
+                Page ->
+                    4
+        )
+        Sort.increasing
 
 
 {-| -}

--- a/styleguide-app/AtomicDesignType.elm
+++ b/styleguide-app/AtomicDesignType.elm
@@ -1,14 +1,12 @@
 module AtomicDesignType exposing
     ( AtomicDesignType(..)
-    , sorter
-    , toString
+    , all, sorter, toString
     )
 
 {-|
 
 @docs AtomicDesignType
-@docs sorter
-@docs toString
+@docs all, sorter, toString
 
 -}
 
@@ -22,6 +20,17 @@ type AtomicDesignType
     | Organism
     | Template
     | Page
+
+
+{-| -}
+all : List AtomicDesignType
+all =
+    [ Atom
+    , Molecule
+    , Organism
+    , Template
+    , Page
+    ]
 
 
 {-| -}

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -5,6 +5,7 @@ import Category exposing (Category)
 import Css exposing (..)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
+import KeyboardShortcuts exposing (KeyboardShortcut)
 import Nri.Ui.Colors.V1 exposing (..)
 import Nri.Ui.Html.Attributes.V2 as AttributeExtras exposing (targetBlank)
 
@@ -17,6 +18,7 @@ type alias Example state msg =
     , view : state -> List (Html msg)
     , categories : List Category
     , atomicDesignType : AtomicDesignType
+    , keyboardShortcuts : List KeyboardShortcut
     }
 
 
@@ -41,6 +43,7 @@ wrapMsg wrapMsg_ unwrapMsg example =
     , view = \state -> List.map (Html.map wrapMsg_) (example.view state)
     , categories = example.categories
     , atomicDesignType = example.atomicDesignType
+    , keyboardShortcuts = example.keyboardShortcuts
     }
 
 
@@ -71,6 +74,7 @@ wrapState wrapState_ unwrapState example =
             >> Maybe.withDefault []
     , categories = example.categories
     , atomicDesignType = example.atomicDesignType
+    , keyboardShortcuts = example.keyboardShortcuts
     }
 
 
@@ -109,6 +113,7 @@ view showFocusLink example =
                 |> (++) "https://github.com/NoRedInk/noredink-ui/blob/master/src/"
                 |> viewLink "Source"
             ]
+        , KeyboardShortcuts.view example.keyboardShortcuts
         , Html.div [ Attributes.css [ padding2 (px 20) zero ] ] (example.view example.state)
         ]
 

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -1,5 +1,6 @@
 module Example exposing (Example, view, wrapMsg, wrapState)
 
+import AtomicDesignType exposing (AtomicDesignType)
 import Category exposing (Category)
 import Css exposing (..)
 import Html.Styled as Html exposing (Html)
@@ -14,6 +15,7 @@ type alias Example state msg =
     , subscriptions : state -> Sub msg
     , view : state -> List (Html msg)
     , categories : List Category
+    , atomicDesignType : AtomicDesignType
     }
 
 
@@ -37,6 +39,7 @@ wrapMsg wrapMsg_ unwrapMsg example =
     , subscriptions = \state -> Sub.map wrapMsg_ (example.subscriptions state)
     , view = \state -> List.map (Html.map wrapMsg_) (example.view state)
     , categories = example.categories
+    , atomicDesignType = example.atomicDesignType
     }
 
 
@@ -66,6 +69,7 @@ wrapState wrapState_ unwrapState example =
             >> Maybe.map example.view
             >> Maybe.withDefault []
     , categories = example.categories
+    , atomicDesignType = example.atomicDesignType
     }
 
 

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -6,6 +6,7 @@ import Css exposing (..)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Nri.Ui.Colors.V1 exposing (..)
+import Nri.Ui.Html.Attributes.V2 as AttributeExtras exposing (targetBlank)
 
 
 type alias Example state msg =
@@ -99,15 +100,14 @@ view showFocusLink example =
                 , marginBottom zero
                 ]
                 []
-                [ Html.text example.name ]
+                [ Html.a [ Attributes.href ("#/doodad/" ++ example.name) ] [ Html.text example.name ] ]
             , String.replace "." "-" example.name
                 |> (++) "https://package.elm-lang.org/packages/NoRedInk/noredink-ui/latest/"
-                |> viewLink "view docs"
-            , if showFocusLink then
-                viewLink "see only this" ("#/doodad/" ++ example.name)
-
-              else
-                Html.text ""
+                |> viewLink "Docs"
+            , String.replace "." "/" example.name
+                ++ ".elm"
+                |> (++) "https://github.com/NoRedInk/noredink-ui/blob/master/src/"
+                |> viewLink "Source"
             ]
         , Html.div [ Attributes.css [ padding2 (px 20) zero ] ] (example.view example.state)
         ]
@@ -116,8 +116,10 @@ view showFocusLink example =
 viewLink : String -> String -> Html msg
 viewLink text href =
     Html.a
-        [ Attributes.href href
-        , Attributes.css [ Css.display Css.block, marginLeft (px 20) ]
-        ]
+        ([ Attributes.href href
+         , Attributes.css [ Css.display Css.block, marginLeft (px 20) ]
+         ]
+            ++ targetBlank
+        )
         [ Html.text text
         ]

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -5,7 +5,7 @@ import Category exposing (Category)
 import Css exposing (..)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
-import KeyboardShortcuts exposing (KeyboardShortcut)
+import KeyboardSupport exposing (KeyboardSupport)
 import Nri.Ui.Colors.V1 exposing (..)
 import Nri.Ui.Html.Attributes.V2 as AttributeExtras exposing (targetBlank)
 
@@ -18,7 +18,7 @@ type alias Example state msg =
     , view : state -> List (Html msg)
     , categories : List Category
     , atomicDesignType : AtomicDesignType
-    , keyboardShortcuts : List KeyboardShortcut
+    , keyboardSupport : List KeyboardSupport
     }
 
 
@@ -43,7 +43,7 @@ wrapMsg wrapMsg_ unwrapMsg example =
     , view = \state -> List.map (Html.map wrapMsg_) (example.view state)
     , categories = example.categories
     , atomicDesignType = example.atomicDesignType
-    , keyboardShortcuts = example.keyboardShortcuts
+    , keyboardSupport = example.keyboardSupport
     }
 
 
@@ -74,7 +74,7 @@ wrapState wrapState_ unwrapState example =
             >> Maybe.withDefault []
     , categories = example.categories
     , atomicDesignType = example.atomicDesignType
-    , keyboardShortcuts = example.keyboardShortcuts
+    , keyboardSupport = example.keyboardSupport
     }
 
 
@@ -113,7 +113,7 @@ view showFocusLink example =
                 |> (++) "https://github.com/NoRedInk/noredink-ui/blob/master/src/"
                 |> viewLink "Source"
             ]
-        , KeyboardShortcuts.view example.keyboardShortcuts
+        , KeyboardSupport.view example.keyboardSupport
         , Html.div [ Attributes.css [ padding2 (px 20) zero ] ] (example.view example.state)
         ]
 

--- a/styleguide-app/Examples/Accordion.elm
+++ b/styleguide-app/Examples/Accordion.elm
@@ -33,7 +33,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , view = view
     , categories = [ Layout ]
-    , atomicDesignType = AtomicDesignType.Molecule
+    , atomicDesignType = Molecule
     }
 
 

--- a/styleguide-app/Examples/Accordion.elm
+++ b/styleguide-app/Examples/Accordion.elm
@@ -17,7 +17,7 @@ import Dict exposing (Dict)
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Accordion.V1 as Accordion
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
@@ -35,7 +35,7 @@ example =
     , view = view
     , categories = [ Layout ]
     , atomicDesignType = Molecule
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     }
 
 

--- a/styleguide-app/Examples/Accordion.elm
+++ b/styleguide-app/Examples/Accordion.elm
@@ -17,6 +17,7 @@ import Dict exposing (Dict)
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Accordion.V1 as Accordion
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
@@ -34,6 +35,7 @@ example =
     , view = view
     , categories = [ Layout ]
     , atomicDesignType = Molecule
+    , keyboardShortcuts = []
     }
 
 

--- a/styleguide-app/Examples/Accordion.elm
+++ b/styleguide-app/Examples/Accordion.elm
@@ -10,6 +10,7 @@ module Examples.Accordion exposing
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css exposing (..)
 import Dict exposing (Dict)
@@ -32,6 +33,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , view = view
     , categories = [ Layout ]
+    , atomicDesignType = AtomicDesignType.Molecule
     }
 
 

--- a/styleguide-app/Examples/AssignmentIcon.elm
+++ b/styleguide-app/Examples/AssignmentIcon.elm
@@ -6,6 +6,7 @@ module Examples.AssignmentIcon exposing (example, State, Msg)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Examples.IconExamples as IconExamples
@@ -28,6 +29,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.AssignmentIcon.V2"
     , categories = [ Icons ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/AssignmentIcon.elm
+++ b/styleguide-app/Examples/AssignmentIcon.elm
@@ -29,7 +29,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.AssignmentIcon.V2"
     , categories = [ Icons ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/AssignmentIcon.elm
+++ b/styleguide-app/Examples/AssignmentIcon.elm
@@ -10,7 +10,7 @@ import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Examples.IconExamples as IconExamples
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.AssignmentIcon.V2 as AssignmentIcon
 import Nri.Ui.Icon.V5 as Icon
 
@@ -31,7 +31,7 @@ example =
     { name = "Nri.Ui.AssignmentIcon.V2"
     , categories = [ Icons ]
     , atomicDesignType = Atom
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/AssignmentIcon.elm
+++ b/styleguide-app/Examples/AssignmentIcon.elm
@@ -10,6 +10,7 @@ import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Examples.IconExamples as IconExamples
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.AssignmentIcon.V2 as AssignmentIcon
 import Nri.Ui.Icon.V5 as Icon
 
@@ -30,6 +31,7 @@ example =
     { name = "Nri.Ui.AssignmentIcon.V2"
     , categories = [ Icons ]
     , atomicDesignType = Atom
+    , keyboardShortcuts = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -29,7 +29,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , view = \state -> [ viewButtonExamples state ]
     , categories = [ Buttons ]
-    , atomicDesignType = Molecule
+    , atomicDesignType = Atom
     , keyboardSupport = []
     }
 

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -13,7 +13,7 @@ import Debug.Control as Control exposing (Control)
 import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css, id)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
@@ -30,7 +30,7 @@ example =
     , view = \state -> [ viewButtonExamples state ]
     , categories = [ Buttons ]
     , atomicDesignType = Molecule
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     }
 
 

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -13,6 +13,7 @@ import Debug.Control as Control exposing (Control)
 import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css, id)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
@@ -29,6 +30,7 @@ example =
     , view = \state -> [ viewButtonExamples state ]
     , categories = [ Buttons ]
     , atomicDesignType = Molecule
+    , keyboardShortcuts = []
     }
 
 

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -6,6 +6,7 @@ module Examples.Button exposing (Msg, State, example)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css exposing (middle, verticalAlign)
 import Debug.Control as Control exposing (Control)
@@ -27,6 +28,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , view = \state -> [ viewButtonExamples state ]
     , categories = [ Buttons ]
+    , atomicDesignType = AtomicDesignType.Molecule
     }
 
 

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -28,7 +28,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , view = \state -> [ viewButtonExamples state ]
     , categories = [ Buttons ]
-    , atomicDesignType = AtomicDesignType.Molecule
+    , atomicDesignType = Molecule
     }
 
 

--- a/styleguide-app/Examples/Callout.elm
+++ b/styleguide-app/Examples/Callout.elm
@@ -7,6 +7,7 @@ module Examples.Callout exposing (example, State, Msg)
 -}
 
 import Accessibility.Styled exposing (text)
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
@@ -30,6 +31,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Callout.V1"
     , categories = [ Messaging ]
+    , atomicDesignType = AtomicDesignType.Molecule
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Callout.elm
+++ b/styleguide-app/Examples/Callout.elm
@@ -31,7 +31,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Callout.V1"
     , categories = [ Messaging ]
-    , atomicDesignType = AtomicDesignType.Molecule
+    , atomicDesignType = Molecule
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Callout.elm
+++ b/styleguide-app/Examples/Callout.elm
@@ -13,7 +13,7 @@ import Css
 import Example exposing (Example)
 import Html.Styled as Html
 import Html.Styled.Attributes exposing (href, title)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Callout.V1 as Callout exposing (callout)
 import Nri.Ui.Heading.V2 as Heading
 
@@ -33,7 +33,7 @@ example =
     { name = "Nri.Ui.Callout.V1"
     , categories = [ Messaging ]
     , atomicDesignType = Molecule
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Callout.elm
+++ b/styleguide-app/Examples/Callout.elm
@@ -13,6 +13,7 @@ import Css
 import Example exposing (Example)
 import Html.Styled as Html
 import Html.Styled.Attributes exposing (href, title)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Callout.V1 as Callout exposing (callout)
 import Nri.Ui.Heading.V2 as Heading
 
@@ -32,6 +33,7 @@ example =
     { name = "Nri.Ui.Callout.V1"
     , categories = [ Messaging ]
     , atomicDesignType = Molecule
+    , keyboardShortcuts = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -12,6 +12,7 @@ import Css
 import Example exposing (Example)
 import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes exposing (css)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Checkbox.V5 as Checkbox
 import Nri.Ui.Data.PremiumLevel as PremiumLevel exposing (PremiumLevel(..))
 import Nri.Ui.PremiumCheckbox.V6 as PremiumCheckbox
@@ -50,6 +51,7 @@ example =
             ]
     , categories = [ Inputs ]
     , atomicDesignType = Molecule
+    , keyboardShortcuts = []
     }
 
 

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -49,7 +49,7 @@ example =
             , viewPremiumCheckboxes state
             ]
     , categories = [ Inputs ]
-    , atomicDesignType = AtomicDesignType.Molecule
+    , atomicDesignType = Molecule
     }
 
 

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -12,7 +12,7 @@ import Css
 import Example exposing (Example)
 import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes exposing (css)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Checkbox.V5 as Checkbox
 import Nri.Ui.Data.PremiumLevel as PremiumLevel exposing (PremiumLevel(..))
 import Nri.Ui.PremiumCheckbox.V6 as PremiumCheckbox
@@ -51,7 +51,7 @@ example =
             ]
     , categories = [ Inputs ]
     , atomicDesignType = Molecule
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     }
 
 

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -6,6 +6,7 @@ module Examples.Checkbox exposing (Msg, State, example)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
@@ -48,6 +49,7 @@ example =
             , viewPremiumCheckboxes state
             ]
     , categories = [ Inputs ]
+    , atomicDesignType = AtomicDesignType.Molecule
     }
 
 

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -15,7 +15,7 @@ import Examples.IconExamples as IconExamples
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.ClickableSvg.V1 as ClickableSvg
 import Nri.Ui.Colors.Extra exposing (fromCssColor, toCssColor)
 import Nri.Ui.Colors.V1 as Colors
@@ -31,7 +31,7 @@ example =
     { name = "Nri.Ui.ClickableSvg.V1"
     , categories = [ Buttons, Icons ]
     , atomicDesignType = Molecule
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -15,6 +15,7 @@ import Examples.IconExamples as IconExamples
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.ClickableSvg.V1 as ClickableSvg
 import Nri.Ui.Colors.Extra exposing (fromCssColor, toCssColor)
 import Nri.Ui.Colors.V1 as Colors
@@ -30,6 +31,7 @@ example =
     { name = "Nri.Ui.ClickableSvg.V1"
     , categories = [ Buttons, Icons ]
     , atomicDesignType = Molecule
+    , keyboardShortcuts = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -6,6 +6,7 @@ module Examples.ClickableSvg exposing (Msg, State, example)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Color exposing (Color)
 import Css
@@ -28,6 +29,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.ClickableSvg.V1"
     , categories = [ Buttons, Icons ]
+    , atomicDesignType = AtomicDesignType.Molecule
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -29,7 +29,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.ClickableSvg.V1"
     , categories = [ Buttons, Icons ]
-    , atomicDesignType = AtomicDesignType.Molecule
+    , atomicDesignType = Molecule
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -6,6 +6,7 @@ module Examples.ClickableText exposing (Msg, State, example)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css exposing (middle, verticalAlign)
 import Debug.Control as Control exposing (Control)
@@ -32,6 +33,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , view = \state -> [ viewExamples state ]
     , categories = [ Buttons ]
+    , atomicDesignType = AtomicDesignType.Molecule
     }
 
 

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -33,7 +33,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , view = \state -> [ viewExamples state ]
     , categories = [ Buttons ]
-    , atomicDesignType = AtomicDesignType.Molecule
+    , atomicDesignType = Molecule
     }
 
 

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -13,6 +13,7 @@ import Debug.Control as Control exposing (Control)
 import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css, id)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Text.V4 as Text
@@ -34,6 +35,7 @@ example =
     , view = \state -> [ viewExamples state ]
     , categories = [ Buttons ]
     , atomicDesignType = Molecule
+    , keyboardShortcuts = []
     }
 
 

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -13,7 +13,7 @@ import Debug.Control as Control exposing (Control)
 import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css, id)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Text.V4 as Text
@@ -35,7 +35,7 @@ example =
     , view = \state -> [ viewExamples state ]
     , categories = [ Buttons ]
     , atomicDesignType = Molecule
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     }
 
 

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -13,7 +13,7 @@ import Css
 import Example exposing (Example)
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes exposing (css)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
@@ -38,7 +38,7 @@ example =
     { name = "Nri.Ui.Colors.V1"
     , categories = [ Colors ]
     , atomicDesignType = Atom
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -6,6 +6,7 @@ module Examples.Colors exposing (example, State, Msg)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Color exposing (highContrast)
 import Css
@@ -34,7 +35,8 @@ type alias Msg =
 example : Example State Msg
 example =
     { name = "Nri.Ui.Colors.V1"
-    , categories = List.singleton Colors
+    , categories = [ Colors ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -36,7 +36,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Colors.V1"
     , categories = [ Colors ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -13,6 +13,7 @@ import Css
 import Example exposing (Example)
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes exposing (css)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
@@ -37,6 +38,7 @@ example =
     { name = "Nri.Ui.Colors.V1"
     , categories = [ Colors ]
     , atomicDesignType = Atom
+    , keyboardShortcuts = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Confetti.elm
+++ b/styleguide-app/Examples/Confetti.elm
@@ -24,7 +24,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Confetti.V2"
     , categories = [ Animations ]
-    , atomicDesignType = Atom
+    , atomicDesignType = Molecule
     , keyboardSupport = []
     , state = Confetti.init 700
     , update = update

--- a/styleguide-app/Examples/Confetti.elm
+++ b/styleguide-app/Examples/Confetti.elm
@@ -23,7 +23,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Confetti.V2"
     , categories = [ Animations ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = Atom
     , state = Confetti.init 700
     , update = update
     , subscriptions =

--- a/styleguide-app/Examples/Confetti.elm
+++ b/styleguide-app/Examples/Confetti.elm
@@ -14,7 +14,7 @@ import Dict exposing (Dict)
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes exposing (css)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Confetti.V2 as Confetti
 
@@ -25,7 +25,7 @@ example =
     { name = "Nri.Ui.Confetti.V2"
     , categories = [ Animations ]
     , atomicDesignType = Atom
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = Confetti.init 700
     , update = update
     , subscriptions =

--- a/styleguide-app/Examples/Confetti.elm
+++ b/styleguide-app/Examples/Confetti.elm
@@ -14,6 +14,7 @@ import Dict exposing (Dict)
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes exposing (css)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Confetti.V2 as Confetti
 
@@ -24,6 +25,7 @@ example =
     { name = "Nri.Ui.Confetti.V2"
     , categories = [ Animations ]
     , atomicDesignType = Atom
+    , keyboardShortcuts = []
     , state = Confetti.init 700
     , update = update
     , subscriptions =

--- a/styleguide-app/Examples/Confetti.elm
+++ b/styleguide-app/Examples/Confetti.elm
@@ -6,6 +6,7 @@ module Examples.Confetti exposing (example, State, Msg)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Browser.Events
 import Category exposing (Category(..))
 import Css exposing (Color)
@@ -22,6 +23,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Confetti.V2"
     , categories = [ Animations ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = Confetti.init 700
     , update = update
     , subscriptions =

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -13,6 +13,7 @@ import Example exposing (Example)
 import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.DisclosureIndicator.V2 as DisclosureIndicator
@@ -32,6 +33,7 @@ example =
     { name = "Nri.Ui.DisclosureIndicator.V2"
     , categories = [ Widgets ]
     , atomicDesignType = Atom
+    , keyboardShortcuts = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -13,7 +13,7 @@ import Example exposing (Example)
 import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.DisclosureIndicator.V2 as DisclosureIndicator
@@ -33,7 +33,7 @@ example =
     { name = "Nri.Ui.DisclosureIndicator.V2"
     , categories = [ Widgets ]
     , atomicDesignType = Atom
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -6,6 +6,7 @@ module Examples.DisclosureIndicator exposing (Msg, State, example)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
@@ -30,6 +31,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.DisclosureIndicator.V2"
     , categories = [ Widgets ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -31,7 +31,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.DisclosureIndicator.V2"
     , categories = [ Widgets ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = Atom
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Divider.elm
+++ b/styleguide-app/Examples/Divider.elm
@@ -6,6 +6,7 @@ module Examples.Divider exposing (Msg, State, example)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
@@ -29,6 +30,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Divider.V2"
     , categories = [ Layout ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = {}
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Divider.elm
+++ b/styleguide-app/Examples/Divider.elm
@@ -12,6 +12,7 @@ import Css
 import Example exposing (Example)
 import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Divider.V2 as Divider
 
 
@@ -31,6 +32,7 @@ example =
     { name = "Nri.Ui.Divider.V2"
     , categories = [ Layout ]
     , atomicDesignType = Atom
+    , keyboardShortcuts = []
     , state = {}
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Divider.elm
+++ b/styleguide-app/Examples/Divider.elm
@@ -12,7 +12,7 @@ import Css
 import Example exposing (Example)
 import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Divider.V2 as Divider
 
 
@@ -32,7 +32,7 @@ example =
     { name = "Nri.Ui.Divider.V2"
     , categories = [ Layout ]
     , atomicDesignType = Atom
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = {}
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Divider.elm
+++ b/styleguide-app/Examples/Divider.elm
@@ -30,7 +30,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Divider.V2"
     , categories = [ Layout ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = Atom
     , state = {}
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Fonts.elm
+++ b/styleguide-app/Examples/Fonts.elm
@@ -6,6 +6,7 @@ module Examples.Fonts exposing (example, State, Msg)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Html.Styled as Html
@@ -28,7 +29,8 @@ type alias Msg =
 example : Example State Msg
 example =
     { name = "Nri.Ui.Fonts.V1"
-    , categories = List.singleton Text
+    , categories = [ Text ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Fonts.elm
+++ b/styleguide-app/Examples/Fonts.elm
@@ -11,7 +11,7 @@ import Category exposing (Category(..))
 import Example exposing (Example)
 import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V2 as Heading
 
@@ -32,7 +32,7 @@ example =
     { name = "Nri.Ui.Fonts.V1"
     , categories = [ Text ]
     , atomicDesignType = Atom
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Fonts.elm
+++ b/styleguide-app/Examples/Fonts.elm
@@ -30,7 +30,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Fonts.V1"
     , categories = [ Text ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Fonts.elm
+++ b/styleguide-app/Examples/Fonts.elm
@@ -11,6 +11,7 @@ import Category exposing (Category(..))
 import Example exposing (Example)
 import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V2 as Heading
 
@@ -31,6 +32,7 @@ example =
     { name = "Nri.Ui.Fonts.V1"
     , categories = [ Text ]
     , atomicDesignType = Atom
+    , keyboardShortcuts = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Heading.elm
+++ b/styleguide-app/Examples/Heading.elm
@@ -11,7 +11,7 @@ import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
 import Html.Styled as Html
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
 
@@ -32,7 +32,7 @@ example =
     { name = "Nri.Ui.Heading.V2"
     , categories = [ Text, Layout ]
     , atomicDesignType = Atom
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Heading.elm
+++ b/styleguide-app/Examples/Heading.elm
@@ -30,7 +30,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Heading.V2"
     , categories = [ Text, Layout ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Heading.elm
+++ b/styleguide-app/Examples/Heading.elm
@@ -11,6 +11,7 @@ import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
 import Html.Styled as Html
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
 
@@ -31,6 +32,7 @@ example =
     { name = "Nri.Ui.Heading.V2"
     , categories = [ Text, Layout ]
     , atomicDesignType = Atom
+    , keyboardShortcuts = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Heading.elm
+++ b/styleguide-app/Examples/Heading.elm
@@ -6,6 +6,7 @@ module Examples.Heading exposing (example, State, Msg)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
@@ -28,7 +29,8 @@ type alias Msg =
 example : Example State Msg
 example =
     { name = "Nri.Ui.Heading.V2"
-    , categories = List.singleton Text
+    , categories = [ Text, Layout ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Icon.elm
+++ b/styleguide-app/Examples/Icon.elm
@@ -6,6 +6,7 @@ module Examples.Icon exposing (example, State, Msg)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css
 import Css.Global
@@ -33,7 +34,8 @@ type alias Msg =
 example : Example State Msg
 example =
     { name = "Nri.Ui.Icon.V5"
-    , categories = List.singleton Icons
+    , categories = [ Icons ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Icon.elm
+++ b/styleguide-app/Examples/Icon.elm
@@ -13,7 +13,7 @@ import Css.Global
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.AssetPath as AssetPath exposing (Asset(..))
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
@@ -37,7 +37,7 @@ example =
     { name = "Nri.Ui.Icon.V5"
     , categories = [ Icons ]
     , atomicDesignType = Atom
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Icon.elm
+++ b/styleguide-app/Examples/Icon.elm
@@ -35,7 +35,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Icon.V5"
     , categories = [ Icons ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Icon.elm
+++ b/styleguide-app/Examples/Icon.elm
@@ -13,6 +13,7 @@ import Css.Global
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.AssetPath as AssetPath exposing (Asset(..))
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
@@ -36,6 +37,7 @@ example =
     { name = "Nri.Ui.Icon.V5"
     , categories = [ Icons ]
     , atomicDesignType = Atom
+    , keyboardShortcuts = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Loading.elm
+++ b/styleguide-app/Examples/Loading.elm
@@ -15,7 +15,7 @@ import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Events as Events
 import Json.Decode
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
@@ -91,7 +91,7 @@ example =
     { name = "Nri.Ui.Loading.V1"
     , categories = [ Pages ]
     , atomicDesignType = Page
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = init
     , update = update
     , subscriptions = subscriptions

--- a/styleguide-app/Examples/Loading.elm
+++ b/styleguide-app/Examples/Loading.elm
@@ -15,6 +15,7 @@ import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Events as Events
 import Json.Decode
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
@@ -90,6 +91,7 @@ example =
     { name = "Nri.Ui.Loading.V1"
     , categories = [ Pages ]
     , atomicDesignType = Page
+    , keyboardShortcuts = []
     , state = init
     , update = update
     , subscriptions = subscriptions

--- a/styleguide-app/Examples/Loading.elm
+++ b/styleguide-app/Examples/Loading.elm
@@ -6,6 +6,7 @@ module Examples.Loading exposing (example, State, Msg)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Browser.Events
 import Category exposing (Category(..))
 import Css
@@ -88,6 +89,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Loading.V1"
     , categories = [ Pages ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = init
     , update = update
     , subscriptions = subscriptions

--- a/styleguide-app/Examples/Loading.elm
+++ b/styleguide-app/Examples/Loading.elm
@@ -89,7 +89,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Loading.V1"
     , categories = [ Pages ]
-    , atomicDesignType = AtomicDesignType.Page
+    , atomicDesignType = Page
     , state = init
     , update = update
     , subscriptions = subscriptions

--- a/styleguide-app/Examples/Loading.elm
+++ b/styleguide-app/Examples/Loading.elm
@@ -89,7 +89,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Loading.V1"
     , categories = [ Pages ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = AtomicDesignType.Page
     , state = init
     , update = update
     , subscriptions = subscriptions

--- a/styleguide-app/Examples/Logo.elm
+++ b/styleguide-app/Examples/Logo.elm
@@ -30,7 +30,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Logo.V1"
     , categories = [ Icons ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Logo.elm
+++ b/styleguide-app/Examples/Logo.elm
@@ -6,6 +6,7 @@ module Examples.Logo exposing (example, State, Msg)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
@@ -28,7 +29,8 @@ type alias Msg =
 example : Example State Msg
 example =
     { name = "Nri.Ui.Logo.V1"
-    , categories = List.singleton Icons
+    , categories = [ Icons ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Logo.elm
+++ b/styleguide-app/Examples/Logo.elm
@@ -11,7 +11,7 @@ import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
 import Examples.IconExamples as IconExamples
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Logo.V1 as Logo
 
@@ -32,7 +32,7 @@ example =
     { name = "Nri.Ui.Logo.V1"
     , categories = [ Icons ]
     , atomicDesignType = Atom
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Logo.elm
+++ b/styleguide-app/Examples/Logo.elm
@@ -11,6 +11,7 @@ import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
 import Examples.IconExamples as IconExamples
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Logo.V1 as Logo
 
@@ -31,6 +32,7 @@ example =
     { name = "Nri.Ui.Logo.V1"
     , categories = [ Icons ]
     , atomicDesignType = Atom
+    , keyboardShortcuts = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/MasteryIcon.elm
+++ b/styleguide-app/Examples/MasteryIcon.elm
@@ -29,7 +29,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.MasteryIcon.V1"
     , categories = [ Icons ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/MasteryIcon.elm
+++ b/styleguide-app/Examples/MasteryIcon.elm
@@ -10,6 +10,7 @@ import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Examples.IconExamples as IconExamples
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.MasteryIcon.V1 as MasteryIcon
 
@@ -30,6 +31,7 @@ example =
     { name = "Nri.Ui.MasteryIcon.V1"
     , categories = [ Icons ]
     , atomicDesignType = Atom
+    , keyboardShortcuts = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/MasteryIcon.elm
+++ b/styleguide-app/Examples/MasteryIcon.elm
@@ -6,6 +6,7 @@ module Examples.MasteryIcon exposing (example, State, Msg)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Examples.IconExamples as IconExamples
@@ -27,7 +28,8 @@ type alias Msg =
 example : Example State Msg
 example =
     { name = "Nri.Ui.MasteryIcon.V1"
-    , categories = List.singleton Icons
+    , categories = [ Icons ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/MasteryIcon.elm
+++ b/styleguide-app/Examples/MasteryIcon.elm
@@ -10,7 +10,7 @@ import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Examples.IconExamples as IconExamples
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.MasteryIcon.V1 as MasteryIcon
 
@@ -31,7 +31,7 @@ example =
     { name = "Nri.Ui.MasteryIcon.V1"
     , categories = [ Icons ]
     , atomicDesignType = Atom
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -13,7 +13,7 @@ import Css
 import Debug.Control as Control exposing (Control)
 import Example exposing (Example)
 import Html.Styled.Attributes exposing (css)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Menu.V1 as Menu
@@ -31,7 +31,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Widgets ]
     , atomicDesignType = Molecule
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , view = view
     }
 

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -29,7 +29,7 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , categories = [ Widgets ]
-    , atomicDesignType = AtomicDesignType.Molecule
+    , atomicDesignType = Molecule
     , view = view
     }
 

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -13,6 +13,7 @@ import Css
 import Debug.Control as Control exposing (Control)
 import Example exposing (Example)
 import Html.Styled.Attributes exposing (css)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Menu.V1 as Menu
@@ -30,6 +31,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Widgets ]
     , atomicDesignType = Molecule
+    , keyboardShortcuts = []
     , view = view
     }
 

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -7,6 +7,7 @@ module Examples.Menu exposing (Msg, State, example)
 -}
 
 import Accessibility.Styled as Html exposing (..)
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css
 import Debug.Control as Control exposing (Control)
@@ -28,6 +29,7 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , categories = [ Widgets ]
+    , atomicDesignType = AtomicDesignType.Molecule
     , view = view
     }
 

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -8,6 +8,7 @@ import Debug.Control as Control exposing (Control)
 import Example exposing (Example)
 import Html.Styled exposing (styled)
 import Html.Styled.Attributes as Attributes exposing (href)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Message.V1 as Message
@@ -125,6 +126,7 @@ example =
     { name = "Nri.Ui.Message.V1"
     , categories = [ Messaging ]
     , atomicDesignType = Molecule
+    , keyboardShortcuts = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -1,6 +1,7 @@
 module Examples.Message exposing (Msg, State, example)
 
 import Accessibility.Styled as Html exposing (..)
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css exposing (..)
 import Debug.Control as Control exposing (Control)
@@ -123,6 +124,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Message.V1"
     , categories = [ Messaging ]
+    , atomicDesignType = AtomicDesignType.Molecule
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -8,7 +8,7 @@ import Debug.Control as Control exposing (Control)
 import Example exposing (Example)
 import Html.Styled exposing (styled)
 import Html.Styled.Attributes as Attributes exposing (href)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Message.V1 as Message
@@ -126,7 +126,7 @@ example =
     { name = "Nri.Ui.Message.V1"
     , categories = [ Messaging ]
     , atomicDesignType = Molecule
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -124,7 +124,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Message.V1"
     , categories = [ Messaging ]
-    , atomicDesignType = AtomicDesignType.Molecule
+    , atomicDesignType = Molecule
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -7,6 +7,7 @@ module Examples.Modal exposing (Msg, State, example)
 -}
 
 import Accessibility.Styled as Html exposing (Html, div, h3, h4, p, span, text)
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css exposing (..)
 import Css.Global
@@ -53,6 +54,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Modal.V8"
     , categories = [ Modals ]
+    , atomicDesignType = AtomicDesignType.Organism
     , state = init
     , update = update
     , subscriptions = subscriptions

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -14,7 +14,7 @@ import Css.Global
 import Example exposing (Example)
 import Html as Root
 import Html.Styled.Attributes as Attributes
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Checkbox.V5 as Checkbox
 import Nri.Ui.ClickableText.V3 as ClickableText
@@ -56,7 +56,7 @@ example =
     { name = "Nri.Ui.Modal.V8"
     , categories = [ Modals ]
     , atomicDesignType = Organism
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = init
     , update = update
     , subscriptions = subscriptions

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -14,6 +14,7 @@ import Css.Global
 import Example exposing (Example)
 import Html as Root
 import Html.Styled.Attributes as Attributes
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Checkbox.V5 as Checkbox
 import Nri.Ui.ClickableText.V3 as ClickableText
@@ -55,6 +56,7 @@ example =
     { name = "Nri.Ui.Modal.V8"
     , categories = [ Modals ]
     , atomicDesignType = Organism
+    , keyboardShortcuts = []
     , state = init
     , update = update
     , subscriptions = subscriptions

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -54,7 +54,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Modal.V8"
     , categories = [ Modals ]
-    , atomicDesignType = AtomicDesignType.Organism
+    , atomicDesignType = Organism
     , state = init
     , update = update
     , subscriptions = subscriptions

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -31,7 +31,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Page.V3"
     , categories = [ Pages ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = AtomicDesignType.Page
     , state = ()
     , update =
         \msg model ->

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -12,7 +12,7 @@ import Css
 import Css.Global exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Page.V3 as Page
 
@@ -33,7 +33,7 @@ example =
     { name = "Nri.Ui.Page.V3"
     , categories = [ Pages ]
     , atomicDesignType = Page
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = ()
     , update =
         \msg model ->

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -6,6 +6,7 @@ module Examples.Page exposing (example, State, Msg)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css
 import Css.Global exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
@@ -29,7 +30,8 @@ type alias Msg =
 example : Example State Msg
 example =
     { name = "Nri.Ui.Page.V3"
-    , categories = List.singleton Pages
+    , categories = [ Pages ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = ()
     , update =
         \msg model ->

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -31,7 +31,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Page.V3"
     , categories = [ Pages ]
-    , atomicDesignType = AtomicDesignType.Page
+    , atomicDesignType = Page
     , state = ()
     , update =
         \msg model ->

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -12,6 +12,7 @@ import Css
 import Css.Global exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Page.V3 as Page
 
@@ -32,6 +33,7 @@ example =
     { name = "Nri.Ui.Page.V3"
     , categories = [ Pages ]
     , atomicDesignType = Page
+    , keyboardShortcuts = []
     , state = ()
     , update =
         \msg model ->

--- a/styleguide-app/Examples/Pennant.elm
+++ b/styleguide-app/Examples/Pennant.elm
@@ -32,7 +32,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Pennant.V2"
     , categories = [ Icons ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Pennant.elm
+++ b/styleguide-app/Examples/Pennant.elm
@@ -12,6 +12,7 @@ import Css exposing (..)
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Pennant.V2 as Pennant
 import Nri.Ui.Svg.V1 as Svg
@@ -33,6 +34,7 @@ example =
     { name = "Nri.Ui.Pennant.V2"
     , categories = [ Icons ]
     , atomicDesignType = Atom
+    , keyboardShortcuts = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Pennant.elm
+++ b/styleguide-app/Examples/Pennant.elm
@@ -6,6 +6,7 @@ module Examples.Pennant exposing (example, State, Msg)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css exposing (..)
 import Example exposing (Example)
@@ -30,7 +31,8 @@ type alias Msg =
 example : Example State Msg
 example =
     { name = "Nri.Ui.Pennant.V2"
-    , categories = List.singleton Icons
+    , categories = [ Icons ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Pennant.elm
+++ b/styleguide-app/Examples/Pennant.elm
@@ -12,7 +12,7 @@ import Css exposing (..)
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Pennant.V2 as Pennant
 import Nri.Ui.Svg.V1 as Svg
@@ -34,7 +34,7 @@ example =
     { name = "Nri.Ui.Pennant.V2"
     , categories = [ Icons ]
     , atomicDesignType = Atom
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -11,6 +11,7 @@ module Examples.SegmentedControl exposing
 -}
 
 import Accessibility.Styled
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Debug.Control as Control exposing (Control)
 import Example exposing (Example)
@@ -62,7 +63,8 @@ example =
                 , width = options.width
                 }
             ]
-    , categories = [ Inputs, Widgets ]
+    , categories = [ Inputs, Widgets, Layout ]
+    , atomicDesignType = AtomicDesignType.Molecule
     }
 
 

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -18,7 +18,7 @@ import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attr
 import Html.Styled.Events as Events
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.SegmentedControl.V9 as SegmentedControl
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
@@ -66,7 +66,7 @@ example =
             ]
     , categories = [ Inputs, Widgets, Layout ]
     , atomicDesignType = Molecule
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     }
 
 

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -18,6 +18,7 @@ import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attr
 import Html.Styled.Events as Events
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.SegmentedControl.V9 as SegmentedControl
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
@@ -65,6 +66,7 @@ example =
             ]
     , categories = [ Inputs, Widgets, Layout ]
     , atomicDesignType = Molecule
+    , keyboardShortcuts = []
     }
 
 

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -64,7 +64,7 @@ example =
                 }
             ]
     , categories = [ Inputs, Widgets, Layout ]
-    , atomicDesignType = AtomicDesignType.Molecule
+    , atomicDesignType = Molecule
     }
 
 

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -12,7 +12,7 @@ import Css
 import Example exposing (Example)
 import Html.Styled
 import Html.Styled.Attributes
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Select.V7 as Select
 
@@ -26,7 +26,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Inputs ]
     , atomicDesignType = Molecule
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , view =
         \state ->
             [ Html.Styled.label

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -12,6 +12,7 @@ import Css
 import Example exposing (Example)
 import Html.Styled
 import Html.Styled.Attributes
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Select.V7 as Select
 
@@ -25,6 +26,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Inputs ]
     , atomicDesignType = Molecule
+    , keyboardShortcuts = []
     , view =
         \state ->
             [ Html.Styled.label

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -6,6 +6,7 @@ module Examples.Select exposing (Msg, State, example)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
@@ -23,6 +24,7 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , categories = [ Inputs ]
+    , atomicDesignType = AtomicDesignType.Molecule
     , view =
         \state ->
             [ Html.Styled.label

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -24,7 +24,7 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , categories = [ Inputs ]
-    , atomicDesignType = AtomicDesignType.Molecule
+    , atomicDesignType = Molecule
     , view =
         \state ->
             [ Html.Styled.label

--- a/styleguide-app/Examples/Slide.elm
+++ b/styleguide-app/Examples/Slide.elm
@@ -13,6 +13,7 @@ import Css
 import Example exposing (Example)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Keyed as Keyed
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import List.Zipper as Zipper exposing (Zipper)
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.V1 as Colors
@@ -38,6 +39,7 @@ example =
     { name = "Nri.Ui.Slide.V1"
     , categories = [ Animations ]
     , atomicDesignType = Atom
+    , keyboardShortcuts = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Slide.elm
+++ b/styleguide-app/Examples/Slide.elm
@@ -7,6 +7,7 @@ module Examples.Slide exposing (Msg, State, example)
 -}
 
 import Accessibility.Styled as Html
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
@@ -36,6 +37,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Slide.V1"
     , categories = [ Animations ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Slide.elm
+++ b/styleguide-app/Examples/Slide.elm
@@ -37,7 +37,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Slide.V1"
     , categories = [ Animations ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = Atom
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Slide.elm
+++ b/styleguide-app/Examples/Slide.elm
@@ -13,7 +13,7 @@ import Css
 import Example exposing (Example)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Keyed as Keyed
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import List.Zipper as Zipper exposing (Zipper)
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.V1 as Colors
@@ -39,7 +39,7 @@ example =
     { name = "Nri.Ui.Slide.V1"
     , categories = [ Animations ]
     , atomicDesignType = Atom
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/SlideModal.elm
+++ b/styleguide-app/Examples/SlideModal.elm
@@ -7,6 +7,7 @@ module Examples.SlideModal exposing (Msg, State, example)
 -}
 
 import Accessibility.Styled as Html exposing (Html, div, h3, p, text)
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
@@ -34,6 +35,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.SlideModal.V2"
     , categories = [ Modals ]
+    , atomicDesignType = AtomicDesignType.Organism
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/SlideModal.elm
+++ b/styleguide-app/Examples/SlideModal.elm
@@ -13,6 +13,7 @@ import Css
 import Example exposing (Example)
 import Html.Styled exposing (fromUnstyled)
 import Html.Styled.Attributes exposing (css)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.SlideModal.V2 as SlideModal
@@ -36,6 +37,7 @@ example =
     { name = "Nri.Ui.SlideModal.V2"
     , categories = [ Modals ]
     , atomicDesignType = Organism
+    , keyboardShortcuts = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/SlideModal.elm
+++ b/styleguide-app/Examples/SlideModal.elm
@@ -35,7 +35,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.SlideModal.V2"
     , categories = [ Modals ]
-    , atomicDesignType = AtomicDesignType.Organism
+    , atomicDesignType = Organism
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/SlideModal.elm
+++ b/styleguide-app/Examples/SlideModal.elm
@@ -13,7 +13,7 @@ import Css
 import Example exposing (Example)
 import Html.Styled exposing (fromUnstyled)
 import Html.Styled.Attributes exposing (css)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.SlideModal.V2 as SlideModal
@@ -37,7 +37,7 @@ example =
     { name = "Nri.Ui.SlideModal.V2"
     , categories = [ Modals ]
     , atomicDesignType = Organism
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/SortableTable.elm
+++ b/styleguide-app/Examples/SortableTable.elm
@@ -36,7 +36,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.SortableTable.V1"
     , categories = [ Tables, Layout ]
-    , atomicDesignType = AtomicDesignType.Molecule
+    , atomicDesignType = Molecule
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/SortableTable.elm
+++ b/styleguide-app/Examples/SortableTable.elm
@@ -10,6 +10,7 @@ import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Html.Styled as Html
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.SortableTable.V1 as SortableTable
 
@@ -37,6 +38,7 @@ example =
     { name = "Nri.Ui.SortableTable.V1"
     , categories = [ Tables, Layout ]
     , atomicDesignType = Molecule
+    , keyboardShortcuts = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/SortableTable.elm
+++ b/styleguide-app/Examples/SortableTable.elm
@@ -10,7 +10,7 @@ import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Html.Styled as Html
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.SortableTable.V1 as SortableTable
 
@@ -38,7 +38,7 @@ example =
     { name = "Nri.Ui.SortableTable.V1"
     , categories = [ Tables, Layout ]
     , atomicDesignType = Molecule
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/SortableTable.elm
+++ b/styleguide-app/Examples/SortableTable.elm
@@ -6,6 +6,7 @@ module Examples.SortableTable exposing (Msg, State, example)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Html.Styled as Html
@@ -34,7 +35,8 @@ type alias State =
 example : Example State Msg
 example =
     { name = "Nri.Ui.SortableTable.V1"
-    , categories = [ Tables ]
+    , categories = [ Tables, Layout ]
+    , atomicDesignType = AtomicDesignType.Molecule
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Svg.elm
+++ b/styleguide-app/Examples/Svg.elm
@@ -15,7 +15,7 @@ import Examples.IconExamples as IconExamples
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.Extra exposing (fromCssColor, toCssColor)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
@@ -30,7 +30,7 @@ example =
     { name = "Nri.Ui.Svg.V1"
     , categories = [ Icons ]
     , atomicDesignType = Atom
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Svg.elm
+++ b/styleguide-app/Examples/Svg.elm
@@ -28,7 +28,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Svg.V1"
     , categories = [ Icons ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = Atom
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Svg.elm
+++ b/styleguide-app/Examples/Svg.elm
@@ -6,6 +6,7 @@ module Examples.Svg exposing (Msg, State, example)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Color exposing (Color)
 import Css
@@ -27,6 +28,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Svg.V1"
     , categories = [ Icons ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Svg.elm
+++ b/styleguide-app/Examples/Svg.elm
@@ -15,6 +15,7 @@ import Examples.IconExamples as IconExamples
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.Extra exposing (fromCssColor, toCssColor)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
@@ -29,6 +30,7 @@ example =
     { name = "Nri.Ui.Svg.V1"
     , categories = [ Icons ]
     , atomicDesignType = Atom
+    , keyboardShortcuts = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -35,7 +35,7 @@ example =
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
     , categories = [ Tables, Layout ]
-    , atomicDesignType = AtomicDesignType.Molecule
+    , atomicDesignType = Molecule
     , view =
         \() ->
             let

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -6,6 +6,7 @@ module Examples.Table exposing (Msg, State, example)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css exposing (..)
 import Example exposing (Example)
@@ -33,7 +34,8 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
-    , categories = [ Tables ]
+    , categories = [ Tables, Layout ]
+    , atomicDesignType = AtomicDesignType.Molecule
     , view =
         \() ->
             let

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -11,7 +11,7 @@ import Category exposing (Category(..))
 import Css exposing (..)
 import Example exposing (Example)
 import Html.Styled as Html
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V5 as Button
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
@@ -37,7 +37,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Tables, Layout ]
     , atomicDesignType = Molecule
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , view =
         \() ->
             let

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -11,6 +11,7 @@ import Category exposing (Category(..))
 import Css exposing (..)
 import Example exposing (Example)
 import Html.Styled as Html
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V5 as Button
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
@@ -36,6 +37,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Tables, Layout ]
     , atomicDesignType = Molecule
+    , keyboardShortcuts = []
     , view =
         \() ->
             let

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -103,7 +103,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Tabs.V5"
     , categories = [ Layout ]
-    , atomicDesignType = AtomicDesignType.Molecule
+    , atomicDesignType = Molecule
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -18,7 +18,7 @@ import Debug.Control as Control exposing (Control)
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html, fromUnstyled)
 import Html.Styled.Attributes exposing (css)
-import KeyboardShortcuts exposing (Key(..))
+import KeyboardSupport exposing (Key(..))
 import List.Zipper exposing (Zipper)
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Tabs.V5 as Tabs exposing (Alignment(..), Tab)
@@ -105,7 +105,7 @@ example =
     { name = "Nri.Ui.Tabs.V5"
     , categories = [ Layout ]
     , atomicDesignType = Molecule
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -105,7 +105,17 @@ example =
     { name = "Nri.Ui.Tabs.V5"
     , categories = [ Layout ]
     , atomicDesignType = Molecule
-    , keyboardSupport = []
+    , keyboardSupport =
+        [ { keys = [ KeyboardSupport.Tab ]
+          , result = "Move focus to and from the currently-selected Tab"
+          }
+        , { keys = [ Arrow KeyboardSupport.Left ]
+          , result = "Select the tab to the left of the currently-selected Tab"
+          }
+        , { keys = [ Arrow KeyboardSupport.Right ]
+          , result = "Select the tab to the right of the currently-selected Tab"
+          }
+        ]
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -18,6 +18,7 @@ import Debug.Control as Control exposing (Control)
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html, fromUnstyled)
 import Html.Styled.Attributes exposing (css)
+import KeyboardShortcuts exposing (Key(..))
 import List.Zipper exposing (Zipper)
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Tabs.V5 as Tabs exposing (Alignment(..), Tab)
@@ -104,6 +105,7 @@ example =
     { name = "Nri.Ui.Tabs.V5"
     , categories = [ Layout ]
     , atomicDesignType = Molecule
+    , keyboardShortcuts = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -10,6 +10,7 @@ module Examples.Tabs exposing
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Browser.Dom as Dom
 import Category exposing (Category(..))
 import Css
@@ -102,6 +103,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Tabs.V5"
     , categories = [ Layout ]
+    , atomicDesignType = AtomicDesignType.Molecule
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -30,7 +30,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Text.V4"
     , categories = [ Text ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -11,6 +11,7 @@ import Category exposing (Category(..))
 import Example exposing (Example)
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Text.V4 as Text
 
@@ -31,6 +32,7 @@ example =
     { name = "Nri.Ui.Text.V4"
     , categories = [ Text ]
     , atomicDesignType = Atom
+    , keyboardShortcuts = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -11,7 +11,7 @@ import Category exposing (Category(..))
 import Example exposing (Example)
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Text.V4 as Text
 
@@ -32,7 +32,7 @@ example =
     { name = "Nri.Ui.Text.V4"
     , categories = [ Text ]
     , atomicDesignType = Atom
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -6,6 +6,7 @@ module Examples.Text exposing (example, State, Msg)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Html.Styled as Html
@@ -28,7 +29,8 @@ type alias Msg =
 example : Example State Msg
 example =
     { name = "Nri.Ui.Text.V4"
-    , categories = List.singleton Text
+    , categories = [ Text ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Text/Writing.elm
+++ b/styleguide-app/Examples/Text/Writing.elm
@@ -27,7 +27,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Text.Writing.V1"
     , categories = [ Text ]
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Text/Writing.elm
+++ b/styleguide-app/Examples/Text/Writing.elm
@@ -10,6 +10,7 @@ import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Html.Styled exposing (text)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Text.Writing.V1 as TextWriting
 
 
@@ -28,6 +29,7 @@ example =
     { name = "Nri.Ui.Text.Writing.V1"
     , categories = [ Text ]
     , atomicDesignType = Atom
+    , keyboardShortcuts = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Text/Writing.elm
+++ b/styleguide-app/Examples/Text/Writing.elm
@@ -6,6 +6,7 @@ module Examples.Text.Writing exposing (example, State, Msg)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Html.Styled exposing (text)
@@ -25,7 +26,8 @@ type alias Msg =
 example : Example State Msg
 example =
     { name = "Nri.Ui.Text.Writing.V1"
-    , categories = List.singleton Text
+    , categories = [ Text ]
+    , atomicDesignType = AtomicDesignType.Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Text/Writing.elm
+++ b/styleguide-app/Examples/Text/Writing.elm
@@ -10,7 +10,7 @@ import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Html.Styled exposing (text)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Text.Writing.V1 as TextWriting
 
 
@@ -29,7 +29,7 @@ example =
     { name = "Nri.Ui.Text.Writing.V1"
     , categories = [ Text ]
     , atomicDesignType = Atom
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -6,6 +6,7 @@ module Examples.TextArea exposing (Msg, State, example)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Dict exposing (Dict)
 import Example exposing (Example)
@@ -41,6 +42,7 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , categories = [ Inputs ]
+    , atomicDesignType = AtomicDesignType.Molecule
     , view =
         \state ->
             [ Heading.h1 [] [ Html.text "Textarea controls" ]

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -11,6 +11,7 @@ import Category exposing (Category(..))
 import Dict exposing (Dict)
 import Example exposing (Example)
 import Html.Styled as Html
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.AssetPath exposing (Asset(..))
 import Nri.Ui.Checkbox.V5 as Checkbox
 import Nri.Ui.Heading.V2 as Heading
@@ -43,6 +44,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Inputs ]
     , atomicDesignType = Molecule
+    , keyboardShortcuts = []
     , view =
         \state ->
             [ Heading.h1 [] [ Html.text "Textarea controls" ]

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -42,7 +42,7 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , categories = [ Inputs ]
-    , atomicDesignType = AtomicDesignType.Molecule
+    , atomicDesignType = Molecule
     , view =
         \state ->
             [ Heading.h1 [] [ Html.text "Textarea controls" ]

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -11,7 +11,7 @@ import Category exposing (Category(..))
 import Dict exposing (Dict)
 import Example exposing (Example)
 import Html.Styled as Html
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.AssetPath exposing (Asset(..))
 import Nri.Ui.Checkbox.V5 as Checkbox
 import Nri.Ui.Heading.V2 as Heading
@@ -44,7 +44,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Inputs ]
     , atomicDesignType = Molecule
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , view =
         \state ->
             [ Heading.h1 [] [ Html.text "Textarea controls" ]

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -14,7 +14,7 @@ import Debug.Control as Control exposing (Control)
 import Dict exposing (Dict)
 import Example exposing (Example)
 import Html.Styled.Attributes exposing (css)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.TextInput.V6 as TextInput
 
@@ -55,7 +55,7 @@ example =
     { name = "Nri.Ui.TextInput.V6"
     , categories = [ Inputs ]
     , atomicDesignType = Molecule
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -7,6 +7,7 @@ module Examples.TextInput exposing (Msg, State, example)
 -}
 
 import Accessibility.Styled as Html exposing (..)
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css exposing (..)
 import Debug.Control as Control exposing (Control)
@@ -52,6 +53,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.TextInput.V6"
     , categories = [ Inputs ]
+    , atomicDesignType = AtomicDesignType.Molecule
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -14,6 +14,7 @@ import Debug.Control as Control exposing (Control)
 import Dict exposing (Dict)
 import Example exposing (Example)
 import Html.Styled.Attributes exposing (css)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.TextInput.V6 as TextInput
 
@@ -54,6 +55,7 @@ example =
     { name = "Nri.Ui.TextInput.V6"
     , categories = [ Inputs ]
     , atomicDesignType = Molecule
+    , keyboardShortcuts = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -53,7 +53,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.TextInput.V6"
     , categories = [ Inputs ]
-    , atomicDesignType = AtomicDesignType.Molecule
+    , atomicDesignType = Molecule
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -12,7 +12,7 @@ import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
 import Html.Styled.Attributes exposing (css, href)
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Text.V4 as Text
 import Nri.Ui.Tooltip.V1 as Tooltip
@@ -58,7 +58,7 @@ example =
     { name = "Nri.Ui.Tooltip.V1"
     , categories = [ Widgets ]
     , atomicDesignType = Molecule
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -7,6 +7,7 @@ module Examples.Tooltip exposing (example, State, Msg)
 -}
 
 import Accessibility.Styled as Html
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
@@ -55,6 +56,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Tooltip.V1"
     , categories = [ Widgets ]
+    , atomicDesignType = AtomicDesignType.Molecule
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -56,7 +56,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.Tooltip.V1"
     , categories = [ Widgets ]
-    , atomicDesignType = AtomicDesignType.Molecule
+    , atomicDesignType = Molecule
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -12,6 +12,7 @@ import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
 import Html.Styled.Attributes exposing (css, href)
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Text.V4 as Text
 import Nri.Ui.Tooltip.V1 as Tooltip
@@ -57,6 +58,7 @@ example =
     { name = "Nri.Ui.Tooltip.V1"
     , categories = [ Widgets ]
     , atomicDesignType = Molecule
+    , keyboardShortcuts = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/UiIcon.elm
+++ b/styleguide-app/Examples/UiIcon.elm
@@ -6,6 +6,7 @@ module Examples.UiIcon exposing (example, State, Msg)
 
 -}
 
+import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Examples.IconExamples as IconExamples
@@ -27,6 +28,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.UiIcon.V1"
     , categories = List.singleton Icons
+    , atomicDesignType = AtomicDesignType.Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/UiIcon.elm
+++ b/styleguide-app/Examples/UiIcon.elm
@@ -10,6 +10,7 @@ import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Examples.IconExamples as IconExamples
+import KeyboardShortcuts exposing (Direction(..), Key(..))
 import Nri.Ui.UiIcon.V1 as UiIcon
 
 
@@ -29,6 +30,7 @@ example =
     { name = "Nri.Ui.UiIcon.V1"
     , categories = List.singleton Icons
     , atomicDesignType = Atom
+    , keyboardShortcuts = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/UiIcon.elm
+++ b/styleguide-app/Examples/UiIcon.elm
@@ -10,7 +10,7 @@ import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Example exposing (Example)
 import Examples.IconExamples as IconExamples
-import KeyboardShortcuts exposing (Direction(..), Key(..))
+import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.UiIcon.V1 as UiIcon
 
 
@@ -30,7 +30,7 @@ example =
     { name = "Nri.Ui.UiIcon.V1"
     , categories = List.singleton Icons
     , atomicDesignType = Atom
-    , keyboardShortcuts = []
+    , keyboardSupport = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/UiIcon.elm
+++ b/styleguide-app/Examples/UiIcon.elm
@@ -28,7 +28,7 @@ example : Example State Msg
 example =
     { name = "Nri.Ui.UiIcon.V1"
     , categories = List.singleton Icons
-    , atomicDesignType = AtomicDesignType.Atom
+    , atomicDesignType = Atom
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/KeyboardShortcuts.elm
+++ b/styleguide-app/KeyboardShortcuts.elm
@@ -23,11 +23,49 @@ type alias KeyboardShortcut =
 
 
 {-| -}
+view : List KeyboardShortcut -> Html msg
+view keyboardShortcuts =
+    case keyboardShortcuts of
+        [] ->
+            text ""
+
+        _ ->
+            details []
+                [ summary [] [ text "Keyboard Support" ]
+                , ul [] (List.map viewKeyboardActions keyboardShortcuts)
+                ]
+
+
+viewKeyboardActions : KeyboardShortcut -> Html msg
+viewKeyboardActions { keys, result } =
+    li []
+        [ strong [] [ text (String.join "+" (List.map keyToString keys)) ]
+        , text result
+        ]
+
+
+{-| -}
 type Key
     = Shift
     | Enter
     | Arrow Direction
     | Tab
+
+
+keyToString : Key -> String
+keyToString key =
+    case key of
+        Shift ->
+            "Shift"
+
+        Enter ->
+            "Enter"
+
+        Arrow direction ->
+            directionToString direction ++ " arrow"
+
+        Tab ->
+            "Tab"
 
 
 {-| -}
@@ -38,9 +76,17 @@ type Direction
     | Left
 
 
-{-| -}
-view : List KeyboardShortcut -> Html msg
-view keyboardShortcuts =
-    div []
-        [ text "TODO"
-        ]
+directionToString : Direction -> String
+directionToString direction =
+    case direction of
+        Up ->
+            "Up"
+
+        Right ->
+            "Right"
+
+        Down ->
+            "Down"
+
+        Left ->
+            "Left"

--- a/styleguide-app/KeyboardShortcuts.elm
+++ b/styleguide-app/KeyboardShortcuts.elm
@@ -1,0 +1,46 @@
+module KeyboardShortcuts exposing
+    ( view
+    , KeyboardShortcut
+    , Key(..), Direction(..)
+    )
+
+{-|
+
+@docs view
+@docs KeyboardShortcut
+@docs Key, Direction
+
+-}
+
+import Html.Styled as Html exposing (..)
+
+
+{-| -}
+type alias KeyboardShortcut =
+    { keys : List Key
+    , result : String
+    }
+
+
+{-| -}
+type Key
+    = Shift
+    | Enter
+    | Arrow Direction
+    | Tab
+
+
+{-| -}
+type Direction
+    = Up
+    | Right
+    | Down
+    | Left
+
+
+{-| -}
+view : List KeyboardShortcut -> Html msg
+view keyboardShortcuts =
+    div []
+        [ text "TODO"
+        ]

--- a/styleguide-app/KeyboardSupport.elm
+++ b/styleguide-app/KeyboardSupport.elm
@@ -1,13 +1,13 @@
-module KeyboardShortcuts exposing
+module KeyboardSupport exposing
     ( view
-    , KeyboardShortcut
+    , KeyboardSupport
     , Key(..), Direction(..)
     )
 
 {-|
 
 @docs view
-@docs KeyboardShortcut
+@docs KeyboardSupport
 @docs Key, Direction
 
 -}
@@ -16,27 +16,27 @@ import Html.Styled as Html exposing (..)
 
 
 {-| -}
-type alias KeyboardShortcut =
+type alias KeyboardSupport =
     { keys : List Key
     , result : String
     }
 
 
 {-| -}
-view : List KeyboardShortcut -> Html msg
-view keyboardShortcuts =
-    case keyboardShortcuts of
+view : List KeyboardSupport -> Html msg
+view keyboardSupport =
+    case keyboardSupport of
         [] ->
             text ""
 
         _ ->
             details []
                 [ summary [] [ text "Keyboard Support" ]
-                , ul [] (List.map viewKeyboardActions keyboardShortcuts)
+                , ul [] (List.map viewKeyboardActions keyboardSupport)
                 ]
 
 
-viewKeyboardActions : KeyboardShortcut -> Html msg
+viewKeyboardActions : KeyboardSupport -> Html msg
 viewKeyboardActions { keys, result } =
     li []
         [ strong [] [ text (String.join "+" (List.map keyToString keys)) ]

--- a/styleguide-app/KeyboardSupport.elm
+++ b/styleguide-app/KeyboardSupport.elm
@@ -12,7 +12,9 @@ module KeyboardSupport exposing
 
 -}
 
+import Css exposing (..)
 import Html.Styled as Html exposing (..)
+import Html.Styled.Attributes exposing (css)
 
 
 {-| -}
@@ -32,14 +34,17 @@ view keyboardSupport =
         _ ->
             details []
                 [ summary [] [ text "Keyboard Support" ]
-                , ul [] (List.map viewKeyboardActions keyboardSupport)
+                , ul
+                    [ css [ listStyle none, margin2 (px 10) zero, padding zero ]
+                    ]
+                    (List.map viewKeyboardActions keyboardSupport)
                 ]
 
 
 viewKeyboardActions : KeyboardSupport -> Html msg
 viewKeyboardActions { keys, result } =
     li []
-        [ strong [] [ text (String.join "+" (List.map keyToString keys)) ]
+        [ strong [] [ text (String.join "+" (List.map keyToString keys) ++ ": ") ]
         , text result
         ]
 

--- a/styleguide-app/Main.elm
+++ b/styleguide-app/Main.elm
@@ -1,5 +1,6 @@
 module Main exposing (init, main)
 
+import Accessibility.Styled as Html exposing (Html, img, text)
 import AtomicDesignType exposing (AtomicDesignType)
 import Browser exposing (Document, UrlRequest(..))
 import Browser.Dom
@@ -11,7 +12,6 @@ import Example exposing (Example)
 import Examples
 import Html as RootHtml
 import Html.Attributes
-import Html.Styled as Html exposing (Html, img)
 import Html.Styled.Attributes as Attributes exposing (..)
 import Html.Styled.Events as Events
 import Nri.Ui.Colors.V1 as Colors
@@ -148,21 +148,22 @@ view_ model =
                 )
                 (Dict.values model.moduleStates)
     in
-    Html.styled Html.div
-        [ displayFlex
-        , alignItems flexStart
-        , minHeight (vh 100)
+    Html.div
+        [ css
+            [ displayFlex
+            , alignItems flexStart
+            , minHeight (vh 100)
+            ]
         ]
-        []
-        [ navigation model.route
-        , Html.styled Html.main_
-            [ flexGrow (int 1) ]
-            [ id "maincontent", Attributes.tabindex -1 ]
+        [ navigation model.route model.atomicDesignTypes
+        , Html.main_
+            [ css [ flexGrow (int 1) ]
+            , id "maincontent"
+            , Attributes.tabindex -1
+            ]
             (case model.route of
                 Routes.Doodad doodad ->
-                    [ Html.styled Html.section
-                        [ sectionStyles ]
-                        []
+                    [ Html.section [ css [ sectionStyles ] ]
                         [ Heading.h2 [] [ Html.text ("Viewing " ++ doodad ++ " doodad only") ]
                         , examples (\m -> m.name == doodad)
                             |> List.map
@@ -175,9 +176,7 @@ view_ model =
                     ]
 
                 Routes.Category category ->
-                    [ Html.styled Html.section
-                        [ sectionStyles ]
-                        []
+                    [ Html.section [ css [ sectionStyles ] ]
                         [ Heading.h2 [] [ Html.text (Category.forDisplay category) ]
                         , examples
                             (\doodad ->
@@ -195,9 +194,7 @@ view_ model =
                     ]
 
                 Routes.All ->
-                    [ Html.styled Html.section
-                        [ sectionStyles ]
-                        []
+                    [ Html.section [ css [ sectionStyles ] ]
                         [ Heading.h2 [] [ Html.text "All" ]
                         , examples (\_ -> True)
                             |> List.map
@@ -212,8 +209,8 @@ view_ model =
         ]
 
 
-navigation : Route -> Html Msg
-navigation route =
+navigation : Route -> Set AtomicDesignType -> Html Msg
+navigation route openAtomicDesignTypes =
     let
         isActive category =
             case route of
@@ -224,18 +221,20 @@ navigation route =
                     False
 
         link active hash displayName =
-            Html.styled Html.a
-                [ backgroundColor transparent
-                , borderStyle none
-                , textDecoration none
-                , if active then
-                    color Colors.navy
+            Html.a
+                [ css
+                    [ backgroundColor transparent
+                    , borderStyle none
+                    , textDecoration none
+                    , if active then
+                        color Colors.navy
 
-                  else
-                    color Colors.azure
-                , Fonts.baseFont
+                      else
+                        color Colors.azure
+                    , Fonts.baseFont
+                    ]
+                , Attributes.href hash
                 ]
-                [ Attributes.href hash ]
                 [ Html.text displayName ]
 
         navLink category =
@@ -253,38 +252,60 @@ navigation route =
                 ]
                 [ element ]
     in
-    Html.styled Html.nav
-        [ flexBasis (px 200)
-        , backgroundColor Colors.gray96
-        , marginRight (px 40)
-        , padding (px 25)
-        , VendorPrefixed.value "position" "sticky"
-        , top (px 150)
-        , flexShrink zero
-        ]
-        [ attribute "aria-label" "Main Navigation"
-        ]
-        [ Html.styled Html.button
-            [ backgroundColor transparent
-            , borderStyle none
-            , textDecoration none
-            , color Colors.azure
-            , Fonts.baseFont
-            , Css.marginBottom (px 20)
+    Html.nav
+        [ css
+            [ flexBasis (px 200)
+            , backgroundColor Colors.gray96
+            , marginRight (px 40)
+            , padding (px 25)
+            , VendorPrefixed.value "position" "sticky"
+            , top (px 55)
+            , flexShrink zero
             ]
-            [ Events.onClick SkipToMainContent, id "skip" ]
+        , attribute "aria-label" "Main Navigation"
+        ]
+        [ Html.button
+            [ css
+                [ backgroundColor transparent
+                , borderStyle none
+                , textDecoration none
+                , color Colors.azure
+                , Fonts.baseFont
+                , Css.marginBottom (px 20)
+                ]
+            , Events.onClick SkipToMainContent
+            , id "skip"
+            ]
             [ Html.text "Skip to main content" ]
         , Heading.h4 [] [ Html.text "Categories" ]
         , (link (route == Routes.All) "#/" "All"
             :: List.map navLink Category.all
           )
             |> List.map toNavLi
-            |> Html.styled Html.ul
-                [ margin4 zero zero (px 40) zero
-                , padding zero
+            |> Html.ul
+                [ css [ margin4 zero zero (px 40) zero, padding zero ]
+                , id "categories"
                 ]
-                [ id "categories" ]
+        , Html.fieldset []
+            (Html.legend [] [ text "Atomic Design type" ]
+                :: List.map (checkAtomicDesignType openAtomicDesignTypes) AtomicDesignType.all
+            )
         ]
+
+
+checkAtomicDesignType : Set AtomicDesignType -> AtomicDesignType -> Html Msg
+checkAtomicDesignType openAtomicDesignTypes atomicDesignType =
+    let
+        isChecked =
+            Set.memberOf openAtomicDesignTypes atomicDesignType
+
+        name =
+            AtomicDesignType.toString atomicDesignType
+    in
+    Html.labelAfter [ css [ display block ] ] (text name) <|
+        Html.checkbox name
+            (Just isChecked)
+            [ Events.onCheck (ToggleAtomicDesignType atomicDesignType) ]
 
 
 sectionStyles : Css.Style


### PR DESCRIPTION
- adds "atomic type" filters (see https://bradfrost.com/blog/post/atomic-web-design/.) I've heard some enthusiasm (cc @BrianHicks , @lukewestby) for us exploring this style of design system. I am not particularly familiar with it, and I didn't take too much time sorting the components into sections. Very MVP!
- adds links to the source files directly (the source link on the package site takes you to the root of the project, which is never where I want to go 🤷 )
- adds section for specifying the desired keyboard behavior. I only added keyboard support information to Nri.Ui.Tabs.V5's examples, but now it should be straightforward to add for any component. And also we ought to! In the future, I'd also like for the keyboard support details section to get cute -- currently, pretty ugly 😅 

My hope is that the keyboard support section can help Design, Eng, and QA to agree on desired behavior, and then get it implemented and tested and out into the world! ⌨️ 

<img width="1123" alt="Screen Shot 2020-06-19 at 2 50 33 PM" src="https://user-images.githubusercontent.com/8811312/85182249-f7005f00-b23c-11ea-8788-248aa3403def.png">

cc @NoRedInk/design 

also cc @krinhorn (this PR is largely inspired by the Juneteenth conf discussion, and in particular your comment here https://noredink.slack.com/archives/C0162CRJ9KK/p1592592178026100?thread_ts=1592589882.015000&cid=C0162CRJ9KK . Sounds like we need more visibility! Would love your thoughts on this 🙏 )