### PR TITLE
remove/lower min heights

### DIFF
--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -692,8 +692,8 @@ viewFooter children =
                 , Css.flexDirection Css.column
                 , Css.flexGrow (Css.int 2)
                 , Css.flexWrap Css.noWrap
-                , Css.margin4 (Css.px 20) Css.zero Css.zero Css.zero
-                , Css.paddingBottom (Css.px 40)
+                , Css.margin4 (Css.px 30) Css.zero Css.zero Css.zero
+                , Css.paddingBottom (Css.px 30)
                 , Css.width (Css.pct 100)
                 ]
             ]

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -408,7 +408,6 @@ modalStyles =
     , margin2 (px 50) auto
 
     -- Size
-    , minHeight (vh 40)
     , width (px 600)
     , backgroundColor Colors.white
 
@@ -624,7 +623,7 @@ viewInnerContent ({ visibleTitle } as config) =
             [ Attrs.css
                 [ Css.overflowY Css.auto
                 , Css.overflowX Css.hidden
-                , Css.minHeight (Css.px 150)
+                , Css.minHeight (Css.px 50)
                 , Css.maxHeight
                     (Css.calc (Css.vh 100)
                         Css.minus


### PR DESCRIPTION
This removes the minimum height for the modal container and reduces it for the modal content area so that modals with a small amount of content don't have a bunch of empty space and modals within a huge viewport don't grow for no good reason. Also tweaks footer spacing. I'm hoping it's OK to keep this on V11 since it's just styling, but let me know.

Outfoxes: https://github.com/NoRedInk/noredink-ui/issues/598

![image](https://user-images.githubusercontent.com/13528834/94867214-a4b30a80-03f5-11eb-833c-5dfc1b352894.png)

![image](https://user-images.githubusercontent.com/13528834/94867254-c57b6000-03f5-11eb-8734-7e76c1964702.png)

![image](https://user-images.githubusercontent.com/13528834/94867288-d6c46c80-03f5-11eb-8fee-d61d383a6d35.png)