### PR TITLE
Raven/modal improvements

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -22,6 +22,7 @@
         "Nri.Ui.DisclosureIndicator.V2",
         "Nri.Ui.Divider.V2",
         "Nri.Ui.Effects.V1",
+        "Nri.Ui.FocusTrap.V1",
         "Nri.Ui.Fonts.V1",
         "Nri.Ui.Heading.V2",
         "Nri.Ui.Html.Attributes.V2",

--- a/elm.json
+++ b/elm.json
@@ -39,6 +39,7 @@
         "Nri.Ui.Message.V2",
         "Nri.Ui.Modal.V3",
         "Nri.Ui.Modal.V10",
+        "Nri.Ui.Modal.V11",
         "Nri.Ui.Page.V3",
         "Nri.Ui.Palette.V1",
         "Nri.Ui.Pennant.V2",

--- a/src/Nri/Ui/FocusTrap/V1.elm
+++ b/src/Nri/Ui/FocusTrap/V1.elm
@@ -1,0 +1,53 @@
+module Nri.Ui.FocusTrap.V1 exposing
+    ( first, last
+    , only
+    )
+
+{-| Create a focus trap.
+
+@docs first, last
+@docs only
+
+-}
+
+import Accessibility.Styled as Html exposing (..)
+import Accessibility.Styled.Key as Key
+import Browser.Dom as Dom
+import Browser.Events
+import Html.Styled.Attributes as Attributes exposing (class, id)
+import Html.Styled.Events as Events exposing (onClick)
+import Json.Decode as Decode exposing (Decoder)
+import Task
+
+
+{-| -}
+only : { focusSelf : msg } -> List (Html.Attribute msg)
+only { focusSelf } =
+    [ onKeyDownPreventDefault
+        [ Key.tab focusSelf
+        , Key.tabBack focusSelf
+        ]
+    , class "focus-trap__only-focusable-element"
+    ]
+
+
+{-| -}
+first : { focusLastId : msg } -> List (Html.Attribute msg)
+first { focusLastId } =
+    [ onKeyDownPreventDefault [ Key.tabBack focusLastId ]
+    , class "focus-trap__first-focusable-element"
+    ]
+
+
+{-| -}
+last : { focusFirstId : msg } -> List (Html.Attribute msg)
+last { focusFirstId } =
+    [ onKeyDownPreventDefault [ Key.tab focusFirstId ]
+    , class "focus-trap__last-focusable-element"
+    ]
+
+
+onKeyDownPreventDefault : List (Decoder msg) -> Html.Attribute msg
+onKeyDownPreventDefault decoders =
+    Events.preventDefaultOn "keydown"
+        (Decode.oneOf (List.map (Decode.map (\msg -> ( msg, True ))) decoders))

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -299,11 +299,6 @@ update { dismissOnEscAndOverlayClick } msg model =
             ( model, Cmd.none )
 
 
-type Autofocus
-    = Default
-    | Last
-
-
 
 -- ATTRIBUTES
 

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -15,6 +15,8 @@ module Nri.Ui.Modal.V11 exposing
   - remove `initOpen`
   - change `open`, `close` to return `(Model, Cmd Msg)` rather than `Msg`
   - make info and warning themes
