### PR TITLE
use cachix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: nix
-sudo: false
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,20 +11,45 @@ cache:
     - ~/.elm
 
 install:
-  # set up cachix
-  # see https://docs.cachix.org/continuous-integration-setup/travis-ci.html
+  # This setup script comes from the cachix docs[1], but we annotate it here so
+  # it's easier to maintain.
+  #
+  # [1]: https://docs.cachix.org/continuous-integration-setup/travis-ci.html
+
+  # First, we need to tell Nix that the current user is trusted to make changes to
+  # the system configuration, so that we can do exactly that in the next step.
   - echo "trusted-users = $USER" | sudo tee -a /etc/nix/nix.conf
   - sudo systemctl restart nix-daemon
+
+  # Next, we need to tell Nix to use our cache to avoid building fresh every time.
+  # Under the covers, this means trusting the signing key and adding the
+  # our-cache-name.cachix.org as a substituter. But we don't really need to worry
+  # a lot about the mechanism here, since the `cachix use` statement here will
+  # take care of everything for us if it has the right permissions.
   - nix-env -iA nixpkgs.cachix
   - cachix use $CACHIX_CACHE
-  - cachix use noredink
+
+  # Next, we list all the paths that Nix currently knows about so that we don't
+  # waste time trying to push them later.
   - nix path-info --all > /tmp/store-path-pre-build
 
-  # get our dependencies
-  - nix-shell
+  # Finally, we run `nix-shell` with a no-op command to download our real
+  # dependencies. This step should now take advantage of the cachix cache and
+  # avoid rebuilding any upstream software we depend on! (At the time of this
+  # writing, that measn we avoid compiling `niv` and `elm-forbid-import` on every
+  # run.)
+  #
+  # Note that this step is technically not necessary--running our build command in
+  # `nix-shell` below would also take care of this--but getting dependencies here
+  # lets us collapse the (huge) download list in the Travis UI.
+  - nix-shell --run 'true'
 
 script:
   - nix-shell --pure --run 'shake --verbose ci'
 
 after_success:
+  # After we successfully build, we want to cache whatever we can. That means that
+  # when dependencies change, we should only build them once. The invocation below
+  # just gets the difference between the derivations we had before the build and
+  # the derivations we have now, and pushes the new ones.
   - comm -13 <(sort /tmp/store-path-pre-build | grep -v '\.drv$') <(nix path-info --all | grep -v '\.drv$' | sort) | cachix push $CACHIX_CACHE

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,30 @@
 language: nix
+sudo: false
+
+env:
+  global:
+    - CACHIX_CACHE=noredink-ui
 
 cache:
   directories:
-    - /nix
     - node_modules
     - ~/.elm
 
 install:
+  # set up cachix
+  # see https://docs.cachix.org/continuous-integration-setup/travis-ci.html
+  - echo "trusted-users = $USER" | sudo tee -a /etc/nix/nix.conf
+  - sudo systemctl restart nix-daemon
+  - nix-env -iA nixpkgs.cachix
+  - cachix use $CACHIX_CACHE
+  - cachix use noredink
+  - nix path-info --all > /tmp/store-path-pre-build
+
+  # get our dependencies
   - nix-shell
 
 script:
   - nix-shell --pure --run 'shake --verbose ci'
+
+after_success:
+  - comm -13 <(sort /tmp/store-path-pre-build | grep -v '\.drv$') <(nix path-info --all | grep -v '\.drv$' | sort) | cachix push $CACHIX_CACHE

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,10 +11,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "9d35b9e4837ab88517210b1701127612c260eccf",
-        "sha256": "0q50xhnm8g2yfyakrh0nly4swyygxpi0a8cb9gp65wcakcgvzvdh",
+        "rev": "ba57d5a29b4e0f2085917010380ef3ddc3cf380f",
+        "sha256": "1kpsvc53x821cmjg1khvp1nz7906gczq8mp83664cr15h94sh8i4",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/9d35b9e4837ab88517210b1701127612c260eccf.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/ba57d5a29b4e0f2085917010380ef3ddc3cf380f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -18,15 +18,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixpkgs-unstable",
-        "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
-        "homepage": "https://github.com/NixOS/nixpkgs",
+        "branch": "master",
+        "description": "Nix Packages collection",
+        "homepage": "",
         "owner": "NixOS",
-        "repo": "nixpkgs-channels",
-        "rev": "502845c3e31ef3de0e424f3fcb09217df2ce6df6",
-        "sha256": "0fcqpsy6y7dgn0y0wgpa56gsg0b0p8avlpjrd79fp4mp9bl18nda",
+        "repo": "nixpkgs",
+        "rev": "0081f50505436a5787cbf50af8ef4d9d04620ad6",
+        "sha256": "1lyxwszp7acwz5z3aj8m5ykih88lb7cpmq7nzv386a0i8hqb719v",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/502845c3e31ef3de0e424f3fcb09217df2ce6df6.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0081f50505436a5787cbf50af8ef4d9d04620ad6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Could potentially speed up builds a lot! Even if we have to pull stuff over the network, at least we won't be building `niv` and `elm-forbid-import` except when we update them.

| Step | Time |
|-|-|
| cold cachix cache, no travis caching (but pushing to cachix) | 13m6s |
| warm cachix cache, no travis caching | 3m13s |