### PR TITLE
FAB/checkbox

### DIFF
--- a/src/Nri/Ui/Checkbox/V5.elm
+++ b/src/Nri/Ui/Checkbox/V5.elm
@@ -303,11 +303,12 @@ viewIcon styles icon =
             , border3 (px 2) solid transparent
             , padding (px 2)
             , borderRadius (px 3)
-            , Css.batch styles
             ]
         , Attributes.class "checkbox-icon-container"
         ]
-        [ Nri.Ui.Svg.V1.toHtml icon
+        [ Html.div [ css [ backgroundColor Colors.white ] ]
+            [ Nri.Ui.Svg.V1.toHtml (Nri.Ui.Svg.V1.withCss styles icon)
+            ]
         ]
 
 

--- a/src/Nri/Ui/Checkbox/V5.elm
+++ b/src/Nri/Ui/Checkbox/V5.elm
@@ -170,7 +170,7 @@ checkboxContainer model =
                     ]
                 ]
             , Css.Global.descendants
-                [ Css.Global.input [ position absolute, top (px 15), left (px 10) ]
+                [ Css.Global.input [ position absolute, top (calc (pct 50) minus (px 10)), left (px 10) ]
                 ]
             ]
         , Attributes.id (model.identifier ++ "-container")

--- a/src/Nri/Ui/Checkbox/V5.elm
+++ b/src/Nri/Ui/Checkbox/V5.elm
@@ -189,9 +189,12 @@ viewCheckbox :
 viewCheckbox model =
     Html.checkbox model.identifier
         (selectedToMaybe model.selected)
