### PR TITLE
don't shrink icons in messages in narrow parents

### DIFF
--- a/src/Nri/Ui/Message/V2.elm
+++ b/src/Nri/Ui/Message/V2.elm
@@ -569,7 +569,7 @@ getIcon size theme =
                         |> NriSvg.withColor Colors.yellow
                         |> NriSvg.withWidth iconSize
                         |> NriSvg.withHeight iconSize
-                        |> NriSvg.withCss [ marginRight ]
+                        |> NriSvg.withCss [ marginRight, Css.flexShrink Css.zero ]
                         |> NriSvg.withLabel "Tip"
                         |> NriSvg.toHtml
 
@@ -578,7 +578,7 @@ getIcon size theme =
                         |> NriSvg.withColor Colors.navy
                         |> NriSvg.withWidth iconSize
                         |> NriSvg.withHeight iconSize
-                        |> NriSvg.withCss [ marginRight ]
+                        |> NriSvg.withCss [ marginRight, Css.flexShrink Css.zero ]
                         |> NriSvg.withLabel "Tip"
                         |> NriSvg.toHtml
 
@@ -591,6 +591,7 @@ getIcon size theme =
                             , Css.marginRight (Css.px 20)
                             , backgroundColor Colors.navy
                             , displayFlex
+                            , Css.flexShrink Css.zero
                             , alignItems center
                             , justifyContent center
                             ]


### PR DESCRIPTION
Icons were being smooshed in messages. Now they're not!

## Before

![image](https://user-images.githubusercontent.com/355401/92736603-0bd22780-f340-11ea-9d06-66241e637f97.png)

## After

![image](https://user-images.githubusercontent.com/355401/92736648-15f42600-f340-11ea-915a-6c9fde30dc92.png)