+  - adds `custom` helper for adding arbitrary html attributes (primarily useful to make limiting the scope of selectors in tests easier by adding ids to modals)
+  - tab and tabback events stop propagation and prevent default
 
 ```
 import Browser exposing (Program, element)

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -109,13 +109,8 @@ type By
 
 
 {-| -}
-close : Msg
-close =
-    CloseModal Other
-
-
-close_ : Model -> ( Model, Cmd Msg )
-close_ model =
+close : Model -> ( Model, Cmd Msg )
+close model =
     case model of
         Opened returnFocusTo ->
             ( Closed, Task.attempt Focused (Dom.focus returnFocusTo) )
@@ -154,11 +149,11 @@ update { dismissOnEscAndOverlayClick } msg model =
         CloseModal by ->
             case by of
                 Other ->
-                    close_ model
+                    close model
 
                 _ ->
                     if dismissOnEscAndOverlayClick then
-                        close_ model
+                        close model
 
                     else
                         ( model, Cmd.none )
@@ -611,7 +606,7 @@ closeButton : (Msg -> msg) -> List (Html.Attribute msg) -> Html msg
 closeButton wrapMsg focusableElementAttrs =
     button
         (Widget.label "Close modal"
-            :: Attrs.map wrapMsg (onClick close)
+            :: Attrs.map wrapMsg (onClick (CloseModal Other))
             :: Attrs.css
                 [ -- in the upper-right corner of the modal
                   Css.position Css.absolute

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -1,16 +1,21 @@
 module Nri.Ui.Modal.V11 exposing
-    ( Model, init, initOpen, isOpen
-    , Msg, open, close, update, subscriptions
+    ( Model, init, open, close
+    , Msg, update, subscriptions
     , Attribute, hideTitle, css
     , FocusManager(..), info, warning
+    , isOpen
     )
 
 {-| Changes from V10:
 
-@docs Model, init, initOpen, isOpen
-@docs Msg, open, close, update, subscriptions
+  - remove `initOpen`
+  - change `open`, `close` to return `(Model, Cmd Msg)` rather than `Msg`
+
+@docs Model, init, open, close
+@docs Msg, update, subscriptions
 @docs Attribute, hideTitle, css
 @docs FocusManager, info, warning
+@docs isOpen
 
     import Html.Styled exposing (text)
     import Nri.Ui.Modal.V11 as Modal
@@ -77,18 +82,22 @@ init =
     Closed
 
 
-{-| Pass the id of the element that should receive focus when the modal is closed.
+{-| Pass the id of the element that should receive focus when the modal closes.
 -}
-initOpen : String -> ( Model, Cmd Msg )
-initOpen returnFocusTo =
+open : String -> ( Model, Cmd Msg )
+open returnFocusTo =
     ( Opened returnFocusTo, focusFirstElement )
 
 
-focusFirstElement : Cmd Msg
-focusFirstElement =
-    Dom.focus autofocusId
-        |> Task.onError (\_ -> Dom.focus firstId)
-        |> Task.attempt Focused
+{-| -}
+close : Model -> ( Model, Cmd Msg )
+close model =
+    case model of
+        Opened returnFocusTo ->
+            ( Closed, Task.attempt Focused (Dom.focus returnFocusTo) )
+
+        Closed ->
+            ( Closed, Cmd.none )
 
 
 {-| -}
@@ -106,17 +115,6 @@ type By
     = EscapeKey
     | OverlayClick
     | Other
-
-
-{-| -}
-close : Model -> ( Model, Cmd Msg )
-close model =
-    case model of
-        Opened returnFocusTo ->
-            ( Closed, Task.attempt Focused (Dom.focus returnFocusTo) )
-
-        Closed ->
-            ( Closed, Cmd.none )
 
 
 {-| -}
@@ -167,16 +165,16 @@ update { dismissOnEscAndOverlayClick } msg model =
             ( model, Cmd.none )
 
 
+focusFirstElement : Cmd Msg
+focusFirstElement =
+    Dom.focus autofocusId
+        |> Task.onError (\_ -> Dom.focus firstId)
+        |> Task.attempt Focused
+
+
 type Autofocus
     = Default
     | Last
-
-
-{-| Pass the id of the element that should receive focus when the modal closes.
--}
-open : String -> Msg
-open =
-    OpenModal
 
 
 

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -1,13 +1,11 @@
-module Nri.Ui.Modal.V10 exposing
+module Nri.Ui.Modal.V11 exposing
     ( Model, init, initOpen, isOpen
     , Msg, open, close, update, subscriptions
     , Attribute, hideTitle, css
     , FocusManager(..), info, warning
     )
 
-{-| Changes from V9:
-
-  - adds hideTitle and css helpers
+{-| Changes from V10:
 
 @docs Model, init, initOpen, isOpen
 @docs Msg, open, close, update, subscriptions
@@ -15,7 +13,7 @@ module Nri.Ui.Modal.V10 exposing
 @docs FocusManager, info, warning
 
     import Html.Styled exposing (text)
-    import Nri.Ui.Modal.V10 as Modal
+    import Nri.Ui.Modal.V11 as Modal
 
     type Msg
         = ModalMsg Modal.Msg

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -79,9 +79,16 @@ init =
 
 {-| Pass the id of the element that should receive focus when the modal is closed.
 -}
-initOpen : String -> Model
-initOpen =
-    Opened
+initOpen : String -> ( Model, Cmd Msg )
+initOpen returnFocusTo =
+    ( Opened returnFocusTo, focusFirstElement )
+
+
+focusFirstElement : Cmd Msg
+focusFirstElement =
+    Dom.focus autofocusId
+        |> Task.onError (\_ -> Dom.focus firstId)
+        |> Task.attempt Focused
 
 
 {-| -}
@@ -126,11 +133,7 @@ update : { dismissOnEscAndOverlayClick : Bool } -> Msg -> Model -> ( Model, Cmd 
 update { dismissOnEscAndOverlayClick } msg model =
     case msg of
         OpenModal returnFocusTo ->
-            ( Opened returnFocusTo
-            , Dom.focus autofocusId
-                |> Task.onError (\_ -> Dom.focus firstId)
-                |> Task.attempt Focused
-            )
+            ( Opened returnFocusTo, focusFirstElement )
 
         CloseModal by ->
             let

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -1,0 +1,653 @@
+module Nri.Ui.Modal.V10 exposing
+    ( Model, init, initOpen, isOpen
+    , Msg, open, close, update, subscriptions
+    , Attribute, hideTitle, css
+    , FocusManager(..), info, warning
+    )
+
+{-| Changes from V9:
+
+  - adds hideTitle and css helpers
+
+@docs Model, init, initOpen, isOpen
+@docs Msg, open, close, update, subscriptions
+@docs Attribute, hideTitle, css
+@docs FocusManager, info, warning
+
+    import Html.Styled exposing (text)
+    import Nri.Ui.Modal.V10 as Modal
+
+    type Msg
+        = ModalMsg Modal.Msg
+
+    ...
+
+    viewModal : Modal.Model -> Html Msg
+    viewModal modalState =
+        Modal.info
+            { title = "Modal Title"
+            , wrapMsg = ModalMsg
+            , focusManager =
+                Modal.OneFocusableElement
+                    (\{ onlyFocusableElement, closeButton } ->
+                        { content =
+                            [ closeButton onlyFocusableElement
+                            , text "Modal Content"
+                            ]
+                        , footer = []
+                        }
+                    )
+            }
+            [ Modal.hideTitle
+            , Modal.css [ padding (px 10) ]
+            ]
+            modalState
+
+-}
+
+import Accessibility.Styled as Html exposing (..)
+import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Key as Key
+import Accessibility.Styled.Role as Role
+import Accessibility.Styled.Widget as Widget
+import Browser
+import Browser.Dom as Dom
+import Browser.Events
+import Color.Transparent as Transparent
+import Css exposing (..)
+import Css.Transitions
+import Html.Styled as Root
+import Html.Styled.Attributes as Attrs exposing (id)
+import Html.Styled.Events exposing (onClick)
+import Nri.Ui.Colors.Extra
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.SpriteSheet
+import Nri.Ui.Svg.V1
+import Task
+
+
+{-| -}
+type Model
+    = Opened String
+    | Closed
+
+
+{-| -}
+init : Model
+init =
+    Closed
+
+
+{-| Pass the id of the element that should receive focus when the modal is closed.
+-}
+initOpen : String -> Model
+initOpen =
+    Opened
+
+
+{-| -}
+isOpen : Model -> Bool
+isOpen model =
+    case model of
+        Opened _ ->
+            True
+
+        Closed ->
+            False
+
+
+type By
+    = EscapeKey
+    | OverlayClick
+    | Other
+
+
+{-| -}
+type Msg
+    = OpenModal String
+    | CloseModal By
+    | Focus String
+    | Focused (Result Dom.Error ())
+
+
+{-| Include the subscription if you want the modal to dismiss on `Esc`.
+-}
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    case model of
+        Opened _ ->
+            Browser.Events.onKeyDown (Key.escape (CloseModal EscapeKey))
+
+        Closed ->
+            Sub.none
+
+
+{-| -}
+update : { dismissOnEscAndOverlayClick : Bool } -> Msg -> Model -> ( Model, Cmd Msg )
+update { dismissOnEscAndOverlayClick } msg model =
+    case msg of
+        OpenModal returnFocusTo ->
+            ( Opened returnFocusTo
+            , Dom.focus autofocusId
+                |> Task.onError (\_ -> Dom.focus firstId)
+                |> Task.attempt Focused
+            )
+
+        CloseModal by ->
+            let
+                closeModal returnFocusTo =
+                    ( Closed, Task.attempt Focused (Dom.focus returnFocusTo) )
+            in
+            case ( model, by, dismissOnEscAndOverlayClick ) of
+                ( Opened returnFocusTo, _, True ) ->
+                    closeModal returnFocusTo
+
+                ( Opened returnFocusTo, Other, False ) ->
+                    closeModal returnFocusTo
+
+                _ ->
+                    ( model, Cmd.none )
+
+        Focus id ->
+            ( model, Task.attempt Focused (Dom.focus id) )
+
+        Focused _ ->
+            -- TODO: consider adding error handling when we didn't successfully
+            -- fous an element
+            ( model, Cmd.none )
+
+
+type Autofocus
+    = Default
+    | Last
+
+
+{-| Pass the id of the element that should receive focus when the modal closes.
+-}
+open : String -> Msg
+open =
+    OpenModal
+
+
+{-| -}
+close : Msg
+close =
+    CloseModal Other
+
+
+
+-- ATTRIBUTES
+
+
+{-| Modals should allow the user to tab forwards & backwards through the modal content.
+The user should never find their Focus lost behind the modal backdrop!
+
+Use the `FocusManager` to tag the focusable elements in your modal, so that we
+know to which element to return focus when the user reaches the last focusable element.
+
+-}
+type FocusManager msg
+    = MultipleFocusableElements
+        ({ firstFocusableElement : List (Html.Attribute msg)
+         , lastFocusableElement : List (Html.Attribute msg)
+         , autofocusElement : Html.Attribute msg
+         , closeButton : List (Html.Attribute msg) -> Html msg
+         }
+         ->
+            { content : List (Html msg)
+            , footer : List (Html msg)
+            }
+        )
+    | OneFocusableElement
+        ({ onlyFocusableElement : List (Html.Attribute msg)
+         , closeButton : List (Html.Attribute msg) -> Html msg
+         }
+         ->
+            { content : List (Html msg)
+            , footer : List (Html msg)
+            }
+        )
+
+
+{-| -}
+type Attribute
+    = Attribute (Attributes -> Attributes)
+
+
+type alias Attributes =
+    { overlayColor : Color
+    , titleColor : Color
+    , visibleTitle : Bool
+    , titleStyles : List Style
+    , customStyles : List Style
+    }
+
+
+defaultAttributes : Attributes
+defaultAttributes =
+    { overlayColor = Nri.Ui.Colors.Extra.withAlpha 0.9 Colors.navy
+    , titleColor = Colors.navy
+    , visibleTitle = True
+    , titleStyles = []
+    , customStyles = []
+    }
+
+
+{-| -}
+hideTitle : Attribute
+hideTitle =
+    Attribute (\attrs -> { attrs | visibleTitle = False })
+
+
+{-| -}
+css : List Style -> Attribute
+css styles =
+    Attribute
+        (\attrs ->
+            { attrs
+                | customStyles =
+                    List.append attrs.customStyles styles
+            }
+        )
+
+
+titleColor : Color -> Attribute
+titleColor color =
+    Attribute
+        (\attrs -> { attrs | titleColor = color })
+
+
+overlayColor : Color -> Attribute
+overlayColor color =
+    Attribute
+        (\attrs -> { attrs | overlayColor = color })
+
+
+buildAttributes : List Attribute -> Attributes -> Attributes
+buildAttributes attrs initial =
+    let
+        result =
+            attrs
+                |> List.foldl (\(Attribute fun) acc -> fun acc) initial
+    in
+    { result | titleStyles = titleStyles result.titleColor result.visibleTitle }
+
+
+modalStyles : List Style
+modalStyles =
+    [ position relative
+
+    -- Border
+    , borderRadius (px 20)
+    , boxShadow5 zero (px 1) (px 10) zero (rgba 0 0 0 0.35)
+
+    -- Spacing
+    , margin2 (px 50) auto
+
+    -- Size
+    , minHeight (vh 40)
+    , width (px 600)
+    , backgroundColor Colors.white
+
+    -- the modal should grow up to the viewport minus a 50px margin
+    , maxHeight (calc (pct 100) minus (px 100))
+    ]
+
+
+titleStyles : Color -> Bool -> List Style
+titleStyles color visibleTitle =
+    if visibleTitle then
+        [ Fonts.baseFont
+        , Css.fontWeight (Css.int 700)
+        , Css.paddingTop (Css.px 40)
+        , Css.paddingBottom (Css.px 20)
+        , Css.margin Css.zero
+        , Css.fontSize (Css.px 20)
+        , Css.textAlign Css.center
+        , Css.color color
+        ]
+
+    else
+        [ -- https://snook.ca/archives/html_and_css/hiding-content-for-accessibility
+          Css.property "clip" "rect(1px, 1px, 1px, 1px)"
+        , Css.position Css.absolute
+        , Css.height (Css.px 1)
+        , Css.width (Css.px 1)
+        , Css.overflow Css.hidden
+        , Css.margin (Css.px -1)
+        , Css.padding Css.zero
+        , Css.border Css.zero
+        ]
+
+
+
+-- VIEW
+
+
+{-| -}
+info :
+    { title : String
+    , wrapMsg : Msg -> msg
+    , focusManager : FocusManager msg
+    }
+    -> List Attribute
+    -> Model
+    -> Html msg
+info config attrsList =
+    view config attrsList
+
+
+{-| -}
+warning :
+    { title : String
+    , wrapMsg : Msg -> msg
+    , focusManager : FocusManager msg
+    }
+    -> List Attribute
+    -> Model
+    -> Html msg
+warning config attrsList =
+    view config
+        (List.append
+            [ overlayColor (Nri.Ui.Colors.Extra.withAlpha 0.9 Colors.gray20)
+            , titleColor Colors.red
+            ]
+            attrsList
+        )
+
+
+view :
+    { title : String
+    , wrapMsg : Msg -> msg
+    , focusManager : FocusManager msg
+    }
+    -> List Attribute
+    -> Model
+    -> Html msg
+view config attrsList model =
+    let
+        attrs =
+            buildAttributes attrsList defaultAttributes
+    in
+    case model of
+        Opened _ ->
+            div
+                [ Attrs.css
+                    [ position fixed
+                    , top zero
+                    , left zero
+                    , width (pct 100)
+                    , height (pct 100)
+                    , displayFlex
+                    , alignItems center
+                    ]
+                ]
+                [ viewBackdrop config.wrapMsg attrs.overlayColor
+                , div [ Attrs.css (List.append modalStyles attrs.customStyles) ] [ viewModal config attrs ]
+                , Root.node "style" [] [ Root.text "body {overflow: hidden;} " ]
+                ]
+                |> List.singleton
+                |> div [ Attrs.css [ Css.position Css.relative, Css.zIndex (Css.int 1) ] ]
+
+        Closed ->
+            text ""
+
+
+viewBackdrop : (Msg -> msg) -> Color -> Html msg
+viewBackdrop wrapMsg color =
+    Root.div
+        -- We use Root html here in order to allow clicking to exit out of
+        -- the overlay. This behavior is available to non-mouse users as
+        -- well via the ESC key, so imo it's fine to have this div
+        -- be clickable but not focusable.
+        [ Attrs.css
+            [ position absolute
+            , width (pct 100)
+            , height (pct 100)
+            , backgroundColor color
+            ]
+        , onClick (wrapMsg (CloseModal OverlayClick))
+        ]
+        []
+
+
+viewModal :
+    { title : String
+    , wrapMsg : Msg -> msg
+    , focusManager : FocusManager msg
+    }
+    ->
+        { a
+            | visibleTitle : Bool
+            , titleStyles : List Style
+        }
+    -> Html msg
+viewModal config styles =
+    section
+        [ Role.dialog
+        , Aria.labeledBy modalTitleId
+        ]
+        [ h1 [ id modalTitleId, Attrs.css styles.titleStyles ] [ text config.title ]
+        , viewContent styles.visibleTitle <|
+            case config.focusManager of
+                OneFocusableElement toContentAndFooter ->
+                    toContentAndFooter
+                        { onlyFocusableElement =
+                            List.map (Attrs.map config.wrapMsg)
+                                [ Key.onKeyDown
+                                    [ Key.tabBack (Focus autofocusId)
+                                    , Key.tab (Focus autofocusId)
+                                    ]
+                                , id autofocusId
+                                ]
+                        , closeButton = closeButton config.wrapMsg
+                        }
+
+                MultipleFocusableElements toContentAndFooter ->
+                    toContentAndFooter
+                        { firstFocusableElement =
+                            List.map (Attrs.map config.wrapMsg)
+                                [ Key.onKeyDown [ Key.tabBack (Focus lastId) ]
+                                , id firstId
+                                ]
+                        , lastFocusableElement =
+                            List.map (Attrs.map config.wrapMsg)
+                                [ Key.onKeyDown [ Key.tab (Focus firstId) ]
+                                , id lastId
+                                ]
+                        , autofocusElement =
+                            Attrs.map config.wrapMsg (id autofocusId)
+                        , closeButton = closeButton config.wrapMsg
+                        }
+        ]
+
+
+{-| -}
+viewContent : Bool -> { content : List (Html msg), footer : List (Html msg) } -> Html msg
+viewContent visibleTitle { content, footer } =
+    div []
+        [ viewInnerContent content visibleTitle (not (List.isEmpty footer))
+        , viewFooter footer
+        ]
+
+
+{-| -}
+viewInnerContent : List (Html msg) -> Bool -> Bool -> Html msg
+viewInnerContent children visibleTitle visibleFooter =
+    let
+        titleHeight =
+            if visibleTitle then
+                45
+
+            else
+                0
+
+        footerHeight =
+            if visibleFooter then
+                180
+
+            else
+                0
+
+        modalTitleStyles =
+            if visibleTitle then
+                []
+
+            else
+                [ Css.borderTopLeftRadius (Css.px 20)
+                , Css.borderTopRightRadius (Css.px 20)
+                , Css.overflowY Css.hidden
+                ]
+
+        modalFooterStyles =
+            if visibleFooter then
+                []
+
+            else
+                [ Css.borderBottomLeftRadius (Css.px 20)
+                , Css.borderBottomRightRadius (Css.px 20)
+                , Css.overflowY Css.hidden
+                ]
+    in
+    div
+        [ Attrs.css (modalTitleStyles ++ modalFooterStyles)
+        ]
+        [ div
+            [ Attrs.css
+                [ Css.overflowY Css.auto
+                , Css.overflowX Css.hidden
+                , Css.minHeight (Css.px 150)
+                , Css.maxHeight
+                    (Css.calc (Css.vh 100)
+                        Css.minus
+                        (Css.px (footerHeight + titleHeight + 145))
+                    )
+                , Css.width (Css.pct 100)
+                , Css.boxSizing Css.borderBox
+                , Css.paddingLeft (Css.px 40)
+                , Css.paddingRight (Css.px 40)
+                , if visibleTitle then
+                    Css.paddingTop Css.zero
+
+                  else
+                    Css.paddingTop (Css.px 40)
+                , if visibleFooter then
+                    Css.paddingBottom Css.zero
+
+                  else
+                    Css.paddingBottom (Css.px 40)
+                , if visibleFooter then
+                    shadow (Transparent.customOpacity 0.15) (Css.px 16)
+
+                  else
+                    shadow (Transparent.customOpacity 0.4) (Css.px 30)
+                ]
+            ]
+            children
+        ]
+
+
+shadow : Transparent.Opacity -> Css.Px -> Css.Style
+shadow opacity bottomShadowHeight =
+    let
+        to =
+            Transparent.fromRGBA { red = 0, green = 0, blue = 0, alpha = opacity }
+                |> Transparent.toRGBAString
+    in
+    Css.batch
+        [ -- Shadows for indicating that the content is scrollable
+          [ "/* TOP shadow */"
+          , "top linear-gradient(to top, rgb(255, 255, 255), rgb(255, 255, 255)) local,"
+          , "top linear-gradient(to top, rgba(255, 255, 255, 0), rgba(0, 0, 0, 0.15)) scroll,"
+          , ""
+          , "/* BOTTOM shadow */"
+          , "bottom linear-gradient(to bottom, rgb(255, 255, 255), rgb(255, 255, 255)) local,"
+          , "bottom linear-gradient(to bottom, rgba(255, 255, 255, 0), " ++ to ++ ") scroll"
+          ]
+            |> String.join "\n"
+            |> Css.property "background"
+        , Css.backgroundSize2 (Css.pct 100) bottomShadowHeight
+        , Css.backgroundRepeat Css.noRepeat
+        ]
+
+
+{-| -}
+viewFooter : List (Html msg) -> Html msg
+viewFooter children =
+    if List.isEmpty children then
+        Html.text ""
+
+    else
+        div
+            [ Attrs.css
+                [ Css.alignItems Css.center
+                , Css.displayFlex
+                , Css.flexDirection Css.column
+                , Css.flexGrow (Css.int 2)
+                , Css.flexWrap Css.noWrap
+                , Css.margin4 (Css.px 20) Css.zero Css.zero Css.zero
+                , Css.paddingBottom (Css.px 40)
+                , Css.width (Css.pct 100)
+                ]
+            ]
+            children
+
+
+
+--BUTTONS
+
+
+{-| -}
+closeButton : (Msg -> msg) -> List (Html.Attribute msg) -> Html msg
+closeButton wrapMsg focusableElementAttrs =
+    button
+        (Widget.label "Close modal"
+            :: Attrs.map wrapMsg (onClick close)
+            :: Attrs.css
+                [ -- in the upper-right corner of the modal
+                  Css.position Css.absolute
+                , Css.top Css.zero
+                , Css.right Css.zero
+
+                -- make the hitspace extend all the way to the corner
+                , Css.width (Css.px 40)
+                , Css.height (Css.px 40)
+                , Css.padding4 (Css.px 20) (Css.px 20) Css.zero Css.zero
+
+                -- apply button styles
+                , Css.borderWidth Css.zero
+                , Css.backgroundColor Css.transparent
+                , Css.cursor Css.pointer
+                , Css.color Colors.azure
+                , Css.hover [ Css.color Colors.azureDark ]
+                , Css.Transitions.transition [ Css.Transitions.color 0.1 ]
+                ]
+            :: focusableElementAttrs
+        )
+        [ Nri.Ui.Svg.V1.toHtml Nri.Ui.SpriteSheet.xSvg
+        ]
+
+
+
+-- IDS
+
+
+modalTitleId : String
+modalTitleId =
+    "modal__title"
+
+
+firstId : String
+firstId =
+    "modal__first-focusable-element"
+
+
+lastId : String
+lastId =
+    "modal__last-focusable-element"
+
+
+autofocusId : String
+autofocusId =
+    "modal__autofocus-element"

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -423,7 +423,6 @@ type alias Attributes =
     { overlayColor : Color
     , titleColor : Color
     , visibleTitle : Bool
-    , titleStyles : List Style
     , customStyles : List Style
     , customAttributes : List (Html.Attribute Never)
     }
@@ -434,7 +433,6 @@ defaultAttributes =
     { overlayColor = Nri.Ui.Colors.Extra.withAlpha 0.9 Colors.navy
     , titleColor = Colors.navy
     , visibleTitle = True
-    , titleStyles = []
     , customStyles = []
     , customAttributes = []
     }
@@ -460,11 +458,8 @@ buildAttributes attrs =
 
                 Batch functions ->
                     List.foldl applyAttrs acc functions
-
-        result =
-            List.foldl applyAttrs defaultAttributes attrs
     in
-    { result | titleStyles = titleStyles result.titleColor result.visibleTitle }
+    List.foldl applyAttrs defaultAttributes attrs
 
 
 modalStyles : List Style
@@ -551,8 +546,8 @@ view config attrsList model =
                         { title = config.title
                         , wrapMsg = config.wrapMsg
                         , focusManager = config.focusManager
+                        , titleColor = attrs.titleColor
                         , visibleTitle = attrs.visibleTitle
-                        , titleStyles = attrs.titleStyles
                         , customAttributes = attrs.customAttributes
                         }
                     ]
@@ -587,8 +582,8 @@ viewModal :
     { title : String
     , wrapMsg : Msg -> msg
     , focusManager : FocusManager msg
+    , titleColor : Color
     , visibleTitle : Bool
-    , titleStyles : List Style
     , customAttributes : List (Html.Attribute Never)
     }
     -> Html msg
@@ -602,7 +597,7 @@ viewModal config =
         )
         [ h1
             [ id modalTitleId
-            , Attrs.css config.titleStyles
+            , Attrs.css (titleStyles config.titleColor config.visibleTitle)
             ]
             [ text config.title ]
         , viewContent config.visibleTitle <|

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -1,5 +1,5 @@
 module Nri.Ui.Modal.V11 exposing
-    ( view, closeButton
+    ( view, closeButton, closeButtonId
     , Model, init, open, close
     , Msg, update, subscriptions
     , Attribute
@@ -7,7 +7,6 @@ module Nri.Ui.Modal.V11 exposing
     , showTitle, hideTitle
     , custom, css
     , isOpen
-    , closeButtonId, firstFocusable, lastFocusable, onlyFocusable
     )
 
 {-| Changes from V10:
@@ -24,6 +23,7 @@ import Browser.Dom as Dom
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (id)
 import Html.Styled.Events as Events
+import Nri.Ui.FocusTrap.V1 as FocusTrap
 import Nri.Ui.Modal.V11 as Modal
 import Task
 
@@ -134,14 +134,14 @@ view model =
                     , wrapMsg = ModalMsg
                     , content =
                         [ Modal.closeButton CloseModal <|
-                            Modal.firstFocusable { focusLastId = Focus "last-element-id" }
+                            FocusTrap.first { focusLastId = Focus "last-element-id" }
                         , text "Modal Content"
                         ]
                     , footer =
                         [ button
                             (Events.onClick CloseModal
                                 :: id "last-element-id"
-                                :: Modal.lastFocusable { focusFirstElement = Focus Modal.closeButtonId }
+                                :: FocusTrap.last { focusFirstElement = Focus Modal.closeButtonId }
                             )
                             [ text "Close" ]
                         ]
@@ -158,7 +158,7 @@ view model =
                     , wrapMsg = ModalMsg
                     , content =
                         [ Modal.closeButton CloseModal <|
-                            Modal.onlyFocusable { focusSelf = Focus Modal.closeButtonId }
+                            FocusTrap.only { focusSelf = Focus Modal.closeButtonId }
                         , text "Modal Content"
                         ]
                     , footer = []
@@ -169,7 +169,7 @@ view model =
         ]
 ```
 
