### PR TITLE
Kraken/clickable svg improvements

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -15,6 +15,7 @@
         "Nri.Ui.Callout.V1",
         "Nri.Ui.Checkbox.V5",
         "Nri.Ui.ClickableSvg.V1",
+        "Nri.Ui.ClickableSvg.V2",
         "Nri.Ui.ClickableText.V3",
         "Nri.Ui.Colors.Extra",
         "Nri.Ui.Colors.V1",

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -53,7 +53,6 @@ import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
-import Nri.Ui.Tooltip.V1 as Tooltip exposing (Tooltip)
 
 
 {-| -}

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -392,27 +392,53 @@ renderLink ((ButtonOrLink config) as link_) =
         ]
 
 
+getSize : Size -> Float
+getSize size =
+    case size of
+        Small ->
+            17
+
+        Medium ->
+            30
+
+        Large ->
+            40
+
+
 renderIcon : ButtonOrLinkAttributes msg -> Html msg
 renderIcon config =
     let
-        ( iconWidth, iconHeight ) =
-            case config.size of
-                Small ->
-                    ( Css.px 17, Css.px 17 )
+        size =
+            getSize config.size
 
-                Medium ->
-                    ( Css.px 30, Css.px 30 )
+        iconWidth =
+            if config.hasBorder then
+                size
+                    - (withBorderHorizontalPadding * 2)
+                    - withBorderLeftBorderWidth
+                    - withBorderRightBorderWidth
 
-                Large ->
-                    ( Css.px 30, Css.px 30 )
+            else
+                size
+
+        iconHeight =
+            if config.hasBorder then
+                size
+                    - withBorderTopPadding
+                    - withBorderBottomPadding
+                    - withBorderTopBorderWidth
+                    - withBorderBottomBorderWidth
+
+            else
+                size
     in
     config.icon
         |> Svg.withCss
             [ Css.displayFlex
             , Css.alignItems Css.center
             , Css.justifyContent Css.center
-            , Css.maxWidth iconWidth
-            , Css.height iconHeight
+            , Css.maxWidth (Css.px iconWidth)
+            , Css.height (Css.px iconHeight)
             ]
         |> Svg.toHtml
 
@@ -461,6 +487,8 @@ buttonOrLinkStyles config =
                 (Css.px withBorderTopPadding)
                 (Css.px withBorderHorizontalPadding)
                 (Css.px withBorderBottomPadding)
+            , Css.width (Css.px (getSize config.size))
+            , Css.height (Css.px (getSize config.size))
             ]
 
         else

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -447,7 +447,8 @@ renderIcon config =
         |> Svg.withCss
             [ Css.displayFlex
             , Css.maxWidth (Css.px iconWidth)
-            , Css.height (Css.px iconHeight)
+            , Css.maxHeight (Css.px iconHeight)
+            , Css.height (Css.pct 100)
             , Css.margin Css.auto
             ]
         |> Svg.toHtml
@@ -501,8 +502,6 @@ buttonOrLinkStyles config =
                 (Css.px bordersAndPadding.rightPadding)
                 (Css.px bordersAndPadding.bottomPadding)
                 (Css.px bordersAndPadding.leftPadding)
-            , Css.width (Css.px (Maybe.withDefault (getSize config.size) config.width))
-            , Css.height (Css.px (Maybe.withDefault (getSize config.size) config.height))
             , Css.height (Css.px (getSize config.size))
             ]
 
@@ -513,20 +512,10 @@ buttonOrLinkStyles config =
             ]
 
     -- Sizing
-    , Css.displayFlex
+    , Css.display Css.inlineBlock
     , Css.boxSizing Css.borderBox
-    , case config.width of
-        Just width ->
-            Css.width (Css.px width)
-
-        Nothing ->
-            Css.batch []
-    , case config.height of
-        Just height ->
-            Css.height (Css.px height)
-
-        Nothing ->
-            Css.batch []
+    , Css.width (Css.px (Maybe.withDefault (getSize config.size) config.width))
+    , Css.height (Css.px (Maybe.withDefault (getSize config.size) config.height))
     ]
 
 

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -392,31 +392,22 @@ renderLink ((ButtonOrLink config) as link_) =
         ]
 
 
-getSize : Size -> Float
-getSize size =
-    case size of
-        Small ->
-            17
-
-        Medium ->
-            30
-
-        Large ->
-            40
-
-
 renderIcon : ButtonOrLinkAttributes msg -> Html msg
 renderIcon config =
     let
         size =
             getSize config.size
 
+        bordersAndPadding =
+            getBorder config.size
+
         iconWidth =
             if config.hasBorder then
                 size
-                    - (withBorderHorizontalPadding * 2)
-                    - withBorderLeftBorderWidth
-                    - withBorderRightBorderWidth
+                    - bordersAndPadding.leftPadding
+                    - bordersAndPadding.rightPadding
+                    - bordersAndPadding.leftBorder
+                    - bordersAndPadding.rightBorder
 
             else
                 size
@@ -424,10 +415,10 @@ renderIcon config =
         iconHeight =
             if config.hasBorder then
                 size
-                    - withBorderTopPadding
-                    - withBorderBottomPadding
-                    - withBorderTopBorderWidth
-                    - withBorderBottomBorderWidth
+                    - bordersAndPadding.topPadding
+                    - bordersAndPadding.bottomPadding
+                    - bordersAndPadding.topBorder
+                    - bordersAndPadding.bottomBorder
 
             else
                 size
@@ -452,6 +443,9 @@ buttonOrLinkStyles config =
 
             else
                 ( applyTheme config.theme, Css.pointer )
+
+        bordersAndPadding =
+            getBorder config.size
     in
     [ Css.property "transition"
         "background-color 0.2s, color 0.2s, border-width 0s, border-color 0.2s"
@@ -474,19 +468,20 @@ buttonOrLinkStyles config =
             [ Css.borderRadius (Css.px 8)
             , Css.borderColor main_
             , Css.borderStyle Css.solid
-            , Css.borderTopWidth (Css.px withBorderTopBorderWidth)
-            , Css.borderRightWidth (Css.px withBorderRightBorderWidth)
-            , Css.borderBottomWidth (Css.px withBorderBottomBorderWidth)
-            , Css.borderLeftWidth (Css.px withBorderLeftBorderWidth)
+            , Css.borderTopWidth (Css.px bordersAndPadding.topBorder)
+            , Css.borderRightWidth (Css.px bordersAndPadding.rightBorder)
+            , Css.borderBottomWidth (Css.px bordersAndPadding.bottomBorder)
+            , Css.borderLeftWidth (Css.px bordersAndPadding.leftBorder)
             , Css.backgroundColor background
             , Css.hover
                 [ Css.borderColor mainHovered
                 , Css.backgroundColor backgroundHovered
                 ]
-            , Css.padding3
-                (Css.px withBorderTopPadding)
-                (Css.px withBorderHorizontalPadding)
-                (Css.px withBorderBottomPadding)
+            , Css.padding4
+                (Css.px bordersAndPadding.topPadding)
+                (Css.px bordersAndPadding.rightPadding)
+                (Css.px bordersAndPadding.bottomPadding)
+                (Css.px bordersAndPadding.leftPadding)
             , Css.width (Css.px (getSize config.size))
             , Css.height (Css.px (getSize config.size))
             ]
@@ -504,36 +499,62 @@ buttonOrLinkStyles config =
     ]
 
 
