### PR TITLE
add Nri.Ui.Switch.V1

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -59,6 +59,7 @@
         "Nri.Ui.SlideModal.V2",
         "Nri.Ui.SortableTable.V2",
         "Nri.Ui.Svg.V1",
+        "Nri.Ui.Switch.V1",
         "Nri.Ui.Table.V4",
         "Nri.Ui.Table.V5",
         "Nri.Ui.Tabs.V6",

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -100,6 +100,13 @@ view attrs isOn =
                 [ Global.descendants
                     [ Global.svg [ Css.borderColor Colors.azure ] ]
                 ]
+            , Css.cursor
+                (if config.onSwitch == Nothing then
+                    Css.default
+
+                 else
+                    Css.pointer
+                )
             ]
         , Aria.controls config.id
         , Widget.checked (Just isOn)
@@ -113,7 +120,6 @@ view attrs isOn =
             (viewSwitch
                 { id = config.id
                 , isOn = isOn
-                , enabled = config.onSwitch /= Nothing
                 }
             )
         , case config.label of
@@ -159,7 +165,6 @@ viewCheckbox config =
 viewSwitch :
     { id : String
     , isOn : Bool
-    , enabled : Bool
     }
     -> Svg
 viewSwitch config =
@@ -175,12 +180,7 @@ viewSwitch config =
         , SvgAttributes.height "30"
         , SvgAttributes.viewBox "0 0 41 30"
         , SvgAttributes.css
-            [ if config.enabled then
-                Css.cursor Css.pointer
-
-              else
-                Css.batch []
-            , Css.zIndex (Css.int 1)
+            [ Css.zIndex (Css.int 1)
             , Css.border3 (Css.px 2) Css.solid Css.transparent
             , Css.padding (Css.px 3)
             , Css.borderRadius (Css.px 21)

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -256,7 +256,7 @@ viewSwitch config =
 
                           else
                             Css.fill Colors.gray92
-                        , transition "fill 0.4s"
+                        , transition "fill 0.2s"
                         ]
                     ]
                     []
@@ -274,7 +274,7 @@ viewSwitch config =
 
                       else
                         Css.transform (Css.translateX (Css.px 0))
-                    , transition "transform 0.4s"
+                    , transition "transform 0.2s ease-in-out"
                     ]
                 ]
                 [ -- <circle cx="15" cy="15" r="14.5" fill="#FFF"/>
@@ -311,7 +311,7 @@ viewSwitch config =
                           else
                             -- gray75, but can't use the Color type here
                             Css.property "stroke" "rgba(255,255,255,0)"
-                        , transition "stroke 0.4s"
+                        , transition "stroke 0.2s"
                         ]
                     ]
                     []

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -217,7 +217,7 @@ viewSwitch config =
                 , SvgAttributes.height "106.7%"
                 , SvgAttributes.x "-2.5%"
                 , SvgAttributes.y "-3.3%"
