### PR TITLE
Adds padding settings to the tab button

### DIFF
--- a/src/Nri/Ui/Tabs/V5.elm
+++ b/src/Nri/Ui/Tabs/V5.elm
@@ -331,6 +331,7 @@ tabStyles isSelected customSpacing =
             , Css.marginTop Css.zero
             , Css.marginRight Css.zero
             , Css.marginLeft (Css.px (Maybe.withDefault 10 customSpacing))
+            , Css.padding2 (Css.px 1) (Css.px 6)
             , Css.marginBottom (Css.px -1)
             , Css.cursor Css.pointer
             , Css.firstChild [ Css.marginLeft Css.zero ]


### PR DESCRIPTION
Relevant to https://www.pivotaltracker.com/story/show/173753959

I believe that after this is released, we'll be able to safely remove the overrides for padding added here: https://github.com/NoRedInk/NoRedInk/pull/28461