### PR TITLE
Raven/reduced motion support 3

### DIFF
--- a/src/Nri/Ui/Confetti/V2.elm
+++ b/src/Nri/Ui/Confetti/V2.elm
@@ -17,6 +17,7 @@ Changes from V1:
 -}
 
 import Css exposing (Color)
+import Css.Media exposing (withMediaQuery)
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
@@ -66,6 +67,8 @@ view (System system _) =
                     , Css.width (Css.pct 100)
                     , Css.height (Css.vh 100)
                     , Css.pointerEvents Css.none
+                    , withMediaQuery [ "(prefers-reduced-motion)" ]
+                        [ Css.display Css.none ]
                     ]
                 ]
             )

--- a/src/Nri/Ui/Confetti/V2.elm
+++ b/src/Nri/Ui/Confetti/V2.elm
@@ -59,7 +59,7 @@ view (System system _) =
     system
         |> ParticleSystem.viewCustom viewConfetti
             (Html.div
-                [ Attributes.style "position" "absolute"
+                [ Attributes.style "position" "fixed"
                 , Attributes.style "top" "0"
                 , Attributes.style "left" "0"
                 , Attributes.style "width" "100%"

--- a/src/Nri/Ui/Confetti/V2.elm
+++ b/src/Nri/Ui/Confetti/V2.elm
@@ -59,12 +59,14 @@ view (System system _) =
     system
         |> ParticleSystem.viewCustom viewConfetti
             (Html.div
-                [ Attributes.style "position" "fixed"
-                , Attributes.style "top" "0"
-                , Attributes.style "left" "0"
-                , Attributes.style "width" "100%"
-                , Attributes.style "height" "100vh"
-                , Attributes.style "pointer-events" "none"
+                [ Attributes.css
+                    [ Css.position Css.fixed
+                    , Css.top Css.zero
+                    , Css.left Css.zero
+                    , Css.width (Css.pct 100)
+                    , Css.height (Css.vh 100)
+                    , Css.pointerEvents Css.none
+                    ]
                 ]
             )
 


### PR DESCRIPTION
Don't render confetti if `prefers-reduced-motion` is set!

This won't avoid the computation, but I figured it was better to do it all using css only to keep the widget port-free.

See https://paper.dropbox.com/doc/Reduce-motion-for-site-animations--BDuE8Mq0HRjcjs3jjW_4O4SrAg-UQ2ngQW9PORW1SMa1qapL