### PR TITLE
bump to 12.18.1

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "12.18.0",
+    "version": "12.18.1",
     "exposed-modules": [
         "Nri.Ui",
         "Nri.Ui.Accordion.V1",


### PR DESCRIPTION
- Patches `SegmentedControl.viewRadioGroup` to honour `FillContainer` when tooltips are being used (#688)
- Fixes `ClickableSvg` example so that the content is actually clickable when tooltips are being used (#685)