### PR TITLE
Kraken/clickable svg with border

### DIFF
--- a/src/Nri/Ui/ClickableSvg/V1.elm
+++ b/src/Nri/Ui/ClickableSvg/V1.elm
@@ -445,7 +445,7 @@ buttonOrLinkStyles config =
                         ( Colors.navy, Colors.navy, Css.pointer )
 
                     Danger ->
-                        ( Colors.red, Colors.red, Css.pointer )
+                        ( Colors.red, Colors.redDark, Css.pointer )
     in
     [ Css.property "transition"
         "background-color 0.2s, color 0.2s, border-width 0s, border-color 0.2s"

--- a/src/Nri/Ui/ClickableSvg/V1.elm
+++ b/src/Nri/Ui/ClickableSvg/V1.elm
@@ -585,14 +585,14 @@ withBorderLeftBorderWidth =
 
 withBorderTopPadding : Float
 withBorderTopPadding =
-    3
+    4
 
 
 withBorderBottomPadding : Float
 withBorderBottomPadding =
-    1
+    3
 
 
 withBorderHorizontalPadding : Float
 withBorderHorizontalPadding =
-    4
+    5

--- a/src/Nri/Ui/ClickableSvg/V1.elm
+++ b/src/Nri/Ui/ClickableSvg/V1.elm
@@ -480,6 +480,7 @@ buttonOrLinkStyles config =
             ]
 
     -- Sizing
+    , Css.display Css.inlineBlock
     , Css.boxSizing Css.contentBox
     , Css.width config.width
     , Css.height config.height

--- a/src/Nri/Ui/ClickableSvg/V1.elm
+++ b/src/Nri/Ui/ClickableSvg/V1.elm
@@ -58,7 +58,7 @@ module Nri.Ui.ClickableSvg.V1 exposing
 
 import Accessibility.Styled.Widget as Widget
 import ClickableAttributes exposing (ClickableAttributes)
-import Css exposing (Style)
+import Css exposing (Color, Style)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Nri.Ui.Colors.V1 as Colors
@@ -200,6 +200,44 @@ type Theme
     = Primary
     | Secondary
     | Danger
+    | DangerSecondary
+
+
+type alias AppliedTheme =
+    { mainColor : Color
+    , hoverColor : Color
+    }
+
+
+disabledTheme : AppliedTheme
+disabledTheme =
+    { mainColor = Colors.gray75
+    , hoverColor = Colors.gray75
+    }
+
+
+applyTheme : Theme -> AppliedTheme
+applyTheme theme =
+    case theme of
+        Primary ->
+            { mainColor = Colors.azure
+            , hoverColor = Colors.azureDark
+            }
+
+        Secondary ->
+            { mainColor = Colors.navy
+            , hoverColor = Colors.navy
+            }
+
+        Danger ->
+            { mainColor = Colors.red
+            , hoverColor = Colors.redDark
+            }
+
+        DangerSecondary ->
+            { mainColor = Colors.red
+            , hoverColor = Colors.redDark
+            }
 
 
 {-| -}
@@ -211,10 +249,7 @@ primary =
 {-| -}
 secondary : Attribute msg
 secondary =
-    set
-        (\attributes ->
-            { attributes | theme = Secondary }
-        )
+    set (\attributes -> { attributes | theme = Secondary })
 
 
 {-| -}
@@ -447,20 +482,12 @@ renderIcon config =
 buttonOrLinkStyles : ButtonOrLinkAttributes msg -> List Style
 buttonOrLinkStyles config =
     let
-        ( mainColor, hoverColor, cursor ) =
+        ( { mainColor, hoverColor }, cursor ) =
             if config.disabled then
-                ( Colors.gray75, Colors.gray75, Css.notAllowed )
+                ( disabledTheme, Css.notAllowed )
 
             else
-                case config.theme of
-                    Primary ->
-                        ( Colors.azure, Colors.azureDark, Css.pointer )
-
-                    Secondary ->
-                        ( Colors.navy, Colors.navy, Css.pointer )
-
-                    Danger ->
-                        ( Colors.red, Colors.redDark, Css.pointer )
+                ( applyTheme config.theme, Css.pointer )
     in
     [ Css.property "transition"
         "background-color 0.2s, color 0.2s, border-width 0s, border-color 0.2s"

--- a/src/Nri/Ui/ClickableSvg/V1.elm
+++ b/src/Nri/Ui/ClickableSvg/V1.elm
@@ -6,6 +6,7 @@ module Nri.Ui.ClickableSvg.V1 exposing
     , width, height
     , disabled
     , withBorder
+    , primary, secondary, danger
     , custom, css
     , withTooltipAbove, withTooltipBelow
     )
@@ -44,6 +45,8 @@ module Nri.Ui.ClickableSvg.V1 exposing
 ## Customization
 
 @docs withBorder
+@docs primary, secondary, danger
+
 @docs custom, css
 
 
@@ -193,6 +196,33 @@ withBorder =
     set (\config -> { config | hasBorder = True })
 
 
+type Theme
+    = Primary
+    | Secondary
+    | Danger
+
+
+{-| -}
+primary : Attribute msg
+primary =
+    set (\attributes -> { attributes | theme = Primary })
+
+
+{-| -}
+secondary : Attribute msg
+secondary =
+    set
+        (\attributes ->
+            { attributes | theme = Secondary }
+        )
+
+
+{-| -}
+danger : Attribute msg
+danger =
+    set (\attributes -> { attributes | theme = Danger })
+
+
 {-| Use this helper to add custom attributes.
 
 Do NOT use this helper to add css styles, as they may not be applied the way
@@ -306,6 +336,7 @@ build label icon =
         , customStyles = []
         , tooltip = Nothing
         , hasBorder = False
+        , theme = Primary
         }
 
 
@@ -324,6 +355,7 @@ type alias ButtonOrLinkAttributes msg =
     , customStyles : List Style
     , tooltip : Maybe (TooltipSettings msg)
     , hasBorder : Bool
+    , theme : Theme
     }
 
 
@@ -405,7 +437,15 @@ buttonOrLinkStyles config =
                 ( Colors.gray75, Colors.gray75, Css.notAllowed )
 
             else
