### PR TITLE
Adjust title padding

### DIFF
--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -421,8 +421,7 @@ titleStyles color visibleTitle =
     if visibleTitle then
         [ Fonts.baseFont
         , Css.fontWeight (Css.int 700)
-        , Css.paddingTop (Css.px 40)
-        , Css.paddingBottom (Css.px 20)
+        , Css.padding3 (Css.px 40) (Css.px 40) (Css.px 20)
         , Css.margin Css.zero
         , Css.fontSize (Css.px 20)
         , Css.textAlign Css.center


### PR DESCRIPTION
Adds left-right padding to modal titles. Next up: make it so long titles don't squash the footer?

<img width="691" alt="image" src="https://user-images.githubusercontent.com/13528834/95499761-9ebfab00-095a-11eb-8012-07543ae0a759.png">