-        [ Events.onCheck (\_ -> onCheck model)
-        , Attributes.id model.identifier
-        , Attributes.disabled model.disabled
+        [ Attributes.id model.identifier
+        , if model.disabled then
+            Widget.disabled True
+
+          else
+            Events.onCheck (\_ -> onCheck model)
         ]
 
 
@@ -209,7 +212,6 @@ viewEnabledLabel model labelView icon =
     Html.Styled.label
         [ Attributes.for model.identifier
         , Aria.controls model.identifier
-        , Widget.disabled False
         , Widget.checked (selectedToMaybe model.selected)
         , labelClass model.selected
         , css
@@ -240,7 +242,6 @@ viewDisabledLabel model labelView icon =
     Html.Styled.label
         [ Attributes.for model.identifier
         , Aria.controls model.identifier
-        , Widget.disabled True
         , Widget.checked (selectedToMaybe model.selected)
         , labelClass model.selected
         , css

--- a/src/Nri/Ui/Checkbox/V5.elm
+++ b/src/Nri/Ui/Checkbox/V5.elm
@@ -162,10 +162,16 @@ checkboxContainer model =
             [ display block
             , height inherit
             , position relative
-            , focusWithin
-                [ outline auto ]
+            , pseudoClass "focus-within"
+                [ Css.Global.descendants
+                    [ Css.Global.class "checkbox-icon-container"
+                        [ borderColor (rgb 0 95 204)
+                        ]
+                    ]
+                ]
             , Css.Global.descendants
-                [ Css.Global.input [ position absolute, top (px 15), left (px 15) ] ]
+                [ Css.Global.input [ position absolute, top (px 15), left (px 10) ]
+                ]
             ]
         , Attributes.id (model.identifier ++ "-container")
         , Events.stopPropagationOn "click" (Json.Decode.fail "stop click propagation")
@@ -292,11 +298,14 @@ viewIcon styles icon =
         [ css
             [ position absolute
             , left zero
-            , top (calc (pct 50) minus (px 14))
-            , width (px 24)
-            , height (px 24)
+            , top (calc (pct 50) minus (px 18))
+            , height (px 27)
+            , border3 (px 2) solid transparent
+            , padding (px 2)
+            , borderRadius (px 3)
             , Css.batch styles
             ]
+        , Attributes.class "checkbox-icon-container"
         ]
         [ Nri.Ui.Svg.V1.toHtml icon
         ]

--- a/src/Nri/Ui/Checkbox/V5.elm
+++ b/src/Nri/Ui/Checkbox/V5.elm
@@ -299,14 +299,20 @@ viewIcon styles icon =
             [ position absolute
             , left zero
             , top (calc (pct 50) minus (px 18))
-            , height (px 27)
             , border3 (px 2) solid transparent
             , padding (px 2)
             , borderRadius (px 3)
+            , height (Css.px 27)
             ]
         , Attributes.class "checkbox-icon-container"
         ]
-        [ Html.div [ css [ backgroundColor Colors.white ] ]
+        [ Html.div
+            [ css
+                [ display inlineBlock
+                , backgroundColor Colors.white
+                , height (Css.px 27)
+                ]
+            ]
             [ Nri.Ui.Svg.V1.toHtml (Nri.Ui.Svg.V1.withCss styles icon)
             ]
         ]

--- a/src/Nri/Ui/Checkbox/V5.elm
+++ b/src/Nri/Ui/Checkbox/V5.elm
@@ -161,7 +161,11 @@ checkboxContainer model =
         [ css
             [ display block
             , height inherit
-            --, Css.Global.descendants [ Css.Global.input [ display none ] ]
+            , position relative
+            , focusWithin
+                [ outline auto ]
+            , Css.Global.descendants
+                [ Css.Global.input [ position absolute, top (px 15), left (px 15) ] ]
             ]
         , Attributes.id (model.identifier ++ "-container")
         , Events.stopPropagationOn "click" (Json.Decode.fail "stop click propagation")
@@ -201,17 +205,6 @@ viewEnabledLabel model labelView icon =
         , Aria.controls model.identifier
         , Widget.disabled False
         , Widget.checked (selectedToMaybe model.selected)
-        , Attributes.tabindex 0
-        , HtmlExtra.onKeyUp
-            { defaultOptions | preventDefault = True }
-            (\keyCode ->
-                -- 32 is the space bar, 13 is enter
-                if keyCode == 32 || keyCode == 13 then
-                    Just (onCheck model)
-
-                else
-                    Nothing
-            )
         , labelClass model.selected
         , css
             [ positioning
@@ -219,9 +212,8 @@ viewEnabledLabel model labelView icon =
             , cursor pointer
             ]
         ]
-        [ --viewIcon [] icon
-        --,
-            labelView model.label
+        [ viewIcon [] icon
+        , labelView model.label
         ]
 
 

--- a/src/Nri/Ui/Checkbox/V5.elm
+++ b/src/Nri/Ui/Checkbox/V5.elm
@@ -161,7 +161,7 @@ checkboxContainer model =
         [ css
             [ display block
             , height inherit
-            , Css.Global.descendants [ Css.Global.input [ display none ] ]
+            --, Css.Global.descendants [ Css.Global.input [ display none ] ]
             ]
         , Attributes.id (model.identifier ++ "-container")
         , Events.stopPropagationOn "click" (Json.Decode.fail "stop click propagation")
@@ -219,8 +219,9 @@ viewEnabledLabel model labelView icon =
             , cursor pointer
             ]
         ]
-        [ viewIcon [] icon
-        , labelView model.label
+        [ --viewIcon [] icon
+        --,
+            labelView model.label
         ]
 
 

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -53,10 +53,7 @@ example =
     , categories = [ Inputs ]
     , atomicDesignType = Molecule
     , keyboardSupport =
-        [ { keys = [ Enter ]
-          , result = "Select or deselect the checkbox"
-          }
-        , { keys = [ Space ]
+        [ { keys = [ Space ]
           , result = "Select or deselect the checkbox (may cause page scroll)"
           }
         ]

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -46,7 +46,7 @@ example =
             , viewIndeterminateCheckbox "styleguide-checkbox-indeterminate" state
             , viewLockedOnInsideCheckbox "styleguide-locked-on-inside-checkbox" state
             , viewDisabledCheckbox "styleguide-checkbox-disabled" state
-            , viewMultilineCheckboxes
+            , viewMultilineCheckboxes state
             , h3 [] [ text "Premium Checkboxes" ]
             , viewPremiumCheckboxes state
             ]
@@ -141,16 +141,20 @@ viewDisabledCheckbox id state =
         }
 
 
-viewMultilineCheckboxes : Html Msg
-viewMultilineCheckboxes =
+viewMultilineCheckboxes : State -> Html Msg
+viewMultilineCheckboxes state =
     Html.section
         [ css [ Css.width (Css.px 500) ] ]
         [ Html.h3 [] [ Html.text "Multiline Text in Checkboxes" ]
-        , Checkbox.viewWithLabel
-            { identifier = "fake-not-selected"
+        , let
+            id =
+                "styleguide-checkbox-multiline"
+          in
+          Checkbox.viewWithLabel
+            { identifier = id
             , label = "Ut nobis et vel. Nulla rerum sit eos accusamus placeat. Iure sunt earum voluptatibus autem ratione soluta sint.\n\nIste perferendis eum corporis ullam magnam incidunt eos."
-            , setterMsg = ToggleCheck "fake-not-selected"
-            , selected = Checkbox.NotSelected
+            , setterMsg = ToggleCheck id
+            , selected = isSelected id state
             , disabled = False
             , theme = Checkbox.Square
             }

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -52,7 +52,14 @@ example =
             ]
     , categories = [ Inputs ]
     , atomicDesignType = Molecule
-    , keyboardSupport = []
+    , keyboardSupport =
+        [ { keys = [ Enter ]
+          , result = "Select or deselect the checkbox"
+          }
+        , { keys = [ Space ]
+          , result = "Select or deselect the checkbox (may cause page scroll)"
+          }
+        ]
     }
 
 

--- a/tests/Spec/Nri/Ui/PremiumCheckbox.elm
+++ b/tests/Spec/Nri/Ui/PremiumCheckbox.elm
@@ -100,7 +100,7 @@ spec =
                         , isLocked = False
                         , isPremium = False
                         }
-                        |> Query.has [ Selector.disabled False ]
+                        |> Query.hasNot [ Selector.attribute (Attributes.attribute "aria-disabled" "true") ]
             , test "is disabled when disabled = True" <|
                 \() ->
                     premiumView
@@ -109,6 +109,6 @@ spec =
                         , isLocked = False
                         , isPremium = False
                         }
-                        |> Query.has [ Selector.disabled True ]
+                        |> Query.has [ Selector.attribute (Attributes.attribute "aria-disabled" "true") ]
             ]
         ]


