### PR TITLE
Adds non-square ui icons to the button example

### DIFF
--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -121,10 +121,12 @@ init =
 iconChoice : Control.Control (Maybe Svg)
 iconChoice =
     Control.choice
-        [ ( "Nothing", Control.value Nothing )
-        , ( "Just Performance", Control.value (Just UiIcon.performance) )
-        , ( "Just Share", Control.value (Just UiIcon.share) )
-        , ( "Just Download", Control.value (Just UiIcon.download) )
+        [ ( "none", Control.value Nothing )
+        , ( "preview", Control.value (Just UiIcon.preview) )
+        , ( "arrowLeft", Control.value (Just UiIcon.arrowLeft) )
+        , ( "performance", Control.value (Just UiIcon.performance) )
+        , ( "share", Control.value (Just UiIcon.share) )
+        , ( "download", Control.value (Just UiIcon.download) )
         ]
 
 


### PR DESCRIPTION
<img width="654" alt="Screen Shot 2020-10-28 at 9 38 25 AM" src="https://user-images.githubusercontent.com/8811312/97467419-6a0f9580-1901-11eb-9702-31f3a9bcd9b8.png">
<img width="651" alt="Screen Shot 2020-10-28 at 9 38 18 AM" src="https://user-images.githubusercontent.com/8811312/97467428-6bd95900-1901-11eb-9d59-783f892e5bba.png">


cc @NoRedInk/design for https://noredink.slack.com/archives/CB5ERR51P/p1603839309007300

Looks like at some point our Button stopped constraining icon size nicely (or it never did properly 😅)