### PR TITLE
Clean up button icon styling code

### DIFF
--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -605,6 +605,8 @@ viewLabel maybeSvg label_ =
         [ Css.overflow Css.hidden -- Keep scrollbars out of our button
         , Css.overflowWrap Css.breakWord -- Ensure that words that exceed the button width break instead of disappearing
         , Css.padding2 (Css.px 2) Css.zero -- Without a bit of bottom padding, text that extends below the baseline, like "g" gets cut off
+        , Css.displayFlex
+        , Css.alignItems Css.center
         ]
         []
         (case maybeSvg of
@@ -848,15 +850,13 @@ sizeStyle size width =
                 [ Css.height (Css.px config.imageHeight)
                 , Css.width Css.auto
                 , Css.marginRight (Css.px 5)
-                , Css.position Css.relative
-                , Css.verticalAlign Css.middle
+                , Css.flexShrink Css.zero
                 ]
             , Css.Global.svg
                 [ Css.height (Css.px config.imageHeight)
                 , Css.width Css.auto
                 , Css.marginRight (Css.px 5)
-                , Css.position Css.relative
-                , Css.verticalAlign Css.middle
+                , Css.flexShrink Css.zero
                 ]
             ]
         ]

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -846,26 +846,16 @@ sizeStyle size width =
         , Css.Global.descendants
             [ Css.Global.img
                 [ Css.height (Css.px config.imageHeight)
-                , Css.marginRight (Css.px <| config.imageHeight / 6)
+                , Css.width Css.auto
+                , Css.marginRight (Css.px 5)
                 , Css.position Css.relative
-                , Css.bottom (Css.px 2)
                 , Css.verticalAlign Css.middle
                 ]
             , Css.Global.svg
-                [ Css.height (Css.px config.imageHeight) |> Css.important
-                , Css.width (Css.px config.imageHeight) |> Css.important
-                , Css.marginRight (Css.px <| config.imageHeight / 6)
+                [ Css.height (Css.px config.imageHeight)
+                , Css.width Css.auto
+                , Css.marginRight (Css.px 5)
                 , Css.position Css.relative
-                , Css.bottom (Css.px 2)
-                , Css.verticalAlign Css.middle
-                ]
-            , Css.Global.svg
-                [ Css.important <| Css.height (Css.px config.imageHeight)
-                , Css.important <| Css.width Css.auto
-                , Css.maxWidth (Css.px (config.imageHeight * 1.25))
-                , Css.paddingRight (Css.px <| config.imageHeight / 6)
-                , Css.position Css.relative
-                , Css.bottom (Css.px 2)
                 , Css.verticalAlign Css.middle
                 ]
             ]


### PR DESCRIPTION
In normal circumstances, there should be no changes besides icons and text being slightly better aligned. In cases where text runs to two lines, icons are now center aligned rather than being inline.

<img width="723" alt="image" src="https://user-images.githubusercontent.com/13528834/95796065-c4251f80-0ca0-11eb-873e-609a4325dea3.png">

<img width="783" alt="image" src="https://user-images.githubusercontent.com/13528834/95795995-a8217e00-0ca0-11eb-801c-f6de311efa2d.png">