### PR TITLE
700 -> 750

### DIFF
--- a/src/Nri/Ui/MediaQuery/V1.elm
+++ b/src/Nri/Ui/MediaQuery/V1.elm
@@ -48,5 +48,5 @@ quizEngineMobile : MediaQuery
 quizEngineMobile =
     only screen
         [ minWidth (px 1)
-        , maxWidth (px 700)
+        , maxWidth (px 750)
         ]


### PR DESCRIPTION
Right now, our quiz engine content has a max width of 800px, while the breakpoint is at 700px, which creates a no-student's-land in between. This changes the breakpoint to 750, a nice middle ground (between 700 and 800, as well 500 and 1000, our other two recently codified content widths), and will also update things on the monolith side.