### PR TITLE
Dismiss button tweaks

### DIFF
--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -162,7 +162,10 @@ view attributes_ =
                              borderRadius (px 8)
                            , padding (px 20)
                            , backgroundColor_
-                           , position relative
+                           , Css.Media.withMedia
+                                [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
+                                [ padding (px 15)
+                                ]
                            ]
                     )
                  ]
@@ -209,7 +212,10 @@ view attributes_ =
                     (baseStyles
                         ++ [ backgroundColor_
                            , padding (px 20)
-                           , position relative
+                           , Css.Media.withMedia
+                                [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
+                                [ padding (px 15)
+                                ]
                            ]
                     )
                  ]
@@ -833,12 +839,11 @@ largeDismissButton : msg -> Html msg
 largeDismissButton msg =
     Nri.Ui.styled div
         "dismiss-button-container"
-        [ padding (px 20)
+        [ padding2 zero (px 20)
+        , displayFlex
         , Css.Media.withMedia
             [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
-            [ position absolute
-            , right zero
-            , padding (px 10)
+            [ padding4 (px 10) zero (px 10) (px 15)
             ]
         ]
         []
@@ -855,12 +860,11 @@ bannerDismissButton : msg -> Html msg
 bannerDismissButton msg =
     Nri.Ui.styled div
         "dismiss-button-container"
-        [ padding (px 20)
+        [ padding2 zero (px 20)
+        , displayFlex
         , Css.Media.withMedia
             [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
-            [ position absolute
-            , right zero
-            , padding (px 10)
+            [ padding4 (px 10) zero (px 10) (px 15)
             ]
         ]
         []

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -737,7 +737,7 @@ viewCloseButton closeModal =
                 , Css.right Css.zero
 
                 -- make appear above lesson content
-                , Css.zIndex (Css.int 1)
+                , Css.zIndex (Css.int 10)
                 , Css.backgroundColor (rgba 255 255 255 0.5)
                 , Css.borderRadius (pct 50)
 

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -736,14 +736,18 @@ viewCloseButton closeModal =
                 , Css.top Css.zero
                 , Css.right Css.zero
 
-                -- make the hitspace extend all the way to the corner
-                , Css.width (Css.px 40)
-                , Css.height (Css.px 40)
-                , Css.padding4 (Css.px 20) (Css.px 20) Css.zero Css.zero
+                -- make appear above lesson content
+                , Css.zIndex (Css.int 1)
+                , Css.backgroundColor (rgba 255 255 255 0.5)
+                , Css.borderRadius (pct 50)
+
+                -- make the hitspace extend all the way around x
+                , Css.width (Css.px 60)
+                , Css.height (Css.px 60)
+                , Css.padding (Css.px 20)
 
                 -- apply button styles
                 , Css.borderWidth Css.zero
-                , Css.backgroundColor Css.transparent
                 , Css.cursor Css.pointer
                 , Css.color Colors.azure
                 , Css.hover [ Css.color Colors.azureDark ]


### PR DESCRIPTION
Some more tweaks to Modal and Message to improve the dismiss experience

Modal:
- Touch target extends all the way around x
- Translucent background and z-index ensure x won't be covered up or obscured by lesson content on mobile

Message
- Dismiss button no longer increases height of large and banner
- Padding is now even on large and banner on mobile