### PR TITLE
Kraken/http message

### DIFF
--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -182,6 +182,12 @@ view attributes_ =
 
                     Just msg ->
                         largeDismissButton msg
+                , case attributes.codeDetails of
+                    Just details ->
+                        viewCodeDetails details
+
+                    Nothing ->
+                        text ""
                 ]
 
         Banner ->
@@ -233,6 +239,12 @@ view attributes_ =
 
                     Just msg ->
                         bannerDismissButton msg
+                , case attributes.codeDetails of
+                    Just details ->
+                        viewCodeDetails details
+
+                    Nothing ->
+                        text ""
                 ]
 
 

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -106,31 +106,43 @@ view attributes_ =
     in
     case attributes.size of
         Tiny ->
-            div
-                ([ ExtraAttributes.nriDescription "Nri-Ui-Message--tiny"
-                 , Attributes.css
-                    (baseStyles
-                        ++ [ displayFlex
-                           , justifyContent start
-                           , alignItems center
-                           , paddingTop (px 6)
-                           , paddingBottom (px 8)
-                           , fontSize (px 13)
-                           ]
-                    )
-                 ]
-                    ++ role
-                    ++ attributes.customAttributes
-                )
-                [ Nri.Ui.styled div "Nri-Ui-Message--icon" [ alignSelf flexStart ] [] [ icon_ ]
-                , div [] attributes.content
-                , case attributes.onDismiss of
-                    Nothing ->
-                        text ""
+            let
+                tinyMessage =
+                    div
+                        ([ ExtraAttributes.nriDescription "Nri-Ui-Message--tiny"
+                         , Attributes.css
+                            (baseStyles
+                                ++ [ displayFlex
+                                   , justifyContent start
+                                   , alignItems center
+                                   , paddingTop (px 6)
+                                   , paddingBottom (px 8)
+                                   , fontSize (px 13)
+                                   ]
+                            )
+                         ]
+                            ++ role
+                            ++ attributes.customAttributes
+                        )
+                        [ Nri.Ui.styled div "Nri-Ui-Message--icon" [ alignSelf flexStart ] [] [ icon_ ]
+                        , div [] attributes.content
+                        , case attributes.onDismiss of
+                            Nothing ->
+                                text ""
 
-                    Just msg ->
-                        tinyDismissButton msg
-                ]
+                            Just msg ->
+                                tinyDismissButton msg
+                        ]
+            in
+            case attributes.codeDetails of
+                Just details ->
+                    div []
+                        [ tinyMessage
+                        , viewCodeDetails details
+                        ]
+
+                Nothing ->
+                    tinyMessage
 
         Large ->
             div
@@ -232,14 +244,12 @@ view attributes_ =
 -}
 somethingWentWrong : String -> Html msg
 somethingWentWrong errorMessageForEngineers =
-    div []
-        [ view
-            [ tiny
-            , error
-            , alertRole
-            , plaintext somethingWentWrongMessage
-            ]
-        , viewCodeDetails errorMessageForEngineers
+    view
+        [ tiny
+        , error
+        , alertRole
+        , plaintext somethingWentWrongMessage
+        , codeDetails errorMessageForEngineers
         ]
 
 
@@ -373,6 +383,11 @@ httpError error_ =
                             -- TODO!
                             []
             }
