### PR TITLE
use text underlines instead of bottom-borders for multiline buttons

### DIFF
--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -16,7 +16,7 @@ module Nri.Ui.ClickableText.V3 exposing
 
   - uses ClickableAttributes
   - adds `css` helper
-  - add bottom border on hover instead of text decoration
+  - removes underline on hover and recolors to azureDark
 
 
 # Changes from V2

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -301,6 +301,7 @@ clickableTextStyles =
     , Css.textAlign Css.left
     , Css.borderStyle Css.none
     , Css.textDecoration Css.none
+    , Css.borderBottom3 (Css.px 1) Css.solid Css.transparent
     , Css.padding Css.zero
     , Css.display Css.inlineBlock
     , Css.verticalAlign Css.textBottom

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -300,8 +300,6 @@ clickableTextStyles =
     , Css.textAlign Css.left
     , Css.borderStyle Css.none
     , Css.textDecoration Css.none
-    , Css.borderBottom3 (Css.px 1) Css.solid Css.transparent
-    , Css.hover [ Css.textDecoration Css.none, Css.borderBottom3 (Css.px 1) Css.solid Colors.azure ]
     , Css.padding Css.zero
     , Css.display Css.inlineBlock
     , Css.verticalAlign Css.textBottom

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -295,6 +295,7 @@ clickableTextStyles =
     , Css.border Css.zero
     , Css.disabled [ Css.cursor Css.notAllowed ]
     , Css.color Colors.azure
+    , Css.hover [ Css.color Colors.azureDark ]
     , Css.backgroundColor Css.transparent
     , Css.fontWeight (Css.int 600)
     , Css.textAlign Css.left


### PR DESCRIPTION
Sometimes `ClickableText` gets line-wrapped. When that happens, the hover styles don't look right:

| ![Screen Shot 2020-07-07 at 2 25 38 PM](https://user-images.githubusercontent.com/355401/90937963-8c4ed980-e3cd-11ea-8007-2268800bfbce.png) | ![Screen Shot 2020-07-07 at 2 23 04 PM](https://user-images.githubusercontent.com/355401/90937965-8f49ca00-e3cd-11ea-83d5-301d18a1648f.png) | ![Screen Shot 2020-07-07 at 2 24 48 PM](https://user-images.githubusercontent.com/355401/90938024-b6a09700-e3cd-11ea-9755-a10915a8b11e.png)
|-|-|-|

the way to fix this is to use `text-decoration: underline` instead of `border-bottom: 1px solid $azure`. This looks fine for both single-line and multiple-line buttons:

![image](https://user-images.githubusercontent.com/355401/90938183-1e56e200-e3ce-11ea-9f7c-f55dab0302a6.png)

![image](https://user-images.githubusercontent.com/355401/90938265-4f371700-e3ce-11ea-84a5-bbc77b066322.png)

… but it also has some other effects. Namely, it creates a conflict in our text styles, since most of the things in `Nri.Ui.Text.V4` set a blue `border-bottom` on links. When things are inline, this works OK, but it means that we shouldn't combine `ClickableText` with `Text`, which seems silly (and, in fact, the style guide has an example of this…)

![image](https://user-images.githubusercontent.com/355401/90938293-6118ba00-e3ce-11ea-82b6-f4f335a2d0da.png)

So, while this PR (currently) fixes the multiline case, I think more changes are needed to make underlined links work consistently (although it'd be reasonable… changing `border-bottom` to a `text-decoration` in `Nri.Ui.Text.V4` and the other places it needs to match.)