-withBorderTopBorderWidth : Float
-withBorderTopBorderWidth =
-    1
+getSize : Size -> Float
+getSize size =
+    case size of
+        Small ->
+            17
+
+        Medium ->
+            30
+
+        Large ->
+            40
 
 
-withBorderRightBorderWidth : Float
-withBorderRightBorderWidth =
-    1
+getBorder :
+    Size
+    ->
+        { topBorder : Float
+        , topPadding : Float
+        , rightBorder : Float
+        , rightPadding : Float
+        , bottomBorder : Float
+        , bottomPadding : Float
+        , leftBorder : Float
+        , leftPadding : Float
+        }
+getBorder size =
+    case size of
+        Small ->
+            { topBorder = 1
+            , topPadding = 2
+            , rightBorder = 1
+            , rightPadding = 2
+            , bottomBorder = 1
+            , bottomPadding = 2
+            , leftBorder = 1
+            , leftPadding = 2
+            }
 
+        Medium ->
+            { topBorder = 1
+            , topPadding = 4
+            , rightBorder = 1
+            , rightPadding = 5
+            , bottomBorder = 2
+            , bottomPadding = 3
+            , leftBorder = 1
+            , leftPadding = 5
+            }
 
-withBorderBottomBorderWidth : Float
-withBorderBottomBorderWidth =
-    2
-
-
-withBorderLeftBorderWidth : Float
-withBorderLeftBorderWidth =
-    1
-
-
-withBorderTopPadding : Float
-withBorderTopPadding =
-    4
-
-
-withBorderBottomPadding : Float
-withBorderBottomPadding =
-    3
-
-
-withBorderHorizontalPadding : Float
-withBorderHorizontalPadding =
-    5
+        Large ->
+            { topBorder = 1
+            , topPadding = 4
+            , rightBorder = 1
+            , rightPadding = 7
+            , bottomBorder = 3
+            , bottomPadding = 3
+            , leftBorder = 1
+            , leftPadding = 7
+            }

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -581,25 +581,25 @@ getBorder size width height =
             else if h < mediumSize then
                 -- Small size vertical settings
                 { topBorder = 1
-                , topPadding = 2
+                , topPadding = 7
                 , bottomBorder = 2
-                , bottomPadding = 2
+                , bottomPadding = 7
                 }
 
             else if h < largeSize then
                 -- Medium size vertical settings
                 { topBorder = 1
-                , topPadding = 2
+                , topPadding = 10
                 , bottomBorder = 3
-                , bottomPadding = 2
+                , bottomPadding = 8
                 }
 
             else
                 -- Large size vertical settings
                 { topBorder = 1
-                , topPadding = 2
+                , topPadding = 13
                 , bottomBorder = 4
-                , bottomPadding = 2
+                , bottomPadding = 11
                 }
 
         horizontalSettings =
@@ -614,25 +614,25 @@ getBorder size width height =
             else if w < mediumSize then
                 -- Small size horizontal settings
                 { rightBorder = 1
-                , rightPadding = 4
+                , rightPadding = 7
                 , leftBorder = 1
-                , leftPadding = 4
+                , leftPadding = 7
                 }
 
             else if w < largeSize then
                 -- Medium size horizontal settings
                 { rightBorder = 1
-                , rightPadding = 4
+                , rightPadding = 9
                 , leftBorder = 1
-                , leftPadding = 4
+                , leftPadding = 9
                 }
 
             else
                 -- Large size horizontal settings
                 { rightBorder = 1
-                , rightPadding = 4
+                , rightPadding = 12
                 , leftBorder = 1
-                , leftPadding = 4
+                , leftPadding = 12
                 }
     in
     { topBorder = verticalSettings.topBorder

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -4,6 +4,7 @@ module Nri.Ui.ClickableSvg.V2 exposing
     , onClick
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     , small, medium, large
+    , exactWidth
     , disabled
     , withBorder
     , primary, secondary, danger, dangerSecondary
@@ -28,6 +29,7 @@ module Nri.Ui.ClickableSvg.V2 exposing
 ## Sizing
 
 @docs small, medium, large
+@docs exactWidth
 
 
 ## State
@@ -164,6 +166,13 @@ medium =
 large : Attribute msg
 large =
     set (\attributes -> { attributes | size = Large })
+
+
+{-| Define a size in `px` for the button's total width.
+-}
+exactWidth : Int -> Attribute msg
+exactWidth inPx =
+    set (\attributes -> { attributes | width = Just (toFloat inPx) })
 
 
 
@@ -319,6 +328,7 @@ build label icon =
         , icon = icon
         , disabled = False
         , size = Small
+        , width = Nothing
         , customAttributes = []
         , customStyles = []
         , hasBorder = False
@@ -336,6 +346,7 @@ type alias ButtonOrLinkAttributes msg =
     , icon : Svg
     , disabled : Bool
     , size : Size
+    , width : Maybe Float
     , customAttributes : List (Html.Attribute msg)
     , customStyles : List Style
     , hasBorder : Bool
@@ -426,10 +437,9 @@ renderIcon config =
     config.icon
         |> Svg.withCss
             [ Css.displayFlex
-            , Css.alignItems Css.center
-            , Css.justifyContent Css.center
             , Css.maxWidth (Css.px iconWidth)
             , Css.height (Css.px iconHeight)
+            , Css.margin Css.auto
             ]
         |> Svg.toHtml
 
@@ -482,7 +492,7 @@ buttonOrLinkStyles config =
                 (Css.px bordersAndPadding.rightPadding)
                 (Css.px bordersAndPadding.bottomPadding)
                 (Css.px bordersAndPadding.leftPadding)
-            , Css.width (Css.px (getSize config.size))
+            , Css.width (Css.px (Maybe.withDefault (getSize config.size) config.width))
             , Css.height (Css.px (getSize config.size))
             ]
 
@@ -496,6 +506,12 @@ buttonOrLinkStyles config =
     , Css.display Css.inlineBlock
     , Css.boxSizing Css.borderBox
     , Css.lineHeight (Css.num 1)
+    , case config.width of
+        Just width ->
+            Css.width (Css.px width)
+
+        Nothing ->
+            Css.batch []
     ]
 
 

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -519,13 +519,13 @@ getSize : Size -> Float
 getSize size =
     case size of
         Small ->
-            17
+            36
 
         Medium ->
-            30
+            45
 
         Large ->
-            40
+            56
 
 
 getBorder :
@@ -546,31 +546,31 @@ getBorder size =
             { topBorder = 1
             , topPadding = 2
             , rightBorder = 1
-            , rightPadding = 2
-            , bottomBorder = 1
+            , rightPadding = 4
+            , bottomBorder = 2
             , bottomPadding = 2
             , leftBorder = 1
-            , leftPadding = 2
+            , leftPadding = 4
             }
 
         Medium ->
             { topBorder = 1
-            , topPadding = 4
+            , topPadding = 2
             , rightBorder = 1
-            , rightPadding = 5
-            , bottomBorder = 2
-            , bottomPadding = 3
+            , rightPadding = 4
+            , bottomBorder = 3
+            , bottomPadding = 2
             , leftBorder = 1
-            , leftPadding = 5
+            , leftPadding = 4
             }
 
         Large ->
             { topBorder = 1
-            , topPadding = 4
+            , topPadding = 2
             , rightBorder = 1
-            , rightPadding = 7
-            , bottomBorder = 3
-            , bottomPadding = 3
+            , rightPadding = 4
+            , bottomBorder = 4
+            , bottomPadding = 2
             , leftBorder = 1
-            , leftPadding = 7
+            , leftPadding = 4
             }

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -8,16 +8,9 @@ module Nri.Ui.ClickableSvg.V2 exposing
     , withBorder
     , primary, secondary, danger, dangerSecondary
     , custom, css
