### PR TITLE
Axe/segmented control and tabs

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -45,6 +45,7 @@
         "Nri.Ui.RadioButton.V1",
         "Nri.Ui.SegmentedControl.V9",
         "Nri.Ui.SegmentedControl.V10",
+        "Nri.Ui.SegmentedControl.V11",
         "Nri.Ui.Select.V5",
         "Nri.Ui.Select.V7",
         "Nri.Ui.Slide.V1",

--- a/elm.json
+++ b/elm.json
@@ -55,6 +55,7 @@
         "Nri.Ui.Table.V4",
         "Nri.Ui.Table.V5",
         "Nri.Ui.Tabs.V5",
+        "Nri.Ui.Tabs.V6",
         "Nri.Ui.Text.V2",
         "Nri.Ui.Text.V4",
         "Nri.Ui.Text.V5",

--- a/src/Nri/Ui/SegmentedControl/V11.elm
+++ b/src/Nri/Ui/SegmentedControl/V11.elm
@@ -4,14 +4,12 @@ module Nri.Ui.SegmentedControl.V11 exposing
     , Width(..)
     )
 
-{-| Changes from V9:
+{-| Changes from V10:
 
-  - hides non-displayed content rather than fully removing from the DOM, allowing for the content the SegmentedControl controls to have overflowY: auto & maintain scroll position
-  - 💀 removes NavConfig and SelectConfig
-  - combines `view` and `viewSpa` (for V9 `view` behavior, be sure `toUrl` is Nothing. for V9 `viewSpa` behavior, pass through a Just as `toUrl`)
-  - add custom attributes hole to the Option (in order to make SegmentedControls compatible with the Modal component)
-  - combine `css` attributes into one to prevent class-name-order-change css :bug:s
-  - :bug: fix overflowing-y svg icon issue
+  - change selection using left/right arrow keys
+  - only currently-selected or first control is tabbable
+  - `viewSelect` renamed to `viewRadioGroup`, `SelectOption` renamed to `Radio`
+  - `viewRadioGroup` uses native HTML radio input internally
 
 @docs Option, view
 @docs SelectOption, viewSelect

--- a/src/Nri/Ui/SegmentedControl/V11.elm
+++ b/src/Nri/Ui/SegmentedControl/V11.elm
@@ -9,6 +9,7 @@ module Nri.Ui.SegmentedControl.V11 exposing
   - change selection using left/right arrow keys
   - only currently-selected or first control is tabbable
   - tabpanel is tabbable
+  - Uses TabsInternal under the hood
   - `viewSelect` renamed to `viewRadioGroup`, `SelectOption` renamed to `Radio`
   - `viewRadioGroup` uses native HTML radio input internally
 
@@ -96,6 +97,7 @@ viewRadioGroup config =
 {-| -}
 type alias Option value msg =
     { value : value
+    , idString : String
     , label : String
     , attributes : List (Attribute msg)
     , icon : Maybe Svg
@@ -122,6 +124,16 @@ view :
     -> Html msg
 view config =
     let
+        toInternalTab : Option a msg -> TabsInternal.Tab a msg
+        toInternalTab option =
+            { id = option.value
+            , idString = option.idString
+            , tabAttributes = option.attributes
+            , tabView = [ viewIcon option.icon, text option.label ]
+            , panelView = option.content
+            , spaHref = Maybe.map (\toUrl -> toUrl option.value) config.toUrl
+            }
+
         isSelected option =
             option.value == config.selected
 

--- a/src/Nri/Ui/SegmentedControl/V11.elm
+++ b/src/Nri/Ui/SegmentedControl/V11.elm
@@ -8,6 +8,7 @@ module Nri.Ui.SegmentedControl.V11 exposing
 
   - change selection using left/right arrow keys
   - only currently-selected or first control is tabbable
+  - tabpanel is tabbable
   - `viewSelect` renamed to `viewRadioGroup`, `SelectOption` renamed to `Radio`
   - `viewRadioGroup` uses native HTML radio input internally
 

--- a/src/Nri/Ui/SegmentedControl/V11.elm
+++ b/src/Nri/Ui/SegmentedControl/V11.elm
@@ -20,6 +20,7 @@ module Nri.Ui.SegmentedControl.V11 exposing
 import Accessibility.Styled exposing (..)
 import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Role as Role
+import Accessibility.Styled.Style as Style
 import Accessibility.Styled.Widget as Widget
 import Css exposing (..)
 import EventExtras
@@ -51,8 +52,7 @@ type alias Radio value msg =
     }
 
 
-{-| Creates _just the segmented select_ when you need the ui element itself and
-not a page control
+{-| Creates a set of radio buttons styled to look like a segmented control.
 
   - `onClick` : the message to produce when an option is selected (clicked) by the user
   - `options`: the list of options available
@@ -62,9 +62,11 @@ not a page control
 -}
 viewRadioGroup :
     { onClick : a -> msg
+    , toString : a -> String
     , options : List (Radio a msg)
     , selected : Maybe a
     , width : Width
+    , name : String
     }
     -> Html msg
 viewRadioGroup config =
@@ -74,30 +76,18 @@ viewRadioGroup config =
                 isSelected =
                     Just option.value == config.selected
             in
-            button
-                ([ Attributes.id (segmentIdFor option)
-                 , css (getStyles { isSelected = isSelected, width = config.width })
-                 , Role.radio
-                 , if isSelected then
-                    Widget.selected True
-
-                   else
-                    Widget.selected False
-                 , Events.onClick (config.onClick option.value)
-                 ]
-                    ++ option.attributes
-                )
-                [ viewIcon option.icon
-                , text option.label
+            labelAfter
+                [ css (getStyles { isSelected = isSelected, width = config.width })
                 ]
+                (div [] [ viewIcon option.icon, text option.label ])
+                (radio config.name (config.toString option.value) isSelected <|
+                    (Events.onCheck (\_ -> config.onClick option.value)
+                        :: css [ Css.opacity Css.zero ]
+                        :: Style.invisible
+                    )
+                )
     in
-    div
-        [ css
-            [ displayFlex
-            , cursor pointer
-            ]
-        , Role.radioGroup
-        ]
+    div [ css [ displayFlex, cursor pointer ] ]
         (List.map viewRadio config.options)
 
 

--- a/src/Nri/Ui/SegmentedControl/V11.elm
+++ b/src/Nri/Ui/SegmentedControl/V11.elm
@@ -36,6 +36,7 @@ import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Util exposing (dashify)
+import TabsInternal
 
 
 {-| -}

--- a/src/Nri/Ui/SegmentedControl/V11.elm
+++ b/src/Nri/Ui/SegmentedControl/V11.elm
@@ -35,6 +35,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
+import Nri.Ui.Util exposing (dashify)
 import TabsInternal
 
 
@@ -60,7 +61,9 @@ type alias Radio value msg =
   - `options`: the list of options available
   - `selected`: if present, the value of the currently-selected option
   - `width`: how to size the segmented control
-  - `name`: value used to group the radio buttons together
+  - `legend`:
+      - value read to screenreader users to explain the radio group's purpose <https://dequeuniversity.com/rules/axe/3.3/radiogroup?application=axeAPI>
+      - after lowercasing & dashifying, this value is used to group the radio buttons together
 
 -}
 viewRadioGroup :
@@ -69,7 +72,7 @@ viewRadioGroup :
     , options : List (Radio a msg)
     , selected : Maybe a
     , width : Width
-    , name : String
+    , legend : String
     }
     -> Html msg
 viewRadioGroup config =
@@ -90,15 +93,27 @@ viewRadioGroup config =
                     )
                 ]
                 (div [] [ viewIcon option.icon, text option.label ])
