### PR TITLE
Tessa/fix heading mistake slide modal

### DIFF
--- a/src/Nri/Ui/Heading/V2.elm
+++ b/src/Nri/Ui/Heading/V2.elm
@@ -32,9 +32,6 @@ import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
 
 
 {-| Make a first-level heading (styled like a top-level heading by default.)
-
-Use this to upgrade from `Nri.Ui.Text.V2.heading`.
-
 -}
 h1 : List (Attribute msg) -> List (Html msg) -> Html msg
 h1 =
@@ -46,9 +43,6 @@ h1 =
 
 
 {-| Make a second-level heading (styled like a tagline by default.)
-
-Use this to upgrade from `Nri.Ui.Text.V2.tagline`.
-
 -}
 h2 : List (Attribute msg) -> List (Html msg) -> Html msg
 h2 =
@@ -60,9 +54,6 @@ h2 =
 
 
 {-| Make a third-level heading (styled like a subhead by default.)
-
-Use this to upgrade from `Nri.Ui.Text.V2.subHeading`.
-
 -}
 h3 : List (Attribute msg) -> List (Html msg) -> Html msg
 h3 =
@@ -74,9 +65,6 @@ h3 =
 
 
 {-| Make a fourth-level heading (styled like a small heading by default.)
-
-Use this to upgrade from `Nri.Ui.Text.V2.smallHeading`.
-
 -}
 h4 : List (Attribute msg) -> List (Html msg) -> Html msg
 h4 =

--- a/src/Nri/Ui/SlideModal/V2.elm
+++ b/src/Nri/Ui/SlideModal/V2.elm
@@ -148,7 +148,7 @@ viewModal config (State { previousPanel }) summary =
                 , panelContainer config.height
                     [ Slide.animateOut direction ]
                     [ viewIcon panelView.icon
-                    , Heading.h4 []
+                    , Heading.h3 []
                         [ span [ Html.Styled.Attributes.id (panelId panelView) ] [ Html.text panelView.title ]
                         ]
                     , viewContent panelView.content
@@ -167,7 +167,7 @@ viewModalContent config summary styles =
       , panelContainer config.height
             styles
             [ viewIcon summary.current.icon
-            , Heading.h4 []
+            , Heading.h3 []
                 [ span
                     [ Html.Styled.Attributes.id (panelId summary.current)
                     , css [ Css.margin2 Css.zero (Css.px 21) ]

--- a/src/Nri/Ui/Text/V5.elm
+++ b/src/Nri/Ui/Text/V5.elm
@@ -9,10 +9,6 @@ module Nri.Ui.Text.V5 exposing
 
   - adjusts link styles
 
-Changes from V3:
-
-  - Removes Headings (they now live in Nri.Ui.Heading.V2)
-
 Changes from V4:
 
   - Added `Attribute` for customizing styles
@@ -32,18 +28,7 @@ Changes from V4:
 
 ## Headings
 
-Headings now live in Nri.Ui.Heading.V2. Here's a mapping to help with upgrades:
-
-    | Nri.Ui.Text.V3    | Nri.Ui.Heading.V2 |
-    |===================|===================|
-    | Text.heading      | Heading.h1        |
-    | Text.tagline      | Heading.h2        |
-    | Text.subHeading   | Heading.h3        |
-    | Text.smallHeading | Heading.h4        |
-
-If you look at your new code and go "hmm, those shouldn't be at this level of
-heading" then you can customize the tag apart from the style using the new
-API. See the Nri.Ui.Heading.V2 docs for details.
+You're in the wrong place! Headings live in Nri.Ui.Heading.V2.
 
 
 ## Paragraph styles


### PR DESCRIPTION
Off-by-one heading error in translating from Text -> Heading in SlideModal! See https://jenkins.noredink.com/blue/organizations/jenkins/shake-ci/detail/auto/3309/tests/ failure.