-                , SvgAttributes.filterUnits "objectboundingBox"
+                , SvgAttributes.filterUnits "objectBoundingBox"
                 ]
                 [ Svg.feOffset
                     [ SvgAttributes.dy "2"
@@ -271,7 +271,7 @@ viewSwitch config =
                 , Svg.use
                     [ SvgAttributes.xlinkHref ("#" ++ shadowBoxId)
                     , SvgAttributes.fill "#000"
-                    , SvgAttributes.filter ("url(" ++ shadowFilterId ++ ")")
+                    , SvgAttributes.filter ("url(#" ++ shadowFilterId ++ ")")
                     ]
                     []
                 ]

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -1,8 +1,8 @@
-module Nri.Ui.Switch.V1 exposing (view, Attribute, onSwitch, id, label)
+module Nri.Ui.Switch.V1 exposing (view, Attribute, onSwitch, disabled, id, label)
 
 {-|
 
-@docs view, Attribute, onSwitch, id, label
+@docs view, Attribute, onSwitch, disabled, id, label
 
 -}
 
@@ -22,11 +22,19 @@ type Attribute msg
     = OnSwitch (Bool -> msg)
     | Id String
     | Label (Html msg)
+    | Disabled
 
 
 onSwitch : (Bool -> msg) -> Attribute msg
 onSwitch =
     OnSwitch
+
+
+{-| note that this will be the default
+-}
+disabled : Attribute msg
+disabled =
+    Disabled
 
 
 id : String -> Attribute msg
@@ -63,6 +71,9 @@ customize attr config =
     case attr of
         OnSwitch onSwitch_ ->
             { config | onSwitch = Just onSwitch_ }
+
+        Disabled ->
+            { config | onSwitch = Nothing }
 
         Id id_ ->
             { config | id = id_ }

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -21,6 +21,7 @@ import Svg.Styled as Svg
 import Svg.Styled.Attributes as SvgAttributes
 
 
+{-| -}
 type Attribute msg
     = OnSwitch (Bool -> msg)
     | Id String
@@ -28,26 +29,34 @@ type Attribute msg
     | Disabled
 
 
+{-| Specify what happens when the switch is toggled.
+-}
 onSwitch : (Bool -> msg) -> Attribute msg
 onSwitch =
     OnSwitch
 
 
-{-| note that this will be the default
+{-| Explicitly specify that you want this switch to be disabled. If you don't
+specify `onSwitch`, this is the default, but it's provided so you don't have
+to resort to `filterMap` or similar to build a clean list of attributes.
 -}
 disabled : Attribute msg
 disabled =
     Disabled
 
 
+{-| Set the HTML ID of the switch toggle. If you have only one on the page,
+you don't need to set this, but you should definitely set it if you have
+more than one.
+-}
 id : String -> Attribute msg
 id =
     Id
 
 
-{-| Labeling text requirements: should be descriptive but not interactive
-(that is, this API would be `Html Never` if it was ergonomic to do so)
-and should be styled so that it can be displayed inline.
+{-| Add labeling text to the switch. This text should be descriptive and
+able to be displayed inline. It should _not_ be interactive (if it were
+ergonomic to make this argument `Html Never`, we would!)
 -}
 label : Html msg -> Attribute msg
 label =
@@ -85,6 +94,9 @@ customize attr config =
             { config | label = Just label_ }
 
 
+{-| Render a switch. The boolean here indicates whether the switch is on
+or not.
+-}
 view : List (Attribute msg) -> Bool -> Html msg
 view attrs isOn =
     let

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -93,7 +93,7 @@ view attrs isOn =
         [ Attributes.id (config.id ++ "-container")
         , Attributes.css
             [ Css.displayFlex
-            , Css.alignItems Css.middle
+            , Css.alignItems Css.center
             , Css.position Css.relative
             ]
         , Aria.controls config.id

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -136,25 +136,20 @@ viewCheckbox :
 viewCheckbox config =
     Html.checkbox config.id
         (Just config.checked)
-        (List.concat
-            [ [ Attributes.id config.id
-              , Attributes.css
-                    [ Css.position Css.absolute
-                    , Css.top (Css.px 10)
-                    , Css.left (Css.px 10)
-                    , Css.zIndex (Css.int 0)
-                    ]
-              ]
-            , case config.onCheck of
-                Just onCheck ->
-                    [ Events.onCheck onCheck ]
-
-                Nothing ->
-                    [ Attributes.disabled True
-                    , Widget.disabled True
-                    ]
+        [ Attributes.id config.id
+        , Attributes.css
+            [ Css.position Css.absolute
+            , Css.top (Css.px 10)
+            , Css.left (Css.px 10)
+            , Css.zIndex (Css.int 0)
             ]
-        )
+        , case config.onCheck of
+            Just onCheck ->
+                Events.onCheck onCheck
+
+            Nothing ->
+                Widget.disabled True
+        ]
 
 
 viewSwitch :

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -7,6 +7,7 @@ module Nri.Ui.Switch.V1 exposing (view, Attribute, onSwitch, disabled, id, label
 -}
 
 import Accessibility.Styled as Html exposing (Html)
+import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Widget as Widget
 import Css
 import Html.Styled as WildWildHtml
@@ -95,6 +96,8 @@ view attrs isOn =
             , Css.alignItems Css.middle
             , Css.position Css.relative
             ]
+        , Aria.controls config.id
+        , Widget.checked (Just isOn)
         ]
         [ viewCheckbox
             { id = config.id

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -8,9 +8,14 @@ module Nri.Ui.Switch.V1 exposing (view, Attribute, onSwitch, id, label)
 
 import Accessibility.Styled as Html exposing (Html)
 import Accessibility.Styled.Widget as Widget
+import Css
 import Html.Styled as WildWildHtml
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Svg.V1 exposing (Svg)
+import Svg.Styled as Svg
+import Svg.Styled.Attributes as SvgAttributes
 
 
 type Attribute msg
@@ -81,7 +86,12 @@ view attrs isOn =
             }
         , WildWildHtml.label
             [ Attributes.for config.id ]
-            [ Html.text "TODO: switch"
+            [ Nri.Ui.Svg.V1.toHtml
+                (viewSwitch
+                    { id = config.id
+                    , isOn = isOn
+                    }
+                )
             , Maybe.withDefault (Html.text "") config.label
             ]
         ]
@@ -108,3 +118,139 @@ viewCheckbox config =
                     ]
             ]
         )
+
+
+viewSwitch :
+    { id : String
+    , isOn : Bool
+    }
+    -> Svg
+viewSwitch config =
+    let
+        shadowFilterId =
+            config.id ++ "-shadow-filter"
+
+        shadowBoxId =
+            config.id ++ "-shadow-box"
+    in
+    Svg.svg
+        [ SvgAttributes.width "40"
+        , SvgAttributes.height "30"
+        , SvgAttributes.viewBox "0 0 41 30"
+        , SvgAttributes.css [ Css.cursor Css.pointer ]
+        ]
+        [ Svg.defs []
+            [ Svg.filter
+                [ SvgAttributes.id shadowFilterId
+                , SvgAttributes.width "105%"
+                , SvgAttributes.height "106.7%"
+                , SvgAttributes.x "-2.5%"
+                , SvgAttributes.y "-3.3%"
+                , SvgAttributes.filterUnits "objectboundingBox"
+                ]
+                [ Svg.feOffset
+                    [ SvgAttributes.dy "2"
+                    , SvgAttributes.in_ "SourceAlpha"
+                    , SvgAttributes.result "shadowOffsetInner1"
+                    ]
+                    []
+                , Svg.feComposite
+                    [ SvgAttributes.in_ "shadowOffsetInner1"
+                    , SvgAttributes.in2 "SourceAlpha"
+                    , SvgAttributes.k2 "-1"
+                    , SvgAttributes.k3 "1"
+                    , SvgAttributes.operator "arithmetic"
+                    , SvgAttributes.result "shadowInnerInner1"
+                    ]
+                    []
+                , Svg.feColorMatrix
+                    [ SvgAttributes.in_ "shadowInnerInner1"
+                    , SvgAttributes.values "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"
+                    ]
+                    []
+                ]
+            , Svg.rect
+                [ SvgAttributes.id shadowBoxId
+                , SvgAttributes.width "40"
+                , SvgAttributes.height "30"
+                , SvgAttributes.x "0"
+                , SvgAttributes.y "0"
+                , SvgAttributes.rx "15"
+                ]
+                []
+            ]
+        , Svg.g
+            [ SvgAttributes.fill "none"
+            , SvgAttributes.fillRule "even-odd"
+            ]
+            [ Svg.g []
+                [ Svg.use
+                    [ SvgAttributes.xlinkHref ("#" ++ shadowBoxId)
+                    , SvgAttributes.css
+                        [ if config.isOn then
+                            Css.fill Colors.glacier
+
+                          else
+                            Css.fill Colors.gray92
+                        , Css.property "transition" "fill 0.4s"
+                        ]
+                    ]
+                    []
+                , Svg.use
+                    [ SvgAttributes.xlinkHref ("#" ++ shadowBoxId)
+                    , SvgAttributes.fill "#000"
+                    , SvgAttributes.filter ("url(" ++ shadowFilterId ++ ")")
+                    ]
+                    []
+                ]
+            , Svg.g
+                [ SvgAttributes.css
+                    [ if config.isOn then
+                        Css.transform (Css.translateX (Css.px 11))
+
+                      else
+                        Css.batch []
+                    , Css.property "transition" "transform 0.4s"
+                    ]
+                ]
+                [ -- <circle cx="15" cy="15" r="14.5" fill="#FFF"/>
+                  Svg.circle
+                    [ SvgAttributes.cx "15"
+                    , SvgAttributes.cy "15"
+                    , SvgAttributes.r "14.5"
+                    , SvgAttributes.fill "#FFF"
+                    , SvgAttributes.css
+                        [ if config.isOn then
+                            -- azure, but can't use the Color type here
+                            Css.property "stroke" "#146AFF"
+
+                          else
+                            -- gray75, but can't use the Color type here
+                            Css.property "stroke" "#EBEBEB"
+                        , Css.property "transition" "stroke 0.4s"
+                        ]
+                    ]
+                    []
+
+                -- <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M8 15.865L12.323 20 21.554 10"/>
+                , Svg.path
+                    [ SvgAttributes.strokeLinecap "round"
+                    , SvgAttributes.strokeLinejoin "round"
+                    , SvgAttributes.strokeWidth "3"
+                    , SvgAttributes.d "M8 15.865L12.323 20 21.554 10"
+                    , SvgAttributes.css
+                        [ if config.isOn then
+                            -- azure, but can't use the Color type here
+                            Css.property "stroke" "#146AFF"
+
+                          else
+                            -- gray75, but can't use the Color type here
+                            Css.property "stroke" "rgba(255,255,255,0)"
+                        , Css.property "transition" "stroke 0.4s"
+                        ]
+                    ]
+                    []
+                ]
+            ]
+        ]
+        |> Nri.Ui.Svg.V1.fromHtml

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -99,7 +99,12 @@ view attrs isOn =
             , Css.position Css.relative
             , Css.pseudoClass "focus-within"
                 [ Global.descendants
-                    [ Global.svg [ Css.borderColor Colors.azure ] ]
+                    [ Global.class "switch-slider"
+                        [ -- azure, but can't use the Color type here
+                          Css.property "stroke" "#146AFF"
+                        , Css.property "stroke-width" "3px"
+                        ]
+                    ]
                 ]
             , Css.cursor
                 (if config.onSwitch == Nothing then
@@ -129,6 +134,7 @@ view attrs isOn =
                     [ Attributes.css
                         [ Css.fontWeight (Css.int 600)
                         , Css.color Colors.navy
+                        , Css.paddingLeft (Css.px 5)
                         ]
                     ]
                     [ label_ ]
@@ -177,14 +183,11 @@ viewSwitch config =
             config.id ++ "-shadow-box"
     in
     Svg.svg
-        [ SvgAttributes.width "40"
-        , SvgAttributes.height "30"
-        , SvgAttributes.viewBox "0 0 41 30"
+        [ SvgAttributes.width "43"
+        , SvgAttributes.height "32"
+        , SvgAttributes.viewBox "0 0 43 32"
         , SvgAttributes.css
             [ Css.zIndex (Css.int 1)
-            , Css.border3 (Css.px 2) Css.solid Css.transparent
-            , Css.padding (Css.px 3)
-            , Css.borderRadius (Css.px 21)
             ]
         ]
         [ Svg.defs []

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -77,24 +77,33 @@ view attrs isOn =
         config =
             List.foldl customize defaultConfig attrs
     in
-    WildWildHtml.span
-        [ Attributes.id (config.id ++ "-container") ]
+    WildWildHtml.label
+        [ Attributes.id (config.id ++ "-container")
+        , Attributes.css
+            [ Css.displayFlex
+            , Css.alignItems Css.middle
+            ]
+        ]
         [ viewCheckbox
             { id = config.id
             , onCheck = config.onSwitch
             , checked = isOn
             }
-        , WildWildHtml.label
-            [ Attributes.for config.id ]
-            [ Nri.Ui.Svg.V1.toHtml
-                (viewSwitch
-                    { id = config.id
-                    , isOn = isOn
-                    , enabled = config.onSwitch /= Nothing
-                    }
-                )
-            , Maybe.withDefault (Html.text "") config.label
-            ]
+        , Nri.Ui.Svg.V1.toHtml
+            (viewSwitch
+                { id = config.id
+                , isOn = isOn
+                , enabled = config.onSwitch /= Nothing
+                }
+            )
+        , case config.label of
+            Just label_ ->
+                Html.span
+                    [ Attributes.css [ Css.paddingLeft (Css.px 5) ] ]
+                    [ label_ ]
+
+            Nothing ->
+                Html.text ""
         ]
 
 

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -107,7 +107,13 @@ viewCheckbox config =
     Html.checkbox config.id
         (Just config.checked)
         (List.concat
-            [ [ Attributes.id config.id ]
+            [ [ Attributes.id config.id
+              , Attributes.css
+                    [ Css.position Css.absolute
+                    , Css.top (Css.px 10)
+                    , Css.left (Css.px 10)
+                    ]
+              ]
             , case config.onCheck of
                 Just onCheck ->
                     [ Events.onCheck onCheck ]

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -119,7 +119,11 @@ view attrs isOn =
         , case config.label of
             Just label_ ->
                 Html.span
-                    [ Attributes.css [ Css.paddingLeft (Css.px 5) ] ]
+                    [ Attributes.css
+                        [ Css.fontWeight (Css.int 600)
+                        , Css.color Colors.navy
+                        ]
+                    ]
                     [ label_ ]
 
             Nothing ->

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -317,7 +317,6 @@ viewSwitch config =
                             Css.property "stroke" "#146AFF"
 
                           else
-                            -- gray75, but can't use the Color type here
                             Css.property "stroke" "rgba(255,255,255,0)"
                         , transition "stroke 0.2s"
                         ]

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -11,6 +11,7 @@ import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Widget as Widget
 import Css
 import Css.Global as Global
+import Css.Media
 import Html.Styled as WildWildHtml
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
@@ -229,6 +230,7 @@ viewSwitch config =
         , Svg.g
             [ SvgAttributes.fill "none"
             , SvgAttributes.fillRule "even-odd"
+            , SvgAttributes.transform "translate(1, 1)"
             ]
             [ Svg.g []
                 [ Svg.use
@@ -239,7 +241,7 @@ viewSwitch config =
 
                           else
                             Css.fill Colors.gray92
-                        , Css.property "transition" "fill 0.4s"
+                        , transition "fill 0.4s"
                         ]
                     ]
                     []
@@ -256,8 +258,8 @@ viewSwitch config =
                         Css.transform (Css.translateX (Css.px 11))
 
                       else
-                        Css.batch []
-                    , Css.property "transition" "transform 0.4s"
+                        Css.transform (Css.translateX (Css.px 0))
+                    , transition "transform 0.4s"
                     ]
                 ]
                 [ -- <circle cx="15" cy="15" r="14.5" fill="#FFF"/>
@@ -274,8 +276,9 @@ viewSwitch config =
                           else
                             -- gray75, but can't use the Color type here
                             Css.property "stroke" "#EBEBEB"
-                        , Css.property "transition" "stroke 0.4s"
+                        , transition "stroke 0.1s"
                         ]
+                    , SvgAttributes.class "switch-slider"
                     ]
                     []
 
@@ -293,7 +296,7 @@ viewSwitch config =
                           else
                             -- gray75, but can't use the Color type here
                             Css.property "stroke" "rgba(255,255,255,0)"
-                        , Css.property "transition" "stroke 0.4s"
+                        , transition "stroke 0.4s"
                         ]
                     ]
                     []
@@ -301,3 +304,10 @@ viewSwitch config =
             ]
         ]
         |> Nri.Ui.Svg.V1.fromHtml