-                (radio config.name (config.toString option.value) isSelected <|
+                (radio name (config.toString option.value) isSelected <|
                     (Events.onCheck (\_ -> config.onSelect option.value)
                         :: css [ Css.opacity Css.zero ]
                         :: Style.invisible
                     )
                 )
+
+        name =
+            dashify (String.toLower config.legend)
+
+        legendId =
+            "legend-" ++ name
     in
-    div [ css [ displayFlex, cursor pointer ] ]
-        (List.map viewRadio config.options)
+    div
+        [ Role.radioGroup
+        , Aria.labelledBy legendId
+        , css [ displayFlex, cursor pointer ]
+        ]
+        (p (Attributes.id legendId :: Style.invisible) [ text config.legend ]
+            :: List.map viewRadio config.options
+        )
 
 
 {-| -}

--- a/src/Nri/Ui/SegmentedControl/V11.elm
+++ b/src/Nri/Ui/SegmentedControl/V11.elm
@@ -165,7 +165,7 @@ view config =
                 , onFocus = config.onFocus
                 , selected = config.selected
                 , tabs = List.map toInternalTab config.options
-                , tabListStyles = [ displayFlex, cursor pointer ]
+                , tabListStyles = [ displayFlex, cursor pointer, marginBottom (px 10) ]
                 , tabStyles = styles config.width
                 }
     in

--- a/src/Nri/Ui/SegmentedControl/V11.elm
+++ b/src/Nri/Ui/SegmentedControl/V11.elm
@@ -79,7 +79,16 @@ viewRadioGroup config =
                 isSelected =
                     Just option.value == config.selected
             in