+
+
+codeDetails : String -> Attribute msg
+codeDetails code =
+    Attribute <| \config -> { config | codeDetails = Just code }
 
 
 {-| This is the default theme for a Message.

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -149,39 +149,43 @@ view attributes_ =
                 ([ ExtraAttributes.nriDescription "Nri-Ui-Message-large"
                  , Attributes.css
                     (baseStyles
-                        ++ [ displayFlex
-                           , alignItems center
-
-                           -- Box
-                           , borderRadius (px 8)
+                        ++ [ -- Box
+                             borderRadius (px 8)
                            , padding (px 20)
                            , backgroundColor_
-
-                           -- Fonts
-                           , fontSize (px 15)
-                           , fontWeight (int 600)
-                           , lineHeight (px 21)
                            ]
                     )
                  ]
                     ++ role
                     ++ attributes.customAttributes
                 )
-                [ icon_
-                , div
+                [ div
                     [ Attributes.css
-                        [ minWidth (px 100)
-                        , flexBasis (px 100)
-                        , flexGrow (int 1)
+                        [ displayFlex
+                        , alignItems center
+
+                        -- Fonts
+                        , fontSize (px 15)
+                        , fontWeight (int 600)
+                        , lineHeight (px 21)
                         ]
                     ]
-                    attributes.content
-                , case attributes.onDismiss of
-                    Nothing ->
-                        text ""
+                    [ icon_
+                    , div
+                        [ Attributes.css
+                            [ minWidth (px 100)
+                            , flexBasis (px 100)
+                            , flexGrow (int 1)
+                            ]
+                        ]
+                        attributes.content
+                    , case attributes.onDismiss of
+                        Nothing ->
+                            text ""
 
-                    Just msg ->
-                        largeDismissButton msg
+                        Just msg ->
+                            largeDismissButton msg
+                    ]
                 , case attributes.codeDetails of
                     Just details ->
                         viewCodeDetails details
@@ -194,51 +198,52 @@ view attributes_ =
             div
                 ([ ExtraAttributes.nriDescription "Nri-Ui-Message-banner"
                  , Attributes.css
-                    (baseStyles
-                        ++ [ displayFlex
-                           , justifyContent center
-                           , alignItems center
-                           , backgroundColor_
-
-                           -- Fonts
-                           , fontSize (px 20)
-                           , fontWeight (int 700)
-                           , lineHeight (px 27)
-                           ]
-                    )
+                    (baseStyles ++ [ backgroundColor_, padding (px 20) ])
                  ]
                     ++ role
                     ++ attributes.customAttributes
                 )
-                [ span
+                [ div
                     [ Attributes.css
                         [ alignItems center
                         , displayFlex
                         , justifyContent center
-                        , padding (px 20)
-                        , width (Css.pct 100)
                         ]
                     ]
-                    [ icon_
-                    , Nri.Ui.styled div
-                        "banner-alert-notification"
-                        [ fontSize (px 20)
-                        , fontWeight (int 700)
-                        , lineHeight (px 27)
-                        , maxWidth (px 600)
-                        , minWidth (px 100)
-                        , flexShrink (int 1)
-                        , Fonts.baseFont
-                        ]
-                        []
-                        attributes.content
-                    ]
-                , case attributes.onDismiss of
-                    Nothing ->
-                        text ""
+                    [ div
+                        [ Attributes.css
+                            [ alignItems center
+                            , displayFlex
+                            , justifyContent center
+                            , width (Css.pct 100)
 
-                    Just msg ->
-                        bannerDismissButton msg
+                            -- Fonts
+                            , fontSize (px 20)
+                            , fontWeight (int 700)
+                            , lineHeight (px 27)
+                            ]
+                        ]
+                        [ icon_
+                        , Nri.Ui.styled div
+                            "banner-alert-notification"
+                            [ fontSize (px 20)
+                            , fontWeight (int 700)
+                            , lineHeight (px 27)
+                            , maxWidth (px 600)
+                            , minWidth (px 100)
+                            , flexShrink (int 1)
+                            , Fonts.baseFont
+                            ]
+                            []
+                            attributes.content
+                        ]
+                    , case attributes.onDismiss of
+                        Nothing ->
+                            text ""
+
+                        Just msg ->
+                            bannerDismissButton msg
+                    ]
                 , case attributes.codeDetails of
                     Just details ->
                         viewCodeDetails details
@@ -373,7 +378,7 @@ httpError error_ =
 
                 Http.Timeout ->
                     ( Nothing
-                    , [ text "There was a problem! This request took too long to complete." ]
+                    , [ text "This request took too long to complete." ]
                     )
 
                 Http.NetworkError ->
@@ -823,8 +828,7 @@ largeDismissButton : msg -> Html msg
 largeDismissButton msg =
     Nri.Ui.styled div
         "dismiss-button-container"
-        [ padding2 Css.zero (px 20)
-        ]
+        [ padding2 Css.zero (px 20) ]
         []
         [ ClickableSvg.button "Dismiss message"
             UiIcon.x
@@ -839,7 +843,7 @@ bannerDismissButton : msg -> Html msg
 bannerDismissButton msg =
     Nri.Ui.styled div
         "dismiss-button-container"
-        [ padding2 (px 30) (px 40) ]
+        [ padding2 Css.zero (px 20) ]
         []
         [ ClickableSvg.button "Dismiss banner"
             UiIcon.x

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -96,66 +96,32 @@ view attributes_ =
         icon_ =
             getIcon attributes.icon attributes.size attributes.theme
 
-        ( description, containerStyles ) =
-            case attributes.size of
-                Tiny ->
-                    ( "Nri-Ui-Message--tiny"
-                    , [ displayFlex
-                      , justifyContent start
-                      , alignItems center
-                      , paddingTop (px 6)
-                      , paddingBottom (px 8)
-                      , fontSize (px 13)
-                      ]
-                    )
-
-                Large ->
-                    ( "Nri-Ui-Message-large"
-                    , [ displayFlex
-                      , alignItems center
-
-                      -- Box
-                      , borderRadius (px 8)
-                      , padding (px 20)
-                      , backgroundColor_
-
-                      -- Fonts
-                      , fontSize (px 15)
-                      , fontWeight (int 600)
-                      , lineHeight (px 21)
-                      ]
-                    )
-
-                Banner ->
-                    ( "Nri-Ui-Message-banner"
-                    , [ displayFlex
-                      , justifyContent center
-                      , alignItems center
-                      , backgroundColor_
-
-                      -- Fonts
-                      , fontSize (px 20)
-                      , fontWeight (int 700)
-                      , lineHeight (px 27)
-                      ]
-                    )
-    in
-    div
-        ([ ExtraAttributes.nriDescription description
-         , Attributes.css
+        baseStyles =
             [ Fonts.baseFont
             , color color_
             , boxSizing borderBox
             , styleOverrides
-            , Css.batch containerStyles
             , Css.batch attributes.customStyles
             ]
-         ]
-            ++ role
-            ++ attributes.customAttributes
-        )
-        (case attributes.size of
-            Tiny ->
+    in
+    case attributes.size of
+        Tiny ->
+            div
+                ([ ExtraAttributes.nriDescription "Nri-Ui-Message--tiny"
+                 , Attributes.css
+                    (baseStyles
+                        ++ [ displayFlex
+                           , justifyContent start
+                           , alignItems center
+                           , paddingTop (px 6)
+                           , paddingBottom (px 8)
+                           , fontSize (px 13)
+                           ]
+                    )
+                 ]
+                    ++ role
+                    ++ attributes.customAttributes
+                )
                 [ Nri.Ui.styled div "Nri-Ui-Message--icon" [ alignSelf flexStart ] [] [ icon_ ]
                 , div [] attributes.content
                 , case attributes.onDismiss of
@@ -166,7 +132,29 @@ view attributes_ =
                         tinyDismissButton msg
                 ]
 
-            Large ->
+        Large ->
+            div
+                ([ ExtraAttributes.nriDescription "Nri-Ui-Message-large"
+                 , Attributes.css
+                    (baseStyles
+                        ++ [ displayFlex
+                           , alignItems center
+
+                           -- Box
+                           , borderRadius (px 8)
+                           , padding (px 20)
+                           , backgroundColor_
+
+                           -- Fonts
+                           , fontSize (px 15)
+                           , fontWeight (int 600)
+                           , lineHeight (px 21)
+                           ]
+                    )
+                 ]
+                    ++ role
+                    ++ attributes.customAttributes
+                )
                 [ icon_
                 , div
                     [ Attributes.css
@@ -184,7 +172,26 @@ view attributes_ =
                         largeDismissButton msg
                 ]
 
-            Banner ->
+        Banner ->
+            div
+                ([ ExtraAttributes.nriDescription "Nri-Ui-Message-banner"
+                 , Attributes.css
+                    (baseStyles
+                        ++ [ displayFlex
+                           , justifyContent center
+                           , alignItems center
+                           , backgroundColor_
+
+                           -- Fonts
+                           , fontSize (px 20)
+                           , fontWeight (int 700)
+                           , lineHeight (px 27)
+                           ]
+                    )
+                 ]
+                    ++ role
+                    ++ attributes.customAttributes
+                )
                 [ span
                     [ Attributes.css
                         [ alignItems center
@@ -215,7 +222,6 @@ view attributes_ =
                     Just msg ->
                         bannerDismissButton msg
                 ]
-        )
 
 
 {-| Shows an appropriate error message for when something unhandled happened.

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -527,7 +527,30 @@ contentToHtml content =
         Html html_ ->
             html_
 
-        HttpError error_ ->
+        HttpError (Http.BadUrl _) ->
+            []
+
+        HttpError Http.Timeout ->
+            -- TODO!
+            []
+
+        HttpError Http.NetworkError ->
+            -- TODO!
+            []
+
+        HttpError (Http.BadStatus 401) ->
+            -- TODO!
+            []
+
+        HttpError (Http.BadStatus 404) ->
+            -- TODO!
+            []
+
+        HttpError (Http.BadStatus status) ->
+            -- TODO!
+            []
+
+        HttpError (Http.BadBody body) ->
             -- TODO!
             []
 

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -363,38 +363,45 @@ html content =
 -}
 httpError : Http.Error -> Attribute msg
 httpError error_ =
-    Attribute <|
-        \config ->
-            { config
-                | content =
-                    case error_ of
-                        Http.BadUrl _ ->
-                            []
+    let
+        ( codeDetails_, content ) =
+            case error_ of
+                Http.BadUrl url ->
+                    ( Just ("Bad url: " ++ url)
+                    , [ text somethingWentWrongMessage ]
+                    )
 
-                        Http.Timeout ->
-                            -- TODO!
-                            []
+                Http.Timeout ->
+                    ( Nothing
+                    , [ text "There was a problem! This request took too long to complete." ]
+                    )
 
-                        Http.NetworkError ->
-                            -- TODO!
-                            []
+                Http.NetworkError ->
+                    ( Nothing
+                    , [ text "Something went wrong, and we think the problem is probably with your internet connection." ]
+                    )
 
-                        Http.BadStatus 401 ->
-                            -- TODO!
-                            []
+                Http.BadStatus 401 ->
+                    ( Nothing
+                    , [ text "You were logged out. Please log in again to continue working." ]
+                    )
 
-                        Http.BadStatus 404 ->
-                            -- TODO!
-                            []
+                Http.BadStatus 404 ->
+                    ( Nothing
+                    , [ text "We couldn’t find that!" ]
+                    )
 
-                        Http.BadStatus status ->
-                            -- TODO!
-                            []
+                Http.BadStatus status ->
+                    ( Just ("Bad status: " ++ String.fromInt status)
+                    , [ text somethingWentWrongMessage ]
+                    )
 
-                        Http.BadBody body ->
-                            -- TODO!
-                            []
-            }
+                Http.BadBody body ->
+                    ( Just body
+                    , [ text somethingWentWrongMessage ]
+                    )
+    in
+    Attribute <| \config -> { config | content = content, codeDetails = codeDetails_ }
 
 
 codeDetails : String -> Attribute msg

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -499,6 +499,7 @@ type alias BannerConfig msg =
     { onDismiss : Maybe msg
     , role : Maybe Role
     , content : List (Html msg)
+    , codeDetails : Maybe String
     , theme : Theme
     , size : Size
     , icon : Maybe Svg
@@ -515,6 +516,7 @@ configFromAttributes attr =
         { onDismiss = Nothing
         , role = Nothing
         , content = []
+        , codeDetails = Nothing
         , theme = Tip
         , size = Tiny
         , icon = Nothing

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -234,33 +234,43 @@ somethingWentWrong errorMessageForEngineers =
             [ tiny
             , error
             , alertRole
-            , plaintext "Sorry, something went wrong.  Please try again later."
+            , plaintext somethingWentWrongMessage
             ]
-        , details []
-            [ summary
-                [ Attributes.css
-                    [ Fonts.baseFont
-                    , fontSize (px 14)
-                    , color Colors.gray45
-                    ]
+        , viewCodeDetails errorMessageForEngineers
+        ]
+
+
+somethingWentWrongMessage : String
+somethingWentWrongMessage =
+    "Sorry, something went wrong.  Please try again later."
+
+
+viewCodeDetails : String -> Html msg
+viewCodeDetails errorMessageForEngineers =
+    details []
+        [ summary
+            [ Attributes.css
+                [ Fonts.baseFont
+                , fontSize (px 14)
+                , color Colors.gray45
                 ]
-                [ text "Details for NoRedInk engineers" ]
-            , code
-                [ Attributes.css
-                    [ display block
-                    , whiteSpace normal
-                    , overflowWrap breakWord
-                    , color Colors.gray45
-                    , backgroundColor Colors.gray96
-                    , border3 (px 1) solid Colors.gray92
-                    , borderRadius (px 3)
-                    , padding2 (px 2) (px 4)
-                    , fontSize (px 12)
-                    , fontFamily monospace
-                    ]
-                ]
-                [ text errorMessageForEngineers ]
             ]
+            [ text "Details for NoRedInk engineers" ]
+        , code
+            [ Attributes.css
+                [ display block
+                , whiteSpace normal
+                , overflowWrap breakWord
+                , color Colors.gray45
+                , backgroundColor Colors.gray96
+                , border3 (px 1) solid Colors.gray92
+                , borderRadius (px 3)
+                , padding2 (px 2) (px 4)
+                , fontSize (px 12)
+                , fontFamily monospace
+                ]
+            ]
+            [ text errorMessageForEngineers ]
         ]
 
 

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -3,7 +3,7 @@ module Nri.Ui.Message.V3 exposing
     , view, Attribute
     , icon, custom, css, testId, id
     , tiny, large, banner
-    , plaintext, markdown, html
+    , plaintext, markdown, html, httpError
     , tip, error, alert, success, customTheme
     , alertRole, alertDialogRole
     , onDismiss
@@ -12,6 +12,10 @@ module Nri.Ui.Message.V3 exposing
 {-| Changes from V2:
 
     - adds helpers: `custom`,`css`,`icon`,`testId`,`id`
+
+Patch changes:
+
+  - add `httpError`
 
 
 # View
@@ -28,7 +32,7 @@ module Nri.Ui.Message.V3 exposing
 
 ## Content
 
-@docs plaintext, markdown, html
+@docs plaintext, markdown, html, httpError
 
 
 ## Theme
@@ -54,6 +58,7 @@ import Css exposing (..)
 import Css.Global
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events exposing (onClick)
+import Http
 import Markdown
 import Nri.Ui
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
@@ -310,6 +315,12 @@ html content =
     Attribute <| \config -> { config | content = Html content }
 
 
+{-| -}
+httpError : Http.Error -> Attribute msg
+httpError error_ =
+    Attribute <| \config -> { config | content = HttpError error_ }
+
+
 {-| This is the default theme for a Message.
 -}
 tip : Attribute msg
@@ -484,12 +495,14 @@ type Size
   - `Plain`: provide a plain-text string
   - `Markdown`: provide a string that will be rendered as markdown
   - `Html`: provide custom HTML
+  - `HttpError`: provide an HTTP error, which will be rendered as user-friendly messages
 
 -}
 type Content msg
     = Plain String
     | Markdown String
     | Html (List (Html msg))
+    | HttpError Http.Error
 
 
 contentToHtml : Content msg -> List (Html msg)
@@ -503,6 +516,10 @@ contentToHtml content =
 
         Html html_ ->
             html_
+
+        HttpError error_ ->
+            -- TODO!
+            []
 
 
 

--- a/styleguide-app/CommonControls.elm
+++ b/styleguide-app/CommonControls.elm
@@ -1,0 +1,40 @@
+module CommonControls exposing (httpError)
+
+import Debug.Control as Control exposing (Control)
+import Http
+
+
+httpError : Control Http.Error
+httpError =
+    Control.choice
+        [ ( "Bad Url", Control.value (Http.BadUrl "/request-url") )
+        , ( "Timeout", Control.value Http.Timeout )
+        , ( "Network Error", Control.value Http.NetworkError )
+        , ( "Bad Status: 401", Control.value (Http.BadStatus 401) )
+        , ( "Bad Status: 404", Control.value (Http.BadStatus 404) )
+        , ( "Bad Status: ???", Control.value (Http.BadStatus 500) )
+        , ( "Bad Body (often, a JSON decoding problem)"
+          , Control.value
+                (Http.BadBody
+                    """
+                        The Json.Decode.oneOf at json.draft failed in the following 2 ways:
+
+
+
+                        (1) Problem with the given value:
+
+                            null
+
+                            Expecting an OBJECT with a field named `content`
+
+
+
+                        (2) Problem with the given value:
+
+                            null
+
+                            Expecting an OBJECT with a field named `code`
+                        """
+                )
+          )
+        ]

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -199,9 +199,10 @@ example =
                     else
                         text "Nice! The messages were dismissed. 👍"
             in
-            [ Control.view UpdateControl state.control
+            [ Heading.h3 [ Heading.css [ Css.marginBottom (Css.px 20) ] ]
+                [ text "Message.view" ]
+            , Control.view UpdateControl state.control
                 |> Html.fromUnstyled
-            , Heading.h3 [] [ text "Message.view" ]
             , orDismiss <|
                 Html.table [ css [ width (pct 100) ] ]
                     [ Html.tbody []
@@ -219,7 +220,14 @@ example =
                             ]
                         ]
                     ]
-            , Heading.h3 [] [ text "Message.somethingWentWrong" ]
+            , Heading.h3
+                [ Heading.css
+                    [ Css.marginTop (Css.px 20)
+                    , Css.borderTop3 (Css.px 2) Css.solid Colors.gray96
+                    , Css.paddingTop (Css.px 20)
+                    ]
+                ]
+                [ text "Message.somethingWentWrong" ]
             , Message.somethingWentWrong exampleRailsError
             ]
     }

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -3,6 +3,7 @@ module Examples.Message exposing (Msg, State, example)
 import Accessibility.Styled as Html exposing (..)
 import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
+import CommonControls
 import Css exposing (..)
 import Debug.Control as Control exposing (Control)
 import Example exposing (Example)
@@ -117,6 +118,9 @@ controlContent =
                     , text " to check out NoRedInk."
                     ]
                 )
+          )
+        , ( "httpError"
+          , Control.map Message.httpError CommonControls.httpError
           )
         ]
 

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -8,6 +8,7 @@ module Examples.Page exposing (example, State, Msg)
 
 import AtomicDesignType exposing (AtomicDesignType(..))
 import Category exposing (Category(..))
+import CommonControls
 import Css
 import Css.Global exposing (Snippet, adjacentSiblings, children, class, descendants, each, everything, media, selector, withClass)
 import Debug.Control as Control exposing (Control)
@@ -60,7 +61,7 @@ example =
     , categories = [ Pages ]
     , atomicDesignType = Page
     , keyboardSupport = []
-    , state = { httpError = initHttpError, recoveryText = initRecoveryText }
+    , state = { httpError = CommonControls.httpError, recoveryText = initRecoveryText }
     , update = update
     , subscriptions = \_ -> Sub.none
     , view =
@@ -107,42 +108,6 @@ viewExample viewName view recoveryText extras =
                     ++ " }"
             ]
         , view { link = ShowItWorked viewName, recoveryText = recoveryText }
-        ]
-
-
-initHttpError : Control Http.Error
-initHttpError =
-    Control.choice
-        [ ( "Bad Url", Control.value (Http.BadUrl "/request-url") )
-        , ( "Timeout", Control.value Http.Timeout )
-        , ( "Network Error", Control.value Http.NetworkError )
-        , ( "Bad Status: 401", Control.value (Http.BadStatus 401) )
-        , ( "Bad Status: 404", Control.value (Http.BadStatus 404) )
-        , ( "Bad Status: ???", Control.value (Http.BadStatus 500) )
-        , ( "Bad Body (often, a JSON decoding problem)"
-          , Control.value
-                (Http.BadBody
-                    """
-                        The Json.Decode.oneOf at json.draft failed in the following 2 ways:
-
-
-
-                        (1) Problem with the given value:
-
-                            null
-
-                            Expecting an OBJECT with a field named `content`
-
-
-
-                        (2) Problem with the given value:
-
-                            null
-
-                            Expecting an OBJECT with a field named `code`
-                        """
-                )
-          )
         ]
 
 


### PR DESCRIPTION
Update the Message component to support taking Http.Errors directly & producing nicely formatted, user-friendly error views.

You can play with this experience [here](https://deploy-preview-694--noredink-ui.netlify.app/#/doodad/Message). cc @NoRedInk/design 

# Bad Url, Bad Status, Bad Body

<img width="1211" alt="Screen Shot 2021-05-14 at 3 00 44 PM" src="https://user-images.githubusercontent.com/8811312/118336027-bef1b280-b4c5-11eb-88dd-af8106689d5c.png">

# 404

<img width="1194" alt="Screen Shot 2021-05-14 at 3 01 30 PM" src="https://user-images.githubusercontent.com/8811312/118336028-c0bb7600-b4c5-11eb-8b35-eb8e47155493.png">

# 401

<img width="1185" alt="Screen Shot 2021-05-14 at 3 01 20 PM" src="https://user-images.githubusercontent.com/8811312/118336030-c1540c80-b4c5-11eb-9c90-71a7d45b3979.png">

# Network Error

<img width="1191" alt="Screen Shot 2021-05-14 at 3 01 12 PM" src="https://user-images.githubusercontent.com/8811312/118336032-c1eca300-b4c5-11eb-988b-2f3f6ba40f0e.png">

# Timeout

<img width="1192" alt="Screen Shot 2021-05-14 at 3 00 54 PM" src="https://user-images.githubusercontent.com/8811312/118336034-c1eca300-b4c5-11eb-8fb1-6a7a527d30ca.png">
