### PR TITLE
Add verticalAlign: middle to toggleButtons

### DIFF
--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -597,6 +597,7 @@ toggleButton config =
         (styledName "toggleButton")
         [ buttonStyles Medium WidthUnbounded secondaryColors []
         , toggledStyles
+        , Css.verticalAlign Css.middle
         ]
         [ Events.onClick
             (if config.pressed then


### PR DESCRIPTION
Fixes [this story in Pivotal Tracker, "Grades buttons change position/height when pressed"](https://www.pivotaltracker.com/story/show/178325503) by setting `vertical-align: middle` as the default on toggle buttons. This way, it should avoid any visual jitter regardless of how the button's parent container is displayed (like `display: block` or `display: flex`).

This follows up on the conversation with @bendansby from [this previous PR to make toggle buttons clickable in the style guide](https://github.com/NoRedInk/noredink-ui/pull/726).

Note: I tried running the `script/test-elm-package.py` as mentioned in this repo's README, but no luck yet in getting these changes to show up in the monolith locally.