### PR TITLE
add "for" attribute to the switch's label

### DIFF
--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -149,6 +149,7 @@ view attrs isOn =
                         , Css.color Colors.navy
                         , Css.paddingLeft (Css.px 5)
                         ]
+                    , Attributes.for config.id
                     ]
                     [ label_ ]
 


### PR DESCRIPTION
this will associate the label with the input, giving us some nice things such as:
  - screen readers will read the label when the input is focused
  - clicking on the label toggles the switch
  - toggling the switch with elm-program-test is now possible without manually simulating dom events


For https://github.com/NoRedInk/noredink-ui/issues/665

NOTE: I tested that this plays well with elm-program-test by symlinking on the monolith's `CustomizeRubricSpec`