### PR TITLE
Fab/accordion v2

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -7,6 +7,7 @@
     "exposed-modules": [
         "Nri.Ui",
         "Nri.Ui.Accordion.V1",
+        "Nri.Ui.Accordion.V2",
         "Nri.Ui.AssetPath",
         "Nri.Ui.AssignmentIcon.V2",
         "Nri.Ui.Button.V10",

--- a/src/Nri/Ui/Accordion/V2.elm
+++ b/src/Nri/Ui/Accordion/V2.elm
@@ -1,16 +1,17 @@
 module Nri.Ui.Accordion.V2 exposing
     ( view
-    , viewCaret, Caret(..)
+    , Caret(..)
     , StyleOptions
     )
 
 {-| Changes from V1:
 
-  - combine view and viewKeyed so that nodes are always keyed
+  - Combine view and viewKeyed so that nodes are always keyed
+  - Removes viewCaret from the API -- it's possible to use the DisclosureIndicator directly
   - Changed implementation to follow recommendations from <https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html>
 
-@docs view, viewKeyed
-@docs viewCaret, Caret
+@docs view
+@docs Caret
 @docs StyleOptions
 
 -}

--- a/src/Nri/Ui/Accordion/V2.elm
+++ b/src/Nri/Ui/Accordion/V2.elm
@@ -1,10 +1,12 @@
-module Nri.Ui.Accordion.V1 exposing
+module Nri.Ui.Accordion.V2 exposing
     ( view, viewKeyed
     , viewCaret, Caret(..)
     , AccordionOptions, StyleOptions
     )
 
-{-|
+{-| Changes from V1:
+
+  - Changed implementation to follow recommendations from <https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html>
 
 @docs view, viewKeyed
 @docs viewCaret, Caret

--- a/src/Nri/Ui/Accordion/V2.elm
+++ b/src/Nri/Ui/Accordion/V2.elm
@@ -208,7 +208,7 @@ viewEntry :
 viewEntry { headerId, headerLevel, viewHeader, viewContent, styleOptions, caret, toggle, entry, isExpanded, arrowDown, arrowUp } =
     let
         newStyleOptions =
-            case Maybe.map (\styles_ -> styles_ entry) styleOptions of
+            case Maybe.map (\toStyles -> toStyles entry) styleOptions of
                 Just { entryStyles, entryExpandedStyles, entryClosedStyles, headerStyles, headerExpandedStyles, headerClosedStyles, contentStyles } ->
                     { entryStyles = defaultStyleOptions.entryStyles ++ entryStyles
                     , entryExpandedStyles = defaultStyleOptions.entryExpandedStyles ++ entryExpandedStyles

--- a/src/Nri/Ui/Accordion/V2.elm
+++ b/src/Nri/Ui/Accordion/V2.elm
@@ -1,0 +1,246 @@
+module Nri.Ui.Accordion.V1 exposing
+    ( view, viewKeyed
+    , viewCaret, Caret(..)
+    , AccordionOptions, StyleOptions
+    )
+
+{-|
+
+@docs view, viewKeyed
+@docs viewCaret, Caret
+@docs AccordionOptions, StyleOptions
+
+-}
+
+import Accessibility.Styled exposing (Attribute, Html, button, div, text)
+import Accessibility.Styled.Role as Role
+import Css exposing (..)
+import Css.Global
+import Html.Styled.Attributes as Attributes
+import Html.Styled.Events exposing (onClick)
+import Html.Styled.Keyed
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.DisclosureIndicator.V2 as DisclosureIndicator
+import Nri.Ui.Fonts.V1 as Fonts
+
+
+{-| -}
+type alias AccordionOptions entry msg =
+    { entries : List ( entry, Bool )
+    , viewHeader : entry -> Html msg
+    , viewContent : entry -> Html msg
+    , customStyles : Maybe (entry -> StyleOptions)
+    , caret : Caret
+    , toggle : entry -> Bool -> msg
+    }
+
+
+{-| -}
+type alias StyleOptions =
+    { entryStyles : List Style
+    , entryExpandedStyles : List Style
+    , entryClosedStyles : List Style
+    , headerStyles : List Style
+    , headerExpandedStyles : List Style
+    , headerClosedStyles : List Style
+    , contentStyles : List Style
+    }
+
+
+defaultStyleOptions : StyleOptions
+defaultStyleOptions =
+    { entryStyles =
+        [ position relative
+        , marginBottom (px 10)
+        ]
+    , entryExpandedStyles = []
+    , entryClosedStyles = []
+    , headerStyles =
+        [ displayFlex
+        , alignItems center
+        , boxSizing borderBox
+        , minWidth (pct 100)
+        , overflow hidden
+        , padding2 (px 8) (px 15)
+        , backgroundColor Colors.gray96
+
+        -- button resets
+        , cursor pointer
+        , borderWidth Css.zero
+        , margin zero
+
+        -- fonts & text
+        , textAlign left
+        , Fonts.baseFont
+        , fontSize (px 16)
+        , fontWeight (int 600)
+        , lineHeight (num 1.2)
+        ]
+    , headerExpandedStyles =
+        [ color Colors.navy
+        , borderRadius4 (px 8) (px 8) (px 0) (px 0)
+        ]
+    , headerClosedStyles =
+        [ color Colors.azure
+        , borderRadius (px 8)
+        ]
+    , contentStyles = [ overflow hidden ]
+    }
+
+
+{-| DefaultCaret is the blue caret
+-}
+type Caret
+    = DefaultCaret
+    | WhiteCaret
+    | NoneCaret
+
+
+{-| -}
+view : AccordionOptions entry msg -> Html msg
+view { entries, viewHeader, viewContent, customStyles, caret, toggle } =
+    div
+        [ Attributes.class "accordion"
+        , Attributes.attribute "role" "tablist"
+        , Attributes.attribute "aria-live" "polite"
+        ]
+        (List.map (viewEntry viewHeader viewContent customStyles caret toggle) entries)
+
+
+{-| If your accordion's rows can be moved around, use viewKeyed. It prevents
+the caret's animation from firing off incorrectly when rows move.
+-}
+viewKeyed : AccordionOptions entry msg -> (entry -> String) -> Html msg
+viewKeyed { entries, viewHeader, viewContent, customStyles, caret, toggle } identifier =
+    div
+        [ Attributes.class "accordion"
+        , Attributes.attribute "role" "tablist"
+        , Attributes.attribute "aria-live" "polite"
+        ]
+        [ Html.Styled.Keyed.node "div"
+            []
+            (List.map
+                (\( entry, isExpanded ) ->
+                    ( identifier entry
+                    , viewEntry viewHeader viewContent customStyles caret toggle ( entry, isExpanded )
+                    )
+                )
+                entries
+            )
+        ]
+
+
+viewEntry :
+    (entry -> Html msg)
+    -> (entry -> Html msg)
+    -> Maybe (entry -> StyleOptions)
+    -> Caret
+    -> (entry -> Bool -> msg)
+    -> ( entry, Bool )
+    -> Html msg
+viewEntry viewHeader viewContent styleOptions caret toggle ( entry, expanded ) =
+    let
+        newStyleOptions =
+            case Maybe.map (\styles_ -> styles_ entry) styleOptions of
+                Just { entryStyles, entryExpandedStyles, entryClosedStyles, headerStyles, headerExpandedStyles, headerClosedStyles, contentStyles } ->
+                    { entryStyles = defaultStyleOptions.entryStyles ++ entryStyles
+                    , entryExpandedStyles = defaultStyleOptions.entryExpandedStyles ++ entryExpandedStyles
+                    , entryClosedStyles = defaultStyleOptions.entryClosedStyles ++ entryClosedStyles
+                    , headerStyles = defaultStyleOptions.headerStyles ++ headerStyles
+                    , headerExpandedStyles = defaultStyleOptions.headerExpandedStyles ++ headerExpandedStyles
+                    , headerClosedStyles = defaultStyleOptions.headerClosedStyles ++ headerClosedStyles
+                    , contentStyles = defaultStyleOptions.contentStyles ++ contentStyles
+                    }
+
+                Nothing ->
+                    defaultStyleOptions
+
+        styles =
+            if expanded then
+                { entry = newStyleOptions.entryStyles ++ newStyleOptions.entryExpandedStyles
+                , header = newStyleOptions.headerStyles ++ newStyleOptions.headerExpandedStyles
+                , content = newStyleOptions.contentStyles
+                }
+
+            else
+                { entry = newStyleOptions.entryStyles ++ newStyleOptions.entryClosedStyles
+                , header = newStyleOptions.headerStyles ++ newStyleOptions.headerClosedStyles
+                , content = [ maxHeight (px 0) ]
+                }
+    in
+    div
+        [ entryClass expanded
+        , Attributes.attribute "role" "tab"
+        , Attributes.css styles.entry
+        ]
+        [ entryHeader expanded viewHeader styles.header caret toggle entry
+        , entryPanel expanded viewContent styles.content entry
+        ]
+
+
+{-| Used for tests that rely on classnames, and couple edge cases where we need to override styles using sass
+-}
+entryClass : Bool -> Attribute msg
+entryClass expanded =
+    Attributes.classList
+        [ ( "accordion-entry", True )
+        , ( "accordion-entry-state-expanded", expanded )
+        , ( "accordion-entry-state-collapsed", not expanded )
+        ]
+
+
+entryHeader :
+    Bool
+    -> (entry -> Html msg)
+    -> List Style
+    -> Caret
+    -> (entry -> Bool -> msg)
+    -> entry
+    -> Html msg
+entryHeader expanded viewHeader styles caret toggle entry =
+    button
+        [ Attributes.class "accordion-entry-header"
+        , onClick (toggle entry (not expanded))
+        , Attributes.css styles
+        ]
+        [ viewCaret expanded caret
+        , viewHeader entry
+        ]
+
+
+
+-- TODO change content/body instances to panel
+
+
+entryPanel : Bool -> (entry -> Html msg) -> List Style -> entry -> Html msg
+entryPanel expanded viewContent styles entry =
+    div
+        [ Attributes.class "accordion-entry-panel"
+        , Attributes.hidden (not expanded)
+        , Attributes.attribute "role" "tabpanel"
+        , Attributes.css styles
+        ]
+        [ viewContent entry ]
+
+
+{-| Just the caret!
+-}
+viewCaret : Bool -> Caret -> Html msg
+viewCaret expanded caret =
+    case caret of
+        DefaultCaret ->
+            DisclosureIndicator.large
+                [ marginRight (px 8)
+                ]
+                expanded
+
+        WhiteCaret ->
+            DisclosureIndicator.large
+                [ marginRight (px 8)
+                , Css.Global.descendants
+                    [ Css.Global.everything [ color Colors.white ] ]
+                ]
+                expanded
+
+        NoneCaret ->
+            text ""

--- a/src/Nri/Ui/Accordion/V2.elm
+++ b/src/Nri/Ui/Accordion/V2.elm
@@ -1,7 +1,7 @@
 module Nri.Ui.Accordion.V2 exposing
     ( view, viewKeyed
     , viewCaret, Caret(..)
-    , AccordionOptions, StyleOptions
+    , StyleOptions
     )
 
 {-| Changes from V1:
@@ -10,7 +10,7 @@ module Nri.Ui.Accordion.V2 exposing
 
 @docs view, viewKeyed
 @docs viewCaret, Caret
-@docs AccordionOptions, StyleOptions
+@docs StyleOptions
 
 -}
 
@@ -24,17 +24,6 @@ import Html.Styled.Keyed
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.DisclosureIndicator.V2 as DisclosureIndicator
 import Nri.Ui.Fonts.V1 as Fonts
-
-
-{-| -}
-type alias AccordionOptions entry msg =
-    { entries : List ( entry, Bool )
-    , viewHeader : entry -> Html msg
-    , viewContent : entry -> Html msg
-    , customStyles : Maybe (entry -> StyleOptions)
-    , caret : Caret
-    , toggle : entry -> Bool -> msg
-    }
 
 
 {-| -}
@@ -99,7 +88,15 @@ type Caret
 
 
 {-| -}
-view : AccordionOptions entry msg -> Html msg
+view :
+    { entries : List ( entry, Bool )
+    , viewHeader : entry -> Html msg
+    , viewContent : entry -> Html msg
+    , customStyles : Maybe (entry -> StyleOptions)
+    , caret : Caret
+    , toggle : entry -> Bool -> msg
+    }
+    -> Html msg
 view { entries, viewHeader, viewContent, customStyles, caret, toggle } =
     div
         [ Attributes.class "accordion"
@@ -112,7 +109,16 @@ view { entries, viewHeader, viewContent, customStyles, caret, toggle } =
 {-| If your accordion's rows can be moved around, use viewKeyed. It prevents
 the caret's animation from firing off incorrectly when rows move.
 -}
-viewKeyed : AccordionOptions entry msg -> (entry -> String) -> Html msg
+viewKeyed :
+    { entries : List ( entry, Bool )
+    , viewHeader : entry -> Html msg
+    , viewContent : entry -> Html msg
+    , customStyles : Maybe (entry -> StyleOptions)
+    , caret : Caret
+    , toggle : entry -> Bool -> msg
+    }
+    -> (entry -> String)
+    -> Html msg
 viewKeyed { entries, viewHeader, viewContent, customStyles, caret, toggle } identifier =
     div
         [ Attributes.class "accordion"

--- a/src/Nri/Ui/Accordion/V2.elm
+++ b/src/Nri/Ui/Accordion/V2.elm
@@ -1,11 +1,12 @@
 module Nri.Ui.Accordion.V2 exposing
-    ( view, viewKeyed
+    ( view
     , viewCaret, Caret(..)
     , StyleOptions
     )
 
 {-| Changes from V1:
 
+  - combine view and viewKeyed so that nodes are always keyed
   - Changed implementation to follow recommendations from <https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html>
 
 @docs view, viewKeyed
@@ -89,7 +90,7 @@ type Caret
 
 {-| -}
 view :
-    { entries : List ( entry, Bool )
+    { entries : List ( String, entry, Bool )
     , viewHeader : entry -> Html msg
     , viewContent : entry -> Html msg
     , customStyles : Maybe (entry -> StyleOptions)
@@ -103,33 +104,11 @@ view { entries, viewHeader, viewContent, customStyles, caret, toggle } =
         , Attributes.attribute "role" "tablist"
         , Attributes.attribute "aria-live" "polite"
         ]
-        (List.map (viewEntry viewHeader viewContent customStyles caret toggle) entries)
-
-
-{-| If your accordion's rows can be moved around, use viewKeyed. It prevents
-the caret's animation from firing off incorrectly when rows move.
--}
-viewKeyed :
-    { entries : List ( entry, Bool )
-    , viewHeader : entry -> Html msg
-    , viewContent : entry -> Html msg
-    , customStyles : Maybe (entry -> StyleOptions)
-    , caret : Caret
-    , toggle : entry -> Bool -> msg
-    }
-    -> (entry -> String)
-    -> Html msg
-viewKeyed { entries, viewHeader, viewContent, customStyles, caret, toggle } identifier =
-    div
-        [ Attributes.class "accordion"
-        , Attributes.attribute "role" "tablist"
-        , Attributes.attribute "aria-live" "polite"
-        ]
         [ Html.Styled.Keyed.node "div"
             []
             (List.map
-                (\( entry, isExpanded ) ->
-                    ( identifier entry
+                (\( identifier, entry, isExpanded ) ->
+                    ( identifier
                     , viewEntry viewHeader viewContent customStyles caret toggle ( entry, isExpanded )
                     )
                 )

--- a/src/Nri/Ui/Accordion/V2.elm
+++ b/src/Nri/Ui/Accordion/V2.elm
@@ -238,7 +238,7 @@ viewEntry { headerId, headerLevel, viewHeader, viewContent, styleOptions, caret,
         panelId =
             "accordion-panel__" ++ headerId
     in
-    section
+    div
         [ entryClass isExpanded
         , Attributes.css styles.entry
         ]
@@ -260,8 +260,9 @@ viewEntry { headerId, headerLevel, viewHeader, viewContent, styleOptions, caret,
                 [ viewCaret isExpanded caret
                 , viewHeader entry
                 ]
-        , div
+        , section
             [ Attributes.id panelId
+            , Aria.labelledBy headerId
             , Attributes.class "accordion-entry-panel"
             , Attributes.hidden (not isExpanded)
             , Attributes.css styles.content

--- a/styleguide-app/Examples/Accordion.elm
+++ b/styleguide-app/Examples/Accordion.elm
@@ -52,7 +52,10 @@ view model =
             ]
                 |> List.map
                     (\entry ->
-                        ( entry, Dict.get entry.id model |> Maybe.withDefault False )
+                        ( "accordion-entry__" ++ String.fromInt entry.id
+                        , entry
+                        , Dict.get entry.id model |> Maybe.withDefault False
+                        )
                     )
         , viewHeader = .title >> Html.text
         , viewContent = \{ content } -> Text.smallBody [ Html.text content ]
@@ -81,7 +84,10 @@ view model =
             ]
                 |> List.map
                     (\entry ->
-                        ( entry, Dict.get entry.id model |> Maybe.withDefault False )
+                        ( "accordion-entry__" ++ String.fromInt entry.id
+                        , entry
+                        , Dict.get entry.id model |> Maybe.withDefault False
+                        )
                     )
         , viewHeader = .title >> Html.text
         , viewContent = .content

--- a/styleguide-app/Examples/Accordion.elm
+++ b/styleguide-app/Examples/Accordion.elm
@@ -66,6 +66,7 @@ view model =
                         , isExpanded = Dict.get entry.id model |> Maybe.withDefault False
                         }
                     )
+        , headerLevel = Accordion.H4
         , viewHeader = .title >> Html.text
         , viewContent = \{ content } -> Text.smallBody [ Html.text content ]
         , customStyles = Nothing
@@ -99,6 +100,7 @@ view model =
                         , isExpanded = Dict.get entry.id model |> Maybe.withDefault False
                         }
                     )
+        , headerLevel = Accordion.H4
         , viewHeader = .title >> Html.text
         , viewContent = .content
         , customStyles =

--- a/styleguide-app/Examples/Accordion.elm
+++ b/styleguide-app/Examples/Accordion.elm
@@ -18,7 +18,7 @@ import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Direction(..), Key(..))
-import Nri.Ui.Accordion.V1 as Accordion
+import Nri.Ui.Accordion.V2 as Accordion
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V2 as Heading
@@ -29,7 +29,7 @@ import Nri.Ui.Text.V4 as Text
 example : Example State Msg
 example =
     { name = "Accordion"
-    , version = 1
+    , version = 2
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none


### PR DESCRIPTION
- Combine view and viewKeyed so that nodes are always keyed
  - Removes viewCaret from the API -- it's possible to use the DisclosureIndicator directly
  - Changed implementation to follow recommendations from <https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html>
      - Adds Up and Down keyboard handling for navigating between the accordions
      - Adds aria-expanded and aria-controls
      - Changes accordion container to a section
      - removes tablist/tab/tabpanel roles
      - Adds heading levels for the accordion header (including style resets)

![accordion](https://user-images.githubusercontent.com/8811312/92970540-b119f800-f433-11ea-91c4-c93968d2134f.gif)
