### PR TITLE
add checked attribute to SegmentedControl radio view

### DIFF
--- a/src/Nri/Ui/SegmentedControl/V11.elm
+++ b/src/Nri/Ui/SegmentedControl/V11.elm
@@ -29,6 +29,7 @@ import EventExtras
 import Html.Styled
 import Html.Styled.Attributes as Attributes exposing (css, href)
 import Html.Styled.Events as Events
+import Json.Encode as Encode
 import Nri.Ui
 import Nri.Ui.Colors.Extra exposing (withAlpha)
 import Nri.Ui.Colors.V1 as Colors
@@ -96,7 +97,13 @@ viewRadioGroup config =
                 (radio name (config.toString option.value) isSelected <|
                     (Events.onCheck (\_ -> config.onSelect option.value)
                         :: css [ Css.opacity Css.zero ]
-                        :: Attributes.checked isSelected
+                        :: Attributes.attribute "data-nri-checked"
+                            (if isSelected then
+                                "true"
+
+                             else
+                                "false"
+                            )
                         :: Style.invisible
                     )
                 )

--- a/src/Nri/Ui/SegmentedControl/V11.elm
+++ b/src/Nri/Ui/SegmentedControl/V11.elm
@@ -96,6 +96,7 @@ viewRadioGroup config =
                 (radio name (config.toString option.value) isSelected <|
                     (Events.onCheck (\_ -> config.onSelect option.value)
                         :: css [ Css.opacity Css.zero ]
+                        :: Attributes.checked isSelected
                         :: Style.invisible
                     )
                 )

--- a/tests/Spec/Nri/Ui/SegmentedControl.elm
+++ b/tests/Spec/Nri/Ui/SegmentedControl.elm
@@ -54,7 +54,7 @@ spec =
                                 , Selector.containing
                                     [ Selector.tag "input"
                                     , Selector.attribute (Attributes.type_ "radio")
-                                    , Selector.attribute (Attributes.checked True)
+                                    , Selector.attribute (Attributes.attribute "data-nri-checked" "true")
                                     ]
                                 ]
                             ]
@@ -69,7 +69,7 @@ spec =
                                 , Selector.containing
                                     [ Selector.tag "input"
                                     , Selector.attribute (Attributes.type_ "radio")
-                                    , Selector.attribute (Attributes.checked False)
+                                    , Selector.attribute (Attributes.attribute "data-nri-checked" "false")
                                     ]
                                 ]
                             ]

--- a/tests/Spec/Nri/Ui/SegmentedControl.elm
+++ b/tests/Spec/Nri/Ui/SegmentedControl.elm
@@ -1,0 +1,77 @@
+module Spec.Nri.Ui.SegmentedControl exposing (..)
+
+import Expect
+import Html.Attributes as Attributes
+import Html.Styled
+import Json.Encode as Encode
+import Nri.Ui.SegmentedControl.V11 as SegmentedControl
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+
+
+spec : Test
+spec =
+    describe "segmented controls"
+        [ describe "radio groups indicate when they're selected" <|
+            -- nb. this is tested especially since QA is including this
+            -- attribute in their automated tests. Make sure it doesn't break
+            -- them!
+            let
+                selected =
+                    "I'm Selected!"
+
+                notSelected =
+                    "I'm Not Selected!"
+
+                control =
+                    SegmentedControl.viewRadioGroup
+                        { onSelect = identity
+                        , toString = identity
+                        , options =
+                            List.map
+                                (\value ->
+                                    { value = value
+                                    , label = value
+                                    , attributes = []
+                                    , icon = Nothing
+                                    }
+                                )
+                                [ selected, notSelected ]
+                        , selected = Just selected
+                        , width = SegmentedControl.FitContent
+                        , legend = "A Segmented Control Example"
+                        }
+            in
+            [ test "a checked=true attribute is added to the selected control" <|
+                \_ ->
+                    Html.Styled.toUnstyled control
+                        |> Query.fromHtml
+                        |> Query.has
+                            [ Selector.all
+                                [ Selector.tag "label"
+                                , Selector.containing [ Selector.text selected ]
+                                , Selector.containing
+                                    [ Selector.tag "input"
+                                    , Selector.attribute (Attributes.type_ "radio")
+                                    , Selector.attribute (Attributes.checked True)
+                                    ]
+                                ]
+                            ]
+            , test "a checked=false attribute is added to a non-selected control" <|
+                \_ ->
+                    Html.Styled.toUnstyled control
+                        |> Query.fromHtml
+                        |> Query.has
+                            [ Selector.all
+                                [ Selector.tag "label"
+                                , Selector.containing [ Selector.text notSelected ]
+                                , Selector.containing
+                                    [ Selector.tag "input"
+                                    , Selector.attribute (Attributes.type_ "radio")
+                                    , Selector.attribute (Attributes.checked False)
+                                    ]
+                                ]
+                            ]
+            ]
+        ]


### PR DESCRIPTION
# ⚠️ don't merge until #579 is in `master`.

this adds `checked=true` to segmented controls so we can have a programmatic way of determining which thing is selected that doesn't depend on class names, etc. QA needs it to un-break their tests!