### PR TITLE
Make tests nicer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ axe-report: tests/axe-report.json script/format-axe-report.sh script/axe-report.
 percy-tests:
 	script/percy-tests.sh
 
-tests/deprecated-imports-report.txt: $(shell find src -type f) script/deprecated-imports.py
+tests/deprecated-imports-report.txt: $(shell find src tests -type f) script/deprecated-imports.py
 	script/deprecated-imports.py report > $@
 
-script/deprecated-imports.csv: $(shell find src -type f) script/deprecated-imports.py
+script/deprecated-imports.csv: $(shell find src tests -type f) script/deprecated-imports.py
 	script/deprecated-imports.py --imports-file $@ update
 
 .PHONY: deprecated-imports-report

--- a/script/deprecated-imports.csv
+++ b/script/deprecated-imports.csv
@@ -10,8 +10,8 @@ src/Nri/Ui/Icon/V5.elm,Html,DEPRECATED
 src/Nri/Ui/Icon/V4.elm,Accessibility.Role,DEPRECATED
 src/Nri/Ui/Icon/V4.elm,Html,DEPRECATED
 src/Nri/Ui/Modal/V3.elm,Nri.Ui.Icon,3
+tests/Spec/Nri/Ui/Tooltip.elm,Accessibility.Aria,DEPRECATED
+tests/Spec/Nri/Ui/Tooltip.elm,Accessibility.Widget,DEPRECATED
+tests/Spec/Nri/Ui/Tooltip.elm,Html,DEPRECATED
 tests/Spec/Nri/Ui/Select.elm,Html,DEPRECATED
 tests/Spec/Nri/Ui/Select.elm,Nri.Ui.Select,5
-tests/Spec/Nri/Ui/Tooltip/V1.elm,Accessibility.Aria,DEPRECATED
-tests/Spec/Nri/Ui/Tooltip/V1.elm,Accessibility.Widget,DEPRECATED
-tests/Spec/Nri/Ui/Tooltip/V1.elm,Html,DEPRECATED

--- a/script/deprecated-imports.csv
+++ b/script/deprecated-imports.csv
@@ -10,3 +10,8 @@ src/Nri/Ui/Icon/V5.elm,Html,DEPRECATED
 src/Nri/Ui/Icon/V4.elm,Accessibility.Role,DEPRECATED
 src/Nri/Ui/Icon/V4.elm,Html,DEPRECATED
 src/Nri/Ui/Modal/V3.elm,Nri.Ui.Icon,3
+tests/Spec/Nri/Ui/Select.elm,Html,DEPRECATED
+tests/Spec/Nri/Ui/Select.elm,Nri.Ui.Select,5
+tests/Spec/Nri/Ui/Tooltip/V1.elm,Accessibility.Aria,DEPRECATED
+tests/Spec/Nri/Ui/Tooltip/V1.elm,Accessibility.Widget,DEPRECATED
+tests/Spec/Nri/Ui/Tooltip/V1.elm,Html,DEPRECATED

--- a/script/deprecated-imports.py
+++ b/script/deprecated-imports.py
@@ -27,6 +27,10 @@ class ElmJson:
         self.elm_version = self.data["elm-version"]
         self.source_directories = ["src"]
 
+        potential_test_directory = os.path.join(os.path.dirname(path), 'tests')
+        if os.path.exists(potential_test_directory):
+            self.source_directories.append(potential_test_directory)
+
 
 class NriUiModules:
     """

--- a/tests/Spec/Nri/Ui/Page.elm
+++ b/tests/Spec/Nri/Ui/Page.elm
@@ -1,4 +1,4 @@
-module Spec.Nri.Ui.Page.V3 exposing (all)
+module Spec.Nri.Ui.Page exposing (all)
 
 import Expect exposing (Expectation)
 import Html.Styled as Html

--- a/tests/Spec/Nri/Ui/PremiumCheckbox.elm
+++ b/tests/Spec/Nri/Ui/PremiumCheckbox.elm
@@ -1,4 +1,4 @@
-module Spec.Nri.Ui.PremiumCheckbox.V6 exposing (spec)
+module Spec.Nri.Ui.PremiumCheckbox exposing (spec)
 
 import Html.Attributes as Attributes
 import Html.Styled

--- a/tests/Spec/Nri/Ui/SlideModal.elm
+++ b/tests/Spec/Nri/Ui/SlideModal.elm
@@ -1,4 +1,4 @@
-module Spec.Nri.Ui.SlideModal.V2 exposing (all)
+module Spec.Nri.Ui.SlideModal exposing (all)
 
 import Css
 import Expect exposing (Expectation)

--- a/tests/Spec/Nri/Ui/SortableTable.elm
+++ b/tests/Spec/Nri/Ui/SortableTable.elm
@@ -1,4 +1,4 @@
-module Spec.Nri.Ui.SortableTable.V2 exposing (spec)
+module Spec.Nri.Ui.SortableTable exposing (spec)
 
 import Expect exposing (Expectation)
 import Html.Styled

--- a/tests/Spec/Nri/Ui/TextInput.elm
+++ b/tests/Spec/Nri/Ui/TextInput.elm
@@ -1,4 +1,4 @@
-module Spec.Nri.Ui.TextInput.V6 exposing (spec)
+module Spec.Nri.Ui.TextInput exposing (spec)
 
 import Html.Styled
 import Nri.Ui.TextInput.V6 as TextInput

--- a/tests/Spec/Nri/Ui/Tooltip.elm
+++ b/tests/Spec/Nri/Ui/Tooltip.elm
@@ -1,4 +1,4 @@
-module Spec.Nri.Ui.Tooltip.V1 exposing (spec)
+module Spec.Nri.Ui.Tooltip exposing (spec)
 
 import Accessibility.Aria as Aria
 import Accessibility.Widget as Widget


### PR DESCRIPTION
# ⚠️ don't merge until #579 is in `master`.

this de-versions the test names and adds them to the deprecated imports list. This means that we'll be prompted to upgrade tests when bumping versions, and it'll be a little easier to do so. If we need to test older components for whatever reason, we can follow the pattern in `tests/Spec/Nri/Ui/Select.elm` where both versions are imported and tested separately.