-@docs view, closeButton
+@docs view, closeButton, closeButtonId
 @docs Model, init, open, close
 @docs Msg, update, subscriptions
 
@@ -572,39 +572,6 @@ viewModal config =
             , viewFooter config.footer
             ]
         ]
-
-
-{-| -}
-onlyFocusable : { focusSelf : msg } -> List (Html.Attribute msg)
-onlyFocusable { focusSelf } =
-    [ onKeyDownPreventDefault
-        [ Key.tab focusSelf
-        , Key.tabBack focusSelf
-        ]
-    , Attrs.class "modal__only-focusable-element"
-    ]
-
-
-{-| -}
-firstFocusable : { focusLastId : msg } -> List (Html.Attribute msg)
-firstFocusable { focusLastId } =
-    [ onKeyDownPreventDefault [ Key.tabBack focusLastId ]
-    , Attrs.class "modal__first-focusable-element"
-    ]
-
-
-{-| -}
-lastFocusable : { focusFirstId : msg } -> List (Html.Attribute msg)
-lastFocusable { focusFirstId } =
-    [ onKeyDownPreventDefault [ Key.tab focusFirstId ]
-    , Attrs.class "modal__last-focusable-element"
-    ]
-
-
-onKeyDownPreventDefault : List (Decoder msg) -> Html.Attribute msg
-onKeyDownPreventDefault decoders =
-    Events.preventDefaultOn "keydown"
-        (Decode.oneOf (List.map (Decode.map (\msg -> ( msg, True ))) decoders))
 
 
 {-| -}

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -5,7 +5,7 @@ module Nri.Ui.Modal.V11 exposing
     , FocusManager(..)
     , Attribute
     , info, warning
