### PR TITLE
stop icons from shrinking and top-align them

### DIFF
--- a/src/Nri/Ui/Message/V2.elm
+++ b/src/Nri/Ui/Message/V2.elm
@@ -112,7 +112,7 @@ view attributes_ =
                     "Nri-Ui-Message--tiny"
                     [ displayFlex
                     , justifyContent start
-                    , alignItems center
+                    , alignItems flexStart
                     , paddingTop (px 6)
                     , paddingBottom (px 8)
                     , fontSize (px 13)

--- a/src/Nri/Ui/Message/V2.elm
+++ b/src/Nri/Ui/Message/V2.elm
@@ -540,7 +540,7 @@ getIcon size theme =
                 |> NriSvg.withColor Colors.purple
                 |> NriSvg.withWidth iconSize
                 |> NriSvg.withHeight iconSize
-                |> NriSvg.withCss [ marginRight ]
+                |> NriSvg.withCss [ marginRight, Css.flexShrink Css.zero ]
                 |> NriSvg.withLabel "Error"
                 |> NriSvg.toHtml
 
@@ -558,7 +558,7 @@ getIcon size theme =
                 |> NriSvg.withColor color
                 |> NriSvg.withWidth iconSize
                 |> NriSvg.withHeight iconSize
-                |> NriSvg.withCss [ marginRight ]
+                |> NriSvg.withCss [ marginRight, Css.flexShrink Css.zero ]
                 |> NriSvg.withLabel "Alert"
                 |> NriSvg.toHtml
 
@@ -608,7 +608,7 @@ getIcon size theme =
                 |> NriSvg.withColor Colors.green
                 |> NriSvg.withWidth iconSize
                 |> NriSvg.withHeight iconSize
-                |> NriSvg.withCss [ marginRight ]
+                |> NriSvg.withCss [ marginRight, Css.flexShrink Css.zero ]
                 |> NriSvg.withLabel "Success"
                 |> NriSvg.toHtml
 
@@ -616,7 +616,7 @@ getIcon size theme =
             icon
                 |> NriSvg.withWidth iconSize
                 |> NriSvg.withHeight iconSize
-                |> NriSvg.withCss [ marginRight ]
+                |> NriSvg.withCss [ marginRight, Css.flexShrink Css.zero ]
                 |> NriSvg.toHtml
 
 

--- a/src/Nri/Ui/Message/V2.elm
+++ b/src/Nri/Ui/Message/V2.elm
@@ -112,13 +112,13 @@ view attributes_ =
                     "Nri-Ui-Message--tiny"
                     [ displayFlex
                     , justifyContent start
-                    , alignItems flexStart
+                    , alignItems center
                     , paddingTop (px 6)
                     , paddingBottom (px 8)
                     , fontSize (px 13)
                     ]
                     []
-                    [ icon
+                    [ Nri.Ui.styled div "Nri-Ui-Message--icon" [ alignSelf flexStart ] [] [ icon ]
                     , div [] html_
                     , case attributes.onDismiss of
                         Nothing ->


### PR DESCRIPTION
More icons were shrinking (see https://github.com/NoRedInk/NoRedInk/issues/29526) and Stacey and Ben prefer they be top-aligned (see https://github.com/NoRedInk/NoRedInk/issues/29527.)

This PR fixes both!

<img width="474" alt="image" src="https://user-images.githubusercontent.com/355401/93138618-e2e5c580-f6a4-11ea-9cdd-cf69451fffbc.png">

<img width="465" alt="image" src="https://user-images.githubusercontent.com/355401/93138626-e5481f80-f6a4-11ea-94fb-1c555d907d48.png">

<img width="469" alt="image" src="https://user-images.githubusercontent.com/355401/93138632-e7aa7980-f6a4-11ea-86a5-17efb51b4073.png">

<img width="476" alt="image" src="https://user-images.githubusercontent.com/355401/93138636-ea0cd380-f6a4-11ea-86ad-2435dcd6f577.png">

@NoRedInk/design does that look ok to y'all?