### PR TITLE
Message tweaks

### DIFF
--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -162,6 +162,7 @@ view attributes_ =
                              borderRadius (px 8)
                            , padding (px 20)
                            , backgroundColor_
+                           , position relative
                            ]
                     )
                  ]
@@ -832,7 +833,14 @@ largeDismissButton : msg -> Html msg
 largeDismissButton msg =
     Nri.Ui.styled div
         "dismiss-button-container"
-        [ padding2 Css.zero (px 20) ]
+        [ padding (px 20)
+        , Css.Media.withMedia
+            [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
+            [ position absolute
+            , right zero
+            , padding (px 10)
+            ]
+        ]
         []
         [ ClickableSvg.button "Dismiss message"
             UiIcon.x

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -56,6 +56,7 @@ import Accessibility.Styled.Role as Role
 import Accessibility.Styled.Widget as Widget
 import Css exposing (..)
 import Css.Global
+import Css.Media
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events exposing (onClick)
 import Http

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -119,6 +119,12 @@ view attributes_ =
                                    , paddingTop (px 6)
                                    , paddingBottom (px 8)
                                    , fontSize (px 13)
+                                   , Css.Global.children
+                                        [ Css.Global.div
+                                            [ nthChild "2"
+                                                [ marginTop (px -3) ]
+                                            ]
+                                        ]
                                    ]
                             )
                          ]

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -101,7 +101,6 @@ view attributes_ =
             [ Fonts.baseFont
             , color color_
             , boxSizing borderBox
-            , styleOverrides
             , Css.batch attributes.customStyles
             ]
     in
@@ -798,33 +797,6 @@ getRoleAttribute role =
 
         Nothing ->
             []
-
-
-
--- Style overrides
-
-
-styleOverrides : Style
-styleOverrides =
-    Css.Global.descendants
-        [ Css.Global.a
-            [ textDecoration none
-            , color Colors.azure
-            , borderBottom3 (px 1) solid Colors.azure
-            , visited [ color Colors.azure ]
-            ]
-        , -- This global selector and overrides are necessary due to
-          -- old stylesheets used on the monolith that set the
-          -- `.txt p { font-size: 18px; }` -- without these overrides,
-          -- we may see giant ugly alerts.
-          -- Remove these if you want to! but be emotionally prepped
-          -- to deal with visual regressions. 🙏
-          Css.Global.p
-            [ margin zero
-            , fontSize (px 13)
-            , Fonts.baseFont
-            ]
-        ]
 
 
 

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -216,11 +216,14 @@ view attributes_ =
                             , displayFlex
                             , justifyContent center
                             , width (Css.pct 100)
-
-                            -- Fonts
                             , fontSize (px 20)
                             , fontWeight (int 700)
-                            , lineHeight (px 27)
+                            , lineHeight (num 1.4)
+                            , Css.Media.withMedia
+                                [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
+                                [ fontSize (px 15)
+                                , fontWeight (int 600)
+                                ]
                             ]
                         ]
                         [ icon_
@@ -228,11 +231,16 @@ view attributes_ =
                             "banner-alert-notification"
                             [ fontSize (px 20)
                             , fontWeight (int 700)
-                            , lineHeight (px 27)
+                            , lineHeight (num 1.4)
                             , maxWidth (px 600)
                             , minWidth (px 100)
                             , flexShrink (int 1)
                             , Fonts.baseFont
+                            , Css.Media.withMedia
+                                [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
+                                [ fontSize (px 15)
+                                , fontWeight (int 600)
+                                ]
                             ]
                             []
                             attributes.content
@@ -661,7 +669,7 @@ getIcon customIcon size theme =
                     ( px 35, Css.marginRight (Css.px 10) )
 
                 Banner ->
-                    ( px 50, Css.marginRight (Css.px 20) )
+                    ( px 35, Css.marginRight (Css.px 10) )
     in
     case ( customIcon, theme ) of
         ( Nothing, Error ) ->
@@ -717,18 +725,29 @@ getIcon customIcon size theme =
                             [ borderRadius (pct 50)
                             , height (px 50)
                             , width (px 50)
-                            , Css.marginRight (Css.px 20)
+                            , Css.marginRight (Css.px 10)
                             , backgroundColor Colors.navy
                             , displayFlex
                             , Css.flexShrink Css.zero
                             , alignItems center
                             , justifyContent center
+                            , Css.Media.withMedia
+                                [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
+                                [ height (px 35)
+                                , width (px 35)
+                                ]
                             ]
                         ]
                         [ UiIcon.bulb
                             |> NriSvg.withColor Colors.mustard
                             |> NriSvg.withWidth (Css.px 32)
                             |> NriSvg.withHeight (Css.px 32)
+                            |> NriSvg.withCss
+                                [ Css.Media.withMedia
+                                    [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
+                                    [ height (px 20)
+                                    ]
+                                ]
                             |> NriSvg.toHtml
                         ]
 

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -121,7 +121,10 @@ view attributes_ =
                                    , Css.Global.children
                                         [ Css.Global.div
                                             [ nthChild "2"
-                                                [ marginTop (px -3) ]
+                                                [ marginTop (px -3)
+                                                , Css.Global.children
+                                                    [ Css.Global.p [ margin zero ] ]
+                                                ]
                                             ]
                                         ]
                                    ]
@@ -169,8 +172,6 @@ view attributes_ =
                     [ Attributes.css
                         [ displayFlex
                         , alignItems center
-
-                        -- Fonts
                         , fontSize (px 15)
                         , fontWeight (int 600)
                         , lineHeight (px 21)

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -204,7 +204,12 @@ view attributes_ =
             div
                 ([ ExtraAttributes.nriDescription "Nri-Ui-Message-banner"
                  , Attributes.css
-                    (baseStyles ++ [ backgroundColor_, padding (px 20) ])
+                    (baseStyles
+                        ++ [ backgroundColor_
+                           , padding (px 20)
+                           , position relative
+                           ]
+                    )
                  ]
                     ++ role
                     ++ attributes.customAttributes
@@ -841,7 +846,14 @@ bannerDismissButton : msg -> Html msg
 bannerDismissButton msg =
     Nri.Ui.styled div
         "dismiss-button-container"
-        [ padding2 Css.zero (px 20) ]
+        [ padding (px 20)
+        , Css.Media.withMedia
+            [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
+            [ position absolute
+            , right zero
+            , padding (px 10)
+            ]
+        ]
         []
         [ ClickableSvg.button "Dismiss banner"
             UiIcon.x


### PR DESCRIPTION
Especially mobile styles for the banner size.

<img width="517" alt="Screen Shot 2021-10-03 at 11 34 52 AM" src="https://user-images.githubusercontent.com/13528834/135767001-993889ed-9bb7-46c4-b5d1-cf6c2fccd494.png">
<img width="519" alt="Screen Shot 2021-10-03 at 11 35 03 AM" src="https://user-images.githubusercontent.com/13528834/135767005-c4bbfe33-55e8-4957-82c6-e90520c82ea0.png">
<img width="758" alt="Napkin 2 10-03-21, 12 17 26 PM" src="https://user-images.githubusercontent.com/13528834/135768281-f47f789f-b2e2-4ee3-9e1a-287db5d60799.png">