-                ( Colors.azure, Colors.azureDark, Css.pointer )
+                case config.theme of
+                    Primary ->
+                        ( Colors.azure, Colors.azureDark, Css.pointer )
+
+                    Secondary ->
+                        ( Colors.navy, Colors.navy, Css.pointer )
+
+                    Danger ->
+                        ( Colors.red, Colors.red, Css.pointer )
     in
     [ Css.property "transition"
         "background-color 0.2s, color 0.2s, border-width 0s, border-color 0.2s"

--- a/src/Nri/Ui/ClickableSvg/V1.elm
+++ b/src/Nri/Ui/ClickableSvg/V1.elm
@@ -339,10 +339,7 @@ renderButton ((ButtonOrLink config) as button_) =
             ++ ClickableAttributes.toButtonAttributes config.clickableAttributes
             ++ config.customAttributes
         )
-        [ config.icon
-            |> Svg.withWidth config.width
-            |> Svg.withHeight config.height
-            |> Svg.toHtml
+        [ renderIcon config
         ]
         |> showTooltip config.label config.tooltip
 
@@ -376,12 +373,28 @@ renderLink ((ButtonOrLink config) as link_) =
                )
             ++ config.customAttributes
         )
-        [ config.icon
-            |> Svg.withWidth config.width
-            |> Svg.withHeight config.height
-            |> Svg.toHtml
+        [ renderIcon config
         ]
         |> showTooltip config.label config.tooltip
+
+
+renderIcon : ButtonOrLinkAttributes msg -> Html msg
+renderIcon config =
+    let
+        ( iconWidth, iconHeight ) =
+            if config.hasBorder then
+                ( Css.width (Css.calc config.width Css.minus (Css.px <| 2 * withBorderVerticalPadding))
+                , Css.height (Css.calc config.height Css.minus (Css.px <| 2 * withBorderHorizontalPadding))
+                )
+
+            else
+                ( Css.width config.width
+                , Css.height config.height
+                )
+    in
+    config.icon
+        |> Svg.withCss [ iconWidth, iconHeight ]
+        |> Svg.toHtml
 
 
 buttonOrLinkStyles : ButtonOrLinkAttributes msg -> List Style
@@ -395,7 +408,7 @@ buttonOrLinkStyles config =
                 ( Colors.azure, Colors.azureDark, Css.pointer )
     in
     [ Css.property "transition"
-        "background-color 0.2s, color 0.2s, box-shadow 0.2s, border 0.2s, border-width 0s"
+        "background-color 0.2s, color 0.2s, border-width 0s, border-color 0.2s"
 
     -- Colors, text decoration, cursor
     , Css.backgroundColor Css.transparent
@@ -410,21 +423,35 @@ buttonOrLinkStyles config =
 
     -- Margins, borders, padding
     , Css.margin Css.zero
-    , Css.padding Css.zero
-    , if config.hasBorder then
-        Css.batch
+    , Css.batch <|
+        if config.hasBorder then
             [ Css.borderRadius (Css.px 8)
             , Css.border3 (Css.px 1) Css.solid mainColor
             , Css.borderBottomWidth (Css.px 2)
-            , Css.hover [ Css.color hoverColor ]
+            , Css.hover [ Css.borderColor hoverColor ]
+            , Css.padding3 (Css.px (withBorderVerticalPadding + 1))
+                (Css.px withBorderHorizontalPadding)
+                (Css.px (withBorderVerticalPadding - 1))
             ]
 
-      else
-        Css.borderWidth Css.zero
+        else
+            [ Css.borderWidth Css.zero
+            , Css.padding Css.zero
+            ]
 
     -- Sizing
     , Css.boxSizing Css.contentBox
-    , Css.lineHeight (Css.num 1)
     , Css.width config.width
     , Css.height config.height
+    , Css.lineHeight (Css.num 1)
     ]
+
+
+withBorderVerticalPadding : Float
+withBorderVerticalPadding =
+    2
+
+
+withBorderHorizontalPadding : Float
+withBorderHorizontalPadding =
+    4

--- a/src/Nri/Ui/ClickableSvg/V1.elm
+++ b/src/Nri/Ui/ClickableSvg/V1.elm
@@ -5,6 +5,7 @@ module Nri.Ui.ClickableSvg.V1 exposing
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     , width, height
     , disabled
+    , withBorder
     , custom, css
     , withTooltipAbove, withTooltipBelow
     )
@@ -42,6 +43,7 @@ module Nri.Ui.ClickableSvg.V1 exposing
 
 ## Customization
 
+@docs withBorder
 @docs custom, css
 
 
@@ -184,6 +186,13 @@ disabled disabled_ =
 -- CUSTOMIZATION
 
 
+{-| Display a border around the icon.
+-}
+withBorder : Attribute msg
+withBorder =
+    set (\config -> { config | hasBorder = True })
+
+
 {-| Use this helper to add custom attributes.
 
 Do NOT use this helper to add css styles, as they may not be applied the way
@@ -259,13 +268,15 @@ withTooltip position { id, isOpen, onShow } =
         )
 
 
-{-| -}
+{-| DEPRECATED: prefer to use the Tooltip module directly.
+-}
 withTooltipAbove : { id : String, isOpen : Bool, onShow : Bool -> msg } -> Attribute msg
 withTooltipAbove =
     withTooltip Tooltip.OnTop
 
 
-{-| -}
+{-| DEPRECATED: prefer to use the Tooltip module directly.
+-}
 withTooltipBelow : { id : String, isOpen : Bool, onShow : Bool -> msg } -> Attribute msg
 withTooltipBelow =
     withTooltip Tooltip.OnBottom
@@ -294,6 +305,7 @@ build label icon =
         , customAttributes = []
         , customStyles = []
         , tooltip = Nothing
+        , hasBorder = False
         }
 
 
@@ -311,6 +323,7 @@ type alias ButtonOrLinkAttributes msg =
     , customAttributes : List (Html.Attribute msg)
     , customStyles : List Style
     , tooltip : Maybe (TooltipSettings msg)
+    , hasBorder : Bool
     }
 
 
@@ -373,35 +386,36 @@ renderLink ((ButtonOrLink config) as link_) =
 
 buttonOrLinkStyles : ButtonOrLinkAttributes msg -> List Style
 buttonOrLinkStyles config =