-    , withTooltipAbove, withTooltipBelow
     )
 
 {-|
-
-
-# Post-release patches
-
-  - uses ClickableAttributes
-  - adds tooltip helpers
 
 
 # Create a button or link
@@ -48,11 +41,6 @@ module Nri.Ui.ClickableSvg.V2 exposing
 @docs primary, secondary, danger, dangerSecondary
 
 @docs custom, css
-
-
-## Tooltips
-
-@docs withTooltipAbove, withTooltipBelow
 
 -}
 
@@ -310,67 +298,6 @@ css styles =
 
 
 
--- TOOLTIPS
-
-
-type alias TooltipSettings msg =
-    { position : Tooltip.Position
-    , isOpen : Bool
-    , onShow : Bool -> msg
-    , id : String
-    }
-
-
-showTooltip : String -> Maybe (TooltipSettings msg) -> Html msg -> Html msg
-showTooltip label maybeSettings buttonOrLink =
-    case maybeSettings of
-        Just { position, onShow, isOpen, id } ->
-            let
-                tooltipSettings =
-                    { trigger = Tooltip.OnHover
-                    , onTrigger = onShow
-                    , isOpen = isOpen
-                    , triggerHtml = buttonOrLink
-                    , extraButtonAttrs = []
-                    , id = id ++ "__clickable-svg-tooltip"
-                    }
-            in
-            Tooltip.tooltip [ Html.text label ]
-                |> Tooltip.withPosition position
-                |> Tooltip.withWidth Tooltip.FitToContent
-                |> Tooltip.withPadding Tooltip.SmallPadding
-                |> Tooltip.primaryLabel tooltipSettings
-
-        Nothing ->
-            buttonOrLink
-
-
-withTooltip : Tooltip.Position -> { id : String, isOpen : Bool, onShow : Bool -> msg } -> Attribute msg
-withTooltip position { id, isOpen, onShow } =
-    set
-        (\config ->
-            { config
-                | tooltip =
-                    Just { position = position, id = id, isOpen = isOpen, onShow = onShow }
-            }
-        )
-
-
-{-| DEPRECATED: prefer to use the Tooltip module directly.
--}
-withTooltipAbove : { id : String, isOpen : Bool, onShow : Bool -> msg } -> Attribute msg
-withTooltipAbove =
-    withTooltip Tooltip.OnTop
-
-
-{-| DEPRECATED: prefer to use the Tooltip module directly.
--}
-withTooltipBelow : { id : String, isOpen : Bool, onShow : Bool -> msg } -> Attribute msg
-withTooltipBelow =
-    withTooltip Tooltip.OnBottom
-
-
-
 -- INTERNALS
 
 
@@ -392,7 +319,6 @@ build label icon =
         , disabled = False
         , customAttributes = []
         , customStyles = []
-        , tooltip = Nothing
         , hasBorder = False
         , theme = Secondary
         }
@@ -411,7 +337,6 @@ type alias ButtonOrLinkAttributes msg =
     , disabled : Bool
     , customAttributes : List (Html.Attribute msg)
     , customStyles : List Style
-    , tooltip : Maybe (TooltipSettings msg)
     , hasBorder : Bool
     , theme : Theme
     }
@@ -431,7 +356,6 @@ renderButton ((ButtonOrLink config) as button_) =
         )
         [ renderIcon config
         ]
-        |> showTooltip config.label config.tooltip
 
 
 type Link
@@ -465,7 +389,6 @@ renderLink ((ButtonOrLink config) as link_) =
         )
         [ renderIcon config
         ]
-        |> showTooltip config.label config.tooltip
 
 
 renderIcon : ButtonOrLinkAttributes msg -> Html msg

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -419,7 +419,7 @@ renderIcon config =
             getSize config.size
 
         bordersAndPadding =
-            getBorder config.size
+            getBorder config.size config.width config.height
 
         iconWidth =
             if config.hasBorder then
@@ -464,7 +464,7 @@ buttonOrLinkStyles config =
                 ( applyTheme config.theme, Css.pointer )
 
         bordersAndPadding =
