### PR TITLE
Add border radius to checkbox

### DIFF
--- a/src/Nri/Ui/Checkbox/V5.elm
+++ b/src/Nri/Ui/Checkbox/V5.elm
@@ -314,6 +314,7 @@ viewIcon styles icon =
                 [ display inlineBlock
                 , backgroundColor Colors.white
                 , height (Css.px 27)
+                , borderRadius (px 4)
                 ]
             ]
             [ Nri.Ui.Svg.V1.toHtml (Nri.Ui.Svg.V1.withCss styles icon)


### PR DESCRIPTION
So little white corners don't show when the background is a color (like when a topic is selected in the Assignment Library)

<img width="790" alt="image" src="https://user-images.githubusercontent.com/13528834/131751201-c426c65d-fefc-457f-8b9b-7300dc283259.png">