+
+
+transition : String -> Css.Style
+transition transitionRules =
+    Css.Media.withMediaQuery
+        [ "(prefers-reduced-motion: no-preference)" ]
+        [ Css.property "transition" transitionRules ]

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -10,6 +10,7 @@ import Accessibility.Styled as Html exposing (Html)
 import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Widget as Widget
 import Css
+import Css.Global as Global
 import Html.Styled as WildWildHtml
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
@@ -95,6 +96,10 @@ view attrs isOn =
             [ Css.displayFlex
             , Css.alignItems Css.center
             , Css.position Css.relative
+            , Css.pseudoClass "focus-within"
+                [ Global.descendants
+                    [ Global.svg [ Css.borderColor Colors.azure ] ]
+                ]
             ]
         , Aria.controls config.id
         , Widget.checked (Just isOn)
@@ -177,6 +182,9 @@ viewSwitch config =
               else
                 Css.batch []
             , Css.zIndex (Css.int 1)
+            , Css.border3 (Css.px 2) Css.solid Css.transparent
+            , Css.padding (Css.px 3)
+            , Css.borderRadius (Css.px 21)
             ]
         ]
         [ Svg.defs []

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -285,8 +285,7 @@ viewSwitch config =
                     , transition "transform 0.2s ease-in-out"
                     ]
                 ]
