### PR TITLE
Make toggleButton clickable in style guide

### DIFF
--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -80,12 +80,14 @@ update msg state =
             ( state, Cmd.none )
 
         ToggleToggleButton id ->
-            ( { state | pressedToggleButtons =
-                if Set.member id state.pressedToggleButtons then
-                    Set.remove id state.pressedToggleButtons
-                else
-                    Set.insert id state.pressedToggleButtons
-                }
+            ( { state
+                | pressedToggleButtons =
+                    if Set.member id state.pressedToggleButtons then
+                        Set.remove id state.pressedToggleButtons
+
+                    else
+                        Set.insert id state.pressedToggleButtons
+              }
             , Cmd.none
             )
 

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -59,6 +59,7 @@ type ButtonType
 type Msg
     = SetDebugControlsState (Control Model)
     | ShowItWorked String String
+    | ToggleToggleButton Int
     | NoOp
 
 
@@ -77,6 +78,16 @@ update msg state =
                     Debug.log group message
             in
             ( state, Cmd.none )
+
+        ToggleToggleButton id ->
+            ( { state | pressedToggleButtons =
+                if Set.member id state.pressedToggleButtons then
+                    Set.remove id state.pressedToggleButtons
+                else
+                    Set.insert id state.pressedToggleButtons
+                }
+            , Cmd.none
+            )
 
         NoOp ->
             ( state, Cmd.none )
@@ -238,15 +249,15 @@ toggleButtons pressedToggleButtons =
         [ Heading.h3 [] [ text "Button toggle" ]
         , div [ css [ Css.displayFlex, Css.marginBottom (Css.px 20) ] ]
             [ Button.toggleButton
-                { onDeselect = ShowItWorked "ButtonExample" "onDeselect"
-                , onSelect = ShowItWorked "ButtonExample" "onSelect"
+                { onDeselect = ToggleToggleButton 0
+                , onSelect = ToggleToggleButton 0
                 , label = "5"
                 , pressed = Set.member 0 pressedToggleButtons
                 }
             , Button.toggleButton
-                { onDeselect = ShowItWorked "ButtonExample" "onDeselect"
-                , onSelect = ShowItWorked "ButtonExample" "onSelect"
-                , label = "5"
+                { onDeselect = ToggleToggleButton 1
+                , onSelect = ToggleToggleButton 1
+                , label = "Kindergarten"
                 , pressed = Set.member 1 pressedToggleButtons
                 }
             ]

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -17,6 +17,7 @@ import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.UiIcon.V1 as UiIcon
+import Set exposing (Set)
 
 
 {-| -}
@@ -36,6 +37,7 @@ example =
 {-| -}
 type alias State =
     { debugControlsState : Control Model
+    , pressedToggleButtons : Set Int
     }
 
 
@@ -43,6 +45,7 @@ type alias State =
 init : State
 init =
     { debugControlsState = initDebugControls
+    , pressedToggleButtons = Set.singleton 1
     }
 
 
@@ -146,7 +149,7 @@ viewButtonExamples state =
     [ Control.view SetDebugControlsState state.debugControlsState
         |> fromUnstyled
     , buttons model
-    , toggleButtons
+    , toggleButtons state.pressedToggleButtons
     , Button.link "linkExternalWithTracking"
         [ Button.unboundedWidth
         , Button.secondary
@@ -229,8 +232,8 @@ buttons model =
         |> table []
 
 
-toggleButtons : Html Msg
-toggleButtons =
+toggleButtons : Set Int -> Html Msg
+toggleButtons pressedToggleButtons =
     div []
         [ Heading.h3 [] [ text "Button toggle" ]
         , div [ css [ Css.displayFlex, Css.marginBottom (Css.px 20) ] ]
@@ -238,13 +241,13 @@ toggleButtons =
                 { onDeselect = ShowItWorked "ButtonExample" "onDeselect"
                 , onSelect = ShowItWorked "ButtonExample" "onSelect"
                 , label = "5"
-                , pressed = False
+                , pressed = Set.member 0 pressedToggleButtons
                 }
             , Button.toggleButton
                 { onDeselect = ShowItWorked "ButtonExample" "onDeselect"
                 , onSelect = ShowItWorked "ButtonExample" "onSelect"
                 , label = "5"
-                , pressed = True
+                , pressed = Set.member 1 pressedToggleButtons
                 }
             ]
         ]

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -34,8 +34,16 @@ example =
 
 
 {-| -}
-type State
-    = State (Control Model)
+type alias State =
+    { debugControlsState : Control Model
+    }
+
+
+{-| -}
+init : State
+init =
+    { debugControlsState = initDebugControls
+    }
 
 
 {-| -}
@@ -46,7 +54,7 @@ type ButtonType
 
 {-| -}
 type Msg
-    = SetState State
+    = SetDebugControlsState (Control Model)
     | ShowItWorked String String
     | NoOp
 
@@ -55,8 +63,10 @@ type Msg
 update : Msg -> State -> ( State, Cmd Msg )
 update msg state =
     case msg of
-        SetState newState ->
-            ( newState, Cmd.none )
+        SetDebugControlsState newDebugControlsState ->
+            ( { state | debugControlsState = newDebugControlsState }
+            , Cmd.none
+            )
 
         ShowItWorked group message ->
             let
@@ -83,8 +93,8 @@ type alias Model =
 
 
 {-| -}
-init : State
-init =
+initDebugControls : Control Model
+initDebugControls =
     Control.record Model
         |> Control.field "label" (Control.string "Label")
         |> Control.field "icon" iconChoice
@@ -113,7 +123,6 @@ init =
                 , ( "success", Control.value Button.success )
                 ]
             )
-        |> State
 
 
 iconChoice : Control.Control (Maybe Svg)
@@ -129,12 +138,12 @@ iconChoice =
 
 
 viewButtonExamples : State -> Html Msg
-viewButtonExamples (State control) =
+viewButtonExamples state =
     let
         model =
-            Control.currentValue control
+            Control.currentValue state.debugControlsState
     in
-    [ Control.view (State >> SetState) control
+    [ Control.view SetDebugControlsState state.debugControlsState
         |> fromUnstyled
     , buttons model
     , toggleButtons


### PR DESCRIPTION
Related to [this story in Pivotal Tracker, "Grades buttons change position/height when pressed"](https://www.pivotaltracker.com/story/show/178325503) -- wanted to check if this bug would appear in the style guide (just ruled it out), and thought this would be a nice small improvement.

Now you can click on the toggle buttons under "Button toggle" to preview how they change state visually: 
![image](https://user-images.githubusercontent.com/1555022/131909768-a7d6907a-09f7-4e31-9ce3-7f527d653f54.png)

Thank you @tesk9 for pairing with me on this! 