### PR TITLE
Label styles

### DIFF
--- a/src/Nri/Ui/InputStyles/V3.elm
+++ b/src/Nri/Ui/InputStyles/V3.elm
@@ -41,11 +41,12 @@ label theme inError =
             batch
                 [ backgroundColor white
                 , left (px 10)
-                , top (px 1)
+                , top zero
                 , fontSize (px 12)
                 , Nri.Ui.Fonts.V1.baseFont
                 , position absolute
                 , fontWeight (int 600)
+                , borderRadius (px 4)
                 , property "transition" "all 0.4s ease"
                 ]
     in
@@ -53,7 +54,7 @@ label theme inError =
         Standard ->
             batch
                 [ sharedStyles
-                , padding2 zero (px 5)
+                , padding2 (px 2) (px 5)
                 , fontSize (px 12)
                 , color navy
                 , if inError then


### PR DESCRIPTION
Adds border radius and padding to standard input labels so they look better on a non-white background.

<img width="473" alt="Screen Shot 2021-10-14 at 8 22 20 AM" src="https://user-images.githubusercontent.com/13528834/137348537-b491ee4c-cd5b-4523-8f28-2064a47b4666.png">