-                [ -- <circle cx="15" cy="15" r="14.5" fill="#FFF"/>
-                  Svg.circle
+                [ Svg.circle
                     [ SvgAttributes.cx "15"
                     , SvgAttributes.cy "15"
                     , SvgAttributes.r "14.5"
@@ -304,8 +303,6 @@ viewSwitch config =
                     , SvgAttributes.class "switch-slider"
                     ]
                     []
-
-                -- <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M8 15.865L12.323 20 21.554 10"/>
                 , Svg.path
                     [ SvgAttributes.strokeLinecap "round"
                     , SvgAttributes.strokeLinejoin "round"

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -90,6 +90,7 @@ view attrs isOn =
                 (viewSwitch
                     { id = config.id
                     , isOn = isOn
+                    , enabled = config.onSwitch /= Nothing
                     }
                 )
             , Maybe.withDefault (Html.text "") config.label
@@ -129,6 +130,7 @@ viewCheckbox config =
 viewSwitch :
     { id : String
     , isOn : Bool
+    , enabled : Bool
     }
     -> Svg
 viewSwitch config =
@@ -143,7 +145,13 @@ viewSwitch config =
         [ SvgAttributes.width "40"
         , SvgAttributes.height "30"
         , SvgAttributes.viewBox "0 0 41 30"
-        , SvgAttributes.css [ Css.cursor Css.pointer ]
+        , SvgAttributes.css
+            [ if config.enabled then
+                Css.cursor Css.pointer
+
+              else
+                Css.batch []
+            ]
         ]
         [ Svg.defs []
             [ Svg.filter

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -93,6 +93,7 @@ view attrs isOn =
         , Attributes.css
             [ Css.displayFlex
             , Css.alignItems Css.middle
+            , Css.position Css.relative
             ]
         ]
         [ viewCheckbox
@@ -133,6 +134,7 @@ viewCheckbox config =
                     [ Css.position Css.absolute
                     , Css.top (Css.px 10)
                     , Css.left (Css.px 10)
+                    , Css.zIndex (Css.int 0)
                     ]
               ]
             , case config.onCheck of
@@ -171,6 +173,7 @@ viewSwitch config =
 
               else
                 Css.batch []
+            , Css.zIndex (Css.int 1)
             ]
         ]
         [ Svg.defs []

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -119,11 +119,11 @@ view attrs isOn =
                     ]
                 ]
             , Css.cursor
-                (if config.onSwitch == Nothing then
-                    Css.default
+                (if config.onSwitch /= Nothing then
+                    Css.pointer
 
                  else
-                    Css.pointer
+                    Css.notAllowed
                 )
             ]
         , Aria.controls config.id
@@ -138,6 +138,7 @@ view attrs isOn =
             (viewSwitch
                 { id = config.id
                 , isOn = isOn
+                , enabled = config.onSwitch /= Nothing
                 }
             )
         , case config.label of
@@ -171,6 +172,7 @@ viewCheckbox config =
             , Css.top (Css.px 10)
             , Css.left (Css.px 10)
             , Css.zIndex (Css.int 0)
+            , Css.opacity (Css.num 0)
             ]
         , case config.onCheck of
             Just onCheck ->