-    , hideTitle
+    , showTitle, hideTitle
     , custom, css
     , isOpen
     )
@@ -168,7 +168,7 @@ view model =
 
 @docs Attribute
 @docs info, warning
-@docs hideTitle
+@docs showTitle, hideTitle
 @docs custom, css
 
 
@@ -366,6 +366,13 @@ warning =
         [ overlayColor (Nri.Ui.Colors.Extra.withAlpha 0.9 Colors.gray20)
         , titleColor Colors.red
         ]
+
+
+{-| This is the default setting.
+-}
+showTitle : Attribute
+showTitle =
+    Attribute (\attrs -> { attrs | visibleTitle = True })
 
 
 {-| -}

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -64,7 +64,8 @@ import Css exposing (..)
 import Css.Transitions
 import Html.Styled as Root
 import Html.Styled.Attributes as Attrs exposing (id)
-import Html.Styled.Events exposing (onClick)
+import Html.Styled.Events as Events exposing (onClick)
+import Json.Decode as Decode exposing (Decoder)
 import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
@@ -438,7 +439,7 @@ viewModal config styles =
                     toContentAndFooter
                         { onlyFocusableElement =
                             List.map (Attrs.map config.wrapMsg)
-                                [ Key.onKeyDown
+                                [ onKeyDownPreventDefault
                                     [ Key.tabBack (Focus autofocusId)
                                     , Key.tab (Focus autofocusId)
                                     ]
@@ -451,12 +452,16 @@ viewModal config styles =
                     toContentAndFooter
                         { firstFocusableElement =
                             List.map (Attrs.map config.wrapMsg)
-                                [ Key.onKeyDown [ Key.tabBack (Focus lastId) ]
+                                [ onKeyDownPreventDefault
+                                    [ Key.tabBack (Focus lastId)
+                                    ]
                                 , id firstId
                                 ]
                         , lastFocusableElement =
                             List.map (Attrs.map config.wrapMsg)
-                                [ Key.onKeyDown [ Key.tab (Focus firstId) ]
+                                [ onKeyDownPreventDefault
+                                    [ Key.tab (Focus firstId)
+                                    ]
                                 , id lastId
                                 ]
                         , autofocusElement =
@@ -464,6 +469,12 @@ viewModal config styles =
                         , closeButton = closeButton config.wrapMsg
                         }
         ]
+
+
+onKeyDownPreventDefault : List (Decoder msg) -> Html.Attribute msg
+onKeyDownPreventDefault decoders =
+    Events.preventDefaultOn "keydown"
+        (Decode.oneOf (List.map (Decode.map (\msg -> ( msg, True ))) decoders))
 
 
 {-| -}

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -132,6 +132,7 @@ view model =
                     }
                     [ Modal.hideTitle
                     , Modal.css [ padding (px 10) ]
+                    , Modal.custom [ id "first-modal" ]
                     ]
                     model.modalState
 

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -430,6 +430,7 @@ viewModal :
 viewModal config styles =
     section
         [ Role.dialog
+        , Widget.modal True
         , Aria.labeledBy modalTitleId
         ]
         [ h1 [ id modalTitleId, Attrs.css styles.titleStyles ] [ text config.title ]

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -125,8 +125,7 @@ view model =
                                     ]
                                 , footer =
                                     [ button
-                                        [ Events.onClick CloseModal
-                                        ]
+                                        (Events.onClick CloseModal :: lastFocusableElement)
                                         [ text "Close" ]
                                     ]
                                 }

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -109,6 +109,22 @@ type By
 
 
 {-| -}
+close : Msg
+close =
+    CloseModal Other
+
+
+close_ : Model -> ( Model, Cmd Msg )
+close_ model =
+    case model of
+        Opened returnFocusTo ->
+            ( Closed, Task.attempt Focused (Dom.focus returnFocusTo) )
+
+        Closed ->
+            ( Closed, Cmd.none )
+
+
+{-| -}
 type Msg
     = OpenModal String
     | CloseModal By
@@ -136,19 +152,16 @@ update { dismissOnEscAndOverlayClick } msg model =
             ( Opened returnFocusTo, focusFirstElement )
 
         CloseModal by ->
-            let
-                closeModal returnFocusTo =
-                    ( Closed, Task.attempt Focused (Dom.focus returnFocusTo) )
-            in
-            case ( model, by, dismissOnEscAndOverlayClick ) of
-                ( Opened returnFocusTo, _, True ) ->
-                    closeModal returnFocusTo
-
-                ( Opened returnFocusTo, Other, False ) ->
-                    closeModal returnFocusTo
+            case by of
+                Other ->
+                    close_ model
 
                 _ ->
-                    ( model, Cmd.none )
+                    if dismissOnEscAndOverlayClick then
+                        close_ model
+
+                    else
+                        ( model, Cmd.none )
 
         Focus id ->
             ( model, Task.attempt Focused (Dom.focus id) )
@@ -169,12 +182,6 @@ type Autofocus
 open : String -> Msg
 open =
     OpenModal
-
-
-{-| -}
-close : Msg
-close =
-    CloseModal Other
 
 
 

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -158,12 +158,7 @@ makeFocusManager settings =
                         , viewModalContent settings.content
                         ]
                     , footer =
-                        [ Button.button "Continue"
-                            [ Button.premium
-                            , Button.onClick ForceClose
-                            , Button.large
-                            , Button.custom [ modalOptions.autofocusElement ]
-                            ]
+                        [ continueButton [ modalOptions.autofocusElement ]
                         , closeClickableText modalOptions.lastFocusableElement
                         ]
                     }
@@ -199,12 +194,10 @@ makeFocusManager settings =
                         , viewModalContent settings.content
                         ]
                     , footer =
