### PR TITLE
bump to 12.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
 cache:
   directories:
     - node_modules
+    - ~/.elm
 
 before_install:
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
 cache:
   directories:
     - node_modules
+    - sysconfcpus
     - ~/.elm
 
 before_install:

--- a/elm.json
+++ b/elm.json
@@ -75,14 +75,14 @@
         "elm/browser": "1.0.1 <= v < 2.0.0",
         "elm/core": "1.0.1 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
-        "elm/json": "1.1.1 <= v < 2.0.0",
+        "elm/json": "1.1.3 <= v < 2.0.0",
         "elm/random": "1.0.0 <= v < 2.0.0",
         "elm/regex": "1.0.0 <= v < 2.0.0",
         "elm/svg": "1.0.1 <= v < 2.0.0",
         "elm-community/random-extra": "3.1.0 <= v < 4.0.0",
         "elm-community/string-extra": "4.0.1 <= v < 5.0.0",
         "pablohirafuji/elm-markdown": "2.0.5 <= v < 3.0.0",
-        "rtfeldman/elm-css": "16.0.0 <= v < 17.0.0",
+        "rtfeldman/elm-css": "16.1.0 <= v < 17.0.0",
         "tesk9/accessible-html": "4.0.0 <= v < 5.0.0",
         "tesk9/accessible-html-with-css": "2.1.1 <= v < 3.0.0",
         "tesk9/modal": "5.0.1 <= v < 6.0.0",