@@ -184,6 +186,7 @@ viewCheckbox config =
 viewSwitch :
     { id : String
     , isOn : Bool
+    , enabled : Bool
     }
     -> Svg
 viewSwitch config =
@@ -200,6 +203,11 @@ viewSwitch config =
         , SvgAttributes.viewBox "0 0 43 32"
         , SvgAttributes.css
             [ Css.zIndex (Css.int 1)
+            , if config.enabled then
+                Css.opacity (Css.num 1)
+
+              else
+                Css.opacity (Css.num 0.4)
             ]
         ]
         [ Svg.defs []

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -93,7 +93,7 @@ view attrs isOn =
     WildWildHtml.label
         [ Attributes.id (config.id ++ "-container")
         , Attributes.css
-            [ Css.displayFlex
+            [ Css.display Css.inlineFlex
             , Css.alignItems Css.center
             , Css.position Css.relative
             , Css.pseudoClass "focus-within"

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -298,7 +298,7 @@ viewSwitch config =
 
                           else
                             -- gray75, but can't use the Color type here
-                            Css.property "stroke" "#EBEBEB"
+                            Css.property "stroke" "#BFBFBF"
                         , transition "stroke 0.1s"
                         ]
                     , SvgAttributes.class "switch-slider"

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -1,0 +1,110 @@
+module Nri.Ui.Switch.V1 exposing (view, Attribute, onSwitch, id, label)
+
+{-|
+
+@docs view, Attribute, onSwitch, id, label
+
+-}
+
+import Accessibility.Styled as Html exposing (Html)
+import Accessibility.Styled.Widget as Widget
+import Html.Styled as WildWildHtml
+import Html.Styled.Attributes as Attributes
+import Html.Styled.Events as Events
+
+
+type Attribute msg
+    = OnSwitch (Bool -> msg)
+    | Id String
+    | Label (Html msg)
+
+
+onSwitch : (Bool -> msg) -> Attribute msg
+onSwitch =
+    OnSwitch
+
+
+id : String -> Attribute msg
+id =
+    Id
+
+
+{-| Labeling text requirements: should be descriptive but not interactive
+(that is, this API would be `Html Never` if it was ergonomic to do so)
+and should be styled so that it can be displayed inline.
+-}
+label : Html msg -> Attribute msg
+label =
+    Label
+
+
+type alias Config msg =
+    { onSwitch : Maybe (Bool -> msg)
+    , id : String
+    , label : Maybe (Html msg)
+    }
+
+
+defaultConfig : Config msg
+defaultConfig =
+    { onSwitch = Nothing
+    , id = "nri-ui-switch-with-default-id"
+    , label = Nothing
+    }
+
+
+customize : Attribute msg -> Config msg -> Config msg
+customize attr config =
+    case attr of
+        OnSwitch onSwitch_ ->
+            { config | onSwitch = Just onSwitch_ }
+
+        Id id_ ->
+            { config | id = id_ }
+
+        Label label_ ->
+            { config | label = Just label_ }
+
+
+view : List (Attribute msg) -> Bool -> Html msg
+view attrs isOn =
+    let
+        config =
+            List.foldl customize defaultConfig attrs
+    in
+    WildWildHtml.span
+        [ Attributes.id (config.id ++ "-container") ]
+        [ viewCheckbox
+            { id = config.id
+            , onCheck = config.onSwitch
+            , checked = isOn
+            }
+        , WildWildHtml.label
+            [ Attributes.for config.id ]
+            [ Html.text "TODO: switch"
+            , Maybe.withDefault (Html.text "") config.label
+            ]
+        ]
+
+
+viewCheckbox :
+    { id : String
+    , onCheck : Maybe (Bool -> msg)
+    , checked : Bool
+    }
+    -> Html msg
+viewCheckbox config =
+    Html.checkbox config.id
+        (Just config.checked)
+        (List.concat
+            [ [ Attributes.id config.id ]
+            , case config.onCheck of
+                Just onCheck ->
+                    [ Events.onCheck onCheck ]
+
+                Nothing ->
+                    [ Attributes.disabled True
+                    , Widget.disabled True
+                    ]
+            ]
+        )

--- a/styleguide-app/Examples.elm
+++ b/styleguide-app/Examples.elm
@@ -30,6 +30,7 @@ import Examples.Slide as Slide
 import Examples.SlideModal as SlideModal
 import Examples.SortableTable as SortableTable
 import Examples.Svg as Svg
+import Examples.Switch as Switch
 import Examples.Table as Table
 import Examples.Tabs as Tabs
 import Examples.Text as Text
@@ -593,6 +594,25 @@ all =
                     _ ->
                         Nothing
             )
+    , Switch.example
+        |> Example.wrapMsg SwitchMsg
+            (\msg ->
+                case msg of
+                    SwitchMsg childMsg ->
+                        Just childMsg
+
+                    _ ->
+                        Nothing
+            )
+        |> Example.wrapState SwitchState
+            (\msg ->
+                case msg of
+                    SwitchState childState ->
+                        Just childState
+
+                    _ ->
+                        Nothing
+            )
     , Table.example
         |> Example.wrapMsg TableMsg
             (\msg ->
@@ -778,6 +798,7 @@ type State
     | SlideModalState SlideModal.State
     | SortableTableState SortableTable.State
     | SvgState Svg.State
+    | SwitchState Switch.State
     | TableState Table.State
     | TabsState Tabs.State
     | TextState Text.State
@@ -818,6 +839,7 @@ type Msg
     | SlideModalMsg SlideModal.Msg
     | SortableTableMsg SortableTable.Msg
     | SvgMsg Svg.Msg
+    | SwitchMsg Switch.Msg
     | TableMsg Table.Msg
     | TabsMsg Tabs.Msg
     | TextMsg Text.Msg

--- a/styleguide-app/Examples/Switch.elm
+++ b/styleguide-app/Examples/Switch.elm
@@ -52,14 +52,16 @@ example =
             , Heading.h3 [] [ Html.text "Disabled" ]
             , Text.mediumBody []
                 [ Switch.view
-                    [ Switch.id "switch-disabled-on"
+                    [ Switch.disabled
+                    , Switch.id "switch-disabled-on"
                     , Switch.label (Html.text "Permanently on")
                     ]
                     True
                 ]
             , Text.mediumBody []
                 [ Switch.view
-                    [ Switch.id "switch-disabled-off"
+                    [ Switch.disabled
+                    , Switch.id "switch-disabled-off"
                     , Switch.label (Html.text "Permanently off")
                     ]
                     False

--- a/styleguide-app/Examples/Switch.elm
+++ b/styleguide-app/Examples/Switch.elm
@@ -1,0 +1,71 @@
+module Examples.Switch exposing (Msg, State, example)
+
+{-|
+
+@docs Msg, State, example
+
+-}
+
+import AtomicDesignType
+import Category
+import Example exposing (Example)
+import Html.Styled as Html
+import Nri.Ui.Heading.V2 as Heading
+import Nri.Ui.Switch.V1 as Switch
+import Nri.Ui.Text.V5 as Text
+
+
+{-| -}
+type alias State =
+    Bool
+
+
+{-| -}
+type Msg
+    = Switch Bool
+
+
+example : Example State Msg
+example =
+    { name = "Switch"
+    , version = 1
+    , state = True
+    , update = \(Switch new) _ -> ( new, Cmd.none )
+    , subscriptions = \_ -> Sub.none
+    , view =
+        \interactiveIsOn ->
+            [ Heading.h3 [] [ Html.text "Interactive" ]
+            , Text.mediumBody []
+                [ Switch.view
+                    [ Switch.onSwitch Switch
+                    , Switch.id "switch-interactive"
+                    , Switch.label
+                        (if interactiveIsOn then
+                            Html.text "On"
+
+                         else
+                            Html.text "Off"
+                        )
+                    ]
+                    interactiveIsOn
+                ]
+            , Heading.h3 [] [ Html.text "Disabled" ]
+            , Text.mediumBody []
+                [ Switch.view
+                    [ Switch.id "switch-disabled-on"
+                    , Switch.label (Html.text "Permanently on")
+                    ]
+                    True
+                ]
+            , Text.mediumBody []
+                [ Switch.view
+                    [ Switch.id "switch-disabled-off"
+                    , Switch.label (Html.text "Permanently off")
+                    ]
+                    False
+                ]
+            ]
+    , categories = [ Category.Inputs ]
+    , atomicDesignType = AtomicDesignType.Atom
+    , keyboardSupport = [{- TODO -}]
+    }

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -55,6 +55,7 @@
         "Nri.Ui.SlideModal.V2",
         "Nri.Ui.SortableTable.V2",
         "Nri.Ui.Svg.V1",
+        "Nri.Ui.Switch.V1",
         "Nri.Ui.Table.V4",
         "Nri.Ui.Table.V5",
         "Nri.Ui.Tabs.V6",


### PR DESCRIPTION
We finally have a reason to add switches! Hooray!

These switches look nice, have nice animations, and should be reasonably accessible (at least as far as I can tell.) The animation also stops if the user-agent says the user prefers reduced motion—I'm not sure what the threshold for those things is, so I just turned off animation altogether if it's disabled. Apple seems to just do color fades instead, so I may be being too conservative here.

Here's how keyboard and mouse interaction goes:

![switch-interactions](https://user-images.githubusercontent.com/355401/101832070-7724c480-3afc-11eb-8ef0-0e0917829407.gif)