### PR TITLE
Raven/disabled tabs

### DIFF
--- a/src/Nri/Ui/SegmentedControl/V13.elm
+++ b/src/Nri/Ui/SegmentedControl/V13.elm
@@ -190,6 +190,7 @@ view config =
             , tabView = [ viewIcon option.icon, option.label ]
             , panelView = option.content
             , spaHref = Maybe.map (\toUrl -> toUrl option.value) config.toUrl
+            , disabled = False
             , labelledBy = Nothing
             }
 

--- a/src/Nri/Ui/SegmentedControl/V14.elm
+++ b/src/Nri/Ui/SegmentedControl/V14.elm
@@ -206,6 +206,7 @@ view config =
             , tabView = [ viewIcon option.icon, option.label ]
             , panelView = option.content
             , spaHref = Maybe.map (\toUrl -> toUrl option.value) config.toUrl
+            , disabled = False
             }
 
         { tabList, tabPanels } =

--- a/src/Nri/Ui/Tabs/V7.elm
+++ b/src/Nri/Ui/Tabs/V7.elm
@@ -2,9 +2,9 @@ module Nri.Ui.Tabs.V7 exposing
     ( view
     , Alignment(..)
     , Tab, Attribute, build
-    , tabString, tabHtml, withTooltip
-    , panelHtml
+    , tabString, tabHtml, withTooltip, disabled
     , spaHref
+    , panelHtml
     )
 
 {-| Changes from V6:
@@ -16,8 +16,8 @@ module Nri.Ui.Tabs.V7 exposing
 @docs view
 @docs Alignment
 @docs Tab, Attribute, build
-@docs tabString, tabHtml, withTooltip
-@docs panelHtml
+@docs tabString, tabHtml, withTooltip, disabled
+@docs th@docs panelHtml
 @docs spaHref
 
 -}
@@ -60,6 +60,13 @@ tabHtml content =
 withTooltip : List (Tooltip.Attribute msg) -> Attribute id msg
 withTooltip attributes =
     Attribute (\tab -> { tab | tabTooltip = attributes })
+
+
+{-| Makes it so that the tab can't be clicked or focused via keyboard navigation
+-}
+disabled : Bool -> Attribute id msg
+disabled isDisabled =
+    Attribute (\tab -> { tab | disabled = isDisabled })
 
 
 {-| -}

--- a/src/Nri/Ui/Tabs/V7.elm
+++ b/src/Nri/Ui/Tabs/V7.elm
@@ -63,6 +63,8 @@ withTooltip attributes =
     Attribute (\tab -> { tab | tabTooltip = attributes })
 
 
+{-| Makes it so that the tab can't be clicked or focused via keyboard navigation
+-}
 disabled : Bool -> Attribute id msg
 disabled isDisabled =
     Attribute (\tab -> { tab | disabled = isDisabled })

--- a/src/TabsInternal/V2.elm
+++ b/src/TabsInternal/V2.elm
@@ -168,10 +168,10 @@ keyEvents { focusAndSelect, tabs } thisTab keyCode =
                 ( True, Nothing ) ->
                     ( True
                     , if tab.disabled then
-                        Just { select = tab.id, focus = Just (tabToId tab.idString) }
+                        Nothing
 
                       else
-                        Nothing
+                        Just { select = tab.id, focus = Just (tabToId tab.idString) }
                     )
 
                 ( False, Nothing ) ->

--- a/src/TabsInternal/V2.elm
+++ b/src/TabsInternal/V2.elm
@@ -44,6 +44,7 @@ type alias Tab id msg =
     , tabView : List (Html msg)
     , panelView : Html msg
     , spaHref : Maybe String
+    , disabled : Bool
     }
 
 
@@ -59,6 +60,7 @@ fromList { id, idString } attributes =
             , tabView = []
             , panelView = Html.text ""
             , spaHref = Nothing
+            , disabled = False
             }
     in
     List.foldl (\applyAttr acc -> applyAttr acc) defaults attributes
@@ -125,6 +127,7 @@ viewTab_ config index tab =
                     ++ tagSpecificAttributes
                     ++ tab.tabAttributes
                     ++ [ Attributes.tabindex tabIndex
+                       , Attributes.disabled tab.disabled
                        , Widget.selected isSelected
                        , Role.tab
                        , Attributes.id (tabToId tab.idString)
@@ -160,7 +163,13 @@ keyEvents { focusAndSelect, tabs } thisTab keyCode =
                     acc
 
                 ( True, Nothing ) ->
-                    ( True, Just { select = tab.id, focus = Just (tabToId tab.idString) } )
+                    ( True
+                    , if tab.disabled then
+                        Just { select = tab.id, focus = Just (tabToId tab.idString) }
+
+                      else
+                        Nothing
+                    )
 
                 ( False, Nothing ) ->
                     ( tab.id == thisTab.id, Nothing )

--- a/src/TabsInternal/V2.elm
+++ b/src/TabsInternal/V2.elm
@@ -127,7 +127,10 @@ viewTab_ config index tab =
                     ++ tagSpecificAttributes
                     ++ tab.tabAttributes
                     ++ [ Attributes.tabindex tabIndex
-                       , Attributes.disabled tab.disabled
+                       , -- check for isSelected because otherwise users won't
+                         -- be able to focus on the current tab with the
+                         -- keyboard.
+                         Attributes.disabled (not isSelected && tab.disabled)
                        , Widget.selected isSelected
                        , Role.tab
                        , Attributes.id (tabToId tab.idString)

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -179,7 +179,8 @@ allTabs openTooltipId =
         , Tabs.panelHtml (Html.text "First Panel")
         ]
     , Tabs.build { id = Second, idString = "tab-1" }
-        [ Tabs.tabString "Second Tab"
+        [ Tabs.tabString "Second Tab (disabled)"
+        , Tabs.disabled True
         , Tabs.panelHtml (Html.text "Second Panel")
         ]
     , Tabs.build { id = Third, idString = "tab-2" }


### PR DESCRIPTION
Adds the ability to disable tabs to `Nri.Ui.Tabs.V7`.

Disabled tabs can't be selected and also can't be focused with the keyboard using the left/right arrow keys.

This is needed for https://github.com/NoRedInk/NoRedInk/issues/33574. We'll use this so that keypresses will skip to focusing on the tab we want users to focus instead of whatever tab comes after the current one.

### Preview

https://user-images.githubusercontent.com/753421/119571177-6b198000-bd87-11eb-8fd9-b7facd335274.mov

