### PR TITLE
:bowtie: fix border

### DIFF
--- a/src/Nri/Ui/Checkbox/V5.elm
+++ b/src/Nri/Ui/Checkbox/V5.elm
@@ -11,6 +11,7 @@ module Nri.Ui.Checkbox.V5 exposing
 
   - Use Nri.Ui.Svg.V1 rather than a custom Icon type specific to this module
   - Make the filter ids within the svg unique (now the id depends on the checkbox identifier)
+  - Explicitly box-sizing content-box on the label (<https://github.com/NoRedInk/NoRedInk/pull/30886#issuecomment-737854831>)
 
 
 # Changes from V5:
@@ -304,6 +305,7 @@ viewIcon styles icon =
             , padding (px 2)
             , borderRadius (px 3)
             , height (Css.px 27)
+            , boxSizing contentBox
             ]
         , Attributes.class "checkbox-icon-container"
         ]


### PR DESCRIPTION
Fixes https://github.com/NoRedInk/noredink-ui/issues/653

In the screenshots, please note that I've added `* {box-sizing: border-box;}` which is a global style that's (sometimes? always?) applied in the monolith layouts.

<details><summary>Before</summary>

![image](https://user-images.githubusercontent.com/8811312/102550365-94b0db80-4072-11eb-91d6-2500200e33f3.png)

</details>

<img width="490" alt="Screen Shot 2020-12-17 at 2 15 17 PM" src="https://user-images.githubusercontent.com/8811312/102550260-629f7980-4072-11eb-957b-8e8267069495.png">