-            getBorder config.size
+            getBorder config.size config.width config.height
     in
     [ Css.property "transition"
         "background-color 0.2s, color 0.2s, border-width 0s, border-color 0.2s"
@@ -534,17 +534,34 @@ getSize : Size -> Float
 getSize size =
     case size of
         Small ->
-            36
+            smallSize
 
         Medium ->
-            45
+            mediumSize
 
         Large ->
-            56
+            largeSize
+
+
+smallSize : Float
+smallSize =
+    36
+
+
+mediumSize : Float
+mediumSize =
+    45
+
+
+largeSize : Float
+largeSize =
+    56
 
 
 getBorder :
     Size
+    -> Maybe Float
+    -> Maybe Float
     ->
         { topBorder : Float
         , topPadding : Float
@@ -555,37 +572,86 @@ getBorder :
         , leftBorder : Float
         , leftPadding : Float
         }
-getBorder size =
-    case size of
-        Small ->
-            { topBorder = 1
-            , topPadding = 2
-            , rightBorder = 1
-            , rightPadding = 4
-            , bottomBorder = 2
-            , bottomPadding = 2
-            , leftBorder = 1
-            , leftPadding = 4
-            }
+getBorder size width height =
+    let
+        w =
+            Maybe.withDefault (getSize size) width
 
-        Medium ->
-            { topBorder = 1
-            , topPadding = 2
-            , rightBorder = 1
-            , rightPadding = 4
-            , bottomBorder = 3
-            , bottomPadding = 2
-            , leftBorder = 1
-            , leftPadding = 4
-            }
+        h =
+            Maybe.withDefault (getSize size) height
 
-        Large ->
-            { topBorder = 1
-            , topPadding = 2
-            , rightBorder = 1
-            , rightPadding = 4
-            , bottomBorder = 4
-            , bottomPadding = 2
-            , leftBorder = 1
-            , leftPadding = 4
-            }
+        verticalSettings =
+            if h < smallSize then
+                -- Teeny size vertical settings
+                { topBorder = 1
+                , topPadding = 1
+                , bottomBorder = 2
+                , bottomPadding = 1
+                }
+
+            else if h < mediumSize then
+                -- Small size vertical settings
+                { topBorder = 1
+                , topPadding = 2
+                , bottomBorder = 2
+                , bottomPadding = 2
+                }
+
+            else if h < largeSize then
+                -- Medium size vertical settings
+                { topBorder = 1
+                , topPadding = 2
+                , bottomBorder = 3
+                , bottomPadding = 2
+                }
+
+            else
+                -- Large size vertical settings
+                { topBorder = 1
+                , topPadding = 2
+                , bottomBorder = 4
+                , bottomPadding = 2
+                }
+
+        horizontalSettings =
+            if w < smallSize then
+                -- Teeny size horizontal settings
+                { rightBorder = 1
+                , rightPadding = 2
+                , leftBorder = 1
+                , leftPadding = 2
+                }
+
+            else if w < mediumSize then
+                -- Small size horizontal settings
+                { rightBorder = 1
+                , rightPadding = 4
+                , leftBorder = 1
+                , leftPadding = 4
+                }
+
+            else if w < largeSize then
+                -- Medium size horizontal settings
+                { rightBorder = 1
+                , rightPadding = 4
+                , leftBorder = 1
+                , leftPadding = 4
+                }
+
+            else
+                -- Large size horizontal settings
+                { rightBorder = 1
+                , rightPadding = 4
+                , leftBorder = 1
+                , leftPadding = 4
+                }
+    in
+    { topBorder = verticalSettings.topBorder
+    , topPadding = verticalSettings.topPadding
+    , bottomBorder = verticalSettings.bottomBorder
+    , bottomPadding = verticalSettings.bottomPadding
+    , rightBorder = horizontalSettings.rightBorder
+    , rightPadding = horizontalSettings.rightPadding
+    , leftBorder = horizontalSettings.leftBorder
+    , leftPadding = horizontalSettings.leftPadding
+    }

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -3,6 +3,7 @@ module Nri.Ui.ClickableSvg.V2 exposing
     , Attribute
     , onClick
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
+    , small, medium, large
     , disabled
     , withBorder
     , primary, secondary, danger, dangerSecondary
@@ -25,6 +26,8 @@ module Nri.Ui.ClickableSvg.V2 exposing
 
 
 ## Sizing
+
+@docs small, medium, large
 
 
 ## State
@@ -132,6 +135,35 @@ linkExternal url =
 linkExternalWithTracking : { track : msg, url : String } -> Attribute msg
 linkExternalWithTracking config =
     setClickableAttributes (ClickableAttributes.linkExternalWithTracking config)
+
+
+
+-- SIZING
+
+
+type Size
+    = Small
+    | Medium
+    | Large
+
+
+{-| This is the default.
+-}
+small : Attribute msg
+small =
+    set (\attributes -> { attributes | size = Small })
+
+
+{-| -}
+medium : Attribute msg
+medium =
+    set (\attributes -> { attributes | size = Medium })
+
+
+{-| -}
+large : Attribute msg
+large =
+    set (\attributes -> { attributes | size = Large })
 
 
 
@@ -286,6 +318,7 @@ build label icon =
         , label = label
         , icon = icon
         , disabled = False
+        , size = Small
         , customAttributes = []
         , customStyles = []
         , hasBorder = False
@@ -302,6 +335,7 @@ type alias ButtonOrLinkAttributes msg =
     , label : String
     , icon : Svg
     , disabled : Bool
+    , size : Size
     , customAttributes : List (Html.Attribute msg)
     , customStyles : List Style
     , hasBorder : Bool
@@ -360,14 +394,26 @@ renderLink ((ButtonOrLink config) as link_) =
 
 renderIcon : ButtonOrLinkAttributes msg -> Html msg
 renderIcon config =
+    let
+        ( iconWidth, iconHeight ) =
+            case config.size of
+                Small ->
+                    ( Css.px 17, Css.px 17 )
+
+                Medium ->
+                    ( Css.px 30, Css.px 30 )
+
+                Large ->
+                    ( Css.px 30, Css.px 30 )
+    in
     config.icon
         |> Svg.withCss
-            (if config.hasBorder then
-                []
-
-             else
-                []
-            )
+            [ Css.displayFlex
+            , Css.alignItems Css.center
+            , Css.justifyContent Css.center
+            , Css.maxWidth iconWidth
+            , Css.height iconHeight
+            ]
         |> Svg.toHtml
 
 

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -3,7 +3,6 @@ module Nri.Ui.ClickableSvg.V2 exposing
     , Attribute
     , onClick
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
-    , width, height
     , disabled
     , withBorder
     , primary, secondary, danger, dangerSecondary
@@ -26,8 +25,6 @@ module Nri.Ui.ClickableSvg.V2 exposing
 
 
 ## Sizing
-
-@docs width, height
 
 
 ## State
@@ -135,32 +132,6 @@ linkExternal url =
 linkExternalWithTracking : { track : msg, url : String } -> Attribute msg
 linkExternalWithTracking config =
     setClickableAttributes (ClickableAttributes.linkExternalWithTracking config)
-
-
-
--- SIZING
-
-
-{-| Default width is 17px.
-
-Note: changing this width will change the width of the icon. The button or link
-may be wider if you add a border or margin to it.
-
--}
-width : Css.Px -> Attribute msg
-width px =
-    set (\attributes -> { attributes | width = px })
-
-
-{-| Default height is 17px.
-
-Note: changing this height will change the height of the icon. The button or link
-may be taller if you add a border or margin to it.
-
--}
-height : Css.Px -> Attribute msg
-height px =
-    set (\attributes -> { attributes | height = px })
 
 
 
@@ -314,8 +285,6 @@ build label icon =
         { clickableAttributes = ClickableAttributes.init
         , label = label
         , icon = icon
-        , height = Css.px 17
-        , width = Css.px 17
         , disabled = False
         , customAttributes = []
         , customStyles = []
@@ -332,8 +301,6 @@ type alias ButtonOrLinkAttributes msg =
     { clickableAttributes : ClickableAttributes msg
     , label : String
     , icon : Svg
-    , height : Css.Px
-    , width : Css.Px
     , disabled : Bool
     , customAttributes : List (Html.Attribute msg)
     , customStyles : List Style
@@ -396,31 +363,10 @@ renderIcon config =
     config.icon
         |> Svg.withCss
             (if config.hasBorder then
-                [ Css.width
-                    (Css.calc config.width
-                        Css.minus
-                        (Css.px <|
-                            (2 * withBorderHorizontalPadding)
-                                + withBorderLeftBorderWidth
-                                + withBorderRightBorderWidth
-                        )
-                    )
-                , Css.height
-                    (Css.calc config.height
-                        Css.minus
-                        (Css.px <|
-                            withBorderTopPadding
-                                + withBorderBottomPadding
-                                + withBorderTopBorderWidth
-                                + withBorderBottomBorderWidth
-                        )
-                    )
-                ]
+                []
 
              else
-                [ Css.width config.width
-                , Css.height config.height
-                ]
+                []
             )
         |> Svg.toHtml
 
@@ -480,8 +426,6 @@ buttonOrLinkStyles config =
     -- Sizing
     , Css.display Css.inlineBlock
     , Css.boxSizing Css.borderBox
-    , Css.width config.width
-    , Css.height config.height
     , Css.lineHeight (Css.num 1)
     ]
 

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -4,7 +4,7 @@ module Nri.Ui.ClickableSvg.V2 exposing
     , onClick
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     , small, medium, large
-    , exactWidth
+    , exactWidth, exactHeight
     , disabled
     , withBorder
     , primary, secondary, danger, dangerSecondary
@@ -29,7 +29,7 @@ module Nri.Ui.ClickableSvg.V2 exposing
 ## Sizing
 
 @docs small, medium, large
-@docs exactWidth
+@docs exactWidth, exactHeight
 
 
 ## State
@@ -168,11 +168,18 @@ large =
     set (\attributes -> { attributes | size = Large })
 
 
-{-| Define a size in `px` for the button's total width.
+{-| Define a size in `px` for the element's total width.
 -}
 exactWidth : Int -> Attribute msg
 exactWidth inPx =
     set (\attributes -> { attributes | width = Just (toFloat inPx) })
+
+
+{-| Define a size in `px` for the element's total height.
+-}
+exactHeight : Int -> Attribute msg
+exactHeight inPx =
+    set (\attributes -> { attributes | height = Just (toFloat inPx) })
 
 
 
@@ -329,6 +336,7 @@ build label icon =
         , disabled = False
         , size = Small
         , width = Nothing
+        , height = Nothing
         , customAttributes = []
         , customStyles = []
         , hasBorder = False
@@ -347,6 +355,7 @@ type alias ButtonOrLinkAttributes msg =
     , disabled : Bool
     , size : Size
     , width : Maybe Float
+    , height : Maybe Float
     , customAttributes : List (Html.Attribute msg)
     , customStyles : List Style
     , hasBorder : Bool
@@ -421,7 +430,7 @@ renderIcon config =
                     - bordersAndPadding.rightBorder
 
             else
-                size
+                Maybe.withDefault size config.width
 
         iconHeight =
             if config.hasBorder then
@@ -432,7 +441,7 @@ renderIcon config =
                     - bordersAndPadding.bottomBorder
 
             else
-                size
+                Maybe.withDefault size config.height
     in
     config.icon
         |> Svg.withCss
@@ -493,6 +502,7 @@ buttonOrLinkStyles config =
                 (Css.px bordersAndPadding.bottomPadding)
                 (Css.px bordersAndPadding.leftPadding)
             , Css.width (Css.px (Maybe.withDefault (getSize config.size) config.width))
+            , Css.height (Css.px (Maybe.withDefault (getSize config.size) config.height))
             , Css.height (Css.px (getSize config.size))
             ]
 
@@ -503,12 +513,17 @@ buttonOrLinkStyles config =
             ]
 
     -- Sizing
-    , Css.display Css.inlineBlock
+    , Css.displayFlex
     , Css.boxSizing Css.borderBox
-    , Css.lineHeight (Css.num 1)
     , case config.width of
         Just width ->
             Css.width (Css.px width)
+
+        Nothing ->
+            Css.batch []
+    , case config.height of
+        Just height ->
+            Css.height (Css.px height)
 
         Nothing ->
             Css.batch []

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -1,0 +1,598 @@
+module Nri.Ui.ClickableSvg.V2 exposing
+    ( button, link
+    , Attribute
+    , onClick
+    , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
+    , width, height
+    , disabled
+    , withBorder
+    , primary, secondary, danger, dangerSecondary
+    , custom, css
+    , withTooltipAbove, withTooltipBelow
+    )
+
+{-|
+
+
+# Post-release patches
+
+  - uses ClickableAttributes
+  - adds tooltip helpers
+
+
+# Create a button or link
+
+@docs button, link
+@docs Attribute
+
+
+## Behavior
+
+@docs onClick
+@docs href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
+
+
+## Sizing
+
+@docs width, height
+
+
+## State
+
+@docs disabled
+
+
+## Customization
+
+@docs withBorder
+@docs primary, secondary, danger, dangerSecondary
+
+@docs custom, css
+
+
+## Tooltips
+
+@docs withTooltipAbove, withTooltipBelow
+
+-}
+
+import Accessibility.Styled.Widget as Widget
+import ClickableAttributes exposing (ClickableAttributes)
+import Css exposing (Color, Style)
+import Html.Styled as Html exposing (Html)
+import Html.Styled.Attributes as Attributes
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Svg.V1 as Svg exposing (Svg)
+import Nri.Ui.Tooltip.V1 as Tooltip exposing (Tooltip)
+
+
+{-| -}
+type Attribute msg
+    = Attribute (ButtonOrLink msg -> ButtonOrLink msg)
+
+
+{-| -}
+button : String -> Svg -> List (Attribute msg) -> Html msg
+button name icon attributes =
+    attributes
+        |> List.foldl (\(Attribute attribute) b -> attribute b) (build name icon)
+        |> renderButton
+
+
+{-| -}
+link : String -> Svg -> List (Attribute msg) -> Html msg
+link name icon attributes =
+    attributes
+        |> List.foldl (\(Attribute attribute) b -> attribute b) (build name icon)
+        |> renderLink
+
+
+
+-- LINKING, CLICKING, and TRACKING BEHAVIOR
+
+
+setClickableAttributes :
+    (ClickableAttributes msg -> ClickableAttributes msg)
+    -> Attribute msg
+setClickableAttributes apply =
+    set
+        (\attributes ->
+            { attributes | clickableAttributes = apply attributes.clickableAttributes }
+        )
+
+
+{-| -}
+onClick : msg -> Attribute msg
+onClick msg =
+    setClickableAttributes (ClickableAttributes.onClick msg)
+
+
+{-| -}
+href : String -> Attribute msg
+href url =
+    setClickableAttributes (ClickableAttributes.href url)
+
+
+{-| Use this link for routing within a single page app.
+
+This will make a normal <a> tag, but change the Events.onClick behavior to avoid reloading the page.
+
+See <https://github.com/elm-lang/html/issues/110> for details on this implementation.
+
+-}
+linkSpa : String -> Attribute msg
+linkSpa url =
+    setClickableAttributes (ClickableAttributes.linkSpa url)
+
+
+{-| -}
+linkWithMethod : { method : String, url : String } -> Attribute msg
+linkWithMethod config =
+    setClickableAttributes (ClickableAttributes.linkWithMethod config)
+
+
+{-| -}
+linkWithTracking : { track : msg, url : String } -> Attribute msg
+linkWithTracking config =
+    setClickableAttributes (ClickableAttributes.linkWithTracking config)
+
+
+{-| -}
+linkExternal : String -> Attribute msg
+linkExternal url =
+    setClickableAttributes (ClickableAttributes.linkExternal url)
+
+
+{-| -}
+linkExternalWithTracking : { track : msg, url : String } -> Attribute msg
+linkExternalWithTracking config =
+    setClickableAttributes (ClickableAttributes.linkExternalWithTracking config)
+
+
+
+-- SIZING
+
+
+{-| Default width is 17px.
+
+Note: changing this width will change the width of the icon. The button or link
+may be wider if you add a border or margin to it.
+
+-}
+width : Css.Px -> Attribute msg
+width px =
+    set (\attributes -> { attributes | width = px })
+
+
+{-| Default height is 17px.
+
+Note: changing this height will change the height of the icon. The button or link
+may be taller if you add a border or margin to it.
+
+-}
+height : Css.Px -> Attribute msg
+height px =
+    set (\attributes -> { attributes | height = px })
+
+
+
+-- STATE
+
+
+{-| -}
+disabled : Bool -> Attribute msg
+disabled disabled_ =
+    set (\attributes -> { attributes | disabled = disabled_ })
+
+
+
+-- CUSTOMIZATION
+
+
+{-| Display a border around the icon.
+-}
+withBorder : Attribute msg
+withBorder =
+    set (\config -> { config | hasBorder = True })
+
+
+type Theme
+    = Primary
+    | Secondary
+    | Danger
+    | DangerSecondary
+
+
+type alias AppliedTheme =
+    { main_ : Color
+    , mainHovered : Color
+    , background : Color
+    , backgroundHovered : Color
+    }
+
+
+disabledTheme : AppliedTheme
+disabledTheme =
+    { main_ = Colors.gray75
+    , mainHovered = Colors.gray75
+    , background = Colors.white
+    , backgroundHovered = Colors.white
+    }
+
+
+applyTheme : Theme -> AppliedTheme
+applyTheme theme =
+    case theme of
+        Primary ->
+            { main_ = Colors.white
+            , mainHovered = Colors.white
+            , background = Colors.azure
+            , backgroundHovered = Colors.azureDark
+            }
+
+        Secondary ->
+            { main_ = Colors.azure
+            , mainHovered = Colors.azureDark
+            , background = Colors.white
+            , backgroundHovered = Colors.glacier
+            }
+
+        Danger ->
+            { main_ = Colors.white
+            , mainHovered = Colors.white
+            , background = Colors.red
+            , backgroundHovered = Colors.redDark
+            }
+
+        DangerSecondary ->
+            { main_ = Colors.red
+            , mainHovered = Colors.redDark
+            , background = Colors.white
+            , backgroundHovered = Colors.redLight
+            }
+
+
+{-| white/transparent icon on an azure background.
+-}
+primary : Attribute msg
+primary =
+    set (\attributes -> { attributes | theme = Primary })
+
+
+{-| This is the default: a blue icon on a transparent background, or a blue icon
+on a white/glacier icon with a blue border.
+-}
+secondary : Attribute msg
+secondary =
+    set (\attributes -> { attributes | theme = Secondary })
+
+
+{-| White/transparent icon on a red background.
+-}
+danger : Attribute msg
+danger =
+    set (\attributes -> { attributes | theme = Danger })
+
+
+{-| Red icon on a white/transparent background.
+-}
+dangerSecondary : Attribute msg
+dangerSecondary =
+    set (\attributes -> { attributes | theme = DangerSecondary })
+
+
+{-| Use this helper to add custom attributes.
+
+Do NOT use this helper to add css styles, as they may not be applied the way
+you want/expect if underlying Button styles change.
+Instead, please use the `css` helper.
+
+-}
+custom : List (Html.Attribute msg) -> Attribute msg
+custom attributes =
+    set
+        (\config ->
+            { config
+                | customAttributes = List.append config.customAttributes attributes
+            }
+        )
+
+
+{-| -}
+css : List Style -> Attribute msg
+css styles =
+    set
+        (\config ->
+            { config
+                | customStyles = List.append config.customStyles styles
+            }
+        )
+
+
+
+-- TOOLTIPS
+
+
+type alias TooltipSettings msg =
+    { position : Tooltip.Position
+    , isOpen : Bool
+    , onShow : Bool -> msg
+    , id : String
+    }
+
+
+showTooltip : String -> Maybe (TooltipSettings msg) -> Html msg -> Html msg
+showTooltip label maybeSettings buttonOrLink =
+    case maybeSettings of
+        Just { position, onShow, isOpen, id } ->
+            let
+                tooltipSettings =
+                    { trigger = Tooltip.OnHover
+                    , onTrigger = onShow
+                    , isOpen = isOpen
+                    , triggerHtml = buttonOrLink
+                    , extraButtonAttrs = []
+                    , id = id ++ "__clickable-svg-tooltip"
+                    }
+            in
+            Tooltip.tooltip [ Html.text label ]
+                |> Tooltip.withPosition position
+                |> Tooltip.withWidth Tooltip.FitToContent
+                |> Tooltip.withPadding Tooltip.SmallPadding
+                |> Tooltip.primaryLabel tooltipSettings
+
+        Nothing ->
+            buttonOrLink
+
+
+withTooltip : Tooltip.Position -> { id : String, isOpen : Bool, onShow : Bool -> msg } -> Attribute msg
+withTooltip position { id, isOpen, onShow } =
+    set
+        (\config ->
+            { config
+                | tooltip =
+                    Just { position = position, id = id, isOpen = isOpen, onShow = onShow }
+            }
+        )
+
+
+{-| DEPRECATED: prefer to use the Tooltip module directly.
+-}
+withTooltipAbove : { id : String, isOpen : Bool, onShow : Bool -> msg } -> Attribute msg
+withTooltipAbove =
+    withTooltip Tooltip.OnTop
+
+
+{-| DEPRECATED: prefer to use the Tooltip module directly.
+-}
+withTooltipBelow : { id : String, isOpen : Bool, onShow : Bool -> msg } -> Attribute msg
+withTooltipBelow =
+    withTooltip Tooltip.OnBottom
+
+
+
+-- INTERNALS
+
+
+set :
+    (ButtonOrLinkAttributes msg -> ButtonOrLinkAttributes msg)
+    -> Attribute msg
+set with =
+    Attribute (\(ButtonOrLink config) -> ButtonOrLink (with config))
+
+
+build : String -> Svg -> ButtonOrLink msg
+build label icon =
+    ButtonOrLink
+        { clickableAttributes = ClickableAttributes.init
+        , label = label
+        , icon = icon
+        , height = Css.px 17
+        , width = Css.px 17
+        , disabled = False
+        , customAttributes = []
+        , customStyles = []
+        , tooltip = Nothing
+        , hasBorder = False
+        , theme = Secondary
+        }
+
+
+type ButtonOrLink msg
+    = ButtonOrLink (ButtonOrLinkAttributes msg)
+
+
+type alias ButtonOrLinkAttributes msg =
+    { clickableAttributes : ClickableAttributes msg
+    , label : String
+    , icon : Svg
+    , height : Css.Px
+    , width : Css.Px
+    , disabled : Bool
+    , customAttributes : List (Html.Attribute msg)
+    , customStyles : List Style
+    , tooltip : Maybe (TooltipSettings msg)
+    , hasBorder : Bool
+    , theme : Theme
+    }
+
+
+renderButton : ButtonOrLink msg -> Html msg
+renderButton ((ButtonOrLink config) as button_) =
+    Html.button
+        ([ Attributes.class "Nri-Ui-Clickable-Svg-V1__button"
+         , Attributes.type_ "button"
+         , Attributes.css (buttonOrLinkStyles config ++ config.customStyles)
+         , Attributes.disabled config.disabled
+         , Widget.label config.label
+         ]
+            ++ ClickableAttributes.toButtonAttributes config.clickableAttributes
+            ++ config.customAttributes
+        )
+        [ renderIcon config
+        ]
+        |> showTooltip config.label config.tooltip
+
+
+type Link
+    = Default
+    | WithTracking
+    | SinglePageApp
+    | WithMethod String
+    | External
+    | ExternalWithTracking
+
+
+renderLink : ButtonOrLink msg -> Html msg
+renderLink ((ButtonOrLink config) as link_) =
+    let
+        ( linkFunctionName, extraAttrs ) =
+            ClickableAttributes.toLinkAttributes config.clickableAttributes
+    in
+    Html.a
+        ([ Attributes.class ("Nri-Ui-Clickable-Svg-" ++ linkFunctionName)
+         , Attributes.css (buttonOrLinkStyles config ++ config.customStyles)
+         , Widget.disabled config.disabled
+         , Widget.label config.label
+         ]
+            ++ (if not config.disabled then
+                    extraAttrs
+
+                else
+                    []
+               )
+            ++ config.customAttributes
+        )
+        [ renderIcon config
+        ]
+        |> showTooltip config.label config.tooltip
+
+
+renderIcon : ButtonOrLinkAttributes msg -> Html msg
+renderIcon config =
+    config.icon
+        |> Svg.withCss
+            (if config.hasBorder then
+                [ Css.width
+                    (Css.calc config.width
+                        Css.minus
+                        (Css.px <|
+                            (2 * withBorderHorizontalPadding)
+                                + withBorderLeftBorderWidth
+                                + withBorderRightBorderWidth
+                        )
+                    )
+                , Css.height
+                    (Css.calc config.height
+                        Css.minus
+                        (Css.px <|
+                            withBorderTopPadding
+                                + withBorderBottomPadding
+                                + withBorderTopBorderWidth
+                                + withBorderBottomBorderWidth
+                        )
+                    )
+                ]
+
+             else
+                [ Css.width config.width
+                , Css.height config.height
+                ]
+            )
+        |> Svg.toHtml
+
+
+buttonOrLinkStyles : ButtonOrLinkAttributes msg -> List Style
+buttonOrLinkStyles config =
+    let
+        ( { main_, mainHovered, background, backgroundHovered }, cursor ) =
+            if config.disabled then
+                ( disabledTheme, Css.notAllowed )
+
+            else
+                ( applyTheme config.theme, Css.pointer )
+    in
+    [ Css.property "transition"
+        "background-color 0.2s, color 0.2s, border-width 0s, border-color 0.2s"
+
+    -- Colors, text decoration, cursor
+    , Css.textDecoration Css.none
+    , Css.color main_
+    , Css.visited [ Css.color main_ ]
+    , Css.hover
+        [ Css.textDecoration Css.none
+        , Css.color mainHovered
+        , Css.cursor cursor
+        ]
+
+    -- Margins, borders, padding
+    , Css.margin Css.zero
+    , Css.textAlign Css.center
+    , Css.batch <|
+        if config.hasBorder then
+            [ Css.borderRadius (Css.px 8)
+            , Css.borderColor main_
+            , Css.borderStyle Css.solid
+            , Css.borderTopWidth (Css.px withBorderTopBorderWidth)
+            , Css.borderRightWidth (Css.px withBorderRightBorderWidth)
+            , Css.borderBottomWidth (Css.px withBorderBottomBorderWidth)
+            , Css.borderLeftWidth (Css.px withBorderLeftBorderWidth)
+            , Css.backgroundColor background
+            , Css.hover
+                [ Css.borderColor mainHovered
+                , Css.backgroundColor backgroundHovered
+                ]
+            , Css.padding3
+                (Css.px withBorderTopPadding)
+                (Css.px withBorderHorizontalPadding)
+                (Css.px withBorderBottomPadding)
+            ]
+
+        else
+            [ Css.borderWidth Css.zero
+            , Css.padding Css.zero
+            , Css.backgroundColor Css.transparent
+            ]
+
+    -- Sizing
+    , Css.display Css.inlineBlock
+    , Css.boxSizing Css.borderBox
+    , Css.width config.width
+    , Css.height config.height
+    , Css.lineHeight (Css.num 1)
+    ]
+
+
+withBorderTopBorderWidth : Float
+withBorderTopBorderWidth =
+    1
+
+
+withBorderRightBorderWidth : Float
+withBorderRightBorderWidth =
+    1
+
+
+withBorderBottomBorderWidth : Float
+withBorderBottomBorderWidth =
+    2
+
+
+withBorderLeftBorderWidth : Float
+withBorderLeftBorderWidth =
+    1
+
+
+withBorderTopPadding : Float
+withBorderTopPadding =
+    4
+
+
+withBorderBottomPadding : Float
+withBorderBottomPadding =
+    3
+
+
+withBorderHorizontalPadding : Float
+withBorderHorizontalPadding =
+    5

--- a/src/Nri/Ui/Message/V2.elm
+++ b/src/Nri/Ui/Message/V2.elm
@@ -61,7 +61,7 @@ import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
 import Markdown
 import Nri.Ui
-import Nri.Ui.ClickableSvg.V1 as ClickableSvg
+import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Svg.V1 as NriSvg exposing (Svg)
@@ -682,8 +682,8 @@ tinyDismissButton msg =
         [ ClickableSvg.button "Dismiss message"
             UiIcon.x
             [ ClickableSvg.onClick msg
-            , ClickableSvg.width (px 16)
-            , ClickableSvg.height (px 16)
+            , ClickableSvg.exactWidth 16
+            , ClickableSvg.exactHeight 16
             , ClickableSvg.css
                 [ Css.verticalAlign Css.middle
                 , Css.marginLeft (Css.px 5)
@@ -702,8 +702,8 @@ largeDismissButton msg =
         [ ClickableSvg.button "Dismiss message"
             UiIcon.x
             [ ClickableSvg.onClick msg
-            , ClickableSvg.width (px 16)
-            , ClickableSvg.height (px 16)
+            , ClickableSvg.exactWidth 16
+            , ClickableSvg.exactHeight 16
             ]
         ]
 
@@ -717,7 +717,7 @@ bannerDismissButton msg =
         [ ClickableSvg.button "Dismiss banner"
             UiIcon.x
             [ ClickableSvg.onClick msg
-            , ClickableSvg.width (px 16)
-            , ClickableSvg.height (px 16)
+            , ClickableSvg.exactWidth 16
+            , ClickableSvg.exactHeight 16
             ]
         ]

--- a/src/Nri/Ui/RadioButton/V1.elm
+++ b/src/Nri/Ui/RadioButton/V1.elm
@@ -19,7 +19,7 @@ import Html.Styled as Html
 import Html.Styled.Attributes exposing (..)
 import Html.Styled.Events exposing (onClick, stopPropagationOn)
 import Json.Decode
-import Nri.Ui.ClickableSvg.V1 as ClickableSvg
+import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Data.PremiumLevel as PremiumLevel exposing (PremiumLevel)
 import Nri.Ui.Fonts.V1 as Fonts
@@ -250,8 +250,8 @@ internalView config =
                         ClickableSvg.button "Premium"
                             Pennant.premiumFlag
                             [ ClickableSvg.onClick config.premiumMsg
-                            , ClickableSvg.width (px 26)
-                            , ClickableSvg.height (px 24)
+                            , ClickableSvg.exactWidth 26
+                            , ClickableSvg.exactHeight 24
                             , ClickableSvg.css [ marginLeft (px 8) ]
                             ]
                     )

--- a/src/Nri/Ui/Tooltip/V2.elm
+++ b/src/Nri/Ui/Tooltip/V2.elm
@@ -83,7 +83,7 @@ import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Json.Encode as Encode
 import Nri.Ui
-import Nri.Ui.ClickableSvg.V1 as ClickableSvg
+import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Svg.V1 as Svg
@@ -453,8 +453,8 @@ toggleTip { label } attributes_ =
             \events ->
                 ClickableSvg.button label
                     UiIcon.help
-                    [ ClickableSvg.width (Css.px 20)
-                    , ClickableSvg.height (Css.px 20)
+                    [ ClickableSvg.exactWidth 20
+                    , ClickableSvg.exactHeight 20
                     , ClickableSvg.custom events
                     , ClickableSvg.css
                         [ -- Take up enough room within the document flow

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -222,16 +222,17 @@ type alias Settings msg =
     , disabled : ClickableSvg.Attribute msg
     , size : ClickableSvg.Attribute msg
     , width : Maybe (ClickableSvg.Attribute msg)
+    , height : Maybe (ClickableSvg.Attribute msg)
     }
 
 
 applySettings : Control (Settings msg) -> ( Svg, List (ClickableSvg.Attribute msg) )
 applySettings settings =
     let
-        { icon, disabled, size, width } =
+        { icon, disabled, size, width, height } =
             Control.currentValue settings
     in
-    ( icon, List.filterMap identity [ Just disabled, Just size, width ] )
+    ( icon, List.filterMap identity [ Just disabled, Just size, width, height ] )
 
 
 initSettings : Control (Settings msg)
@@ -262,6 +263,8 @@ initSettings =
             )
         |> Control.field "exactWidth"
             (Control.maybe False (Control.map ClickableSvg.exactWidth (controlInt 40)))
+        |> Control.field "exactHeight"
+            (Control.maybe False (Control.map ClickableSvg.exactHeight (controlInt 20)))
 
 
 controlInt : Int -> Control Int

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -220,16 +220,17 @@ update msg state =
 type alias Settings msg =
     { icon : Svg
     , disabled : ClickableSvg.Attribute msg
+    , size : ClickableSvg.Attribute msg
     }
 
 
 applySettings : Control (Settings msg) -> ( Svg, List (ClickableSvg.Attribute msg) )
 applySettings settings =
     let
-        { icon, disabled } =
+        { icon, disabled, size } =
             Control.currentValue settings
     in
-    ( icon, [ disabled ] )
+    ( icon, [ disabled, size ] )
 
 
 initSettings : Control (Settings msg)
@@ -251,6 +252,13 @@ initSettings =
             )
         |> Control.field "disabled"
             (Control.map ClickableSvg.disabled (Control.bool False))
+        |> Control.field "size"
+            (Control.choice
+                [ ( "small", Control.value ClickableSvg.small )
+                , ( "medium", Control.value ClickableSvg.medium )
+                , ( "large", Control.value ClickableSvg.large )
+                ]
+            )
 
 
 controlNumber : Float -> Control Float

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -221,16 +221,17 @@ type alias Settings msg =
     { icon : Svg
     , disabled : ClickableSvg.Attribute msg
     , size : ClickableSvg.Attribute msg
+    , width : Maybe (ClickableSvg.Attribute msg)
     }
 
 
 applySettings : Control (Settings msg) -> ( Svg, List (ClickableSvg.Attribute msg) )
 applySettings settings =
     let
-        { icon, disabled, size } =
+        { icon, disabled, size, width } =
             Control.currentValue settings
     in
-    ( icon, [ disabled, size ] )
+    ( icon, List.filterMap identity [ Just disabled, Just size, width ] )
 
 
 initSettings : Control (Settings msg)
@@ -259,9 +260,11 @@ initSettings =
                 , ( "large", Control.value ClickableSvg.large )
                 ]
             )
+        |> Control.field "exactWidth"
+            (Control.maybe False (Control.map ClickableSvg.exactWidth (controlInt 40)))
 
 
-controlNumber : Float -> Control Float
-controlNumber default =
-    Control.map (String.toFloat >> Maybe.withDefault default)
-        (Control.string (String.fromFloat default))
+controlInt : Int -> Control Int
+controlInt default =
+    Control.map (String.toInt >> Maybe.withDefault default)
+        (Control.string (String.fromInt default))

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -17,7 +17,7 @@ import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import KeyboardSupport exposing (Direction(..), Key(..))
-import Nri.Ui.ClickableSvg.V1 as ClickableSvg
+import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Colors.Extra exposing (fromCssColor, toCssColor)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
@@ -31,7 +31,7 @@ import Nri.Ui.UiIcon.V1 as UiIcon
 example : Example State Msg
 example =
     { name = "ClickableSvg"
-    , version = 1
+    , version = 2
     , categories = [ Buttons, Icons ]
     , atomicDesignType = Molecule
     , keyboardSupport = []

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -53,9 +53,7 @@ Tooltip.view
         \\attrs ->
             ClickableSvg.button "Preview"
                 UiIcon.preview
-                [ ClickableSvg.width (Css.px 20)
-                , ClickableSvg.height (Css.px 20)
-                , ClickableSvg.onClick (ShowItWorked "You clicked the preview button!")
+                [ ClickableSvg.onClick (ShowItWorked "You clicked the preview button!")
                 , ClickableSvg.custom attrs
                 ]
     , id = "preview-tooltip"
@@ -74,9 +72,7 @@ Tooltip.view
                         \attrs ->
                             ClickableSvg.button "Preview"
                                 UiIcon.preview
-                                [ ClickableSvg.width (Css.px 20)
-                                , ClickableSvg.height (Css.px 20)
-                                , ClickableSvg.onClick (ShowItWorked "You clicked the preview button!")
+                                [ ClickableSvg.onClick (ShowItWorked "You clicked the preview button!")
                                 , ClickableSvg.custom attrs
                                 ]
                     , id = "preview-tooltip"
@@ -224,18 +220,16 @@ update msg state =
 type alias Settings msg =
     { icon : Svg
     , disabled : ClickableSvg.Attribute msg
-    , width : ClickableSvg.Attribute msg
-    , height : ClickableSvg.Attribute msg
     }
 
 
 applySettings : Control (Settings msg) -> ( Svg, List (ClickableSvg.Attribute msg) )
 applySettings settings =
     let
-        { icon, disabled, width, height } =
+        { icon, disabled } =
             Control.currentValue settings
     in
-    ( icon, [ disabled, width, height ] )
+    ( icon, [ disabled ] )
 
 
 initSettings : Control (Settings msg)
@@ -257,10 +251,6 @@ initSettings =
             )
         |> Control.field "disabled"
             (Control.map ClickableSvg.disabled (Control.bool False))
-        |> Control.field "width"
-            (Control.map (Css.px >> ClickableSvg.width) (controlNumber 30))
-        |> Control.field "height"
-            (Control.map (Css.px >> ClickableSvg.height) (controlNumber 30))
 
 
 controlNumber : Float -> Control Float

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -11,6 +11,7 @@
         "Nri.Ui.Callout.V1",
         "Nri.Ui.Checkbox.V5",
         "Nri.Ui.ClickableSvg.V1",
+        "Nri.Ui.ClickableSvg.V2",
         "Nri.Ui.ClickableText.V3",
         "Nri.Ui.Colors.Extra",
         "Nri.Ui.Colors.V1",


### PR DESCRIPTION
<img width="432" alt="Screen Shot 2020-10-21 at 10 42 55 AM" src="https://user-images.githubusercontent.com/8811312/96757574-79836180-138a-11eb-834a-50a80165942d.png">

Ookkkkkkkkayyyyy I made a new version of ClickableSvg with a different API for width/height. Instead of always having to do `ClickableSvg.height` and `ClickableSvg.width`, there are preset sizes (`small`, `medium`, `large`), and then you can set the width of the button to be something exact with `exactWidth` if you want.

@NoRedInk/design I'm not sure what the presets should actually be! I picked some values somewhat at random. Would love instructions or commits! 🙏 