+    let
+        ( mainColor, hoverColor, cursor ) =
+            if config.disabled then
+                ( Colors.gray75, Colors.gray75, Css.notAllowed )
+
+            else
+                ( Colors.azure, Colors.azureDark, Css.pointer )
+    in
     [ -- Colors, text decoration, cursor
       Css.backgroundColor Css.transparent
     , Css.textDecoration Css.none
-    , if config.disabled then
-        Css.batch
-            [ Css.color Colors.gray75
-            , Css.visited [ Css.color Colors.gray75 ]
-            , Css.hover
-                [ Css.textDecoration Css.none
-                , Css.color Colors.gray75
-                , Css.cursor Css.notAllowed
-                ]
-            ]
-
-      else
-        Css.batch
-            [ Css.color Colors.azure
-            , Css.visited [ Css.color Colors.azure ]
-            , Css.hover
-                [ Css.textDecoration Css.none
-                , Css.color Colors.azureDark
-                , Css.cursor Css.pointer
-                ]
-            ]
+    , Css.color mainColor
+    , Css.visited [ Css.color mainColor ]
+    , Css.hover
+        [ Css.textDecoration Css.none
+        , Css.color hoverColor
+        , Css.cursor cursor
+        ]
 
     -- Margins, borders, padding
     , Css.margin Css.zero
     , Css.padding Css.zero
-    , Css.borderWidth Css.zero
+    , if config.hasBorder then
+        Css.batch
+            [ Css.border3 (Css.px 1) Css.solid mainColor
+            , Css.hover [ Css.color hoverColor ]
+            ]
+
+      else
+        Css.borderWidth Css.zero
 
     -- Sizing
     , Css.boxSizing Css.contentBox

--- a/src/Nri/Ui/ClickableSvg/V1.elm
+++ b/src/Nri/Ui/ClickableSvg/V1.elm
@@ -6,7 +6,7 @@ module Nri.Ui.ClickableSvg.V1 exposing
     , width, height
     , disabled
     , withBorder
-    , primary, secondary, danger
+    , primary, secondary, danger, dangerSecondary
     , custom, css
     , withTooltipAbove, withTooltipBelow
     )
@@ -45,7 +45,7 @@ module Nri.Ui.ClickableSvg.V1 exposing
 ## Customization
 
 @docs withBorder
-@docs primary, secondary, danger
+@docs primary, secondary, danger, dangerSecondary
 
 @docs custom, css
 
@@ -204,15 +204,19 @@ type Theme
 
 
 type alias AppliedTheme =