-            labelAfter [ css (styles config.width isSelected) ]
+            labelAfter
+                [ css
+                    -- ensure that the focus state is visible, even
+                    -- though the radio button that technically has focus
+                    -- is not
+                    (Css.pseudoClass "focus-within"
+                        [ Css.property "outline-style" "auto" ]
+                        :: styles config.width isSelected
+                    )
+                ]
                 (div [] [ viewIcon option.icon, text option.label ])
                 (radio config.name (config.toString option.value) isSelected <|
                     (Events.onCheck (\_ -> config.onSelect option.value)

--- a/src/Nri/Ui/SegmentedControl/V11.elm
+++ b/src/Nri/Ui/SegmentedControl/V11.elm
@@ -1,6 +1,6 @@
 module Nri.Ui.SegmentedControl.V11 exposing
     ( Option, view
-    , SelectOption, viewSelect
+    , Radio, viewRadioGroup
     , Width(..)
     )
 
@@ -12,7 +12,7 @@ module Nri.Ui.SegmentedControl.V11 exposing
   - `viewRadioGroup` uses native HTML radio input internally
 
 @docs Option, view
-@docs SelectOption, viewSelect
+@docs Radio, viewRadioGroup
 @docs Width
 
 -}
@@ -43,7 +43,7 @@ type Width
 
 
 {-| -}
-type alias SelectOption value msg =
+type alias Radio value msg =
     { value : value
     , label : String
     , attributes : List (Attribute msg)
@@ -60,14 +60,14 @@ not a page control
   - `width`: how to size the segmented control
 
 -}
-viewSelect :
+viewRadioGroup :
     { onClick : a -> msg
-    , options : List (SelectOption a msg)
+    , options : List (Radio a msg)
     , selected : Maybe a
     , width : Width
     }
     -> Html msg
-viewSelect config =
+viewRadioGroup config =
     let
         viewRadio option =
             let

--- a/src/Nri/Ui/SegmentedControl/V11.elm
+++ b/src/Nri/Ui/SegmentedControl/V11.elm
@@ -1,0 +1,305 @@
+module Nri.Ui.SegmentedControl.V11 exposing
+    ( Option, view
+    , SelectOption, viewSelect
+    , Width(..)
+    )
+
+{-| Changes from V9:
+
+  - hides non-displayed content rather than fully removing from the DOM, allowing for the content the SegmentedControl controls to have overflowY: auto & maintain scroll position
+  - 💀 removes NavConfig and SelectConfig
+  - combines `view` and `viewSpa` (for V9 `view` behavior, be sure `toUrl` is Nothing. for V9 `viewSpa` behavior, pass through a Just as `toUrl`)
+  - add custom attributes hole to the Option (in order to make SegmentedControls compatible with the Modal component)
+  - combine `css` attributes into one to prevent class-name-order-change css :bug:s
+  - :bug: fix overflowing-y svg icon issue
+
+@docs Option, view
+@docs SelectOption, viewSelect
+@docs Width
+
+-}
+
+import Accessibility.Styled exposing (..)
+import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Role as Role
+import Accessibility.Styled.Widget as Widget
+import Css exposing (..)
+import EventExtras
+import Html.Styled
+import Html.Styled.Attributes as Attributes exposing (css, href)
+import Html.Styled.Events as Events
+import Html.Styled.Keyed as Keyed
+import Nri.Ui
+import Nri.Ui.Colors.Extra exposing (withAlpha)
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Html.Attributes.V2 as AttributesExtra
+import Nri.Ui.Svg.V1 as Svg exposing (Svg)
+import Nri.Ui.Util exposing (dashify)
+
+
+{-| -}
+type Width
+    = FitContent
+    | FillContainer
+
+
+{-| -}
+type alias SelectOption value msg =
+    { value : value
+    , label : String
+    , attributes : List (Attribute msg)
+    , icon : Maybe Svg
+    }
+
+
+{-| Creates _just the segmented select_ when you need the ui element itself and
+not a page control
+
+  - `onClick` : the message to produce when an option is selected (clicked) by the user
+  - `options`: the list of options available
+  - `selected`: if present, the value of the currently-selected option
+  - `width`: how to size the segmented control
+
+-}
+viewSelect :
+    { onClick : a -> msg
+    , options : List (SelectOption a msg)
+    , selected : Maybe a
+    , width : Width
+    }
+    -> Html msg
+viewSelect config =
+    let
+        viewRadio option =
+            let
+                isSelected =
+                    Just option.value == config.selected
+            in
+            button
+                ([ Attributes.id (segmentIdFor option)
+                 , css (getStyles { isSelected = isSelected, width = config.width })
+                 , Role.radio
+                 , if isSelected then
+                    Widget.selected True
+
+                   else
+                    Widget.selected False
+                 , Events.onClick (config.onClick option.value)
+                 ]
+                    ++ option.attributes
+                )
+                [ viewIcon option.icon
+                , text option.label
+                ]
+    in
+    div
+        [ css
+            [ displayFlex
+            , cursor pointer
+            ]
+        , Role.radioGroup
+        ]
+        (List.map viewRadio config.options)
+
+
+{-| -}
+type alias Option value msg =
+    { value : value
+    , label : String
+    , attributes : List (Attribute msg)
+    , icon : Maybe Svg
+    , content : Html msg
+    }
+
+
+{-|
+
+  - `onClick` : the message to produce when an option is selected (clicked) by the user
+  - `options`: the list of options available
+  - `selected`: the value of the currently-selected option
+  - `width`: how to size the segmented control
+  - `toUrl`: a optional function that takes a `route` and returns the URL of that route. You should always use pass a `toUrl` function when the segmented control options correspond to routes in your SPA.
+
+-}
+view :
+    { onClick : a -> msg
+    , options : List (Option a msg)
+    , selected : a
+    , width : Width
+    , toUrl : Maybe (a -> String)
+    }
+    -> Html msg
+view config =
+    let
+        isSelected option =
+            option.value == config.selected
+
+        viewTab option =
+            case config.toUrl of
+                Just toUrl ->
+                    -- This is a for a SPA view
+                    Html.Styled.a
+                        (href (toUrl option.value)
+                            :: EventExtras.onClickPreventDefaultForLinkWithHref
+                                (config.onClick option.value)
+                            :: tabAttributes option
+                            ++ option.attributes
+                        )
+                        [ viewIcon option.icon
+                        , text option.label
+                        ]
+
+                Nothing ->
+                    -- This is for a non-SPA view
+                    button
+                        (Events.onClick (config.onClick option.value)
+                            :: tabAttributes option
+                            ++ option.attributes
+                        )
+                        [ viewIcon option.icon
+                        , text option.label
+                        ]
+
+        tabAttributes option =
+            [ Attributes.id (segmentIdFor option)
+            , css (getStyles { isSelected = isSelected option, width = config.width })
+            , Role.tab
+            , if isSelected option then
+                Aria.currentPage
+
+              else
+                AttributesExtra.none
+            ]
+
+        viewTabPanel option =
+            tabPanel
+                [ Aria.labelledBy (segmentIdFor option)
+                , css
+                    [ paddingTop (px 10)
+                    , if isSelected option then
+                        Css.batch []
+
+                      else
+                        Css.display none
+                    ]
+                , Widget.hidden (not (isSelected option))
+                ]
+                [ option.content
+                ]
+    in
+    div []
+        [ tabList [ css [ displayFlex, cursor pointer ] ]
+            (List.map viewTab config.options)
+        , Keyed.node "div" [] <|
+            List.map (\option -> ( keyedNodeIdFor option, viewTabPanel option ))
+                config.options
+        ]
+
+
+segmentIdFor : { option | label : String } -> String
+segmentIdFor option =
+    "Nri-Ui-SegmentedControl-Segment-" ++ dashify option.label
+
+
+keyedNodeIdFor : { option | label : String } -> String
+keyedNodeIdFor option =
+    "Nri-Ui-SegmentedControl-Panel-keyed-node-" ++ dashify option.label
+
+
+panelIdFor : { option | label : String } -> String
+panelIdFor option =
+    "Nri-Ui-SegmentedControl-Panel-" ++ dashify option.label
+
+
+viewIcon : Maybe Svg.Svg -> Html msg
+viewIcon icon =
+    case icon of
+        Nothing ->
+            text ""
+
+        Just svg ->
+            svg
+                |> Svg.withWidth (px 18)
+                |> Svg.withHeight (px 18)
+                |> Svg.withCss
+                    [ display inlineBlock
+                    , verticalAlign textTop
+                    , lineHeight (px 15)
+                    , marginRight (px 8)
+                    ]
+                |> Svg.toHtml
+
+
+getStyles : { isSelected : Bool, width : Width } -> List Style
+getStyles { isSelected, width } =
+    [ sharedSegmentStyles
+    , if isSelected then
+        focusedSegmentStyles
+
+      else
+        unFocusedSegmentStyles
+    , case width of
+        FitContent ->
+            Css.batch []
+
+        FillContainer ->
+            expandingTabStyles
+    ]
+
+
+sharedSegmentStyles : Style
+sharedSegmentStyles =
+    [ padding2 (px 6) (px 20)
+    , height (px 45)
+    , Fonts.baseFont
+    , fontSize (px 15)
+    , fontWeight bold
+    , lineHeight (px 30)
+    , margin zero
+    , firstOfType
+        [ borderTopLeftRadius (px 8)
+        , borderBottomLeftRadius (px 8)
+        , borderLeft3 (px 1) solid Colors.azure
+        ]
+    , lastOfType
+        [ borderTopRightRadius (px 8)
+        , borderBottomRightRadius (px 8)
+        ]
+    , border3 (px 1) solid Colors.azure
+    , borderLeft (px 0)
+    , boxSizing borderBox
+    , cursor pointer
+    , property "transition" "background-color 0.2s, color 0.2s, box-shadow 0.2s, border 0.2s, border-width 0s"
+    , textDecoration none
+    , hover [ textDecoration none ]
+    , focus [ textDecoration none ]
+    ]
+        |> Css.batch
+
+
+focusedSegmentStyles : Style
+focusedSegmentStyles =
+    [ backgroundColor Colors.glacier
+    , boxShadow5 inset zero (px 3) zero (withAlpha 0.2 Colors.gray20)
+    , color Colors.navy
+    ]
+        |> Css.batch
+
+
+unFocusedSegmentStyles : Style
+unFocusedSegmentStyles =
+    [ backgroundColor Colors.white
+    , boxShadow5 inset zero (px -2) zero Colors.azure
+    , color Colors.azure
+    , hover [ backgroundColor Colors.frost ]
+    ]
+        |> Css.batch
+
+
+expandingTabStyles : Style
+expandingTabStyles =
+    [ flexGrow (int 1)
+    , textAlign center
+    ]
+        |> Css.batch

--- a/src/Nri/Ui/SegmentedControl/V11.elm
+++ b/src/Nri/Ui/SegmentedControl/V11.elm
@@ -55,14 +55,16 @@ type alias Radio value msg =
 
 {-| Creates a set of radio buttons styled to look like a segmented control.
 
-  - `onClick` : the message to produce when an option is selected (clicked) by the user
+  - `onSelect`: the message to produce when an option is selected (clicked) by the user
+  - `toString`: function to get the radio value as a string
   - `options`: the list of options available
   - `selected`: if present, the value of the currently-selected option
   - `width`: how to size the segmented control
+  - `name`: value used to group the radio buttons together
 
 -}
 viewRadioGroup :
-    { onClick : a -> msg
+    { onSelect : a -> msg
     , toString : a -> String
     , options : List (Radio a msg)
     , selected : Maybe a
@@ -80,7 +82,7 @@ viewRadioGroup config =
             labelAfter [ css (styles config.width isSelected) ]
                 (div [] [ viewIcon option.icon, text option.label ])
                 (radio config.name (config.toString option.value) isSelected <|
-                    (Events.onCheck (\_ -> config.onClick option.value)
+                    (Events.onCheck (\_ -> config.onSelect option.value)
                         :: css [ Css.opacity Css.zero ]
                         :: Style.invisible
                     )
@@ -93,7 +95,6 @@ viewRadioGroup config =
 {-| -}
 type alias Option value msg =
     { value : value
-    , idString : String
     , label : String
     , attributes : List (Attribute msg)
     , icon : Maybe Svg
@@ -103,7 +104,9 @@ type alias Option value msg =
 
 {-|
 
-  - `onClick` : the message to produce when an option is selected (clicked) by the user
+  - `onSelect` : the message to produce when an option is selected by the user
+  - `onFocus` : the message to focus an element by id string
+  - `toString` : function to get the option value as a string
   - `options`: the list of options available
   - `selected`: the value of the currently-selected option
   - `width`: how to size the segmented control
@@ -113,6 +116,7 @@ type alias Option value msg =
 view :
     { onSelect : a -> msg
     , onFocus : String -> msg
+    , toString : a -> String
     , options : List (Option a msg)
     , selected : a
     , width : Width
@@ -124,7 +128,7 @@ view config =
         toInternalTab : Option a msg -> TabsInternal.Tab a msg
         toInternalTab option =
             { id = option.value
-            , idString = option.idString
+            , idString = config.toString option.value
             , tabAttributes = option.attributes
             , tabView = [ viewIcon option.icon, text option.label ]
             , panelView = option.content

--- a/src/Nri/Ui/Tabs/V6.elm
+++ b/src/Nri/Ui/Tabs/V6.elm
@@ -72,8 +72,6 @@ view config =
                 , onFocus = config.onFocus
                 , selected = config.selected
                 , tabs = List.map toInternalTab config.tabs
-                , tabToId = \tab -> String.replace " " "-" tab
-                , tabToBodyId = \tab -> "tab-body-" ++ String.replace " " "-" tab
                 , tabStyles = tabStyles config.customSpacing
                 , tabListStyles = stylesTabsAligned config.alignment
                 }
@@ -96,7 +94,7 @@ view config =
                 |> Maybe.withDefault (Html.text "")
             , tabList
             ]
-        , Html.div [] tabPanels
+        , tabPanels
         ]
 
 

--- a/src/Nri/Ui/Tabs/V6.elm
+++ b/src/Nri/Ui/Tabs/V6.elm
@@ -1,0 +1,348 @@
+module Nri.Ui.Tabs.V6 exposing
+    ( view
+    , Alignment(..)
+    , Tab, viewTabDefault
+    )
+
+{-|
+
+@docs view
+@docs Alignment
+@docs Tab, viewTabDefault
+
+-}
+
+import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Role as Role
+import Accessibility.Styled.Widget as Widget
+import Css exposing (..)
+import EventExtras
+import Html.Styled as Html exposing (Attribute, Html)
+import Html.Styled.Attributes as Attributes
+import Html.Styled.Events as Events
+import Json.Decode
+import List.Zipper exposing (Zipper)
+import List.Zipper.Extra
+import Nri.Ui
+import Nri.Ui.Colors.Extra
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1
+import Nri.Ui.Html.Attributes.V2 as AttributesExtra
+
+
+{-| Determines whether tabs are centered or floating to the left or right.
+-}
+type Alignment
+    = Left
+    | Center
+    | Right
+
+
+{-| -}
+type alias Tab id msg =
+    { id : id
+    , idString : String
+    , tabView : Html msg
+    , panelView : Html msg
+    , spaHref : Maybe String
+    }
+
+
+{-| -}
+view :
+    { title : Maybe String
+    , alignment : Alignment
+    , customSpacing : Maybe Float
+    , onSelect : id -> msg
+    , onFocus : String -> msg
+    , selected : id
+    , tabs : List (Tab id msg)
+    }
+    -> Html msg
+view config =
+    Nri.Ui.styled Html.div
+        (styledName "container")
+        []
+        []
+        [ Html.styled Html.div
+            [ Css.displayFlex
+            , Css.alignItems Css.flexEnd
+            , Css.borderBottom (Css.px 1)
+            , Css.borderBottomStyle Css.solid
+            , Css.borderBottomColor Colors.navy
+            , Nri.Ui.Fonts.V1.baseFont
+            ]
+            []
+            [ config.title
+                |> Maybe.map viewTitle
+                |> Maybe.withDefault (Html.text "")
+            , Html.styled Html.div
+                (stylesTabsAligned config.alignment)
+                [ Role.tabList
+                ]
+                (List.map
+                    (viewTab_
+                        { customSpacing = config.customSpacing
+                        , onSelect = config.onSelect
+                        , onFocus = config.onFocus
+                        , tabs = config.tabs
+                        , selected = config.selected
+                        }
+                    )
+                    config.tabs
+                )
+            ]
+        , Html.div []
+            (List.map
+                (\tab ->
+                    Html.div
+                        ([ Role.tabPanel
+                         , Aria.labelledBy (tabToId tab.idString)
+                         , Attributes.id (tabToBodyId tab.idString)
+                         ]
+                            ++ (if tab.id /= config.selected then
+                                    [ Attributes.css [ Css.display none ]
+                                    , Widget.hidden True
+                                    ]
+
+                                else
+                                    [ Widget.hidden False ]
+                               )
+                        )
+                        [ tab.panelView ]
+                )
+                config.tabs
+            )
+        ]
+
+
+{-| -}
+viewTabDefault : String -> Html msg
+viewTabDefault title =
+    Html.div
+        [ Attributes.css
+            [ Css.padding4 (Css.px 14) (Css.px 20) (Css.px 12) (Css.px 20)
+            ]
+        ]
+        [ Html.text title ]
+
+
+viewTitle : String -> Html msg
+viewTitle title =
+    Html.styled Html.h1
+        [ Css.flexGrow (Css.int 2)
+        , Css.fontSize (Css.px 30)
+        , Css.fontWeight Css.bold
+        , Css.margin Css.zero
+        , Css.marginTop (Css.px 5)
+        , Css.marginBottom (Css.px 10)
+        , Css.color Colors.navy
+        , Css.width (Css.px 430)
+        ]
+        []
+        [ Html.text title ]
+
+
+viewTab_ :
+    { onSelect : id -> msg
+    , onFocus : String -> msg
+    , tabs : List (Tab id msg)
+    , selected : id
+    , customSpacing : Maybe Float
+    }
+    -> Tab id msg
+    -> Html msg
+viewTab_ { onSelect, onFocus, tabs, selected, customSpacing } tab =
+    let
+        isSelected =
+            selected == tab.id
+
+        tabIndex =
+            -- From recommendation at https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role#Best_practices
+            if isSelected then
+                0
+
+            else
+                -1
+
+        ( tag, tagSpecificAttributes ) =
+            case tab.spaHref of
+                Just href ->
+                    ( Html.a
+                    , [ if isSelected then
+                            Aria.currentPage
+
+                        else
+                            AttributesExtra.none
+                      , Attributes.href href
+                      , EventExtras.onClickPreventDefaultForLinkWithHref (onSelect tab.id)
+                      ]
+                    )
+
+                Nothing ->
+                    ( Html.button
+                    , [ Events.onClick (onSelect tab.id)
+                      ]
+                    )
+    in
+    Html.styled tag
+        (tabStyles isSelected customSpacing)
+        (tagSpecificAttributes
+            ++ [ Attributes.tabindex tabIndex
+               , Widget.selected isSelected
+               , Role.tab
+               , Attributes.id (tabToId tab.idString)
+               , Events.onFocus (onSelect tab.id)
+               , Events.on "keyup"
+                    (Json.Decode.andThen (keyEvents onFocus tabs tab) Events.keyCode)
+               ]
+        )
+        [ tab.tabView
+        ]
+
+
+keyEvents : (String -> msg) -> List (Tab id msg) -> Tab id msg -> Int -> Json.Decode.Decoder msg
+keyEvents onFocus tabs thisTab keyCode =
+    let
+        findAdjacentTab tab acc =
+            case acc of
+                ( _, Just _ ) ->
+                    acc
+
+                ( True, Nothing ) ->
+                    ( True, Just (tabToId tab.idString) )
+
+                ( False, Nothing ) ->
+                    ( tab.id == thisTab.id, Nothing )
+
+        nextTab =
+            List.foldl findAdjacentTab ( False, Nothing ) tabs
+                |> Tuple.second
+
+        previousTab =
+            List.foldr findAdjacentTab ( False, Nothing ) tabs
+                |> Tuple.second
+    in
+    case keyCode of
+        39 ->
+            -- Right
+            case nextTab of
+                Just next ->
+                    Json.Decode.succeed (onFocus next)
+
+                Nothing ->
+                    Json.Decode.fail "No next tab"
+
+        37 ->
+            -- Left
+            case previousTab of
+                Just previous ->
+                    Json.Decode.succeed (onFocus previous)
+
+                Nothing ->
+                    Json.Decode.fail "No previous tab"
+
+        _ ->
+            Json.Decode.fail "Upsupported key event"
+
+
+
+-- HELP
+
+
+tabToId : String -> String
+tabToId tab =
+    String.replace " " "-" tab
+
+
+tabToBodyId : String -> String
+tabToBodyId tab =
+    "tab-body-" ++ tabToId tab
+
+
+styledName : String -> String
+styledName suffix =
+    "Nri-Ui-Tabs__" ++ suffix
+
+
+
+-- STYLES
+
+
+stylesTabsAligned : Alignment -> List Style
+stylesTabsAligned alignment =
+    let
+        alignmentStyles =
+            case alignment of
+                Left ->
+                    Css.justifyContent Css.flexStart
+
+                Center ->
+                    Css.justifyContent Css.center
+
+                Right ->
+                    Css.justifyContent Css.flexEnd
+    in
+    alignmentStyles
+        :: [ Css.margin Css.zero
+           , Css.fontSize (Css.px 19)
+           , Css.displayFlex
+           , Css.flexGrow (Css.int 1)
+           , Css.padding Css.zero
+           ]
+
+
+tabStyles : Bool -> Maybe Float -> List Style
+tabStyles isSelected customSpacing =
+    let
+        stylesDynamic =
+            if isSelected then
+                [ Css.backgroundColor Colors.white
+                , Css.borderBottom (Css.px 1)
+                , Css.borderBottomStyle Css.solid
+                , Css.borderBottomColor Colors.white
+                ]
+
+            else
+                [ Css.backgroundColor Colors.frost
+                , Css.backgroundImage <|
+                    Css.linearGradient2 Css.toTop
+                        (Css.stop2 (Nri.Ui.Colors.Extra.withAlpha 0.25 Colors.azure) (Css.pct 0))
+                        (Css.stop2 (Nri.Ui.Colors.Extra.withAlpha 0 Colors.azure) (Css.pct 25))
+                        [ Css.stop2 (Nri.Ui.Colors.Extra.withAlpha 0 Colors.azure) (Css.pct 100) ]
+                ]
+
+        baseStyles =
+            [ Css.color Colors.navy
+            , Css.position Css.relative
+            , Css.textDecoration Css.none
+            , Css.property "background" "none"
+            , Css.fontFamily Css.inherit
+            , Css.fontSize Css.inherit
+            , Css.cursor Css.pointer
+            , Css.border zero
+            ]
+
+        stylesTab =
+            [ Css.display Css.inlineBlock
+            , Css.borderTopLeftRadius (Css.px 10)
+            , Css.borderTopRightRadius (Css.px 10)
+            , Css.border3 (Css.px 1) Css.solid Colors.navy
+            , Css.marginTop Css.zero
+            , Css.marginRight Css.zero
+            , Css.marginLeft (Css.px (Maybe.withDefault 10 customSpacing))
+            , Css.padding2 (Css.px 1) (Css.px 6)
+            , Css.marginBottom (Css.px -1)
+            , Css.cursor Css.pointer
+            , Css.firstChild [ Css.marginLeft Css.zero ]
+            , property "transition" "background-color 0.2s"
+            , property "transition" "border-color 0.2s"
+            , hover
+                [ backgroundColor Colors.white
+                , borderTopColor Colors.azure
+                , borderRightColor Colors.azure
+                , borderLeftColor Colors.azure
+                ]
+            ]
+    in
+    baseStyles ++ stylesTab ++ stylesDynamic

--- a/src/Nri/Ui/Tabs/V6.elm
+++ b/src/Nri/Ui/Tabs/V6.elm
@@ -56,12 +56,22 @@ view :
     -> Html msg
 view config =
     let
+        toInternalTab : Tab id msg -> TabsInternal.Tab id msg
+        toInternalTab tab =
+            { id = tab.id
+            , idString = tab.idString
+            , tabAttributes = []
+            , tabView = [ tab.tabView ]
+            , panelView = tab.panelView
+            , spaHref = tab.spaHref
+            }
+
         { tabList, tabPanels } =
             TabsInternal.views
                 { onSelect = config.onSelect
                 , onFocus = config.onFocus
                 , selected = config.selected
-                , tabs = config.tabs
+                , tabs = List.map toInternalTab config.tabs
                 , tabToId = \tab -> String.replace " " "-" tab
                 , tabToBodyId = \tab -> "tab-body-" ++ String.replace " " "-" tab
                 , tabStyles = tabStyles config.customSpacing

--- a/src/Nri/Ui/Tabs/V6.elm
+++ b/src/Nri/Ui/Tabs/V6.elm
@@ -15,22 +15,13 @@ module Nri.Ui.Tabs.V6 exposing
 
 -}
 
-import Accessibility.Styled.Aria as Aria
-import Accessibility.Styled.Role as Role
-import Accessibility.Styled.Widget as Widget
 import Css exposing (..)
-import EventExtras
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes as Attributes
-import Html.Styled.Events as Events
-import Json.Decode
-import List.Zipper exposing (Zipper)
-import List.Zipper.Extra
 import Nri.Ui
-import Nri.Ui.Colors.Extra
+import Nri.Ui.Colors.Extra exposing (withAlpha)
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.Fonts.V1
-import Nri.Ui.Html.Attributes.V2 as AttributesExtra
+import Nri.Ui.Fonts.V1 as Fonts
 import TabsInternal
 
 
@@ -87,7 +78,7 @@ view config =
             , Css.borderBottom (Css.px 1)
             , Css.borderBottomStyle Css.solid
             , Css.borderBottomColor Colors.navy
-            , Nri.Ui.Fonts.V1.baseFont
+            , Fonts.baseFont
             ]
             []
             [ config.title
@@ -168,9 +159,9 @@ tabStyles customSpacing isSelected =
                 [ Css.backgroundColor Colors.frost
                 , Css.backgroundImage <|
                     Css.linearGradient2 Css.toTop
-                        (Css.stop2 (Nri.Ui.Colors.Extra.withAlpha 0.25 Colors.azure) (Css.pct 0))
-                        (Css.stop2 (Nri.Ui.Colors.Extra.withAlpha 0 Colors.azure) (Css.pct 25))
-                        [ Css.stop2 (Nri.Ui.Colors.Extra.withAlpha 0 Colors.azure) (Css.pct 100) ]
+                        (Css.stop2 (withAlpha 0.25 Colors.azure) (Css.pct 0))
+                        (Css.stop2 (withAlpha 0 Colors.azure) (Css.pct 25))
+                        [ Css.stop2 (withAlpha 0 Colors.azure) (Css.pct 100) ]
                 ]
 
         baseStyles =

--- a/src/Nri/Ui/Tabs/V6.elm
+++ b/src/Nri/Ui/Tabs/V6.elm
@@ -4,7 +4,10 @@ module Nri.Ui.Tabs.V6 exposing
     , Tab, viewTabDefault
     )
 
-{-|
+{-| Changes from V5:
+
+  - Uses TabsInternal under the hood
+  - Allows user to focus on the selected tabpanel
 
 @docs view
 @docs Alignment
@@ -28,6 +31,7 @@ import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
+import TabsInternal
 
 
 {-| Determines whether tabs are centered or floating to the left or right.
@@ -60,6 +64,19 @@ view :
     }
     -> Html msg
 view config =
+    let
+        { tabList, tabPanels } =
+            TabsInternal.views
+                { onSelect = config.onSelect
+                , onFocus = config.onFocus
+                , selected = config.selected
+                , tabs = config.tabs
+                , tabToId = tabToId
+                , tabToBodyId = tabToBodyId
+                , tabStyles = tabStyles config.customSpacing
+                , tabListStyles = stylesTabsAligned config.alignment
+                }
+    in
     Nri.Ui.styled Html.div
         (styledName "container")
         []
@@ -186,7 +203,7 @@ viewTab_ { onSelect, onFocus, tabs, selected, customSpacing } tab =
                     )
     in
     Html.styled tag
-        (tabStyles isSelected customSpacing)
+        (tabStyles customSpacing isSelected)
         (tagSpecificAttributes
             ++ [ Attributes.tabindex tabIndex
                , Widget.selected isSelected
@@ -292,8 +309,8 @@ stylesTabsAligned alignment =
            ]
 
 
-tabStyles : Bool -> Maybe Float -> List Style
-tabStyles isSelected customSpacing =
+tabStyles : Maybe Float -> Bool -> List Style
+tabStyles customSpacing isSelected =
     let
         stylesDynamic =
             if isSelected then

--- a/src/TabsInternal.elm
+++ b/src/TabsInternal.elm
@@ -176,11 +176,14 @@ viewTabPanel tab selected =
          , Attributes.id (tabToBodyId tab.idString)
          ]
             ++ (if selected then
-                    [ Widget.hidden False ]
+                    [ Widget.hidden False
+                    , Attributes.tabindex 0
+                    ]
 
                 else
                     [ Attributes.css [ Css.display Css.none ]
                     , Widget.hidden True
+                    , Attributes.tabindex -1
                     ]
                )
         )

--- a/src/TabsInternal.elm
+++ b/src/TabsInternal.elm
@@ -35,7 +35,8 @@ type alias Config id msg =
 type alias Tab id msg =
     { id : id
     , idString : String
-    , tabView : Html msg
+    , tabAttributes : List (Attribute msg)
+    , tabView : List (Html msg)
     , panelView : Html msg
     , spaHref : Maybe String
     }
@@ -75,6 +76,7 @@ viewTab_ config tab =
         ( tag, tagSpecificAttributes ) =
             case tab.spaHref of
                 Just href ->
+                    -- This is a for a SPA view
                     ( Html.a
                     , [ if isSelected then
                             Aria.currentPage
@@ -87,6 +89,7 @@ viewTab_ config tab =
                     )
 
                 Nothing ->
+                    -- This is for a non-SPA view
                     ( Html.button
                     , [ Events.onClick (config.onSelect tab.id)
                       ]
@@ -95,6 +98,7 @@ viewTab_ config tab =
     Html.styled tag
         (config.tabStyles isSelected)
         (tagSpecificAttributes
+            ++ tab.tabAttributes
             ++ [ Attributes.tabindex tabIndex
                , Widget.selected isSelected
                , Role.tab
@@ -104,8 +108,7 @@ viewTab_ config tab =
                     Json.Decode.andThen (keyEvents config tab) Events.keyCode
                ]
         )
-        [ tab.tabView
-        ]
+        tab.tabView
 
 
 keyEvents : Config id msg -> Tab id msg -> Int -> Json.Decode.Decoder msg

--- a/src/TabsInternal.elm
+++ b/src/TabsInternal.elm
@@ -15,10 +15,6 @@ import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Json.Decode
-import Nri.Ui
-import Nri.Ui.Colors.Extra
-import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.Fonts.V1
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
 
 

--- a/src/TabsInternal.elm
+++ b/src/TabsInternal.elm
@@ -1,0 +1,180 @@
+module TabsInternal exposing (Config, Tab, views)
+
+{-|
+
+@docs Config, Tab, views
+
+-}
+
+import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Role as Role
+import Accessibility.Styled.Widget as Widget
+import Css
+import EventExtras
+import Html.Styled as Html exposing (Attribute, Html)
+import Html.Styled.Attributes as Attributes
+import Html.Styled.Events as Events
+import Json.Decode
+import Nri.Ui
+import Nri.Ui.Colors.Extra
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1
+import Nri.Ui.Html.Attributes.V2 as AttributesExtra
+
+
+{-| -}
+type alias Config id msg =
+    { onSelect : id -> msg
+    , onFocus : String -> msg
+    , selected : id
+    , tabs : List (Tab id msg)
+    , tabToId : String -> String
+    , tabToBodyId : String -> String
+    , tabStyles : Bool -> List Css.Style
+    , containerStyles : List Css.Style
+    }
+
+
+{-| -}
+type alias Tab id msg =
+    { id : id
+    , idString : String
+    , tabView : Html msg
+    , panelView : Html msg
+    , spaHref : Maybe String
+    }
+
+
+{-| -}
+views : Config id msg -> { tabList : Html msg, tabPanels : List (Html msg) }
+views config =
+    { tabList = viewTabs config
+    , tabPanels = viewTabPanels config
+    }
+
+
+viewTabs : Config id msg -> Html msg
+viewTabs config =
+    Html.div
+        [ Role.tabList
+        , Attributes.css config.containerStyles
+        ]
+        (List.map (viewTab_ config) config.tabs)
+
+
+viewTab_ : Config id msg -> Tab id msg -> Html msg
+viewTab_ config tab =
+    let
+        isSelected =
+            config.selected == tab.id
+
+        tabIndex =
+            -- From recommendation at https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role#Best_practices
+            if isSelected then
+                0
+
+            else
+                -1
+
+        ( tag, tagSpecificAttributes ) =
+            case tab.spaHref of
+                Just href ->
+                    ( Html.a
+                    , [ if isSelected then
+                            Aria.currentPage
+
+                        else
+                            AttributesExtra.none
+                      , Attributes.href href
+                      , EventExtras.onClickPreventDefaultForLinkWithHref (config.onSelect tab.id)
+                      ]
+                    )
+
+                Nothing ->
+                    ( Html.button
+                    , [ Events.onClick (config.onSelect tab.id)
+                      ]
+                    )
+    in
+    Html.styled tag
+        (config.tabStyles isSelected)
+        (tagSpecificAttributes
+            ++ [ Attributes.tabindex tabIndex
+               , Widget.selected isSelected
+               , Role.tab
+               , Attributes.id (config.tabToId tab.idString)
+               , Events.onFocus (config.onSelect tab.id)
+               , Events.on "keyup" <|
+                    Json.Decode.andThen (keyEvents config tab) Events.keyCode
+               ]
+        )
+        [ tab.tabView
+        ]
+
+
+keyEvents : Config id msg -> Tab id msg -> Int -> Json.Decode.Decoder msg
+keyEvents { onFocus, tabs, tabToId } thisTab keyCode =
+    let
+        findAdjacentTab tab acc =
+            case acc of
+                ( _, Just _ ) ->
+                    acc
+
+                ( True, Nothing ) ->
+                    ( True, Just (tabToId tab.idString) )
+
+                ( False, Nothing ) ->
+                    ( tab.id == thisTab.id, Nothing )
+
+        nextTab =
+            List.foldl findAdjacentTab ( False, Nothing ) tabs
+                |> Tuple.second
+
+        previousTab =
+            List.foldr findAdjacentTab ( False, Nothing ) tabs
+                |> Tuple.second
+    in
+    case keyCode of
+        39 ->
+            -- Right
+            case nextTab of
+                Just next ->
+                    Json.Decode.succeed (onFocus next)
+
+                Nothing ->
+                    Json.Decode.fail "No next tab"
+
+        37 ->
+            -- Left
+            case previousTab of
+                Just previous ->
+                    Json.Decode.succeed (onFocus previous)
+
+                Nothing ->
+                    Json.Decode.fail "No previous tab"
+
+        _ ->
+            Json.Decode.fail "Upsupported key event"
+
+
+viewTabPanels : Config id msg -> List (Html msg)
+viewTabPanels config =
+    List.map
+        (\tab ->
+            Html.div
+                ([ Role.tabPanel
+                 , Aria.labelledBy (config.tabToId tab.idString)
+                 , Attributes.id (config.tabToBodyId tab.idString)
+                 ]
+                    ++ (if tab.id /= config.selected then
+                            [ Attributes.css [ Css.display Css.none ]
+                            , Widget.hidden True
+                            ]
+
+                        else
+                            [ Widget.hidden False ]
+                       )
+                )
+                [ tab.panelView ]
+        )
+        config.tabs

--- a/src/TabsInternal.elm
+++ b/src/TabsInternal.elm
@@ -30,8 +30,8 @@ type alias Config id msg =
     , tabs : List (Tab id msg)
     , tabToId : String -> String
     , tabToBodyId : String -> String
+    , tabListStyles : List Css.Style
     , tabStyles : Bool -> List Css.Style
-    , containerStyles : List Css.Style
     }
 
 
@@ -57,7 +57,7 @@ viewTabs : Config id msg -> Html msg
 viewTabs config =
     Html.div
         [ Role.tabList
-        , Attributes.css config.containerStyles
+        , Attributes.css config.tabListStyles
         ]
         (List.map (viewTab_ config) config.tabs)
 

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -61,7 +61,7 @@ example =
             , Html.p [ css [ Css.marginTop (Css.px 1) ] ]
                 [ Html.text "Use in cases where it would be reasonable to use radio buttons for the same purpose." ]
             , SegmentedControl.viewRadioGroup
-                { name = "segmented-control-radio-group-example"
+                { legend = "SegmentedControls 'viewSelectRadio' example"
                 , onSelect = SelectRadio
                 , toString = String.fromInt
                 , options = List.take options.count (buildRadioOptions options.icon)

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -52,12 +52,12 @@ example =
                 , options = List.take options.count (buildOptions options)
                 }
             , Html.h3 [ css [ Css.marginBottom Css.zero ] ]
-                [ Html.code [] [ Html.text "viewSelect" ] ]
+                [ Html.code [] [ Html.text "viewRadioGroup" ] ]
             , Html.p [ css [ Css.marginTop (Css.px 1) ] ]
                 [ Html.text "Use when you only need the ui element. This view is effectively a fancy Radio button." ]
-            , SegmentedControl.viewSelect
+            , SegmentedControl.viewRadioGroup
                 { onClick = MaybeSelect
-                , options = List.take options.count (buildSelectOptions options.icon)
+                , options = List.take options.count (buildRadioOptions options.icon)
                 , selected = state.optionallySelected
                 , width = options.width
                 }
@@ -126,8 +126,8 @@ buildOptions { icon, longContent } =
     ]
 
 
-buildSelectOptions : Bool -> List (SegmentedControl.SelectOption Int msg)
-buildSelectOptions keepIcon =
+buildRadioOptions : Bool -> List (SegmentedControl.Radio Int msg)
+buildRadioOptions keepIcon =
     let
         buildOption value icon =
             { icon = ifIcon icon

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -72,10 +72,15 @@ example =
     , categories = [ Widgets, Layout ]
     , atomicDesignType = Molecule
     , keyboardSupport =
-        [ { keys = [ Enter ], result = "Select the focused control" }
-        , { keys = [ Space ], result = "Select the focused control" }
-        , { keys = [ Tab ], result = "Focus the next focusable element" }
-        , { keys = [ Tab, Shift ], result = "Focus the previous focusable element" }
+        [ { keys = [ KeyboardSupport.Tab ]
+          , result = "Move focus to the currently-selected Control's content"
+          }
+        , { keys = [ Arrow KeyboardSupport.Left ]
+          , result = "Select the Control to the left of the current selection"
+          }
+        , { keys = [ Arrow KeyboardSupport.Right ]
+          , result = "Select the Control to the right of the current selection"
+          }
         ]
     }
 

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -23,6 +23,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.SegmentedControl.V11 as SegmentedControl
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.UiIcon.V1 as UiIcon
+import String exposing (toLower)
 
 
 {-| -}
@@ -96,6 +97,7 @@ buildOptions { icon, longContent } =
 
                 else
                     Nothing
+            , idString = toLower (Debug.toString value)
             , label = Debug.toString value
             , value = value
             , attributes = []

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -50,6 +50,7 @@ example =
             , SegmentedControl.view
                 { onSelect = SelectPage
                 , onFocus = Focus
+                , toString = \value -> toLower (Debug.toString value)
                 , selected = state.page
                 , width = options.width
                 , toUrl = Nothing
@@ -61,7 +62,7 @@ example =
                 [ Html.text "Use in cases where it would be reasonable to use radio buttons for the same purpose." ]
             , SegmentedControl.viewRadioGroup
                 { name = "segmented-control-radio-group-example"
-                , onClick = MaybeSelect
+                , onSelect = SelectRadio
                 , toString = String.fromInt
                 , options = List.take options.count (buildRadioOptions options.icon)
                 , selected = state.optionallySelected
@@ -100,7 +101,6 @@ buildOptions { icon, longContent } =
 
                 else
                     Nothing
-            , idString = toLower (Debug.toString value)
             , label = Debug.toString value
             , value = value
             , attributes = []
@@ -209,7 +209,7 @@ type Msg
     = Focus String
     | Focused (Result Dom.Error ())
     | SelectPage Page
-    | MaybeSelect Int
+    | SelectRadio Int
     | ChangeOptions (Control Options)
 
 
@@ -232,7 +232,7 @@ update msg state =
             , Cmd.none
             )
 
-        MaybeSelect id ->
+        SelectRadio id ->
             ( { state | optionallySelected = Just id }
             , Cmd.none
             )

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -20,7 +20,7 @@ import Html.Styled.Attributes as Attributes exposing (css)
 import Html.Styled.Events as Events
 import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.SegmentedControl.V10 as SegmentedControl
+import Nri.Ui.SegmentedControl.V11 as SegmentedControl
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.UiIcon.V1 as UiIcon
 
@@ -28,7 +28,7 @@ import Nri.Ui.UiIcon.V1 as UiIcon
 {-| -}
 example : Example State Msg
 example =
-    { name = "Nri.Ui.SegmentedControl.V10"
+    { name = "Nri.Ui.SegmentedControl.V11"
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -43,7 +43,7 @@ example =
             , Html.h3 [ css [ Css.marginBottom Css.zero ] ]
                 [ Html.code [] [ Html.text "view" ] ]
             , Html.p [ css [ Css.marginTop (Css.px 1) ] ]
-                [ Html.text "Use when you need a page control. This view is effectively a fancy Tab/Tabpanel pairing." ]
+                [ Html.text "Use in cases where it would also be reasonable to use Tabs." ]
             , SegmentedControl.view
                 { onClick = SelectPage
                 , selected = state.page
@@ -54,9 +54,11 @@ example =
             , Html.h3 [ css [ Css.marginBottom Css.zero ] ]
                 [ Html.code [] [ Html.text "viewRadioGroup" ] ]
             , Html.p [ css [ Css.marginTop (Css.px 1) ] ]
-                [ Html.text "Use when you only need the ui element. This view is effectively a fancy Radio button." ]
+                [ Html.text "Use in cases where it would be reasonable to use radio buttons for the same purpose." ]
             , SegmentedControl.viewRadioGroup
-                { onClick = MaybeSelect
+                { name = "segmented-control-radio-group-example"
+                , onClick = MaybeSelect
+                , toString = String.fromInt
                 , options = List.take options.count (buildRadioOptions options.icon)
                 , selected = state.optionallySelected
                 , width = options.width

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -12,6 +12,7 @@ module Examples.SegmentedControl exposing
 
 import Accessibility.Styled as Html exposing (Html)
 import AtomicDesignType exposing (AtomicDesignType(..))
+import Browser.Dom as Dom
 import Category exposing (Category(..))
 import Css
 import Debug.Control as Control exposing (Control)
@@ -24,6 +25,7 @@ import Nri.Ui.SegmentedControl.V11 as SegmentedControl
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.UiIcon.V1 as UiIcon
 import String exposing (toLower)
+import Task
 
 
 {-| -}
@@ -46,7 +48,8 @@ example =
             , Html.p [ css [ Css.marginTop (Css.px 1) ] ]
                 [ Html.text "Use in cases where it would also be reasonable to use Tabs." ]
             , SegmentedControl.view
-                { onClick = SelectPage
+                { onSelect = SelectPage
+                , onFocus = Focus
                 , selected = state.page
                 , width = options.width
                 , toUrl = Nothing
@@ -203,7 +206,9 @@ optionsControl =
 
 {-| -}
 type Msg
-    = SelectPage Page
+    = Focus String
+    | Focused (Result Dom.Error ())
+    | SelectPage Page
     | MaybeSelect Int
     | ChangeOptions (Control Options)
 
@@ -212,6 +217,16 @@ type Msg
 update : Msg -> State -> ( State, Cmd Msg )
 update msg state =
     case msg of
+        Focus id ->
+            ( state
+            , Task.attempt Focused (Dom.focus id)
+            )
+
+        Focused _ ->
+            ( state
+            , Cmd.none
+            )
+
         SelectPage page ->
             ( { state | page = page }
             , Cmd.none

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -107,7 +107,7 @@ example =
     , atomicDesignType = Molecule
     , keyboardSupport =
         [ { keys = [ KeyboardSupport.Tab ]
-          , result = "Move focus to and from the currently-selected Tab"
+          , result = "Move focus to the currently-selected Tab's tab panel"
           }
         , { keys = [ Arrow KeyboardSupport.Left ]
           , result = "Select the tab to the left of the currently-selected Tab"

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -21,7 +21,7 @@ import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Key(..))
 import List.Zipper exposing (Zipper)
 import Nri.Ui.Svg.V1 as Svg
-import Nri.Ui.Tabs.V5 as Tabs exposing (Alignment(..), Tab)
+import Nri.Ui.Tabs.V6 as Tabs exposing (Alignment(..), Tab)
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Task
 
@@ -102,7 +102,7 @@ update msg model =
 
 example : Example State Msg
 example =
-    { name = "Nri.Ui.Tabs.V5"
+    { name = "Nri.Ui.Tabs.V6"
     , categories = [ Layout ]
     , atomicDesignType = Molecule
     , keyboardSupport =
@@ -143,7 +143,7 @@ allTabs : List (Tab Id Msg)
 allTabs =
     [ { id = First
       , idString = "tab-0"
-      , spaHref = Just "/#/doodad/Nri.Ui.Tabs.V5"
+      , spaHref = Just "/#/doodad/Nri.Ui.Tabs.V6"
       , tabView = Tabs.viewTabDefault "Link example"
       , panelView = Html.text "First Panel"
       }

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -51,6 +51,7 @@
         "Nri.Ui.Table.V4",
         "Nri.Ui.Table.V5",
         "Nri.Ui.Tabs.V5",
+        "Nri.Ui.Tabs.V6",
         "Nri.Ui.Text.V2",
         "Nri.Ui.Text.V4",
         "Nri.Ui.Text.V5",

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -41,6 +41,7 @@
         "Nri.Ui.RadioButton.V1",
         "Nri.Ui.SegmentedControl.V9",
         "Nri.Ui.SegmentedControl.V10",
+        "Nri.Ui.SegmentedControl.V11",
         "Nri.Ui.Select.V5",
         "Nri.Ui.Select.V7",
         "Nri.Ui.Slide.V1",


### PR DESCRIPTION
@krinhorn and I paired on accessibility checking for Segmented Controls, and we did find some issues.

This PR fixes what we found:
- tabpanels weren't focusable, meaning voiceover wouldn't read the content
- the main segmented controls view and the tabs component followed 2 totally different UX patterns for keyboard navigability, despite fulfilling the same function.
- the secondary viewSelect segmented controls function used aria attributes to emulate radio buttons, but only part of the way (keyboard behavior was quite different than radio buttons). Underlying implementation is now actually radio buttons

## Segmented Control
![segmented control keyboard](https://user-images.githubusercontent.com/8811312/89472585-9e761a00-d735-11ea-8bd9-14836e24bef6.gif)

## Tabs
![tabs keyboard](https://user-images.githubusercontent.com/8811312/89472589-a03fdd80-d735-11ea-95aa-9b1c7cb27006.gif)