-                        [ Button.button "Continue"
-                            [ Button.premium
-                            , Button.onClick ForceClose
-                            , Button.custom (modalOptions.autofocusElement :: modalOptions.lastFocusableElement)
-                            , Button.large
-                            ]
+                        [ continueButton
+                            (modalOptions.autofocusElement
+                                :: modalOptions.lastFocusableElement
+                            )
                         ]
                     }
 
@@ -213,12 +206,10 @@ makeFocusManager settings =
                 \modalOptions ->
                     { content = [ viewModalContent settings.content ]
                     , footer =
-                        [ Button.button "Continue"
-                            [ Button.premium
-                            , Button.onClick ForceClose
-                            , Button.custom (modalOptions.autofocusElement :: modalOptions.firstFocusableElement)
-                            , Button.large
-                            ]
+                        [ continueButton
+                            (modalOptions.autofocusElement
+                                :: modalOptions.firstFocusableElement
+                            )
                         , closeClickableText modalOptions.lastFocusableElement
                         ]
                     }
@@ -227,9 +218,7 @@ makeFocusManager settings =
             Modal.OneFocusableElement
                 (\{ onlyFocusableElement } ->
                     { content = [ viewModalContent settings.content ]
-                    , footer =
-                        [ closeClickableText onlyFocusableElement
-                        ]
+                    , footer = [ closeClickableText onlyFocusableElement ]
                     }
                 )
 
@@ -237,14 +226,7 @@ makeFocusManager settings =
             Modal.OneFocusableElement
                 (\{ onlyFocusableElement } ->
                     { content = [ viewModalContent settings.content ]
-                    , footer =
-                        [ Button.button "Continue"
-                            [ Button.premium
-                            , Button.onClick ForceClose
-                            , Button.custom onlyFocusableElement
-                            , Button.large
-                            ]
-                        ]
+                    , footer = [ continueButton onlyFocusableElement ]
                     }
                 )
 
@@ -263,6 +245,16 @@ viewModalContent content =
         [ span
             [ Attributes.css [ whiteSpace preLine ] ]
             [ text content ]
+        ]
+
+
+continueButton : List (Html.Attribute Msg) -> Html Msg
+continueButton attributes =
+    Button.button "Continue"
+        [ Button.premium
+        , Button.onClick ForceClose
+        , Button.custom attributes
+        , Button.large
         ]
 
 

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -164,12 +164,7 @@ makeFocusManager settings =
                             , Button.large
                             , Button.custom [ modalOptions.autofocusElement ]
                             ]
-                        , ClickableText.button "Close"
-                            [ ClickableText.onClick ForceClose
-                            , ClickableText.large
-                            , ClickableText.custom modalOptions.lastFocusableElement
-                            , ClickableText.css [ Css.marginTop (Css.px 12) ]
-                            ]
+                        , closeClickableText modalOptions.lastFocusableElement
                         ]
                     }
 
@@ -181,12 +176,7 @@ makeFocusManager settings =
                         , viewModalContent settings.content
                         ]
                     , footer =
-                        [ ClickableText.button "Close"
-                            [ ClickableText.onClick ForceClose
-                            , ClickableText.large
-                            , ClickableText.custom (modalOptions.autofocusElement :: modalOptions.lastFocusableElement)
-                            , ClickableText.css [ Css.marginTop (Css.px 12) ]
-                            ]
+                        [ closeClickableText (modalOptions.autofocusElement :: modalOptions.lastFocusableElement)
                         ]
                     }
 
@@ -229,12 +219,7 @@ makeFocusManager settings =
                             , Button.custom (modalOptions.autofocusElement :: modalOptions.firstFocusableElement)
                             , Button.large
                             ]
-                        , ClickableText.button "Close"
-                            [ ClickableText.onClick ForceClose
-                            , ClickableText.large
-                            , ClickableText.custom modalOptions.lastFocusableElement
-                            , ClickableText.css [ Css.marginTop (Css.px 12) ]
-                            ]
+                        , closeClickableText modalOptions.lastFocusableElement
                         ]
                     }
 
