### PR TITLE
bump to 12.0.1

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "12.0.0",
+    "version": "12.0.1",
     "exposed-modules": [
         "Nri.Ui",
         "Nri.Ui.Accordion.V1",


### PR DESCRIPTION
only #589:

```
No API changes detected, so this is a PATCH change.
```

total diff between 12.0.0 and 12.0.1:

```diff
diff --git a/src/Nri/Ui/ClickableText/V3.elm b/src/Nri/Ui/ClickableText/V3.elm
index 48d10bb5..9677539a 100644
--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -16,7 +16,7 @@ module Nri.Ui.ClickableText.V3 exposing
 
   - uses ClickableAttributes
   - adds `css` helper
-  - add bottom border on hover instead of text decoration
+  - removes underline on hover and recolors to azureDark
 
 
 # Changes from V2
@@ -295,13 +295,13 @@ clickableTextStyles =
     , Css.border Css.zero
     , Css.disabled [ Css.cursor Css.notAllowed ]
     , Css.color Colors.azure
+    , Css.hover [ Css.color Colors.azureDark ]
     , Css.backgroundColor Css.transparent
     , Css.fontWeight (Css.int 600)
     , Css.textAlign Css.left
     , Css.borderStyle Css.none
     , Css.textDecoration Css.none
     , Css.borderBottom3 (Css.px 1) Css.solid Css.transparent
-    , Css.hover [ Css.textDecoration Css.none, Css.borderBottom3 (Css.px 1) Css.solid Colors.azure ]
     , Css.padding Css.zero
     , Css.display Css.inlineBlock
     , Css.verticalAlign Css.textBottom

```