-    { mainColor : Color
-    , hoverColor : Color
+    { main_ : Color
+    , mainHovered : Color
+    , background : Color
+    , backgroundHovered : Color
     }
 
 
 disabledTheme : AppliedTheme
 disabledTheme =
-    { mainColor = Colors.gray75
-    , hoverColor = Colors.gray75
+    { main_ = Colors.gray75
+    , mainHovered = Colors.gray75
+    , background = Colors.white
+    , backgroundHovered = Colors.white
     }
 
 
@@ -220,42 +224,61 @@ applyTheme : Theme -> AppliedTheme
 applyTheme theme =
     case theme of
         Primary ->
-            { mainColor = Colors.azure
-            , hoverColor = Colors.azureDark
+            { main_ = Colors.white
+            , mainHovered = Colors.white
+            , background = Colors.azure
+            , backgroundHovered = Colors.azureDark
             }
 
         Secondary ->
-            { mainColor = Colors.navy
-            , hoverColor = Colors.navy
+            { main_ = Colors.azure
+            , mainHovered = Colors.azureDark
+            , background = Colors.white
+            , backgroundHovered = Colors.glacier
             }
 
         Danger ->
-            { mainColor = Colors.red
-            , hoverColor = Colors.redDark
+            { main_ = Colors.white
+            , mainHovered = Colors.white
+            , background = Colors.red
+            , backgroundHovered = Colors.redDark
             }
 
         DangerSecondary ->
-            { mainColor = Colors.red
-            , hoverColor = Colors.redDark
+            { main_ = Colors.red
+            , mainHovered = Colors.redDark
+            , background = Colors.white
+            , backgroundHovered = Colors.redLight
             }
 
 
-{-| -}
+{-| white/transparent icon on an azure background.
+-}
 primary : Attribute msg
 primary =
     set (\attributes -> { attributes | theme = Primary })
 
 
-{-| -}
+{-| This is the default: a blue icon on a transparent background, or a blue icon
+on a white/glacier icon with a blue border.
+-}
 secondary : Attribute msg
 secondary =
     set (\attributes -> { attributes | theme = Secondary })
 
 
-{-| -}
+{-| White/transparent icon on a red background.
+-}
 danger : Attribute msg
 danger =
     set (\attributes -> { attributes | theme = Danger })
+
+
+{-| Red icon on a white/transparent background.
+-}
+dangerSecondary : Attribute msg
+dangerSecondary =
+    set (\attributes -> { attributes | theme = DangerSecondary })
 
 
 {-| Use this helper to add custom attributes.
@@ -371,7 +394,7 @@ build label icon =
         , customStyles = []
         , tooltip = Nothing
         , hasBorder = False
-        , theme = Primary
+        , theme = Secondary
         }
 
 
@@ -482,7 +505,7 @@ renderIcon config =
 buttonOrLinkStyles : ButtonOrLinkAttributes msg -> List Style
 buttonOrLinkStyles config =
     let
-        ( { mainColor, hoverColor }, cursor ) =
+        ( { main_, mainHovered, background, backgroundHovered }, cursor ) =
             if config.disabled then
                 ( disabledTheme, Css.notAllowed )
 
@@ -493,13 +516,12 @@ buttonOrLinkStyles config =
         "background-color 0.2s, color 0.2s, border-width 0s, border-color 0.2s"
 
     -- Colors, text decoration, cursor
-    , Css.backgroundColor Css.transparent
     , Css.textDecoration Css.none
-    , Css.color mainColor
-    , Css.visited [ Css.color mainColor ]
+    , Css.color main_
+    , Css.visited [ Css.color main_ ]
     , Css.hover
         [ Css.textDecoration Css.none
-        , Css.color hoverColor
+        , Css.color mainHovered
         , Css.cursor cursor
         ]
 
@@ -509,13 +531,17 @@ buttonOrLinkStyles config =
     , Css.batch <|
         if config.hasBorder then
             [ Css.borderRadius (Css.px 8)
-            , Css.borderColor mainColor
+            , Css.borderColor main_
             , Css.borderStyle Css.solid
             , Css.borderTopWidth (Css.px withBorderTopBorderWidth)
             , Css.borderRightWidth (Css.px withBorderRightBorderWidth)
             , Css.borderBottomWidth (Css.px withBorderBottomBorderWidth)
             , Css.borderLeftWidth (Css.px withBorderLeftBorderWidth)
-            , Css.hover [ Css.borderColor hoverColor ]
+            , Css.backgroundColor background
+            , Css.hover
+                [ Css.borderColor mainHovered
+                , Css.backgroundColor backgroundHovered
+                ]
             , Css.padding3
                 (Css.px withBorderTopPadding)
                 (Css.px withBorderHorizontalPadding)
@@ -525,6 +551,7 @@ buttonOrLinkStyles config =
         else
             [ Css.borderWidth Css.zero
             , Css.padding Css.zero
+            , Css.backgroundColor Css.transparent
             ]
 
     -- Sizing

--- a/src/Nri/Ui/ClickableSvg/V1.elm
+++ b/src/Nri/Ui/ClickableSvg/V1.elm
@@ -394,8 +394,11 @@ buttonOrLinkStyles config =
             else
                 ( Colors.azure, Colors.azureDark, Css.pointer )
     in
-    [ -- Colors, text decoration, cursor
-      Css.backgroundColor Css.transparent
+    [ Css.property "transition"
+        "background-color 0.2s, color 0.2s, box-shadow 0.2s, border 0.2s, border-width 0s"
+
+    -- Colors, text decoration, cursor
+    , Css.backgroundColor Css.transparent
     , Css.textDecoration Css.none
     , Css.color mainColor
     , Css.visited [ Css.color mainColor ]
@@ -410,7 +413,9 @@ buttonOrLinkStyles config =
     , Css.padding Css.zero
     , if config.hasBorder then
         Css.batch
-            [ Css.border3 (Css.px 1) Css.solid mainColor
+            [ Css.borderRadius (Css.px 8)
+            , Css.border3 (Css.px 1) Css.solid mainColor
+            , Css.borderBottomWidth (Css.px 2)
             , Css.hover [ Css.color hoverColor ]
             ]
 

--- a/src/Nri/Ui/ClickableSvg/V1.elm
+++ b/src/Nri/Ui/ClickableSvg/V1.elm
@@ -412,20 +412,35 @@ renderLink ((ButtonOrLink config) as link_) =
 
 renderIcon : ButtonOrLinkAttributes msg -> Html msg
 renderIcon config =
-    let
-        ( iconWidth, iconHeight ) =
-            if config.hasBorder then
-                ( Css.width (Css.calc config.width Css.minus (Css.px <| 2 * withBorderVerticalPadding))
-                , Css.height (Css.calc config.height Css.minus (Css.px <| 2 * withBorderHorizontalPadding))
-                )
-
-            else
-                ( Css.width config.width
-                , Css.height config.height
-                )
-    in
     config.icon
-        |> Svg.withCss [ iconWidth, iconHeight ]
+        |> Svg.withCss
+            (if config.hasBorder then
+                [ Css.width
+                    (Css.calc config.width
+                        Css.minus
+                        (Css.px <|
+                            (2 * withBorderHorizontalPadding)
+                                + withBorderLeftBorderWidth
+                                + withBorderRightBorderWidth
+                        )
+                    )
+                , Css.height
+                    (Css.calc config.height
+                        Css.minus
+                        (Css.px <|
+                            withBorderTopPadding
+                                + withBorderBottomPadding
+                                + withBorderTopBorderWidth
+                                + withBorderBottomBorderWidth
+                        )
+                    )
+                ]
+
+             else
+                [ Css.width config.width
+                , Css.height config.height
+                ]
+            )
         |> Svg.toHtml
 
 
@@ -463,15 +478,21 @@ buttonOrLinkStyles config =
 
     -- Margins, borders, padding
     , Css.margin Css.zero
+    , Css.textAlign Css.center
     , Css.batch <|
         if config.hasBorder then
             [ Css.borderRadius (Css.px 8)
-            , Css.border3 (Css.px 1) Css.solid mainColor
-            , Css.borderBottomWidth (Css.px 2)
+            , Css.borderColor mainColor
+            , Css.borderStyle Css.solid
+            , Css.borderTopWidth (Css.px withBorderTopBorderWidth)
+            , Css.borderRightWidth (Css.px withBorderRightBorderWidth)
+            , Css.borderBottomWidth (Css.px withBorderBottomBorderWidth)
+            , Css.borderLeftWidth (Css.px withBorderLeftBorderWidth)
             , Css.hover [ Css.borderColor hoverColor ]
-            , Css.padding3 (Css.px (withBorderVerticalPadding + 1))
+            , Css.padding3
+                (Css.px withBorderTopPadding)
                 (Css.px withBorderHorizontalPadding)
-                (Css.px (withBorderVerticalPadding - 1))
+                (Css.px withBorderBottomPadding)
             ]
 
         else
@@ -481,16 +502,41 @@ buttonOrLinkStyles config =
 
     -- Sizing
     , Css.display Css.inlineBlock
-    , Css.boxSizing Css.contentBox
+    , Css.boxSizing Css.borderBox
     , Css.width config.width
     , Css.height config.height
     , Css.lineHeight (Css.num 1)
     ]
 
 
-withBorderVerticalPadding : Float
-withBorderVerticalPadding =
+withBorderTopBorderWidth : Float
+withBorderTopBorderWidth =
+    1
+
+
+withBorderRightBorderWidth : Float
+withBorderRightBorderWidth =
+    1
+
+
+withBorderBottomBorderWidth : Float
+withBorderBottomBorderWidth =
     2
+
+
+withBorderLeftBorderWidth : Float
+withBorderLeftBorderWidth =
+    1
+
+
+withBorderTopPadding : Float
+withBorderTopPadding =
+    3
+
+
+withBorderBottomPadding : Float
+withBorderBottomPadding =
+    1
 
 
 withBorderHorizontalPadding : Float

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -163,37 +163,51 @@ Tooltip.view
 viewExampleTable : Svg -> List (ClickableSvg.Attribute Msg) -> Html Msg
 viewExampleTable icon attributes =
     let
-        cell =
+        viewExampleRow index ( themeName, theme ) =
+            Html.tr []
+                [ cell index [ Html.text themeName ]
+                , cell index
+                    [ ClickableSvg.button "Button example"
+                        icon
+                        (ClickableSvg.onClick (ShowItWorked "You clicked the back button!")
+                            :: theme
+                            :: attributes
+                        )
+                    ]
+                , cell index
+                    [ ClickableSvg.link "Link example"
+                        icon
+                        (ClickableSvg.linkSpa "some_link" :: theme :: attributes)
+                    ]
+                ]
+
+        cell index =
             Html.td
                 [ Attributes.css
-                    [ Css.backgroundColor Colors.gray96
-                    , Css.padding (Css.px 30)
+                    [ if modBy 2 index == 0 then
+                        Css.backgroundColor Colors.gray96
+
+                      else
+                        Css.backgroundColor Colors.white
+                    , Css.padding (Css.px 10)
                     ]
                 ]
     in
     Html.table []
         [ Html.thead []
             [ Html.tr []
-                [ Html.th [] [ Html.text "button" ]
+                [ Html.th [] [ Html.text "theme" ]
+                , Html.th [] [ Html.text "button" ]
                 , Html.th [] [ Html.text "link" ]
                 ]
             ]
-        , Html.tbody []
-            [ Html.tr []
-                [ cell
-                    [ ClickableSvg.button "Button example"
-                        icon
-                        (ClickableSvg.onClick (ShowItWorked "You clicked the back button!")
-                            :: attributes
-                        )
-                    ]
-                , cell
-                    [ ClickableSvg.link "Link example"
-                        icon
-                        (ClickableSvg.linkSpa "some_link" :: attributes)
-                    ]
+        , Html.tbody [] <|
+            List.indexedMap viewExampleRow
+                [ ( "primary", ClickableSvg.primary )
+                , ( "secondary", ClickableSvg.secondary )
+                , ( "danger", ClickableSvg.danger )
+                , ( "dangerSecondary", ClickableSvg.dangerSecondary )
                 ]
-            ]
         ]
 
 
@@ -267,7 +281,6 @@ type alias Settings msg =
     { icon : Svg
     , disabled : ClickableSvg.Attribute msg
     , withBorder : ClickableSvg.Attribute msg
-    , theme : ClickableSvg.Attribute msg
     , width : ClickableSvg.Attribute msg
     , height : ClickableSvg.Attribute msg
     }
@@ -276,10 +289,10 @@ type alias Settings msg =
 applySettings : Control (Settings msg) -> ( Svg, List (ClickableSvg.Attribute msg) )
 applySettings settings =
     let
-        { icon, disabled, withBorder, theme, width, height } =
+        { icon, disabled, withBorder, width, height } =
             Control.currentValue settings
     in
-    ( icon, [ disabled, withBorder, theme, width, height ] )
+    ( icon, [ disabled, withBorder, width, height ] )
 
 
 initSettings : Control (Settings msg)
@@ -311,14 +324,6 @@ initSettings =
                         ClickableSvg.css []
                 )
                 (Control.bool False)
-            )
-        |> Control.field "theme"
-            (Control.choice
-                [ ( "primary", Control.value ClickableSvg.primary )
-                , ( "secondary", Control.value ClickableSvg.secondary )
-                , ( "danger", Control.value ClickableSvg.danger )
-                , ( "dangerSecondary", Control.value ClickableSvg.dangerSecondary )
-                ]
             )
         |> Control.field "width"
             (Control.map (Css.px >> ClickableSvg.width) (controlNumber 30))

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -167,8 +167,8 @@ viewExampleTable icon attributes =
             Html.tr []
                 [ cell index [ Html.text themeName ]
                 , cell index [ buttonExample (theme :: attributes) ]
-                , cell index [ buttonExample (ClickableSvg.withBorder :: theme :: attributes) ]
                 , cell index [ linkExample (theme :: attributes) ]
+                , cell index [ buttonExample (ClickableSvg.withBorder :: theme :: attributes) ]
                 , cell index [ linkExample (ClickableSvg.withBorder :: theme :: attributes) ]
                 ]
 
@@ -200,8 +200,8 @@ viewExampleTable icon attributes =
         [ Html.thead []
             [ Html.tr []
                 [ Html.th [] [ Html.text "theme" ]
-                , Html.th [ Attributes.colspan 2 ] [ Html.text "button" ]
-                , Html.th [ Attributes.colspan 2 ] [ Html.text "link" ]
+                , Html.th [ Attributes.colspan 2 ] [ Html.text "" ]
+                , Html.th [ Attributes.colspan 2 ] [ Html.text "withBorder" ]
                 ]
             ]
         , Html.tbody [] <|
@@ -211,6 +211,15 @@ viewExampleTable icon attributes =
                 , ( "danger", ClickableSvg.danger )
                 , ( "dangerSecondary", ClickableSvg.dangerSecondary )
                 ]
+        , Html.tfoot []
+            [ Html.tr []
+                [ Html.td [] [ Html.text "" ]
+                , Html.td [] [ Html.text "button" ]
+                , Html.td [] [ Html.text "link" ]
+                , Html.td [] [ Html.text "button" ]
+                , Html.td [] [ Html.text "link" ]
+                ]
+            ]
         ]
 
 

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -76,6 +76,7 @@ ClickableSvg.button "Preview"
     , ClickableSvg.height (Css.px 20)
     , ClickableSvg.onClick (ShowItWorked "You clicked the preview button!")
     , ClickableSvg.withTooltipAbove { id = "preview", isOpen = state.tooltipPreview, onShow = SetPreviewTooltip }
+    , ClickableSvg.withBorder
     ]
             """
               <|
@@ -89,6 +90,7 @@ ClickableSvg.button "Preview"
                         , isOpen = state.tooltipPreview
                         , onShow = SetPreviewTooltip
                         }
+                    , ClickableSvg.withBorder
                     ]
             , viewExample
                 """

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -48,26 +48,6 @@ example =
             , viewExampleTable icon attributes
             , viewExample
                 """
-ClickableSvg.button "Go to tutorial"
-    UiIcon.footsteps
-    [ ClickableSvg.width (Css.px 30)
-    , ClickableSvg.height (Css.px 30)
-    , ClickableSvg.onClick (ShowItWorked "You clicked the tutorials button!")
-    , ClickableSvg.custom [ Attributes.id "clickable-svg-customized-example-id" ]
-    , ClickableSvg.css [ Css.border3 (Css.px 1) Css.dashed Colors.azure ]
-    ]
-                """
-              <|
-                ClickableSvg.button "Go to tutorial"
-                    UiIcon.footsteps
-                    [ ClickableSvg.width (Css.px 30)
-                    , ClickableSvg.height (Css.px 30)
-                    , ClickableSvg.onClick (ShowItWorked "You clicked the tutorials button!")
-                    , ClickableSvg.custom [ Attributes.id "clickable-svg-customized-example-id" ]
-                    , ClickableSvg.css [ Css.border3 (Css.px 1) Css.dashed Colors.azure ]
-                    ]
-            , viewExample
-                """
 Tooltip.view
     { trigger =
         \\attrs ->
@@ -76,7 +56,6 @@ Tooltip.view
                 [ ClickableSvg.width (Css.px 20)
                 , ClickableSvg.height (Css.px 20)
                 , ClickableSvg.onClick (ShowItWorked "You clicked the preview button!")
-                , ClickableSvg.withBorder
                 , ClickableSvg.custom attrs
                 ]
     , id = "preview-tooltip"
@@ -87,7 +66,6 @@ Tooltip.view
     , Tooltip.open state.tooltipPreview
     , Tooltip.smallPadding
     , Tooltip.fitToContent
-    , Tooltip.alignEnd (Css.px 28)
     ]
             """
               <|
@@ -99,7 +77,6 @@ Tooltip.view
                                 [ ClickableSvg.width (Css.px 20)
                                 , ClickableSvg.height (Css.px 20)
                                 , ClickableSvg.onClick (ShowItWorked "You clicked the preview button!")
-                                , ClickableSvg.withBorder
                                 , ClickableSvg.custom attrs
                                 ]
                     , id = "preview-tooltip"
@@ -110,51 +87,6 @@ Tooltip.view
                     , Tooltip.open state.tooltipPreview
                     , Tooltip.smallPadding
                     , Tooltip.fitToContent
-                    , Tooltip.alignEnd (Css.px 28)
-                    ]
-            , viewExample
-                """
-Tooltip.view
-    { trigger =
-        \\attrs ->
-            ClickableSvg.button "Share"
-                UiIcon.share
-                [ ClickableSvg.width (Css.px 20)
-                , ClickableSvg.height (Css.px 20)
-                , ClickableSvg.onClick (ShowItWorked "You clicked the share button!")
-                , ClickableSvg.custom attrs
-                ]
-    , id = "share-tooltip"
-    }
-    [ Tooltip.plaintext "Share"
-    , Tooltip.primaryLabel
-    , Tooltip.onHover SetShareTooltip
-    , Tooltip.open state.tooltipShareTo
-    , Tooltip.smallPadding
-    , Tooltip.fitToContent
-    , Tooltip.onRight
-    ]
-            """
-              <|
-                Tooltip.view
-                    { trigger =
-                        \attrs ->
-                            ClickableSvg.button "Share"
-                                UiIcon.share
-                                [ ClickableSvg.width (Css.px 20)
-                                , ClickableSvg.height (Css.px 20)
-                                , ClickableSvg.onClick (ShowItWorked "You clicked the share button!")
-                                , ClickableSvg.custom attrs
-                                ]
-                    , id = "share-tooltip"
-                    }
-                    [ Tooltip.plaintext "Share"
-                    , Tooltip.primaryLabel
-                    , Tooltip.onHover SetShareTooltip
-                    , Tooltip.open state.tooltipShareTo
-                    , Tooltip.smallPadding
-                    , Tooltip.fitToContent
-                    , Tooltip.onRight
                     ]
             ]
     }

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -10,6 +10,7 @@ import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
 import Color exposing (Color)
 import Css
+import Debug.Control as Control exposing (Control)
 import Example exposing (Example)
 import Examples.IconExamples as IconExamples
 import Html.Styled as Html
@@ -39,7 +40,12 @@ example =
     , subscriptions = \_ -> Sub.none
     , view =
         \state ->
-            [ viewExample "ClickableSvg.button \"Back\" UiIcon.arrowLeft [ ClickableSvg.onClick OnClickMsg ]" <|
+            let
+                settings =
+                    Control.currentValue state.settings
+            in
+            [ Html.fromUnstyled (Control.view SetControls state.settings)
+            , viewExample "ClickableSvg.button \"Back\" UiIcon.arrowLeft [ ClickableSvg.onClick OnClickMsg ]" <|
                 ClickableSvg.button "Back"
                     UiIcon.arrowLeft
                     [ ClickableSvg.onClick (ShowItWorked "You clicked the back button!") ]
@@ -187,6 +193,7 @@ viewCode renderStrategy =
 type alias State =
     { tooltipPreview : Bool
     , tooltipShareTo : Bool
+    , settings : Control Settings
     }
 
 
@@ -195,6 +202,7 @@ init : State
 init =
     { tooltipPreview = False
     , tooltipShareTo = False
+    , settings = initSettings
     }
 
 
@@ -203,6 +211,7 @@ type Msg
     = ShowItWorked String
     | SetPreviewTooltip Bool
     | SetShareTooltip Bool
+    | SetControls (Control Settings)
 
 
 {-| -}
@@ -221,3 +230,15 @@ update msg state =
 
         SetShareTooltip bool ->
             ( { state | tooltipShareTo = bool }, Cmd.none )
+
+        SetControls settings ->
+            ( { state | settings = settings }, Cmd.none )
+
+
+type alias Settings =
+    {}
+
+
+initSettings : Control Settings
+initSettings =
+    Control.record Settings

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -22,7 +22,7 @@ import Nri.Ui.Colors.Extra exposing (fromCssColor, toCssColor)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Select.V7 as Select
-import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Tooltip.V2 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon
 
@@ -236,9 +236,59 @@ update msg state =
 
 
 type alias Settings =
-    {}
+    { disabled : ClickableSvg.Attribute Never
+    , withBorder : ClickableSvg.Attribute Never
+    , theme : ClickableSvg.Attribute Never
+    , icon : Svg
+    , width : ClickableSvg.Attribute Never
+    , height : ClickableSvg.Attribute Never
+    }
 
 
 initSettings : Control Settings
 initSettings =
     Control.record Settings
+        |> Control.field "disabled"
+            (Control.map ClickableSvg.disabled (Control.bool False))
+        |> Control.field "withBorder"
+            (Control.map
+                (\hasBorder ->
+                    if hasBorder then
+                        ClickableSvg.withBorder
+
+                    else
+                        ClickableSvg.css []
+                )
+                (Control.bool False)
+            )
+        |> Control.field "theme"
+            (Control.choice
+                [ ( "primary", Control.value ClickableSvg.primary )
+                , ( "secondary", Control.value ClickableSvg.secondary )
+                , ( "danger", Control.value ClickableSvg.danger )
+                ]
+            )
+        |> Control.field "icon"
+            (Control.choice
+                [ ( "arrowLeft", Control.value UiIcon.arrowLeft )
+                , ( "unarchive", Control.value UiIcon.unarchive )
+                , ( "share", Control.value UiIcon.share )
+                , ( "preview", Control.value UiIcon.preview )
+                , ( "skip", Control.value UiIcon.skip )
+                , ( "copyToClipboard", Control.value UiIcon.copyToClipboard )
+                , ( "gift", Control.value UiIcon.gift )
+                , ( "home", Control.value UiIcon.home )
+                , ( "library", Control.value UiIcon.library )
+                , ( "searchInCicle", Control.value UiIcon.searchInCicle )
+                ]
+            )
+        |> Control.field "width"
+            (Control.map (Css.px >> ClickableSvg.width) (controlNumber 30))
+        |> Control.field "height"
+            (Control.map (Css.px >> ClickableSvg.height) (controlNumber 20))
+
+
+controlNumber : Float -> Control Float
+controlNumber default =
+    Control.map (String.toFloat >> Maybe.withDefault default)
+        (Control.string (String.fromFloat default))

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -166,19 +166,10 @@ viewExampleTable icon attributes =
         viewExampleRow index ( themeName, theme ) =
             Html.tr []
                 [ cell index [ Html.text themeName ]
-                , cell index
-                    [ ClickableSvg.button "Button example"
-                        icon
-                        (ClickableSvg.onClick (ShowItWorked "You clicked the back button!")
-                            :: theme
-                            :: attributes
-                        )
-                    ]
-                , cell index
-                    [ ClickableSvg.link "Link example"
-                        icon
-                        (ClickableSvg.linkSpa "some_link" :: theme :: attributes)
-                    ]
+                , cell index [ buttonExample (theme :: attributes) ]
+                , cell index [ buttonExample (ClickableSvg.withBorder :: theme :: attributes) ]
+                , cell index [ linkExample (theme :: attributes) ]
+                , cell index [ linkExample (ClickableSvg.withBorder :: theme :: attributes) ]
                 ]
 
         cell index =
@@ -192,13 +183,25 @@ viewExampleTable icon attributes =
                     , Css.padding (Css.px 10)
                     ]
                 ]
+
+        buttonExample attributes_ =
+            ClickableSvg.button "Button example"
+                icon
+                (ClickableSvg.onClick (ShowItWorked "You clicked the back button!")
+                    :: attributes_
+                )
+
+        linkExample attributes_ =
+            ClickableSvg.link "Link example"
+                icon
+                (ClickableSvg.linkSpa "some_link" :: attributes_)
     in
     Html.table []
         [ Html.thead []
             [ Html.tr []
                 [ Html.th [] [ Html.text "theme" ]
-                , Html.th [] [ Html.text "button" ]
-                , Html.th [] [ Html.text "link" ]
+                , Html.th [ Attributes.colspan 2 ] [ Html.text "button" ]
+                , Html.th [ Attributes.colspan 2 ] [ Html.text "link" ]
                 ]
             ]
         , Html.tbody [] <|
@@ -280,7 +283,6 @@ update msg state =
 type alias Settings msg =
     { icon : Svg
     , disabled : ClickableSvg.Attribute msg
-    , withBorder : ClickableSvg.Attribute msg
     , width : ClickableSvg.Attribute msg
     , height : ClickableSvg.Attribute msg
     }
@@ -289,10 +291,10 @@ type alias Settings msg =
 applySettings : Control (Settings msg) -> ( Svg, List (ClickableSvg.Attribute msg) )
 applySettings settings =
     let
-        { icon, disabled, withBorder, width, height } =
+        { icon, disabled, width, height } =
             Control.currentValue settings
     in
-    ( icon, [ disabled, withBorder, width, height ] )
+    ( icon, [ disabled, width, height ] )
 
 
 initSettings : Control (Settings msg)
@@ -314,17 +316,6 @@ initSettings =
             )
         |> Control.field "disabled"
             (Control.map ClickableSvg.disabled (Control.bool False))
-        |> Control.field "withBorder"
-            (Control.map
-                (\hasBorder ->
-                    if hasBorder then
-                        ClickableSvg.withBorder
-
-                    else
-                        ClickableSvg.css []
-                )
-                (Control.bool False)
-            )
         |> Control.field "width"
             (Control.map (Css.px >> ClickableSvg.width) (controlNumber 30))
         |> Control.field "height"

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -22,6 +22,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Select.V7 as Select
 import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.Tooltip.V2 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon
 
 
@@ -70,49 +71,93 @@ ClickableSvg.button "Go to tutorial"
                     ]
             , viewExample
                 """
-ClickableSvg.button "Preview"
-    UiIcon.preview
-    [ ClickableSvg.width (Css.px 20)
-    , ClickableSvg.height (Css.px 20)
-    , ClickableSvg.onClick (ShowItWorked "You clicked the preview button!")
-    , ClickableSvg.withTooltipAbove { id = "preview", isOpen = state.tooltipPreview, onShow = SetPreviewTooltip }
-    , ClickableSvg.withBorder
+Tooltip.view
+    { trigger =
+        \\attrs ->
+            ClickableSvg.button "Preview"
+                UiIcon.preview
+                [ ClickableSvg.width (Css.px 20)
+                , ClickableSvg.height (Css.px 20)
+                , ClickableSvg.onClick (ShowItWorked "You clicked the preview button!")
+                , ClickableSvg.withBorder
+                , ClickableSvg.custom attrs
+                ]
+    , id = "preview-tooltip"
+    }
+    [ Tooltip.plaintext "Preview"
+    , Tooltip.primaryLabel
+    , Tooltip.onHover SetPreviewTooltip
+    , Tooltip.open state.tooltipPreview
+    , Tooltip.smallPadding
+    , Tooltip.fitToContent
+    , Tooltip.alignEnd (Css.px 28)
     ]
             """
               <|
-                ClickableSvg.button "Preview"
-                    UiIcon.preview
-                    [ ClickableSvg.width (Css.px 20)
-                    , ClickableSvg.height (Css.px 20)
-                    , ClickableSvg.onClick (ShowItWorked "You clicked the preview button!")
-                    , ClickableSvg.withTooltipAbove
-                        { id = "preview"
-                        , isOpen = state.tooltipPreview
-                        , onShow = SetPreviewTooltip
-                        }
-                    , ClickableSvg.withBorder
+                Tooltip.view
+                    { trigger =
+                        \attrs ->
+                            ClickableSvg.button "Preview"
+                                UiIcon.preview
+                                [ ClickableSvg.width (Css.px 20)
+                                , ClickableSvg.height (Css.px 20)
+                                , ClickableSvg.onClick (ShowItWorked "You clicked the preview button!")
+                                , ClickableSvg.withBorder
+                                , ClickableSvg.custom attrs
+                                ]
+                    , id = "preview-tooltip"
+                    }
+                    [ Tooltip.plaintext "Preview"
+                    , Tooltip.primaryLabel
+                    , Tooltip.onHover SetPreviewTooltip
+                    , Tooltip.open state.tooltipPreview
+                    , Tooltip.smallPadding
+                    , Tooltip.fitToContent
+                    , Tooltip.alignEnd (Css.px 28)
                     ]
             , viewExample
                 """
-ClickableSvg.button "Share"
-    UiIcon.share
-    [ ClickableSvg.width (Css.px 20)
-    , ClickableSvg.height (Css.px 20)
-    , ClickableSvg.onClick (ShowItWorked "You clicked the Share button!")
-    , ClickableSvg.withTooltipBelow { id = "share", isOpen = state.tooltipShareTo, onShow = SetShareTooltip }
+Tooltip.view
+    { trigger =
+        \\attrs ->
+            ClickableSvg.button "Share"
+                UiIcon.share
+                [ ClickableSvg.width (Css.px 20)
+                , ClickableSvg.height (Css.px 20)
+                , ClickableSvg.onClick (ShowItWorked "You clicked the share button!")
+                , ClickableSvg.custom attrs
+                ]
+    , id = "share-tooltip"
+    }
+    [ Tooltip.plaintext "Share"
+    , Tooltip.primaryLabel
+    , Tooltip.onHover SetShareTooltip
+    , Tooltip.open state.tooltipShareTo
+    , Tooltip.smallPadding
+    , Tooltip.fitToContent
+    , Tooltip.onRight
     ]
             """
               <|
-                ClickableSvg.button "Share"
-                    UiIcon.share
-                    [ ClickableSvg.width (Css.px 20)
-                    , ClickableSvg.height (Css.px 20)
-                    , ClickableSvg.onClick (ShowItWorked "You clicked the share button!")
-                    , ClickableSvg.withTooltipBelow
-                        { id = "share"
-                        , isOpen = state.tooltipShareTo
-                        , onShow = SetShareTooltip
-                        }
+                Tooltip.view
+                    { trigger =
+                        \attrs ->
+                            ClickableSvg.button "Share"
+                                UiIcon.share
+                                [ ClickableSvg.width (Css.px 20)
+                                , ClickableSvg.height (Css.px 20)
+                                , ClickableSvg.onClick (ShowItWorked "You clicked the share button!")
+                                , ClickableSvg.custom attrs
+                                ]
+                    , id = "share-tooltip"
+                    }
+                    [ Tooltip.plaintext "Share"
+                    , Tooltip.primaryLabel
+                    , Tooltip.onHover SetShareTooltip
+                    , Tooltip.open state.tooltipShareTo
+                    , Tooltip.smallPadding
+                    , Tooltip.fitToContent
+                    , Tooltip.onRight
                     ]
             ]
     }

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -162,6 +162,15 @@ Tooltip.view
 
 viewExampleTable : Svg -> List (ClickableSvg.Attribute Msg) -> Html Msg
 viewExampleTable icon attributes =
+    let
+        cell =
+            Html.td
+                [ Attributes.css
+                    [ Css.backgroundColor Colors.gray96
+                    , Css.padding (Css.px 30)
+                    ]
+                ]
+    in
     Html.table []
         [ Html.thead []
             [ Html.tr []
@@ -171,14 +180,14 @@ viewExampleTable icon attributes =
             ]
         , Html.tbody []
             [ Html.tr []
-                [ Html.td []
+                [ cell
                     [ ClickableSvg.button "Button example"
                         icon
                         (ClickableSvg.onClick (ShowItWorked "You clicked the back button!")
                             :: attributes
                         )
                     ]
-                , Html.td []
+                , cell
                     [ ClickableSvg.link "Link example"
                         icon
                         (ClickableSvg.linkSpa "some_link" :: attributes)
@@ -308,6 +317,7 @@ initSettings =
                 [ ( "primary", Control.value ClickableSvg.primary )
                 , ( "secondary", Control.value ClickableSvg.secondary )
                 , ( "danger", Control.value ClickableSvg.danger )
+                , ( "dangerSecondary", Control.value ClickableSvg.dangerSecondary )
                 ]
             )
         |> Control.field "width"


### PR DESCRIPTION
for clickable svgs:
- adds withBorder setting 
- adds primary, secondary, and danger themes

<img width="589" alt="Screen Shot 2020-09-28 at 12 28 28 PM" src="https://user-images.githubusercontent.com/8811312/94477120-4df3c980-0186-11eb-8a56-7eddb901b52f.png">


Questions:
- "secondary" is currently the navy color -- is that what secondary should mean here?
- do we want background color changes on hover?