### PR DESCRIPTION
FAB Friday checkbox accessibility improvements!

# Change set 1: 

These changes came from FAB Friday on [November 6, 2020](https://paper.dropbox.com/doc/FAB-Fridays-log-and-upcoming-topics--A_WVewOq7TOzbe8LpdckKeyaAg-Yr853teky2oypzanPfSKP#:uid=434012004652331945797748&h2=2020-11-06
)

- When focusing on the “checkbox” element, VoiceOver should recognize it as a checkbox and should instruct you to VO-space bar to select it rather than saying it's a group
- tabbing off the checkbox element, you shouldn't hear VoiceOver reading the label a second time

![Screen Shot 2020-11-06 at 2 55 31 PM](https://user-images.githubusercontent.com/8811312/98422300-2bd04f80-2040-11eb-92fa-727b02f1f4e2.png)

Caveat: I don't think our approach for hiding focus indicators for mouse users will work for checkboxes anymore.

cc @NoRedInk/design 

# Change set 2: 

These changes came from FAB Friday on (Friday 😱) [November 13, 2020](https://paper.dropbox.com/doc/FAB-Fridays-log-and-upcoming-topics--A_WVewOq7TOzbe8LpdckKeyaAg-Yr853teky2oypzanPfSKP#:uid=912008681740817975415360&h2=2020-11-13)

Disabled checkboxes should still be read aloud by voiceover.