@@ -243,12 +228,7 @@ makeFocusManager settings =
                 (\{ onlyFocusableElement } ->
                     { content = [ viewModalContent settings.content ]
                     , footer =
-                        [ ClickableText.button "Close"
-                            [ ClickableText.onClick ForceClose
-                            , ClickableText.large
-                            , ClickableText.custom onlyFocusableElement
-                            , ClickableText.css [ Css.marginTop (Css.px 12) ]
-                            ]
+                        [ closeClickableText onlyFocusableElement
                         ]
                     }
                 )
@@ -283,6 +263,16 @@ viewModalContent content =
         [ span
             [ Attributes.css [ whiteSpace preLine ] ]
             [ text content ]
+        ]
+
+
+closeClickableText : List (Html.Attribute Msg) -> Html Msg
+closeClickableText attributes =
+    ClickableText.button "Close"
+        [ ClickableText.onClick ForceClose
+        , ClickableText.large
+        , ClickableText.custom attributes
+        , ClickableText.css [ Css.marginTop (Css.px 15) ]
         ]
 
 

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -249,7 +249,7 @@ modalSettings settings =
                     [ continueButton <|
                         FocusTrap.first { focusLastId = Focus closeClickableTextId }
                     , closeClickableText <|
-                        FocusTrap.last { focusFirstId = Focus Modal.closeButtonId }
+                        FocusTrap.last { focusFirstId = Focus continueButtonId }
                     ]
             }
 

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -108,7 +108,17 @@ example =
     { name = "Nri.Ui.Modal.V11"
     , categories = [ Modals ]
     , atomicDesignType = Organism
-    , keyboardSupport = []
+    , keyboardSupport =
+        [ { keys = [ KeyboardSupport.Tab ]
+          , result = "Moves focus to the next button within the modal or wraps back to the first element within the modal."
+          }
+        , { keys = [ KeyboardSupport.Tab, KeyboardSupport.Shift ]
+          , result = "Moves focus to the previous button within the modal or wraps back to the last element within the modal."
+          }
+        , { keys = [ KeyboardSupport.Esc ]
+          , result = "If 'dismissOnEscAndOverlayClick' is set to true, closes the modal. Else, does nothing."
+          }
+        ]
     , state = init
     , update = update
     , subscriptions = subscriptions

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -19,7 +19,7 @@ import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Checkbox.V5 as Checkbox
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.Modal.V10 as Modal
+import Nri.Ui.Modal.V11 as Modal
 import Nri.Ui.Text.V4 as Text
 
 
@@ -71,7 +71,7 @@ initModalSettings =
 {-| -}
 example : Example State Msg
 example =
-    { name = "Nri.Ui.Modal.V10"
+    { name = "Nri.Ui.Modal.V11"
     , categories = [ Modals ]
     , atomicDesignType = Organism
     , keyboardSupport = []

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -99,8 +99,16 @@ example =
                     else
                         []
 
+                ( title, themeAttrs, buttonTheme ) =
+                    case state.content of
+                        Info ->
+                            ( "Modal.info", Modal.info, Button.primary )
+
+                        Warning ->
+                            ( "Modal.warning", Modal.warning, Button.danger )
+
                 attrs =
-                    titleAttrs ++ stylingAttrs
+                    themeAttrs :: titleAttrs ++ stylingAttrs
             in
             [ viewSettings state.settings
             , Button.button "Launch Info Modal"
@@ -116,24 +124,13 @@ example =
                 , Button.secondary
                 , Button.medium
                 ]
-            , case state.content of
-                Info ->
-                    Modal.info
-                        { title = "Modal.info"
-                        , wrapMsg = ModalMsg
-                        , focusManager = makeFocusManager Button.primary state.settings
-                        }
-                        attrs
-                        state.state
-
-                Warning ->
-                    Modal.warning
-                        { title = "Modal.warning"
-                        , wrapMsg = ModalMsg
-                        , focusManager = makeFocusManager Button.danger state.settings
-                        }
-                        attrs
-                        state.state
+            , Modal.view
+                { title = title
+                , wrapMsg = ModalMsg
+                , focusManager = makeFocusManager buttonTheme state.settings
+                }
+                attrs
+                state.state
             ]
     }
 

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -39,7 +39,8 @@ init =
 
 
 type alias Settings =
-    { visibleTitle : Bool
+    { titleVisibility : Modal.Attribute
+    , title : String
     , showX : Bool
     , showContinue : Bool
     , showSecondary : Bool
@@ -53,7 +54,8 @@ type alias Settings =
 initModalSettings : Control Settings
 initModalSettings =
     Control.record Settings
-        |> Control.field "visibleTitle" (Control.bool True)
+        |> Control.field "titleVisibility" controlTitleVisibility
+        |> Control.field "title" (Control.string "Modal Title")
         |> Control.field "showX" (Control.bool True)
         |> Control.field "showContinue" (Control.bool True)
         |> Control.field "showSecondary" (Control.bool True)
@@ -68,6 +70,14 @@ initModalSettings =
             )
         |> Control.field "customStyling" (Control.bool False)
         |> Control.field "theme" controlTheme
+
+
+controlTitleVisibility : Control Modal.Attribute
+controlTitleVisibility =
+    Control.choice
+        [ ( "showTitle", Control.value Modal.showTitle )
+        , ( "hideTitle", Control.value Modal.hideTitle )
+        ]
 
 
 controlTheme : Control Modal.Attribute
@@ -94,13 +104,6 @@ example =
                 settings =
                     Control.currentValue state.settings
 
-                titleAttrs =
-                    if settings.visibleTitle then
-                        []
-
-                    else
-                        [ Modal.hideTitle ]
-
                 stylingAttrs =
                     if settings.customStyling then
                         [ Modal.css
@@ -113,7 +116,7 @@ example =
                         []
 
                 attrs =
-                    settings.theme :: titleAttrs ++ stylingAttrs
+                    settings.theme :: settings.titleVisibility :: stylingAttrs
             in
             [ Control.view UpdateSettings state.settings
                 |> Html.fromUnstyled
@@ -124,7 +127,7 @@ example =
                 , Button.medium
                 ]
             , Modal.view
-                { title = "Modal Title"
+                { title = settings.title
                 , wrapMsg = ModalMsg
                 , focusManager = makeFocusManager settings
                 }

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -44,7 +44,7 @@ type alias Settings =
     , showContinue : Bool
     , showSecondary : Bool
     , dismissOnEscAndOverlayClick : Bool
-    , longContent : Bool
+    , content : String
     , customStyling : Bool
     , theme : Modal.Attribute
     }
@@ -58,7 +58,14 @@ initModalSettings =
         |> Control.field "showContinue" (Control.bool True)
         |> Control.field "showSecondary" (Control.bool True)
         |> Control.field "dismissOnEscAndOverlayClick" (Control.bool True)
-        |> Control.field "longContent" (Control.bool True)
+        |> Control.field "content"
+            (Control.stringTextarea <|
+                String.join "\n\n"
+                    [ "Generally, you'll want to pair the Modal.warning theme with the Button.danger theme and the Modal.info theme with the Button.primary theme."
+                    , "Muffin liquorice powder liquorice jujubes biscuit cookie candy canes lemon drops. Liquorice powder carrot cake dragée icing tootsie roll apple pie lemon drops lemon drops. Jujubes danish bear claw cotton candy. Dragée apple pie tiramisu. Sugar plum dessert pastry marzipan chocolate cake dragée sesame snaps. Marshmallow gingerbread lemon drops. Brownie chocolate fruitcake pastry. Powder jelly beans jujubes. Croissant macaroon dessert cookie candy canes jelly jujubes. Muffin liquorice ice cream wafer donut danish soufflé dragée chocolate bar. Candy croissant candy wafer toffee lemon drops croissant danish sugar plum. Cookie cake candy canes. Pastry powder muffin soufflé tootsie roll sweet cookie tiramisu."
+                    , "Candy cake danish gingerbread. Caramels toffee cupcake toffee sweet. Gummi bears candy cheesecake sweet. Pie gingerbread sugar plum halvah muffin icing marzipan wafer icing. Candy fruitcake gummies icing marzipan. Halvah jelly beans candy candy canes biscuit bonbon sesame snaps. Biscuit carrot cake croissant cake chocolate lollipop candy biscuit croissant. Topping jujubes apple pie croissant chocolate cake. Liquorice cookie dragée gummies cotton candy fruitcake lemon drops candy canes. Apple pie lemon drops gummies cake chocolate bar cake jelly-o tiramisu. Chocolate bar icing pudding marshmallow cake soufflé soufflé muffin. Powder lemon drops biscuit sugar plum cupcake carrot cake powder cake dragée. Bear claw gummi bears liquorice sweet roll."
+                    ]
+            )
         |> Control.field "customStyling" (Control.bool False)
         |> Control.field "theme" controlTheme
 
@@ -135,7 +142,7 @@ makeFocusManager settings =
                 \modalOptions ->
                     { content =
                         [ modalOptions.closeButton modalOptions.firstFocusableElement
-                        , viewModalContent settings.longContent
+                        , viewModalContent settings.content
                         ]
                     , footer =
                         [ Button.button "Continue"
@@ -158,7 +165,7 @@ makeFocusManager settings =
                 \modalOptions ->
                     { content =
                         [ modalOptions.closeButton modalOptions.firstFocusableElement
-                        , viewModalContent settings.longContent
+                        , viewModalContent settings.content
                         ]
                     , footer =
                         [ ClickableText.button "Close"
@@ -175,7 +182,7 @@ makeFocusManager settings =
                 (\{ onlyFocusableElement, closeButton } ->
                     { content =
                         [ closeButton onlyFocusableElement
-                        , viewModalContent settings.longContent
+                        , viewModalContent settings.content
                         ]
                     , footer = []
                     }
@@ -186,7 +193,7 @@ makeFocusManager settings =
                 \modalOptions ->
                     { content =
                         [ modalOptions.closeButton modalOptions.firstFocusableElement
-                        , viewModalContent settings.longContent
+                        , viewModalContent settings.content
                         ]
                     , footer =
                         [ Button.button "Continue"
@@ -201,7 +208,7 @@ makeFocusManager settings =
         ( False, True, True ) ->
             Modal.MultipleFocusableElements <|
                 \modalOptions ->
-                    { content = [ viewModalContent settings.longContent ]
+                    { content = [ viewModalContent settings.content ]
                     , footer =
                         [ Button.button "Continue"
                             [ Button.premium
@@ -221,7 +228,7 @@ makeFocusManager settings =
         ( False, False, True ) ->
             Modal.OneFocusableElement
                 (\{ onlyFocusableElement } ->
-                    { content = [ viewModalContent settings.longContent ]
+                    { content = [ viewModalContent settings.content ]
                     , footer =
                         [ ClickableText.button "Close"
                             [ ClickableText.onClick ForceClose
@@ -236,7 +243,7 @@ makeFocusManager settings =
         ( False, True, False ) ->
             Modal.OneFocusableElement
                 (\{ onlyFocusableElement } ->
-                    { content = [ viewModalContent settings.longContent ]
+                    { content = [ viewModalContent settings.content ]
                     , footer =
                         [ Button.button "Continue"
                             [ Button.premium
@@ -251,32 +258,18 @@ makeFocusManager settings =
         ( False, False, False ) ->
             Modal.OneFocusableElement
                 (\_ ->
-                    { content = [ viewModalContent settings.longContent ]
+                    { content = [ viewModalContent settings.content ]
                     , footer = []
                     }
                 )
 
 
-viewModalContent : Bool -> Html msg
-viewModalContent longContent =
+viewModalContent : String -> Html msg
+viewModalContent content =
     Text.mediumBody
-        [ span [ Attributes.css [ whiteSpace preLine ] ]
-            [ if longContent then
-                """Soufflé pastry chocolate cake danish muffin. Candy wafer pastry ice cream cheesecake toffee cookie cake carrot cake. Macaroon pie jujubes gummies cookie pie. Gummi bears brownie pastry carrot cake cotton candy. Jelly-o sweet roll biscuit cake soufflé lemon drops tiramisu marshmallow macaroon. Chocolate jelly halvah marzipan macaroon cupcake sweet cheesecake carrot cake.
-
-                    Sesame snaps pastry muffin cookie. Powder powder sweet roll toffee cake icing. Chocolate cake sweet roll gingerbread icing chupa chups sweet roll sesame snaps. Chocolate croissant chupa chups jelly beans toffee. Jujubes sweet wafer marshmallow halvah jelly. Liquorice sesame snaps sweet.
-
-                    Tootsie roll icing jelly danish ice cream tiramisu sweet roll. Fruitcake ice cream dragée. Bear claw sugar plum sweet jelly beans bonbon dragée tart. Gingerbread chocolate sweet. Apple pie danish toffee sugar plum jelly beans donut. Chocolate cake croissant caramels chocolate bar. Jelly beans caramels toffee chocolate cake liquorice. Toffee pie sugar plum cookie toffee muffin. Marzipan marshmallow marzipan liquorice tiramisu.
-
-                    Brownie ice cream halvah danish candy ice cream sweet roll jujubes chocolate cake. Chocolate bar sesame snaps bear claw gummies. Dragée cookie brownie cake sugar plum chocolate cake fruitcake toffee. Tiramisu tiramisu cookie cake. Lemon drops pie toffee icing powder biscuit cotton candy gummies. Caramels lemon drops cupcake. Lemon drops toffee macaroon liquorice chocolate bar candy bonbon. Cupcake biscuit cupcake chupa chups candy. Chocolate cake sweet toffee bonbon danish biscuit pudding. Tootsie roll brownie jelly tootsie roll. Jujubes jujubes marshmallow gummi bears bear claw sugar plum. Cupcake bonbon soufflé carrot cake powder fruitcake sugar plum brownie.
-
-                    Danish sesame snaps tiramisu chocolate cake powder cotton candy powder. Liquorice cupcake macaroon sweet soufflé jujubes. Jelly-o oat cake caramels sweet roll. Sweet roll sugar plum gummies cheesecake sesame snaps. Gummies pastry tootsie roll marzipan lollipop muffin sweet cake. Wafer carrot cake halvah bear claw jelly beans apple pie cookie halvah. Brownie sugar plum macaroon halvah croissant pastry. Marzipan muffin carrot cake chocolate jelly beans dragée jelly beans dragée tiramisu. Sweet roll powder apple pie icing halvah marshmallow pastry. Pastry marzipan chocolate cake jelly beans sugar plum carrot cake lollipop croissant. Cotton candy chocolate croissant gummies muffin. Dragée jelly beans oat cake pastry muffin pie. Donut marzipan dessert wafer gingerbread tiramisu macaroon. Cotton candy macaroon gummies oat cake cake gingerbread cotton candy sweet roll pie."""
-                    |> text
-
-              else
-                "Generally, you'll want to pair the Modal.warning theme with the Button.danger theme and the Modal.info theme with the Button.primary theme."
-                    |> text
-            ]
+        [ span
+            [ Attributes.css [ whiteSpace preLine ] ]
+            [ text content ]
         ]
 
 

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -39,28 +39,25 @@ init =
 
 
 type alias Settings =
-    { titleVisibility : Modal.Attribute
-    , title : String
+    { title : String
     , showX : Bool
     , showContinue : Bool
     , showSecondary : Bool
     , dismissOnEscAndOverlayClick : Bool
     , content : String
-    , styles : Modal.Attribute
-    , theme : Modal.Attribute
+    , attributes : List Modal.Attribute
     }
 
 
 initModalSettings : Control Settings
 initModalSettings =
     Control.record Settings
-        |> Control.field "titleVisibility" controlTitleVisibility
-        |> Control.field "title" (Control.string "Modal Title")
-        |> Control.field "showX" (Control.bool True)
-        |> Control.field "showContinue" (Control.bool True)
-        |> Control.field "showSecondary" (Control.bool True)
+        |> Control.field "Modal title" (Control.string "Modal Title")
+        |> Control.field "X button" (Control.bool True)
+        |> Control.field "Continue button" (Control.bool True)
+        |> Control.field "Close button" (Control.bool True)
         |> Control.field "dismissOnEscAndOverlayClick" (Control.bool True)
-        |> Control.field "content"
+        |> Control.field "Content"
             (Control.stringTextarea <|
                 String.join "\n\n"
                     [ "Generally, you'll want to pair the Modal.warning theme with the Button.danger theme and the Modal.info theme with the Button.primary theme."
@@ -68,8 +65,15 @@ initModalSettings =
                     , "Candy cake danish gingerbread. Caramels toffee cupcake toffee sweet. Gummi bears candy cheesecake sweet. Pie gingerbread sugar plum halvah muffin icing marzipan wafer icing. Candy fruitcake gummies icing marzipan. Halvah jelly beans candy candy canes biscuit bonbon sesame snaps. Biscuit carrot cake croissant cake chocolate lollipop candy biscuit croissant. Topping jujubes apple pie croissant chocolate cake. Liquorice cookie dragée gummies cotton candy fruitcake lemon drops candy canes. Apple pie lemon drops gummies cake chocolate bar cake jelly-o tiramisu. Chocolate bar icing pudding marshmallow cake soufflé soufflé muffin. Powder lemon drops biscuit sugar plum cupcake carrot cake powder cake dragée. Bear claw gummi bears liquorice sweet roll."
                     ]
             )
-        |> Control.field "css" controlCss
-        |> Control.field "theme" controlTheme
+        |> Control.field "Modal Attributes" controlAttributes
+
+
+controlAttributes : Control (List Modal.Attribute)
+controlAttributes =
+    Control.record (\a b c -> a :: b :: c :: [])
+        |> Control.field "Theme" controlTheme
+        |> Control.field "Title visibility" controlTitleVisibility
+        |> Control.field "Custom css" controlCss
 
 
 controlTitleVisibility : Control Modal.Attribute
@@ -127,10 +131,7 @@ example =
                 , wrapMsg = ModalMsg
                 , focusManager = makeFocusManager settings
                 }
-                [ settings.theme
-                , settings.titleVisibility
-                , settings.styles
-                ]
+                settings.attributes
                 state.state
             ]
     }

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -195,7 +195,7 @@ modalSettings settings =
         ( True, True, True ) ->
             { default
                 | content =
-                    [ Modal.closeButton ModalMsg <|
+                    [ Modal.closeButton CloseModal <|
                         Modal.firstFocusable { focusLastId = Focus closeClickableTextId }
                     , viewModalContent settings.content
                     ]
@@ -209,7 +209,7 @@ modalSettings settings =
         ( True, False, True ) ->
             { default
                 | content =
-                    [ Modal.closeButton ModalMsg <|
+                    [ Modal.closeButton CloseModal <|
                         Modal.firstFocusable { focusLastId = Focus closeClickableTextId }
                     , viewModalContent settings.content
                     ]
@@ -222,7 +222,7 @@ modalSettings settings =
         ( True, False, False ) ->
             { default
                 | content =
-                    [ Modal.closeButton ModalMsg <|
+                    [ Modal.closeButton CloseModal <|
                         Modal.onlyFocusable { focusSelf = Focus closeClickableTextId }
                     , viewModalContent settings.content
                     ]
@@ -231,7 +231,7 @@ modalSettings settings =
         ( True, True, False ) ->
             { default
                 | content =
-                    [ Modal.closeButton ModalMsg <|
+                    [ Modal.closeButton CloseModal <|
                         Modal.firstFocusable { focusLastId = Focus closeClickableTextId }
                     , viewModalContent settings.content
                     ]
@@ -290,7 +290,7 @@ continueButton : List (Html.Attribute Msg) -> Html Msg
 continueButton attributes =
     Button.button "Continue"
         [ Button.premium
-        , Button.onClick ForceClose
+        , Button.onClick CloseModal
         , Button.custom (Attributes.id continueButtonId :: attributes)
         , Button.large
         ]
@@ -304,7 +304,7 @@ closeClickableTextId =
 closeClickableText : List (Html.Attribute Msg) -> Html Msg
 closeClickableText attributes =
     ClickableText.button "Close"
-        [ ClickableText.onClick ForceClose
+        [ ClickableText.onClick CloseModal
         , ClickableText.large
         , ClickableText.custom (Attributes.id closeClickableTextId :: attributes)
         , ClickableText.css [ Css.marginTop (Css.px 15) ]
@@ -315,7 +315,7 @@ closeClickableText attributes =
 type Msg
     = OpenModal { startFocusOn : String, returnFocusTo : String }
     | ModalMsg Modal.Msg
-    | ForceClose
+    | CloseModal
     | UpdateSettings (Control Settings)
     | Focus String
     | Focused (Result Dom.Error ())
@@ -350,7 +350,7 @@ update msg state =
                     , Cmd.map ModalMsg cmd
                     )
 
-        ForceClose ->
+        CloseModal ->
             let
                 ( newState, cmd ) =
                     Modal.close state.state

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -20,6 +20,7 @@ import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Checkbox.V5 as Checkbox
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.FocusTrap.V1 as FocusTrap
 import Nri.Ui.Modal.V11 as Modal
 import Nri.Ui.Text.V4 as Text
 import Task
@@ -196,13 +197,13 @@ modalSettings settings =
             { default
                 | content =
                     [ Modal.closeButton CloseModal <|
-                        Modal.firstFocusable { focusLastId = Focus closeClickableTextId }
+                        FocusTrap.first { focusLastId = Focus closeClickableTextId }
                     , viewModalContent settings.content
                     ]
                 , footer =
                     [ continueButton []
                     , closeClickableText <|
-                        Modal.lastFocusable { focusFirstId = Focus Modal.closeButtonId }
+                        FocusTrap.last { focusFirstId = Focus Modal.closeButtonId }
                     ]
             }
 
@@ -210,12 +211,12 @@ modalSettings settings =
             { default
                 | content =
                     [ Modal.closeButton CloseModal <|
-                        Modal.firstFocusable { focusLastId = Focus closeClickableTextId }
+                        FocusTrap.first { focusLastId = Focus closeClickableTextId }
                     , viewModalContent settings.content
                     ]
                 , footer =
                     [ closeClickableText <|
-                        Modal.lastFocusable { focusFirstId = Focus Modal.closeButtonId }
+                        FocusTrap.last { focusFirstId = Focus Modal.closeButtonId }
                     ]
             }
 
@@ -223,7 +224,7 @@ modalSettings settings =
             { default
                 | content =
                     [ Modal.closeButton CloseModal <|
-                        Modal.onlyFocusable { focusSelf = Focus closeClickableTextId }
+                        FocusTrap.only { focusSelf = Focus closeClickableTextId }
                     , viewModalContent settings.content
                     ]
             }
@@ -232,12 +233,12 @@ modalSettings settings =
             { default
                 | content =
                     [ Modal.closeButton CloseModal <|
-                        Modal.firstFocusable { focusLastId = Focus closeClickableTextId }
+                        FocusTrap.first { focusLastId = Focus closeClickableTextId }
                     , viewModalContent settings.content
                     ]
                 , footer =
                     [ continueButton <|
-                        Modal.lastFocusable { focusFirstId = Focus Modal.closeButtonId }
+                        FocusTrap.last { focusFirstId = Focus Modal.closeButtonId }
                     ]
             }
 
@@ -246,9 +247,9 @@ modalSettings settings =
                 | content = [ viewModalContent settings.content ]
                 , footer =
                     [ continueButton <|
-                        Modal.firstFocusable { focusLastId = Focus closeClickableTextId }
+                        FocusTrap.first { focusLastId = Focus closeClickableTextId }
                     , closeClickableText <|
-                        Modal.lastFocusable { focusFirstId = Focus Modal.closeButtonId }
+                        FocusTrap.last { focusFirstId = Focus Modal.closeButtonId }
                     ]
             }
 
@@ -257,7 +258,7 @@ modalSettings settings =
                 | content = [ viewModalContent settings.content ]
                 , footer =
                     [ closeClickableText <|
-                        Modal.onlyFocusable { focusSelf = Focus closeClickableTextId }
+                        FocusTrap.only { focusSelf = Focus closeClickableTextId }
                     ]
             }
 
@@ -266,7 +267,7 @@ modalSettings settings =
                 | content = [ viewModalContent settings.content ]
                 , footer =
                     [ continueButton <|
-                        Modal.onlyFocusable { focusSelf = Focus continueButtonId }
+                        FocusTrap.only { focusSelf = Focus continueButtonId }
                     ]
             }
 

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -379,18 +379,28 @@ update msg state =
     in
     case msg of
         OpenModal content returnFocusTo ->
-            update (ModalMsg (Modal.open returnFocusTo)) { state | content = content }
+            let
+                ( newState, cmd ) =
+                    Modal.open returnFocusTo
+            in
+            ( { state | content = content, state = newState }
+            , Cmd.map ModalMsg cmd
+            )
 
         ModalMsg modalMsg ->
             case Modal.update updateConfig modalMsg state.state of
-                ( newState, cmds ) ->
+                ( newState, cmd ) ->
                     ( { state | state = newState }
-                    , Cmd.map ModalMsg cmds
+                    , Cmd.map ModalMsg cmd
                     )
 
         ForceClose ->
-            ( { state | state = Modal.init }
-            , Cmd.none
+            let
+                ( newState, cmd ) =
+                    Modal.close state.state
+            in
+            ( { state | state = newState }
+            , Cmd.map ModalMsg cmd
             )
 
         SetVisibleTitle value ->

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -46,7 +46,7 @@ type alias Settings =
     , showSecondary : Bool
     , dismissOnEscAndOverlayClick : Bool
     , content : String
-    , customStyling : Bool
+    , styles : Modal.Attribute
     , theme : Modal.Attribute
     }
 
@@ -68,7 +68,7 @@ initModalSettings =
                     , "Candy cake danish gingerbread. Caramels toffee cupcake toffee sweet. Gummi bears candy cheesecake sweet. Pie gingerbread sugar plum halvah muffin icing marzipan wafer icing. Candy fruitcake gummies icing marzipan. Halvah jelly beans candy candy canes biscuit bonbon sesame snaps. Biscuit carrot cake croissant cake chocolate lollipop candy biscuit croissant. Topping jujubes apple pie croissant chocolate cake. Liquorice cookie dragée gummies cotton candy fruitcake lemon drops candy canes. Apple pie lemon drops gummies cake chocolate bar cake jelly-o tiramisu. Chocolate bar icing pudding marshmallow cake soufflé soufflé muffin. Powder lemon drops biscuit sugar plum cupcake carrot cake powder cake dragée. Bear claw gummi bears liquorice sweet roll."
                     ]
             )
-        |> Control.field "customStyling" (Control.bool False)
+        |> Control.field "css" controlCss
         |> Control.field "theme" controlTheme
 
 
@@ -88,6 +88,16 @@ controlTheme =
         ]
 
 
+controlCss : Control Modal.Attribute
+controlCss =
+    Control.map Modal.css <|
+        Control.choice
+            [ ( "[]", Control.value [] )
+            , ( "[ Css.borderRadius Css.zero ]", Control.value [ Css.borderRadius Css.zero ] )
+            , ( "[ Css.width (Css.px 900) ]", Control.value [ Css.width (Css.px 900) ] )
+            ]
+
+
 {-| -}
 example : Example State Msg
 example =
@@ -103,20 +113,6 @@ example =
             let
                 settings =
                     Control.currentValue state.settings
-
-                stylingAttrs =
-                    if settings.customStyling then
-                        [ Modal.css
-                            [ Css.borderRadius Css.zero
-                            , Css.width (Css.px 800)
-                            ]
-                        ]
-
-                    else
-                        []
-
-                attrs =
-                    settings.theme :: settings.titleVisibility :: stylingAttrs
             in
             [ Control.view UpdateSettings state.settings
                 |> Html.fromUnstyled
@@ -131,7 +127,10 @@ example =
                 , wrapMsg = ModalMsg
                 , focusManager = makeFocusManager settings
                 }
-                attrs
+                [ settings.theme
+                , settings.titleVisibility
+                , settings.styles
+                ]
                 state.state
             ]
     }

--- a/styleguide-app/KeyboardSupport.elm
+++ b/styleguide-app/KeyboardSupport.elm
@@ -56,6 +56,7 @@ type Key
     | Arrow Direction
     | Tab
     | Space
+    | Esc
 
 
 keyToString : Key -> String
@@ -75,6 +76,9 @@ keyToString key =
 
         Space ->
             "Space"
+
+        Esc ->
+            "Escape"
 
 
 {-| -}

--- a/styleguide-app/Main.elm
+++ b/styleguide-app/Main.elm
@@ -269,6 +269,16 @@ navigation route openAtomicDesignTypes =
                 , color Colors.azure
                 , Fonts.baseFont
                 , Css.marginBottom (px 20)
+                , Css.pseudoClass "not(:focus)"
+                    [ Css.property "clip" "rect(1px, 1px, 1px, 1px)"
+                    , Css.position Css.absolute
+                    , Css.height (Css.px 1)
+                    , Css.width (Css.px 1)
+                    , Css.overflow Css.hidden
+                    , Css.margin (Css.px -1)
+                    , Css.padding Css.zero
+                    , Css.border Css.zero
+                    ]
                 ]
             , Events.onClick SkipToMainContent
             , id "skip"

--- a/styleguide-app/Main.elm
+++ b/styleguide-app/Main.elm
@@ -147,6 +147,13 @@ view_ model =
                         && Set.memberOf model.atomicDesignTypes m.atomicDesignType
                 )
                 (Dict.values model.moduleStates)
+
+        mainContentHeader heading =
+            Heading.h2
+                [ Heading.customAttr (id "maincontent")
+                , Heading.customAttr (tabindex -1)
+                ]
+                [ Html.text heading ]
     in
     Html.div
         [ css
@@ -156,54 +163,44 @@ view_ model =
             ]
         ]
         [ navigation model.route model.atomicDesignTypes
-        , Html.main_
-            [ css [ flexGrow (int 1) ]
-            , id "maincontent"
-            , Attributes.tabindex -1
-            ]
+        , Html.main_ [ css [ flexGrow (int 1), sectionStyles ] ]
             (case model.route of
                 Routes.Doodad doodad ->
-                    [ Html.section [ css [ sectionStyles ] ]
-                        [ Heading.h2 [] [ Html.text ("Viewing " ++ doodad ++ " doodad only") ]
-                        , examples (\m -> m.name == doodad)
-                            |> List.map
-                                (\example ->
-                                    Example.view False example
-                                        |> Html.map (UpdateModuleStates example.name)
-                                )
-                            |> Html.div []
-                        ]
+                    [ mainContentHeader ("Viewing " ++ doodad ++ " doodad only")
+                    , examples (\m -> m.name == doodad)
+                        |> List.map
+                            (\example ->
+                                Example.view False example
+                                    |> Html.map (UpdateModuleStates example.name)
+                            )
+                        |> Html.div []
                     ]
 
                 Routes.Category category ->
-                    [ Html.section [ css [ sectionStyles ] ]
-                        [ Heading.h2 [] [ Html.text (Category.forDisplay category) ]
-                        , examples
-                            (\doodad ->
-                                Set.memberOf
-                                    (Set.fromList Category.sorter doodad.categories)
-                                    category
+                    [ mainContentHeader (Category.forDisplay category)
+                    , examples
+                        (\doodad ->
+                            Set.memberOf
+                                (Set.fromList Category.sorter doodad.categories)
+                                category
+                        )
+                        |> List.map
+                            (\example ->
+                                Example.view True example
+                                    |> Html.map (UpdateModuleStates example.name)
                             )
-                            |> List.map
-                                (\example ->
-                                    Example.view True example
-                                        |> Html.map (UpdateModuleStates example.name)
-                                )
-                            |> Html.div [ id (Category.forId category) ]
-                        ]
+                        |> Html.div [ id (Category.forId category) ]
                     ]
 
                 Routes.All ->
-                    [ Html.section [ css [ sectionStyles ] ]
-                        [ Heading.h2 [] [ Html.text "All" ]
-                        , examples (\_ -> True)
-                            |> List.map
-                                (\example ->
-                                    Example.view True example
-                                        |> Html.map (UpdateModuleStates example.name)
-                                )
-                            |> Html.div []
-                        ]
+                    [ mainContentHeader "All"
+                    , examples (\_ -> True)
+                        |> List.map
+                            (\example ->
+                                Example.view True example
+                                    |> Html.map (UpdateModuleStates example.name)
+                            )
+                        |> Html.div []
                     ]
             )
         ]

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -19,6 +19,7 @@
         "Nri.Ui.Divider.V2",
         "Nri.Ui.Effects.V1",
         "Nri.Ui.Fonts.V1",
+        "Nri.Ui.FocusTrap.V1",
         "Nri.Ui.Heading.V2",
         "Nri.Ui.Html.Attributes.V2",
         "Nri.Ui.Html.V3",

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -35,6 +35,7 @@
         "Nri.Ui.Message.V2",
         "Nri.Ui.Modal.V3",
         "Nri.Ui.Modal.V10",
+        "Nri.Ui.Modal.V11",
         "Nri.Ui.Page.V3",
         "Nri.Ui.Palette.V1",
         "Nri.Ui.Pennant.V2",


### PR DESCRIPTION
- Adds new Modal version with API and focus management improvements
- Changes the example to use Debug.Control rather than a bajillion buttons and Msgs
- Adds KeyboardSupport notes to the example
- Hides the Skip to Content Button when it's not focused
- adds `custom` helper for adding arbitrary html attributes (primarily useful to make limiting the scope of selectors in tests easier by adding ids to modals)
- tab and tabback events stop propagation and prevent default 
- Refactors so that the ids don't overwrite each other -- this pushes responsibility for managing focus on to engineers a bit more. Introduces new FocusTrap module. (Hopefully this will be useful for banners like the one for writing connection loss errors)

<img width="771" alt="Screen Shot 2020-09-02 at 2 19 48 PM" src="https://user-images.githubusercontent.com/8811312/92038044-a1a9f900-ed27-11ea-9c8e-d4d00ba209fb.png">

![hide skip button](https://user-images.githubusercontent.com/8811312/92038052-a40c5300-ed27-11ea-8d77-fab4d6ac1e32.gif)


### Known Issues:

With focus in the URL bar (CMD+L), hitting tab takes you under the overlay. I'm tempted to further mess with the tabIndex, unless people have other ideas...?

~~The firstFocusable/lastFocusable/etc attributes overwrite the id of the element to which they're attached. Is there a better alternative here..?~~

Sometimes a modal's outcomes will impact what buttons appear on the page (including whether the button that launched it is present or not). E.g., "Add" button disappears if the user saves from the modal, but doesn't disappear if the user cancels from the modal.