### PR TITLE
SegmentedControl honours FillContainer

### DIFF
--- a/src/Nri/Ui/SegmentedControl/V14.elm
+++ b/src/Nri/Ui/SegmentedControl/V14.elm
@@ -126,7 +126,13 @@ viewRadioGroup config =
                         { id = option.idString ++ "-tooltip"
                         , trigger = inner
                         }
-                        option.tooltip
+                        (case config.positioning of
+                            Left FillContainer ->
+                                Tooltip.containerCss [ Css.width (Css.pct 100) ] :: option.tooltip
+
+                            _ ->
+                                option.tooltip
+                        )
 
         name =
             dashify (String.toLower config.legend)

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -63,7 +63,7 @@ example =
             , SegmentedControl.viewRadioGroup
                 { legend = "SegmentedControls 'viewSelectRadio' example"
                 , onSelect = SelectRadio
-                , options = List.take options.count (buildRadioOptions state.radioTooltip options.content)
+                , options = List.take options.count (buildRadioOptions options state.radioTooltip options.content)
                 , selected = state.optionallySelected
                 , positioning = options.positioning
                 }
@@ -146,8 +146,8 @@ buildOptions { content, longContent, tooltips } openTooltip =
     ]
 
 
-buildRadioOptions : Maybe Int -> Content -> List (SegmentedControl.Radio Int Msg)
-buildRadioOptions currentlyHovered content =
+buildRadioOptions : { options | tooltips : Bool } -> Maybe Int -> Content -> List (SegmentedControl.Radio Int Msg)
+buildRadioOptions options currentlyHovered content =
     let
         buildOption : Int -> ( String, Svg ) -> SegmentedControl.Radio Int Msg
         buildOption value ( text, icon ) =
@@ -162,20 +162,24 @@ buildRadioOptions currentlyHovered content =
             , value = value
             , idString = String.fromInt value
             , tooltip =
-                [ Tooltip.plaintext text
-                , Tooltip.open (currentlyHovered == Just value)
-                , Tooltip.fitToContent
-                , Tooltip.onHover
-                    (\hovered ->
-                        HoverRadio
-                            (if hovered then
-                                Just value
+                if options.tooltips then
+                    [ Tooltip.plaintext text
+                    , Tooltip.open (currentlyHovered == Just value)
+                    , Tooltip.fitToContent
+                    , Tooltip.onHover
+                        (\hovered ->
+                            HoverRadio
+                                (if hovered then
+                                    Just value
 
-                             else
-                                Nothing
-                            )
-                    )
-                ]
+                                 else
+                                    Nothing
+                                )
+                        )
+                    ]
+
+                else
+                    []
             , attributes = []
             }
     in


### PR DESCRIPTION
`viewRadioGroup` was ignoring it when tooltips were being used.

**NOTE: ** this is a bug, but no use cases of `viewRadioGroup` were actually using tooltips (since they were recently introduced for a new feature).

The following combination should now result in full-width controls!

<img width="1316" alt="Screen Shot 2021-04-12 at 18 17 24" src="https://user-images.githubusercontent.com/753421/114463944-7c357580-9bbb-11eb-8ce9-28036b48c3ba.png">