@@ -90,7 +90,7 @@
         "wernerdegroot/listzipper": "3.1.1 <= v < 5.0.0"
     },
     "test-dependencies": {
-        "avh4/elm-program-test": "3.1.0 <= v < 4.0.0",
-        "elm-explorations/test": "1.2.0 <= v < 2.0.0"
+        "avh4/elm-program-test": "3.3.0 <= v < 4.0.0",
+        "elm-explorations/test": "1.2.2 <= v < 2.0.0"
     }
 }

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "12.3.1",
+    "version": "12.4.0",
     "exposed-modules": [
         "Nri.Ui",
         "Nri.Ui.Accordion.V1",

--- a/styleguide-app/elm.json
+++ b/styleguide-app/elm.json
@@ -21,7 +21,7 @@
             "elm-community/random-extra": "3.1.0",
             "elm-community/string-extra": "4.0.1",
             "pablohirafuji/elm-markdown": "2.0.5",
-            "rtfeldman/elm-css": "16.0.1",
+            "rtfeldman/elm-css": "16.1.0",
             "rtfeldman/elm-sorter-experiment": "2.1.1",
             "tesk9/accessible-html": "4.0.0",
             "tesk9/accessible-html-with-css": "2.1.1",
@@ -31,10 +31,9 @@
         },
         "indirect": {
             "NoRedInk/datetimepicker-legacy": "1.0.4",
-            "Skinney/murmur3": "2.0.8",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2",
-            "justinmimbs/date": "3.2.0",
+            "justinmimbs/date": "3.2.1",
             "justinmimbs/time-extra": "1.1.0",
             "owanturist/elm-union-find": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0"


### PR DESCRIPTION
`elm diff`:

```
This is a MINOR change.

---- Nri.Ui.Tooltip.V2 - MINOR ----

    Added:
        containerCss : List.List Css.Style -> Nri.Ui.Tooltip.V2.Attribute msg
```

all the changes:

<details>
<summary>A Big Diff</summary>

```diff
diff --git a/src/Nri/Ui/Message/V2.elm b/src/Nri/Ui/Message/V2.elm
index 994ac442..86cb6062 100644
--- a/src/Nri/Ui/Message/V2.elm
+++ b/src/Nri/Ui/Message/V2.elm
@@ -118,7 +118,7 @@ view attributes_ =
                     , fontSize (px 13)
                     ]
                     []
-                    [ icon
+                    [ Nri.Ui.styled div "Nri-Ui-Message--icon" [ alignSelf flexStart ] [] [ icon ]
                     , div [] html_
                     , case attributes.onDismiss of
                         Nothing ->
@@ -540,7 +540,7 @@ getIcon size theme =
                 |> NriSvg.withColor Colors.purple
                 |> NriSvg.withWidth iconSize
                 |> NriSvg.withHeight iconSize
-                |> NriSvg.withCss [ marginRight ]
+                |> NriSvg.withCss [ marginRight, Css.flexShrink Css.zero ]
                 |> NriSvg.withLabel "Error"
                 |> NriSvg.toHtml
 
@@ -558,7 +558,7 @@ getIcon size theme =
                 |> NriSvg.withColor color
                 |> NriSvg.withWidth iconSize
                 |> NriSvg.withHeight iconSize
-                |> NriSvg.withCss [ marginRight ]
+                |> NriSvg.withCss [ marginRight, Css.flexShrink Css.zero ]
                 |> NriSvg.withLabel "Alert"
                 |> NriSvg.toHtml
 
@@ -608,7 +608,7 @@ getIcon size theme =
                 |> NriSvg.withColor Colors.green
                 |> NriSvg.withWidth iconSize
                 |> NriSvg.withHeight iconSize
-                |> NriSvg.withCss [ marginRight ]
+                |> NriSvg.withCss [ marginRight, Css.flexShrink Css.zero ]
                 |> NriSvg.withLabel "Success"
                 |> NriSvg.toHtml
 
@@ -616,7 +616,7 @@ getIcon size theme =
             icon
                 |> NriSvg.withWidth iconSize
                 |> NriSvg.withHeight iconSize
-                |> NriSvg.withCss [ marginRight ]
+                |> NriSvg.withCss [ marginRight, Css.flexShrink Css.zero ]
                 |> NriSvg.toHtml
 
 
diff --git a/src/Nri/Ui/SegmentedControl/V13.elm b/src/Nri/Ui/SegmentedControl/V13.elm
index 051ed13f..983761bf 100644
--- a/src/Nri/Ui/SegmentedControl/V13.elm
+++ b/src/Nri/Ui/SegmentedControl/V13.elm
@@ -4,7 +4,11 @@ module Nri.Ui.SegmentedControl.V13 exposing
     , Positioning(..), Width(..)
     )
 
-{-| Changes from V12:
+{-| Post-release patches:
+
+  - Fixes <https://github.com/NoRedInk/noredink-ui/issues/608>
+
+Changes from V12:
 
   - Adds tooltip support
   - combine onFocus and onSelect into focusAndSelect msg handler (for tooltips)
@@ -176,7 +180,13 @@ view config =
             { id = option.value
             , idString = option.idString
             , tabAttributes = option.attributes
-            , tabTooltip = option.tabTooltip
+            , tabTooltip =
+                case config.positioning of
+                    Left FillContainer ->
+                        Tooltip.containerCss [ Css.width (Css.pct 100) ] :: option.tabTooltip
+
+                    _ ->
+                        option.tabTooltip
             , tabView = [ viewIcon option.icon, option.label ]
             , panelView = option.content
             , spaHref = Maybe.map (\toUrl -> toUrl option.value) config.toUrl
@@ -234,15 +244,16 @@ styles positioning numEntries index isSelected =
 
       else
         unFocusedSegmentStyles
-    , case positioning of
-        Left FitContent ->
-            Css.batch []
-
-        Left FillContainer ->
-            expandingTabStyles
+    , Css.batch <|
+        case positioning of
+            Left FillContainer ->
+                [ width (Css.pct 100)
+                , flexGrow (int 1)
+                , textAlign center
+                ]
 
-        Center ->
-            Css.batch []
+            _ ->
+                []
     ]
 
 
@@ -297,11 +308,3 @@ unFocusedSegmentStyles =
     , hover [ backgroundColor Colors.frost ]
     ]
         |> Css.batch
-
-
-expandingTabStyles : Style
-expandingTabStyles =
-    [ flexGrow (int 1)
-    , textAlign center
-    ]
-        |> Css.batch
diff --git a/src/Nri/Ui/Tooltip/V2.elm b/src/Nri/Ui/Tooltip/V2.elm
index cc31770e..d7cb88a5 100644
--- a/src/Nri/Ui/Tooltip/V2.elm
+++ b/src/Nri/Ui/Tooltip/V2.elm
@@ -8,7 +8,7 @@ module Nri.Ui.Tooltip.V2 exposing
     , smallPadding, normalPadding, customPadding
     , onClick, onHover
     , open
-    , css, custom, customTriggerAttributes
+    , css, custom, customTriggerAttributes, containerCss
     , primaryLabel, auxillaryDescription
     )
 
@@ -17,6 +17,11 @@ module Nri.Ui.Tooltip.V2 exposing
   - tooltips with focusable content (e.g., a link) will not handle focus correctly for
     keyboard-only users when using the onHover attribute
 
+Post-release patches:
+
+  - mark customTriggerAttributes as deprecated
+  - add containerCss
+
 Changes from V1:
 
   - {Position, withPosition} -> {onTop, onBottom, onLeft, onRight}
@@ -60,7 +65,7 @@ Example usage:
 @docs smallPadding, normalPadding, customPadding
 @docs onClick, onHover
 @docs open
-@docs css, custom, customTriggerAttributes
+@docs css, custom, customTriggerAttributes, containerCss
 @docs primaryLabel, auxillaryDescription
 
 -}
@@ -95,6 +100,7 @@ type alias Tooltip msg =
     , alignment : Alignment
     , content : List (Html msg)
     , attributes : List (Html.Attribute Never)
+    , containerStyles : List Style
     , tooltipStyleOverrides : List Style
     , width : Width
     , padding : Padding
@@ -114,6 +120,12 @@ buildAttributes =
             , alignment = Middle
             , content = []
             , attributes = []
+            , containerStyles =
+                [ Css.boxSizing Css.borderBox
+                , Css.display Css.inlineBlock
+                , Css.textAlign Css.left
+                , Css.position Css.relative
+                ]
             , tooltipStyleOverrides = []
             , width = Exactly 320
             , padding = NormalPadding
@@ -276,18 +288,19 @@ custom attributes =
     Attribute (\config -> { config | attributes = config.attributes ++ attributes })
 
 
-{-| Use this helper to add custom attributes to the tooltip trigger.
-
-Do NOT use this helper to add css styles, as they may not be applied the way
-you want/expect if underlying styles change.
-Instead, please use the `css` helper.
-
+{-| DEPRECATED -- a future release will remove this helper.
 -}
 customTriggerAttributes : List (Html.Attribute msg) -> Attribute msg
 customTriggerAttributes attributes =
     Attribute (\config -> { config | triggerAttributes = config.triggerAttributes ++ attributes })
 
 
+{-| -}
+containerCss : List Style -> Attribute msg
+containerCss styles =
+    Attribute (\config -> { config | containerStyles = config.containerStyles ++ styles })
+
+
 {-| Should the tooltip be exactly some measurement or fit to the width of the
 content?
 -}
@@ -467,14 +480,14 @@ viewTooltip_ :
     }
     -> Tooltip msg
     -> Html msg
-viewTooltip_ { trigger, id } tooltip_ =
+viewTooltip_ { trigger, id } tooltip =
     let
         ( containerEvents, buttonEvents ) =
-            case tooltip_.trigger of
+            case tooltip.trigger of
                 Just (OnClick msg) ->
                     ( []
                     , [ EventExtras.onClickStopPropagation
-                            (msg (not tooltip_.isOpen))
+                            (msg (not tooltip.isOpen))
                       ]
                     )
 
@@ -496,17 +509,13 @@ viewTooltip_ { trigger, id } tooltip_ =
     in
     Nri.Ui.styled Root.div
         "Nri-Ui-Tooltip-V2"
-        [ Css.boxSizing Css.borderBox
-        , Css.display Css.inlineBlock
-        , Css.textAlign Css.left
-        , Css.position Css.relative
-        ]
+        tooltip.containerStyles
         containerEvents
         [ Html.div
             []
             [ trigger
-                ([ if tooltip_.isOpen then
-                    case tooltip_.purpose of
+                ([ if tooltip.isOpen then
+                    case tooltip.purpose of
                         PrimaryLabel ->
                             Aria.labeledBy id
 
@@ -521,15 +530,15 @@ viewTooltip_ { trigger, id } tooltip_ =
                     Attributes.property "data-closed-tooltip" Encode.null
                  ]
                     ++ buttonEvents
-                    ++ tooltip_.triggerAttributes
+                    ++ tooltip.triggerAttributes
                 )
-            , hoverBridge tooltip_
+            , hoverBridge tooltip
             ]
-        , viewOverlay tooltip_
+        , viewOverlay tooltip
 
         -- Popout is rendered after the overlay, to allow client code to give it
         -- priority when clicking by setting its position
-        , viewTooltip (Just id) tooltip_
+        , viewTooltip (Just id) tooltip
         ]
 
```

</details>