### PR TITLE
Kraken/text input v7

### DIFF
--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -9,4 +9,5 @@ Nri.Ui.Select.V5,upgrade to V7
 Nri.Ui.Table.V4,upgrade to V5
 Nri.Ui.Tabs.V6,upgrade to V7
 Nri.Ui.Text.V5,upgrade to V6
+Nri.Ui.TextInput.V6,upgrade to V7
 Nri.Ui.Tooltip.V1,upgrade to V2

--- a/elm.json
+++ b/elm.json
@@ -65,6 +65,7 @@
         "Nri.Ui.Text.Writing.V1",
         "Nri.Ui.TextArea.V4",
         "Nri.Ui.TextInput.V6",
+        "Nri.Ui.TextInput.V7",
         "Nri.Ui.Tooltip.V1",
         "Nri.Ui.Tooltip.V2",
         "Nri.Ui.UiIcon.V1"

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -125,6 +125,9 @@ usages = [
 [forbidden."Nri.Ui.Text.V5"]
 hint = 'upgrade to V6'
 
+[forbidden."Nri.Ui.TextInput.V6"]
+hint = 'upgrade to V7'
+
 [forbidden."Nri.Ui.Tooltip.V1"]
 hint = 'upgrade to V2'
 usages = ['styleguide-app/../src/Nri/Ui/Menu/V1.elm']

--- a/src/Nri/Ui/InputStyles/V3.elm
+++ b/src/Nri/Ui/InputStyles/V3.elm
@@ -1,7 +1,6 @@
 module Nri.Ui.InputStyles.V3 exposing
     ( label, Theme(..), input
-    , inputPaddingVertical, inputLineHeight, textAreaHeight, writingLineHeight, writingPadding, writingPaddingTop, writingMinHeight
-    , defaultMarginTop
+    , inputPaddingVertical, inputLineHeight, textAreaHeight, writingLineHeight, writingPadding, writingPaddingTop, writingMinHeight, defaultMarginTop
     )
 
 {-| InputStyles used by the TextInput and TextArea widgets.
@@ -11,7 +10,7 @@ module Nri.Ui.InputStyles.V3 exposing
 
 ## Shared hardcoded values
 
-@docs inputPaddingVertical, inputLineHeight, textAreaHeight, writingLineHeight, writingPadding, writingPaddingTop, writingMinHeight
+@docs inputPaddingVertical, inputLineHeight, textAreaHeight, writingLineHeight, writingPadding, writingPaddingTop, writingMinHeight, defaultMarginTop
 
 
 ## Changelog
@@ -111,6 +110,7 @@ label theme inError =
                 ]
 
 
+{-| -}
 defaultMarginTop : Float
 defaultMarginTop =
     9

--- a/src/Nri/Ui/InputStyles/V3.elm
+++ b/src/Nri/Ui/InputStyles/V3.elm
@@ -1,6 +1,7 @@
 module Nri.Ui.InputStyles.V3 exposing
     ( label, Theme(..), input
     , inputPaddingVertical, inputLineHeight, textAreaHeight, writingLineHeight, writingPadding, writingPaddingTop, writingMinHeight
+    , defaultMarginTop
     )
 
 {-| InputStyles used by the TextInput and TextArea widgets.
@@ -14,6 +15,8 @@ module Nri.Ui.InputStyles.V3 exposing
 
 
 ## Changelog
+
+  - patch: expose defaultMarginTop
 
   - V3: add UserGenerated
 
@@ -108,6 +111,11 @@ label theme inError =
                 ]
 
 
+defaultMarginTop : Float
+defaultMarginTop =
+    9
+
+
 {-| In order to use these styles in an input module, you will need to add the class "override-sass-styles". This is because sass styles in the monolith have higher precendence than the class styles here.
 -}
 input : Theme -> Bool -> Style
@@ -127,7 +135,7 @@ input theme isInError =
                 , display inlineBlock
                 , verticalAlign top
                 , marginBottom zero
-                , marginTop (px 9)
+                , marginTop (px defaultMarginTop)
                 , boxShadow6 inset zero (px 3) zero zero gray92
                 , property "transition" "border-color 0.4s ease"
                 , boxSizing borderBox

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -46,6 +46,7 @@ module Nri.Ui.TextInput.V7 exposing
 
 -}
 
+import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Style as Accessibility
 import Css exposing (center, num, position, px, relative, textAlign)
 import Css.Global
@@ -61,6 +62,7 @@ import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.InputStyles.V3 as InputStyles exposing (defaultMarginTop)
 import Nri.Ui.Message.V3 as Message
 import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Nri.Ui.Util exposing (dashify)
 
@@ -587,6 +589,12 @@ view label attributes =
             (maybeStep
                 ++ List.map (Attributes.map never) (List.reverse config.custom)
                 ++ [ Attributes.id idValue
+                   , case ( errorMessage_, config.guidance ) of
+                        ( Nothing, Just _ ) ->
+                            Aria.describedBy [ idValue ++ "_guidance" ]
+
+                        _ ->
+                            Extra.none
                    , Attributes.css
                         [ InputStyles.input config.inputStyle isInError
                         , if config.inputStyle == InputStyles.Writing then
@@ -661,8 +669,8 @@ view label attributes =
             eventsAndValues.floatingContent
             eventsAndValues.onInput
             |> Maybe.withDefault (Html.text "")
-        , case errorMessage_ of
-            Just m ->
+        , case ( errorMessage_, config.guidance ) of
+            ( Just m, _ ) ->
                 Message.view
                     [ Message.tiny
                     , Message.error
@@ -670,7 +678,19 @@ view label attributes =
                     , Message.alertRole
                     ]
 
-            Nothing ->
+            ( _, Just guidanceMessage ) ->
+                Text.caption
+                    [ Text.id (idValue ++ "_guidance")
+                    , Text.plaintext guidanceMessage
+                    , -- Match the vertical styles of the error message
+                      Text.css
+                        [ Css.paddingTop (Css.px 6)
+                        , Css.paddingBottom (Css.px 8)
+                        , Css.lineHeight (Css.px 23)
+                        ]
+                    ]
+
+            _ ->
                 Html.text ""
         ]
 

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -11,14 +11,9 @@ module Nri.Ui.TextInput.V7 exposing
 {-|
 
 
-# Patch changes:
+# Changes from V6
 
-  - adds `nriDescription` and `testId` helpers
-
-
-# Changes from V5
-
-  - new Attributes-style API
+  - custom takes a list of attributes and appends them to the end of the previous attributes, instead of prepending a single attr.
 
 @docs view, generateId
 
@@ -272,19 +267,17 @@ noMargin removeMargin =
     Attribute <| \config -> { config | noMarginTop = removeMargin }
 
 
-{-| Add any attribute to the input. Don't use this helper for adding css!
+{-| Use this helper to add custom attributes.
 
-TODO: in V7, change this helper's type to `List (Html.Attribute msg) -> Attribute msg`,
-to be more consistent with other helpers.
-
-Also, we should probably change the implemenation from `attr :: config.custom` to
-`config.custom ++ attributes` for a more intuitive and consistent API.
+Do NOT use this helper to add css styles, as they may not be applied the way
+you want/expect if underlying styles change.
+Instead, please use the `css` helper.
 
 -}
-custom : Html.Attribute msg -> Attribute msg
-custom attr =
+custom : List (Html.Attribute msg) -> Attribute msg
+custom attributes =
     Attribute <|
-        \config -> { config | custom = attr :: config.custom }
+        \config -> { config | custom = config.custom ++ attributes }
 
 
 {-| Set a custom ID for this text input and label. If you don't set this,
@@ -301,13 +294,13 @@ id id_ =
 {-| -}
 nriDescription : String -> Attribute msg
 nriDescription description =
-    custom (Extra.nriDescription description)
+    custom [ Extra.nriDescription description ]
 
 
 {-| -}
 testId : String -> Attribute msg
 testId id_ =
-    custom (Extra.testId id_)
+    custom [ Extra.testId id_ ]
 
 
 {-| This is private. The public API only exposes `Attribute`.

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -5,7 +5,7 @@ module Nri.Ui.TextInput.V7 exposing
     , onBlur, onEnter
     , Attribute, placeholder, hiddenLabel, autofocus
     , css, custom, nriDescription, id, testId, noMargin
-    , disabled, loading, errorIf, errorMessage
+    , disabled, loading, errorIf, errorMessage, guidance
     , writing
     )
 
@@ -41,7 +41,7 @@ module Nri.Ui.TextInput.V7 exposing
 
 @docs Attribute, placeholder, hiddenLabel, autofocus
 @docs css, custom, nriDescription, id, testId, noMargin
-@docs disabled, loading, errorIf, errorMessage
+@docs disabled, loading, errorIf, errorMessage, guidance
 @docs writing
 
 -}
@@ -277,6 +277,14 @@ errorMessage maybeMessage =
             }
 
 
+{-| A guidance message shows below the input, unless an error message is showing instead.
+-}
+guidance : String -> Attribute value msg
+guidance message =
+    Attribute emptyEventsAndValues <|
+        \config -> { config | guidance = Just message }
+
+
 {-| Hides the visible label. (There will still be an invisible label for screen readers.)
 -}
 hiddenLabel : Attribute value msg
@@ -417,6 +425,7 @@ map f toString (Attribute eventsAndValues configF) =
 -}
 type alias Config =
     { inputStyle : InputStyles.Theme
+    , guidance : Maybe String
     , error : ErrorState
     , disabled : Bool
     , loading : Bool
@@ -441,6 +450,7 @@ type ErrorState
 emptyConfig : Config
 emptyConfig =
     { inputStyle = InputStyles.Standard
+    , guidance = Nothing
     , error = NoError
     , disabled = False
     , loading = False

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -308,7 +308,7 @@ you want/expect if underlying styles change.
 Instead, please use the `css` helper.
 
 -}
-custom : List (Html.Attribute msg) -> Attribute value msg
+custom : List (Html.Attribute Never) -> Attribute value msg
 custom attributes =
     Attribute emptyEventsAndValues <|
         \config -> { config | custom = config.custom ++ attributes }
@@ -348,7 +348,7 @@ writing =
 {-| Customizations for the TextInput.
 -}
 type Attribute value msg
-    = Attribute (EventsAndValues value msg) (Config msg -> Config msg)
+    = Attribute (EventsAndValues value msg) (Config -> Config)
 
 
 type alias EventsAndValues value msg =
@@ -391,7 +391,7 @@ map f toString onInput_ (Attribute eventsAndValues configF) =
 
 {-| This is private. The public API only exposes `Attribute`.
 -}
-type alias Config msg =
+type alias Config =
     { inputStyle : InputStyles.Theme
     , error : ErrorState
     , disabled : Bool
@@ -402,7 +402,7 @@ type alias Config msg =
     , noMarginTop : Bool
     , css : List (List Css.Style)
     , id : Maybe String
-    , custom : List (Html.Attribute msg)
+    , custom : List (Html.Attribute Never)
     , fieldType : Maybe String
     , inputMode : Maybe String
     , autocomplete : Maybe String
@@ -414,7 +414,7 @@ type ErrorState
     | Error { message : Maybe String }
 
 
-emptyConfig : Config msg
+emptyConfig : Config
 emptyConfig =
     { inputStyle = InputStyles.Standard
     , error = NoError
@@ -433,7 +433,7 @@ emptyConfig =
     }
 
 
-applyConfig : List (Attribute value msg) -> Config msg
+applyConfig : List (Attribute value msg) -> Config
 applyConfig attributes =
     List.foldl (\(Attribute _ update) config -> update config)
         emptyConfig
@@ -471,7 +471,7 @@ applyEvents =
 view : String -> List (Attribute value msg) -> Html msg
 view label attributes =
     let
-        config : Config msg
+        config : Config
         config =
             applyConfig attributes
 
@@ -551,7 +551,7 @@ view label attributes =
         )
         [ input
             (maybeStep
-                ++ List.reverse config.custom
+                ++ List.map (Attributes.map never) (List.reverse config.custom)
                 ++ [ Attributes.id idValue
                    , Attributes.css
                         [ InputStyles.input config.inputStyle isInError

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -165,7 +165,12 @@ password settings =
                         else
                             "password"
                 , inputMode = Nothing
-                , autocomplete = Just "current-password"
+                , autocomplete =
+                    Just
+                        -- TODO: this should not always be "current-password" --
+                        -- we want "new-password" when users are, uh,
+                        -- creating or confirming a new password!
+                        "current-password"
             }
         )
 

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -53,10 +53,11 @@ import Html.Styled.Attributes as Attributes exposing (..)
 import Html.Styled.Events as Events
 import Keyboard.Event exposing (KeyboardEvent)
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
+import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.Html.V3 exposing (viewJust)
-import Nri.Ui.InputStyles.V3 as InputStyles
+import Nri.Ui.InputStyles.V3 as InputStyles exposing (defaultMarginTop)
 import Nri.Ui.Message.V3 as Message
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -125,6 +126,7 @@ password =
         { emptyEventsAndValues
             | toString = Just identity
             , fromString = Just identity
+            , floatingContent = Just viewPasswordFloatingContent
         }
         (\config ->
             { config
@@ -607,7 +609,7 @@ view label attributes =
              , Attributes.css
                 [ InputStyles.label config.inputStyle isInError
                 , if config.noMarginTop then
-                    Css.top (Css.px -9)
+                    Css.top (Css.px -defaultMarginTop)
 
                   else
                     Css.batch []
@@ -677,7 +679,7 @@ searchIcon config =
             [ Css.position Css.absolute
             , Css.right (Css.px 10)
             , if config.noMarginTop then
-                Css.top (Css.px (22 - 9))
+                Css.top (Css.px (22 - defaultMarginTop))
 
               else
                 Css.top (Css.px 22)
@@ -696,9 +698,30 @@ resetButton config =
             [ Css.position Css.absolute
             , Css.right (Css.px 10)
             , if config.noMarginTop then
-                Css.top (Css.px (25 - 9))
+                Css.top (Css.px (25 - defaultMarginTop))
 
               else
                 Css.top (Css.px 25)
             ]
         ]
+
+
+viewPasswordFloatingContent : FloatingContentConfig msg -> Html msg
+viewPasswordFloatingContent config =
+    if config.stringValue == "" then
+        Html.text ""
+
+    else
+        ClickableText.button "Show password"
+            [ ClickableText.small
+            , ClickableText.css
+                [ Css.position Css.absolute
+                , Css.right (Css.px 15)
+                , if config.noMarginTop then
+                    Css.top (Css.px (22 - defaultMarginTop))
+
+                  else
+                    Css.top (Css.px 22)
+                , Css.fontSize (Css.px 13)
+                ]
+            ]

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -122,7 +122,13 @@ float onInput_ =
         )
 
 
-{-| An input that allows password entry
+{-| An input that allows password entry.
+
+If the user types at least one character into the input box, a
+floating control "Show password" will appear. When clicked, the
+input type will change from "password" to "text", in order
+to enable the user to check what they've typed.
+
 -}
 password :
     { onInput : String -> msg

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -676,7 +676,11 @@ searchIcon config =
         |> Svg.withCss
             [ Css.position Css.absolute
             , Css.right (Css.px 10)
-            , Css.top (Css.px 22)
+            , if config.noMarginTop then
+                Css.top (Css.px (22 - 9))
+
+              else
+                Css.top (Css.px 22)
             ]
         |> Svg.toHtml
 
@@ -691,6 +695,10 @@ resetButton config =
         , ClickableSvg.css
             [ Css.position Css.absolute
             , Css.right (Css.px 10)
-            , Css.top (Css.px 25)
+            , if config.noMarginTop then
+                Css.top (Css.px (25 - 9))
+
+              else
+                Css.top (Css.px 25)
             ]
         ]

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -1,6 +1,6 @@
 module Nri.Ui.TextInput.V7 exposing
     ( view, generateId
-    , number, float, text, password, email, search
+    , number, float, text, newPassword, currentPassword, email, search
     , value, map
     , onBlur, onEnter
     , Attribute, placeholder, hiddenLabel, autofocus
@@ -18,13 +18,14 @@ module Nri.Ui.TextInput.V7 exposing
   - change `view` API so it only takes a list of attributes (meaning the value and input type are now passed in as attributes)
   - make the search icon and reset pattern the default for `search`
   - add "Show password" and "Hide password" as default behavior for `password` inputs
+  - split password into `newPassword` and `currentPassword` to fix the autocomplete behavior
 
 @docs view, generateId
 
 
 ### Input types
 
-@docs number, float, text, password, email, search
+@docs number, float, text, newPassword, currentPassword, email, search
 
 
 ### Input content
@@ -124,7 +125,7 @@ float onInput_ =
         )
 
 
-{-| An input that allows password entry.
+{-| An input that allows password entry with autocomplete value "new-password"
 
 If the user types at least one character into the input box, a
 floating control "Show password" will appear. When clicked, the
@@ -132,13 +133,43 @@ input type will change from "password" to "text", in order
 to enable the user to check what they've typed.
 
 -}
-password :
+newPassword :
     { onInput : String -> msg
     , showPassword : Bool
     , setShowPassword : Bool -> msg
     }
     -> Attribute String msg
-password settings =
+newPassword =
+    password "new-password"
+
+
+{-| An input that allows password entry with autocomplete value "current-password"
+
+If the user types at least one character into the input box, a
+floating control "Show password" will appear. When clicked, the
+input type will change from "password" to "text", in order
+to enable the user to check what they've typed.
+
+-}
+currentPassword :
+    { onInput : String -> msg
+    , showPassword : Bool
+    , setShowPassword : Bool -> msg
+    }
+    -> Attribute String msg
+currentPassword =
+    password "current-password"
+
+
+password :
+    String
+    ->
+        { onInput : String -> msg
+        , showPassword : Bool
+        , setShowPassword : Bool -> msg
+        }
+    -> Attribute String msg
+password autocomplete settings =
     Attribute
         { emptyEventsAndValues
             | toString = Just identity
@@ -165,12 +196,7 @@ password settings =
                         else
                             "password"
                 , inputMode = Nothing
-                , autocomplete =
-                    Just
-                        -- TODO: this should not always be "current-password" --
-                        -- we want "new-password" when users are, uh,
-                        -- creating or confirming a new password!
-                        "current-password"
+                , autocomplete = Just autocomplete
             }
         )
 

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -1,4 +1,4 @@
-module Nri.Ui.TextInput.V6 exposing
+module Nri.Ui.TextInput.V7 exposing
     ( view, generateId
     , InputType, number, float, text, password, email, search
     , Attribute, placeholder, hiddenLabel, autofocus

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -197,6 +197,7 @@ password autocomplete settings =
                             "password"
                 , inputMode = Nothing
                 , autocomplete = Just autocomplete
+                , inputCss = Css.paddingRight (Css.px 135) :: config.inputCss
             }
         )
 
@@ -241,6 +242,7 @@ search onInput_ =
                 | fieldType = Just "search"
                 , inputMode = Nothing
                 , autocomplete = Nothing
+                , inputCss = Css.paddingRight (Css.px 30) :: config.inputCss
             }
         )
 
@@ -347,7 +349,7 @@ autofocus =
         \config -> { config | autofocus = True }
 
 
-{-| Adds CSS to the input container.
+{-| Adds CSS to the element containing the input.
 
 If you want to customize colors, borders, font sizes, etc, you should instead add to the TextInput API
 to support what you need.
@@ -356,7 +358,7 @@ to support what you need.
 css : List Css.Style -> Attribute value msg
 css styles =
     Attribute emptyEventsAndValues <|
-        \config -> { config | css = styles :: config.css }
+        \config -> { config | containerCss = config.containerCss ++ styles }
 
 
 {-| Remove default spacing from the Input.
@@ -458,6 +460,7 @@ map f toString (Attribute eventsAndValues configF) =
 -}
 type alias Config =
     { inputStyle : InputStyles.Theme
+    , inputCss : List Css.Style
     , guidance : Maybe String
     , error : ErrorState
     , disabled : Bool
@@ -466,7 +469,7 @@ type alias Config =
     , placeholder : Maybe String
     , autofocus : Bool
     , noMarginTop : Bool
-    , css : List (List Css.Style)
+    , containerCss : List Css.Style
     , id : Maybe String
     , custom : List (Html.Attribute Never)
     , fieldType : Maybe String
@@ -483,6 +486,7 @@ type ErrorState
 emptyConfig : Config
 emptyConfig =
     { inputStyle = InputStyles.Standard
+    , inputCss = []
     , guidance = Nothing
     , error = NoError
     , disabled = False
@@ -492,7 +496,7 @@ emptyConfig =
     , autofocus = False
     , id = Nothing
     , noMarginTop = False
-    , css = []
+    , containerCss = []
     , custom = []
     , fieldType = Nothing
     , inputMode = Nothing
@@ -609,13 +613,12 @@ view label attributes =
                 |> Events.on "keydown"
     in
     div
-        ([ Attributes.css
-            [ position relative
-            , Css.opacity opacity
-            ]
-         ]
-            ++ List.map Attributes.css (List.reverse config.css)
-        )
+        [ Attributes.css
+            (position relative
+                :: Css.opacity opacity
+                :: config.containerCss
+            )
+        ]
         [ input
             (maybeStep
                 ++ List.map (Attributes.map never) (List.reverse config.custom)
@@ -645,6 +648,7 @@ view label attributes =
 
                           else
                             Css.batch []
+                        , Css.batch config.inputCss |> Css.important
                         ]
                    , Attributes.placeholder placeholder_
                    , Attributes.value stringValue

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -124,18 +124,38 @@ float onInput_ =
 
 {-| An input that allows password entry
 -}
-password : (String -> msg) -> Attribute String msg
-password onInput_ =
+password :
+    { onInput : String -> msg
+    , showPassword : Bool
+    , setShowPassword : Bool -> msg
+    }
+    -> Attribute String msg
+password settings =
     Attribute
         { emptyEventsAndValues
             | toString = Just identity
             , fromString = Just identity
-            , onInput = Just onInput_
-            , floatingContent = Just viewPasswordFloatingContent
+            , onInput = Just settings.onInput
+            , floatingContent =
+                Just <|
+                    viewPasswordFloatingContent
+                        (if settings.showPassword then
+                            "Hide password"
+
+                         else
+                            "Show password"
+                        )
+                        (settings.setShowPassword (not settings.showPassword))
         }
         (\config ->
             { config
-                | fieldType = Just "password"
+                | fieldType =
+                    Just <|
+                        if settings.showPassword then
+                            "text"
+
+                        else
+                            "password"
                 , inputMode = Nothing
                 , autocomplete = Just "current-password"
             }
@@ -701,8 +721,8 @@ resetButton config =
         ]
 
 
-viewPasswordFloatingContent : FloatingContentConfig msg -> Html msg
-viewPasswordFloatingContent config =
+viewPasswordFloatingContent : String -> msg -> FloatingContentConfig msg -> Html msg
+viewPasswordFloatingContent label toggle config =
     if config.stringValue == "" then
         Html.text ""
 
@@ -711,8 +731,9 @@ viewPasswordFloatingContent config =
         -- a checkbox styled to look like a clickable text, or
         -- adding additional aria attributes connecting this clickable
         -- text to the password field.
-        ClickableText.button "Show password"
-            [ ClickableText.small
+        ClickableText.button label
+            [ ClickableText.onClick toggle
+            , ClickableText.small
             , ClickableText.css
                 [ Css.position Css.absolute
                 , Css.right (Css.px 15)

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -1,0 +1,560 @@
+module Nri.Ui.TextInput.V6 exposing
+    ( view, generateId
+    , InputType, number, float, text, password, email, search
+    , Attribute, placeholder, hiddenLabel, autofocus
+    , onBlur, onReset, onEnter
+    , css, custom, nriDescription, id, testId, noMargin
+    , disabled, loading, errorIf, errorMessage
+    , writing
+    )
+
+{-|
+
+
+# Patch changes:
+
+  - adds `nriDescription` and `testId` helpers
+
+
+# Changes from V5
+
+  - new Attributes-style API
+
+@docs view, generateId
+
+
+### Input types
+
+@docs InputType, number, float, text, password, email, search
+
+
+## Attributes
+
+@docs Attribute, placeholder, hiddenLabel, autofocus
+@docs onBlur, onReset, onEnter
+@docs css, custom, nriDescription, id, testId, noMargin
+@docs disabled, loading, errorIf, errorMessage
+@docs writing
+
+-}
+
+import Accessibility.Styled.Style as Accessibility
+import Css exposing (center, num, position, px, relative, textAlign)
+import Css.Global
+import Html.Styled as Html exposing (..)
+import Html.Styled.Attributes as Attributes exposing (..)
+import Html.Styled.Events as Events exposing (onInput)
+import Keyboard.Event exposing (KeyboardEvent)
+import Nri.Ui.ClickableSvg.V2 as ClickableSvg
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Html.Attributes.V2 as Extra
+import Nri.Ui.Html.V3 exposing (viewJust)
+import Nri.Ui.InputStyles.V3 as InputStyles
+import Nri.Ui.Message.V3 as Message
+import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.UiIcon.V1 as UiIcon
+import Nri.Ui.Util exposing (dashify)
+
+
+{-| -}
+type InputType value msg
+    = InputType
+        { toString : value -> String
+        , fromString : String -> msg
+        , fieldType : String
+        , inputMode : Maybe String
+        , autocomplete : Maybe String
+        }
+
+
+{-| An input that allows text entry
+-}
+text : (String -> msg) -> InputType String msg
+text toMsg =
+    InputType
+        { toString = identity
+        , fromString = toMsg
+        , fieldType = "text"
+        , inputMode = Nothing
+        , autocomplete = Nothing
+        }
+
+
+{-| An input that allows integer entry
+-}
+number : (Maybe Int -> msg) -> InputType (Maybe Int) msg
+number toMsg =
+    InputType
+        { toString = Maybe.map String.fromInt >> Maybe.withDefault ""
+        , fromString = String.toInt >> toMsg
+        , fieldType = "number"
+        , inputMode = Nothing
+        , autocomplete = Nothing
+        }
+
+
+{-| An input that allows float entry
+-}
+float : (Maybe Float -> msg) -> InputType (Maybe Float) msg
+float toMsg =
+    InputType
+        { toString = Maybe.map String.fromFloat >> Maybe.withDefault ""
+        , fromString = String.toFloat >> toMsg
+        , fieldType = "number"
+        , inputMode = Nothing
+        , autocomplete = Nothing
+        }
+
+
+{-| An input that allows password entry
+-}
+password : (String -> msg) -> InputType String msg
+password toMsg =
+    InputType
+        { toString = identity
+        , fromString = toMsg
+        , fieldType = "password"
+        , inputMode = Nothing
+        , autocomplete = Just "current-password"
+        }
+
+
+{-| An input that is optimized for email entry
+
+NOTE: this uses `inputmode="email"` so that mobile devices will use the email keyboard,
+but not `type="email"` because that would enable browser-provided validation which is inconsistent and at odds
+with our validation UI.
+
+-}
+email : (String -> msg) -> InputType String msg
+email toMsg =
+    InputType
+        { toString = identity
+        , fromString = toMsg
+        , fieldType = "text"
+        , inputMode = Just "email"
+        , autocomplete = Just "email"
+        }
+
+
+{-| An input with ["search" type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search) specified.
+-}
+search : (String -> msg) -> InputType String msg
+search toMsg =
+    InputType
+        { toString = identity
+        , fromString = toMsg
+        , fieldType = "search"
+        , inputMode = Nothing
+        , autocomplete = Nothing
+        }
+
+
+{-| An optional customization of a TextInput.
+-}
+type Attribute msg
+    = Attribute (Config msg -> Config msg)
+
+
+{-| If not explicit placeholder is given, the input label will be used as the placeholder.
+-}
+placeholder : String -> Attribute msg
+placeholder text_ =
+    Attribute <|
+        \config -> { config | placeholder = Just text_ }
+
+
+{-| This disables the input
+-}
+disabled : Attribute msg
+disabled =
+    Attribute <|
+        \config -> { config | disabled = True }
+
+
+{-| Use this while the form the input is a part of is being submitted.
+-}
+loading : Attribute msg
+loading =
+    Attribute <|
+        \config -> { config | loading = True }
+
+
+{-| Sets whether or not the field will be highlighted as having a validation error.
+If you are always passing `True`, then you don't need to use this attribute.
+-}
+errorIf : Bool -> Attribute msg
+errorIf isInError =
+    Attribute <|
+        \config ->
+            { config
+                | error =
+                    if isInError then
+                        Error { message = Nothing }
+
+                    else
+                        NoError
+            }
+
+
+{-| If `Just`, the field will be highlighted as having a validation error,
+and the given error message will be shown.
+-}
+errorMessage : Maybe String -> Attribute msg
+errorMessage maybeMessage =
+    Attribute <|
+        \config ->
+            { config
+                | error =
+                    case maybeMessage of
+                        Nothing ->
+                            NoError
+
+                        Just message ->
+                            Error { message = Just message }
+            }
+
+
+{-| Hides the visible label. (There will still be an invisible label for screen readers.)
+-}
+hiddenLabel : Attribute msg
+hiddenLabel =
+    Attribute <|
+        \config -> { config | hideLabel = True }
+
+
+{-| Causes the TextInput to produce the given `msg` when the field is blurred.
+-}
+onBlur : msg -> Attribute msg
+onBlur msg =
+    Attribute <|
+        \config -> { config | onBlur = Just msg }
+
+
+{-| -}
+onReset : msg -> Attribute msg
+onReset msg =
+    Attribute <|
+        \config -> { config | onReset = Just msg }
+
+
+{-| -}
+onEnter : msg -> Attribute msg
+onEnter msg =
+    Attribute <|
+        \config -> { config | onEnter = Just msg }
+
+
+{-| Sets the `autofocus` attribute of the resulting HTML input.
+-}
+autofocus : Attribute msg
+autofocus =
+    Attribute <|
+        \config -> { config | autofocus = True }
+
+
+{-| Adds CSS to the input container.
+
+If you want to customize colors, borders, font sizes, etc, you should instead add to the TextInput API
+to support what you need.
+
+-}
+css : List Css.Style -> Attribute msg
+css styles =
+    Attribute <|
+        \config -> { config | css = styles :: config.css }
+
+
+{-| Remove default spacing from the Input.
+-}
+noMargin : Bool -> Attribute msg
+noMargin removeMargin =
+    Attribute <| \config -> { config | noMarginTop = removeMargin }
+
+
+{-| Add any attribute to the input. Don't use this helper for adding css!
+
+TODO: in V7, change this helper's type to `List (Html.Attribute msg) -> Attribute msg`,
+to be more consistent with other helpers.
+
+Also, we should probably change the implemenation from `attr :: config.custom` to
+`config.custom ++ attributes` for a more intuitive and consistent API.
+
+-}
+custom : Html.Attribute msg -> Attribute msg
+custom attr =
+    Attribute <|
+        \config -> { config | custom = attr :: config.custom }
+
+
+{-| Set a custom ID for this text input and label. If you don't set this,
+we'll automatically generate one from the label you pass in, but this can
+cause problems if you have more than one text input with the same label on
+the page. Use this to be more specific and avoid issues with duplicate IDs!
+-}
+id : String -> Attribute msg
+id id_ =
+    Attribute <|
+        \config -> { config | id = Just id_ }
+
+
+{-| -}
+nriDescription : String -> Attribute msg
+nriDescription description =
+    custom (Extra.nriDescription description)
+
+
+{-| -}
+testId : String -> Attribute msg
+testId id_ =
+    custom (Extra.testId id_)
+
+
+{-| This is private. The public API only exposes `Attribute`.
+-}
+type alias Config msg =
+    { inputStyle : InputStyles.Theme
+    , error : ErrorState
+    , disabled : Bool
+    , loading : Bool
+    , hideLabel : Bool
+    , placeholder : Maybe String
+    , onBlur : Maybe msg
+    , onReset : Maybe msg
+    , onEnter : Maybe msg
+    , autofocus : Bool
+    , noMarginTop : Bool
+    , css : List (List Css.Style)
+    , id : Maybe String
+    , custom : List (Html.Attribute msg)
+    }
+
+
+type ErrorState
+    = NoError
+    | Error { message : Maybe String }
+
+
+emptyConfig : Config msg
+emptyConfig =
+    { inputStyle = InputStyles.Standard
+    , error = NoError
+    , disabled = False
+    , loading = False
+    , hideLabel = False
+    , placeholder = Nothing
+    , onBlur = Nothing
+    , onReset = Nothing
+    , onEnter = Nothing
+    , autofocus = False
+    , id = Nothing
+    , noMarginTop = False
+    , css = []
+    , custom = []
+    }
+
+
+{-| Render the TextInput as HTML.
+The input's label, InputType, and current value are all required. Other attributes are all optional.
+-}
+view : String -> InputType value msg -> List (Attribute msg) -> value -> Html msg
+view label inputType attributes currentValue =
+    let
+        config =
+            List.foldl (\(Attribute update) -> update) emptyConfig attributes
+    in
+    view_ label inputType config currentValue
+
+
+{-| Uses the "Writing" input style. See [`Nri.Ui.InputStyles.V2.Theme`](Nri-Ui-InputStyles-V2#Theme).
+-}
+writing : Attribute msg
+writing =
+    Attribute <|
+        \config -> { config | inputStyle = InputStyles.Writing }
+
+
+view_ : String -> InputType value msg -> Config msg -> value -> Html msg
+view_ label (InputType inputType) config currentValue =
+    let
+        idValue =
+            case config.id of
+                Just id_ ->
+                    id_
+
+                Nothing ->
+                    generateId label
+
+        placeholder_ =
+            config.placeholder
+                |> Maybe.withDefault label
+
+        ( isInError, errorMessage_ ) =
+            case config.error of
+                NoError ->
+                    ( False, Nothing )
+
+                Error { message } ->
+                    ( True, message )
+
+        ( opacity, disabled_ ) =
+            case ( config.disabled, config.loading ) of
+                ( False, False ) ->
+                    ( num 1, False )
+
+                ( False, True ) ->
+                    ( num 0.5, True )
+
+                ( True, _ ) ->
+                    ( num 0.4, True )
+
+        maybeStep =
+            if inputType.fieldType == "number" then
+                [ step "any" ]
+
+            else
+                []
+
+        maybeAttr attr maybeValue =
+            maybeValue
+                |> Maybe.map attr
+                |> Maybe.withDefault Extra.none
+
+        stringValue =
+            inputType.toString currentValue
+
+        onEnter_ : msg -> Html.Attribute msg
+        onEnter_ msg =
+            (\event ->
+                case event.key of
+                    Just "Enter" ->
+                        Just msg
+
+                    _ ->
+                        Nothing
+            )
+                |> Keyboard.Event.considerKeyboardEvent
+                |> Events.on "keydown"
+    in
+    div
+        ([ Attributes.css
+            [ position relative
+            , Css.opacity opacity
+            ]
+         ]
+            ++ List.map Attributes.css (List.reverse config.css)
+        )
+        [ input
+            (maybeStep
+                ++ List.reverse config.custom
+                ++ [ Attributes.id idValue
+                   , Attributes.css
+                        [ InputStyles.input config.inputStyle isInError
+                        , if config.inputStyle == InputStyles.Writing then
+                            Css.Global.withClass "override-sass-styles"
+                                [ textAlign center
+                                , Css.height Css.auto
+                                ]
+
+                          else
+                            Css.Global.withClass "override-sass-styles"
+                                [ Css.height (px 45)
+                                ]
+                        , Css.pseudoElement "-webkit-search-cancel-button"
+                            [ Css.display Css.none ]
+                        , if config.noMarginTop then
+                            Css.important (Css.marginTop Css.zero)
+
+                          else
+                            Css.batch []
+                        ]
+                   , Attributes.placeholder placeholder_
+                   , value stringValue
+                   , Attributes.disabled disabled_
+                   , onInput inputType.fromString
+                   , maybeAttr Events.onBlur config.onBlur
+                   , Attributes.autofocus config.autofocus
+                   , type_ inputType.fieldType
+                   , maybeAttr (attribute "inputmode") inputType.inputMode
+                   , maybeAttr (attribute "autocomplete") inputType.autocomplete
+                   , maybeAttr onEnter_ config.onEnter
+                   , class "override-sass-styles"
+                   , Attributes.attribute "aria-invalid" <|
+                        if isInError then
+                            "true"
+
+                        else
+                            "false"
+                   ]
+            )
+            []
+        , let
+            extraStyles =
+                if config.hideLabel then
+                    Accessibility.invisible
+
+                else
+                    []
+          in
+          Html.label
+            ([ for idValue
+             , Attributes.css
+                [ InputStyles.label config.inputStyle isInError
+                , if config.noMarginTop then
+                    Css.top (Css.px -9)
+
+                  else
+                    Css.batch []
+                ]
+             ]
+                ++ extraStyles
+            )
+            [ Html.text label ]
+        , case ( config.onReset, stringValue, inputType.fieldType ) of
+            ( Just _, "", "search" ) ->
+                UiIcon.search
+                    |> Svg.withWidth (Css.px 20)
+                    |> Svg.withHeight (Css.px 20)
+                    |> Svg.withColor Colors.gray75
+                    |> Svg.withCss
+                        [ Css.position Css.absolute
+                        , Css.right (Css.px 10)
+                        , Css.top (Css.px 22)
+                        ]
+                    |> Svg.toHtml
+
+            ( Just resetAction, _, _ ) ->
+                ClickableSvg.button ("Reset " ++ label)
+                    UiIcon.x
+                    [ ClickableSvg.onClick resetAction
+                    , ClickableSvg.exactWidth 14
+                    , ClickableSvg.exactHeight 14
+                    , ClickableSvg.css
+                        [ Css.position Css.absolute
+                        , Css.right (Css.px 10)
+                        , Css.top (Css.px 25)
+                        ]
+                    ]
+
+            ( Nothing, _, _ ) ->
+                Html.text ""
+        , case errorMessage_ of
+            Just m ->
+                Message.view
+                    [ Message.tiny
+                    , Message.error
+                    , Message.plaintext m
+                    , Message.alertRole
+                    ]
+
+            Nothing ->
+                Html.text ""
+        ]
+
+
+{-| Gives you the DOM element id that will be used by a `TextInput.view` with the given label.
+This is for use when you need the DOM element id for use in javascript (such as trigger an event to focus a particular text input)
+-}
+generateId : String -> String
+generateId labelText =
+    "Nri-Ui-TextInput-" ++ dashify labelText

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -2,7 +2,7 @@ module Nri.Ui.TextInput.V7 exposing
     ( view, generateId
     , number, float, text, newPassword, currentPassword, email, search
     , value, map
-    , onBlur, onEnter
+    , onFocus, onBlur, onEnter
     , Attribute, placeholder, hiddenLabel, autofocus
     , css, custom, nriDescription, id, testId, noMargin
     , disabled, loading, errorIf, errorMessage, guidance
@@ -35,7 +35,7 @@ module Nri.Ui.TextInput.V7 exposing
 
 ### Event handlers
 
-@docs onBlur, onEnter
+@docs onFocus, onBlur, onEnter
 
 
 ## Attributes
@@ -328,6 +328,13 @@ hiddenLabel =
         \config -> { config | hideLabel = True }
 
 
+{-| Causes the TextInput to produce the given `msg` when the field is focused.
+-}
+onFocus : msg -> Attribute value msg
+onFocus msg =
+    Attribute { emptyEventsAndValues | onFocus = Just msg } identity
+
+
 {-| Causes the TextInput to produce the given `msg` when the field is blurred.
 -}
 onBlur : msg -> Attribute value msg
@@ -423,6 +430,7 @@ type alias EventsAndValues value msg =
     , toString : Maybe (value -> String)
     , fromString : Maybe (String -> value)
     , onInput : Maybe (String -> msg)
+    , onFocus : Maybe msg
     , onBlur : Maybe msg
     , onEnter : Maybe msg
     , floatingContent : Maybe (FloatingContentConfig msg -> Html msg)
@@ -434,6 +442,7 @@ emptyEventsAndValues =
     { currentValue = Nothing
     , toString = Nothing
     , fromString = Nothing
+    , onFocus = Nothing
     , onBlur = Nothing
     , onEnter = Nothing
     , onInput = Nothing
@@ -448,6 +457,7 @@ map f toString (Attribute eventsAndValues configF) =
         { currentValue = Maybe.map f eventsAndValues.currentValue
         , toString = Just toString
         , fromString = Maybe.map (\from -> from >> f) eventsAndValues.fromString
+        , onFocus = eventsAndValues.onFocus
         , onBlur = eventsAndValues.onBlur
         , onEnter = eventsAndValues.onEnter
         , onInput = eventsAndValues.onInput
@@ -528,6 +538,7 @@ applyEvents =
             { currentValue = orExisting .currentValue eventsAndValues existing
             , toString = orExisting .toString eventsAndValues existing
             , fromString = orExisting .fromString eventsAndValues existing
+            , onFocus = orExisting .onFocus eventsAndValues existing
             , onBlur = orExisting .onBlur eventsAndValues existing
             , floatingContent = orExisting .floatingContent eventsAndValues existing
             , onEnter = orExisting .onEnter eventsAndValues existing
@@ -654,6 +665,7 @@ view label attributes =
                    , Attributes.value stringValue
                    , Attributes.disabled disabled_
                    , maybeAttr Events.onInput eventsAndValues.onInput
+                   , maybeAttr Events.onFocus eventsAndValues.onFocus
                    , maybeAttr Events.onBlur eventsAndValues.onBlur
                    , Attributes.autofocus config.autofocus
                    , maybeAttr type_ config.fieldType

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -707,6 +707,10 @@ viewPasswordFloatingContent config =
         Html.text ""
 
     else
+        -- TODO: consider using a "toggle" clickable text button,
+        -- a checkbox styled to look like a clickable text, or
+        -- adding additional aria attributes connecting this clickable
+        -- text to the password field.
         ClickableText.button "Show password"
             [ ClickableText.small
             , ClickableText.css

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -14,6 +14,7 @@ import Nri.Ui.Message.V3 as Message
 import Nri.Ui.Pennant.V2 as Pennant
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.UiIcon.V1 as UiIcon
+import ViewHelpers exposing (viewExamples)
 
 
 type alias State =
@@ -201,21 +202,10 @@ example =
             , Control.view UpdateControl state.control
                 |> Html.fromUnstyled
             , orDismiss <|
-                Html.table [ css [ width (pct 100) ] ]
-                    [ Html.tbody []
-                        [ tr []
-                            [ th [] [ Html.text "tiny" ]
-                            , td [] [ Message.view (Message.tiny :: attributes) ]
-                            ]
-                        , tr []
-                            [ th [] [ Html.text "large" ]
-                            , td [] [ Message.view (Message.large :: attributes) ]
-                            ]
-                        , tr []
-                            [ th [] [ Html.text "banner" ]
-                            , td [] [ Message.view (Message.banner :: attributes) ]
-                            ]
-                        ]
+                viewExamples
+                    [ ( "tiny", Message.view (Message.tiny :: attributes) )
+                    , ( "large", Message.view (Message.large :: attributes) )
+                    , ( "banner", Message.view (Message.banner :: attributes) )
                     ]
             , Heading.h3
                 [ Heading.css

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -63,8 +63,11 @@ example =
             , viewExamples
                 [ ( "text"
                   , TextInput.view exampleConfig.label
-                        (TextInput.text (SetTextInput 1))
                         (TextInput.id "text-input__text-example"
+                            :: TextInput.text (SetTextInput 1)
+                            :: (TextInput.value <|
+                                    (Maybe.withDefault "" <| Dict.get 1 state.stringInputValues)
+                               )
                             :: attributes
                                 { setField = SetTextInput 1
                                 , onBlur = "Blurred!!!"
@@ -72,73 +75,73 @@ example =
                                 , onEnter = "Entered!!!"
                                 }
                         )
-                        (Maybe.withDefault "" <| Dict.get 1 state.stringInputValues)
                   )
-                , ( "number"
-                  , TextInput.view exampleConfig.label
-                        (TextInput.number SetNumberInput)
-                        (TextInput.id "text-input__number-example"
-                            :: attributes
-                                { setField = SetNumberInput
-                                , onBlur = Just 10000000
-                                , onReset = Nothing
-                                , onEnter = Just 20000000
-                                }
-                        )
-                        state.numberInputValue
-                  )
-                , ( "float"
-                  , TextInput.view exampleConfig.label
-                        (TextInput.float SetFloatInput)
-                        (TextInput.id "text-input__float-example"
-                            :: attributes
-                                { setField = SetFloatInput
-                                , onBlur = Just 1.00000001
-                                , onReset = Nothing
-                                , onEnter = Just 100000001.1
-                                }
-                        )
-                        state.floatInputValue
-                  )
-                , ( "password"
-                  , TextInput.view exampleConfig.label
-                        (TextInput.password SetPassword)
-                        (TextInput.id "text-input__password-example"
-                            :: attributes
-                                { setField = SetPassword
-                                , onBlur = "Blurred!!!"
-                                , onReset = ""
-                                , onEnter = "Entered!!!"
-                                }
-                        )
-                        state.passwordInputValue
-                  )
-                , ( "email"
-                  , TextInput.view exampleConfig.label
-                        (TextInput.email (SetTextInput 2))
-                        (TextInput.id "text-input__email-example"
-                            :: attributes
-                                { setField = SetTextInput 2
-                                , onBlur = "Blurred!!!"
-                                , onReset = ""
-                                , onEnter = "Entered!!!"
-                                }
-                        )
-                        (Maybe.withDefault "" <| Dict.get 2 state.stringInputValues)
-                  )
-                , ( "search"
-                  , TextInput.view exampleConfig.label
-                        (TextInput.search SetSearchTerm)
-                        (TextInput.id "text-input__search-example"
-                            :: attributes
-                                { setField = SetSearchTerm
-                                , onBlur = "Blurred!!!"
-                                , onReset = ""
-                                , onEnter = "Entered!!!"
-                                }
-                        )
-                        state.searchInputValue
-                  )
+
+                --, ( "number"
+                --  , TextInput.view exampleConfig.label
+                --        (TextInput.number SetNumberInput)
+                --        (TextInput.id "text-input__number-example"
+                --            :: attributes
+                --                { setField = SetNumberInput
+                --                , onBlur = Just 10000000
+                --                , onReset = Nothing
+                --                , onEnter = Just 20000000
+                --                }
+                --        )
+                --        state.numberInputValue
+                --  )
+                --, ( "float"
+                --  , TextInput.view exampleConfig.label
+                --        (TextInput.float SetFloatInput)
+                --        (TextInput.id "text-input__float-example"
+                --            :: attributes
+                --                { setField = SetFloatInput
+                --                , onBlur = Just 1.00000001
+                --                , onReset = Nothing
+                --                , onEnter = Just 100000001.1
+                --                }
+                --        )
+                --        state.floatInputValue
+                --  )
+                --, ( "password"
+                --  , TextInput.view exampleConfig.label
+                --        (TextInput.password SetPassword)
+                --        (TextInput.id "text-input__password-example"
+                --            :: attributes
+                --                { setField = SetPassword
+                --                , onBlur = "Blurred!!!"
+                --                , onReset = ""
+                --                , onEnter = "Entered!!!"
+                --                }
+                --        )
+                --        state.passwordInputValue
+                --  )
+                --, ( "email"
+                --  , TextInput.view exampleConfig.label
+                --        (TextInput.email (SetTextInput 2))
+                --        (TextInput.id "text-input__email-example"
+                --            :: attributes
+                --                { setField = SetTextInput 2
+                --                , onBlur = "Blurred!!!"
+                --                , onReset = ""
+                --                , onEnter = "Entered!!!"
+                --                }
+                --        )
+                --        (Maybe.withDefault "" <| Dict.get 2 state.stringInputValues)
+                --  )
+                --, ( "search"
+                --  , TextInput.view exampleConfig.label
+                --        (TextInput.search SetSearchTerm)
+                --        (TextInput.id "text-input__search-example"
+                --            :: attributes
+                --                { setField = SetSearchTerm
+                --                , onBlur = "Blurred!!!"
+                --                , onReset = ""
+                --                , onEnter = "Entered!!!"
+                --                }
+                --        )
+                --        state.searchInputValue
+                --  )
                 ]
             ]
     }
@@ -169,7 +172,7 @@ init =
 
 type alias ExampleConfig =
     { label : String
-    , attributes : List (TextInput.Attribute Msg)
+    , attributes : List (TextInput.Attribute String Msg)
     , onBlur : Bool
     , onReset : Bool
     , onEnter : Bool
@@ -186,7 +189,7 @@ initControl =
         |> Control.field "onEnter" (Control.bool False)
 
 
-controlAttributes : Control (List (TextInput.Attribute msg))
+controlAttributes : Control (List (TextInput.Attribute String msg))
 controlAttributes =
     ControlExtra.list
         |> ControlExtra.optionalListItem "placeholder"

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -126,20 +126,6 @@ example =
                         )
                         (Maybe.withDefault "" <| Dict.get 2 state.stringInputValues)
                   )
-                , ( "writing"
-                  , TextInput.view exampleConfig.label
-                        (TextInput.text (SetTextInput 4))
-                        (TextInput.writing
-                            :: TextInput.id "text-input__writing-example"
-                            :: attributes
-                                { setField = SetTextInput 4
-                                , onBlur = "Blurred!!!"
-                                , onReset = ""
-                                , onEnter = "Entered!!!"
-                                }
-                        )
-                        (Maybe.withDefault "" <| Dict.get 4 state.stringInputValues)
-                  )
                 , ( "search"
                   , TextInput.view exampleConfig.label
                         (TextInput.search SetSearchTerm)
@@ -217,6 +203,8 @@ controlAttributes =
             (Control.value TextInput.disabled)
         |> ControlExtra.optionalListItem "loading"
             (Control.value TextInput.loading)
+        |> ControlExtra.optionalListItem "writing"
+            (Control.value TextInput.writing)
         |> ControlExtra.listItem "noMargin"
             (Control.map TextInput.noMargin (Control.bool False))
         |> ControlExtra.optionalListItem "css"

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -17,7 +17,7 @@ import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Message.V3 as Message
-import Nri.Ui.TextInput.V6 as TextInput
+import Nri.Ui.TextInput.V7 as TextInput
 
 
 {-| -}
@@ -61,7 +61,7 @@ type alias ExampleConfig =
 example : Example State Msg
 example =
     { name = "TextInput"
-    , version = 6
+    , version = 7
     , categories = [ Inputs ]
     , keyboardSupport = []
     , state = init

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -164,7 +164,9 @@ controlAttributes =
         |> ControlExtra.optionalListItem "errorIf"
             (Control.map TextInput.errorIf <| Control.bool True)
         |> ControlExtra.optionalListItem "errorMessage"
-            (Control.map TextInput.errorMessage <| Control.maybe True <| Control.string "The statement must be true.")
+            (Control.map (Just >> TextInput.errorMessage) <| Control.string "The statement must be true.")
+        |> ControlExtra.optionalListItem "guidance"
+            (Control.map TextInput.guidance <| Control.string "The statement must be true.")
         |> ControlExtra.optionalListItem "disabled"
             (Control.value TextInput.disabled)
         |> ControlExtra.optionalListItem "loading"

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -38,7 +38,7 @@ example =
                 exampleConfig =
                     Control.currentValue state.control
 
-                toExample { name, toString, inputType, onBlur, onReset, onEnter } index =
+                toExample { name, toString, inputType, onBlur, onEnter } index =
                     ( name
                     , TextInput.view exampleConfig.label
                         (exampleConfig.attributes
@@ -50,11 +50,6 @@ example =
                             ++ List.filterMap identity
                                 [ if exampleConfig.onBlur then
                                     Just (TextInput.onBlur (SetInput index onBlur))
-
-                                  else
-                                    Nothing
-                                , if exampleConfig.onReset then
-                                    Just (TextInput.onReset (SetInput index onReset))
 
                                   else
                                     Nothing
@@ -75,7 +70,6 @@ example =
                     , toString = identity
                     , inputType = TextInput.text
                     , onBlur = "Blurred!!!"
-                    , onReset = ""
                     , onEnter = "Entered!!!"
                     }
                 , toExample
@@ -83,7 +77,6 @@ example =
                     , toString = Maybe.map String.fromInt >> Maybe.withDefault ""
                     , inputType = TextInput.number
                     , onBlur = "10000000"
-                    , onReset = ""
                     , onEnter = "20000000"
                     }
                 , toExample
@@ -91,7 +84,6 @@ example =
                     , toString = Maybe.map String.fromFloat >> Maybe.withDefault ""
                     , inputType = TextInput.float
                     , onBlur = "1.00000001"
-                    , onReset = ""
                     , onEnter = "100000001.1"
                     }
                 , toExample
@@ -99,7 +91,6 @@ example =
                     , toString = identity
                     , inputType = TextInput.password
                     , onBlur = "Blurred!!!"
-                    , onReset = ""
                     , onEnter = "Entered!!!"
                     }
                 , toExample
@@ -107,7 +98,6 @@ example =
                     , toString = identity
                     , inputType = TextInput.email
                     , onBlur = "Blurred!!!"
-                    , onReset = ""
                     , onEnter = "Entered!!!"
                     }
                 , toExample
@@ -115,7 +105,6 @@ example =
                     , toString = identity
                     , inputType = TextInput.search
                     , onBlur = "Blurred!!!"
-                    , onReset = ""
                     , onEnter = "Entered!!!"
                     }
                 ]
@@ -142,7 +131,6 @@ type alias ExampleConfig =
     { label : String
     , attributes : List (TextInput.Attribute String Msg)
     , onBlur : Bool
-    , onReset : Bool
     , onEnter : Bool
     }
 
@@ -153,7 +141,6 @@ initControl =
         |> Control.field "label" (Control.string "Assignment name")
         |> Control.field "attributes" controlAttributes
         |> Control.field "onBlur" (Control.bool False)
-        |> Control.field "onReset" (Control.bool False)
         |> Control.field "onEnter" (Control.bool False)
 
 

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -38,7 +38,7 @@ example =
                 exampleConfig =
                     Control.currentValue state.control
 
-                toExample { name, toString, inputType, onBlur, onEnter } index =
+                toExample { name, toString, inputType, onFocus, onBlur, onEnter } index =
                     ( name
                     , TextInput.view exampleConfig.label
                         (exampleConfig.attributes
@@ -48,7 +48,12 @@ example =
                                , TextInput.value (Maybe.withDefault "" (Dict.get index state.inputValues))
                                ]
                             ++ List.filterMap identity
-                                [ if exampleConfig.onBlur then
+                                [ if exampleConfig.onFocus then
+                                    Just (TextInput.onFocus (SetInput index onFocus))
+
+                                  else
+                                    Nothing
+                                , if exampleConfig.onBlur then
                                     Just (TextInput.onBlur (SetInput index onBlur))
 
                                   else
@@ -69,6 +74,7 @@ example =
                     { name = "text"
                     , toString = identity
                     , inputType = TextInput.text
+                    , onFocus = "Focused!!!"
                     , onBlur = "Blurred!!!"
                     , onEnter = "Entered!!!"
                     }
@@ -76,6 +82,7 @@ example =
                     { name = "number"
                     , toString = Maybe.map String.fromInt >> Maybe.withDefault ""
                     , inputType = TextInput.number
+                    , onFocus = "1234"
                     , onBlur = "10000000"
                     , onEnter = "20000000"
                     }
@@ -83,6 +90,7 @@ example =
                     { name = "float"
                     , toString = Maybe.map String.fromFloat >> Maybe.withDefault ""
                     , inputType = TextInput.float
+                    , onFocus = "123"
                     , onBlur = "1.00000001"
                     , onEnter = "100000001.1"
                     }
@@ -96,6 +104,7 @@ example =
                                 , showPassword = state.showPassword
                                 , setShowPassword = SetShowPassword
                                 }
+                    , onFocus = "Focused!!!"
                     , onBlur = "Blurred!!!"
                     , onEnter = "Entered!!!"
                     }
@@ -103,6 +112,7 @@ example =
                     { name = "email"
                     , toString = identity
                     , inputType = TextInput.email
+                    , onFocus = "Focused!!!"
                     , onBlur = "Blurred!!!"
                     , onEnter = "Entered!!!"
                     }
@@ -110,6 +120,7 @@ example =
                     { name = "search"
                     , toString = identity
                     , inputType = TextInput.search
+                    , onFocus = "Focused!!!"
                     , onBlur = "Blurred!!!"
                     , onEnter = "Entered!!!"
                     }
@@ -138,6 +149,7 @@ init =
 type alias ExampleConfig =
     { label : String
     , attributes : List (TextInput.Attribute String Msg)
+    , onFocus : Bool
     , onBlur : Bool
     , onEnter : Bool
     }
@@ -148,6 +160,7 @@ initControl =
     Control.record ExampleConfig
         |> Control.field "label" (Control.string "Assignment name")
         |> Control.field "attributes" controlAttributes
+        |> Control.field "onFocus" (Control.bool False)
         |> Control.field "onBlur" (Control.bool False)
         |> Control.field "onEnter" (Control.bool False)
 

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -64,7 +64,8 @@ example =
                 [ ( "text"
                   , TextInput.view exampleConfig.label
                         (TextInput.id "text-input__text-example"
-                            :: TextInput.text (SetTextInput 1)
+                            :: TextInput.text
+                            :: TextInput.onInput (SetTextInput 1)
                             :: (TextInput.value <|
                                     (Maybe.withDefault "" <| Dict.get 1 state.stringInputValues)
                                )

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -38,8 +38,13 @@ example =
                 exampleConfig =
                     Control.currentValue state.control
 
+                sharedAttributes : List (TextInput.Attribute value Msg)
+                sharedAttributes =
+                    List.map (TextInput.map never (\_ -> "") (\_ -> NoOp))
+                        exampleConfig.attributes
+
                 attributes { setField, onBlur, onReset, onEnter } =
-                    exampleConfig.attributes
+                    sharedAttributes
                         ++ List.filterMap identity
                             [ if exampleConfig.onBlur then
                                 Just (TextInput.onBlur (setField onBlur))
@@ -77,72 +82,76 @@ example =
                                 }
                         )
                   )
-
-                --, ( "number"
-                --  , TextInput.view exampleConfig.label
-                --        (TextInput.number SetNumberInput)
-                --        (TextInput.id "text-input__number-example"
-                --            :: attributes
-                --                { setField = SetNumberInput
-                --                , onBlur = Just 10000000
-                --                , onReset = Nothing
-                --                , onEnter = Just 20000000
-                --                }
-                --        )
-                --        state.numberInputValue
-                --  )
-                --, ( "float"
-                --  , TextInput.view exampleConfig.label
-                --        (TextInput.float SetFloatInput)
-                --        (TextInput.id "text-input__float-example"
-                --            :: attributes
-                --                { setField = SetFloatInput
-                --                , onBlur = Just 1.00000001
-                --                , onReset = Nothing
-                --                , onEnter = Just 100000001.1
-                --                }
-                --        )
-                --        state.floatInputValue
-                --  )
-                --, ( "password"
-                --  , TextInput.view exampleConfig.label
-                --        (TextInput.password SetPassword)
-                --        (TextInput.id "text-input__password-example"
-                --            :: attributes
-                --                { setField = SetPassword
-                --                , onBlur = "Blurred!!!"
-                --                , onReset = ""
-                --                , onEnter = "Entered!!!"
-                --                }
-                --        )
-                --        state.passwordInputValue
-                --  )
-                --, ( "email"
-                --  , TextInput.view exampleConfig.label
-                --        (TextInput.email (SetTextInput 2))
-                --        (TextInput.id "text-input__email-example"
-                --            :: attributes
-                --                { setField = SetTextInput 2
-                --                , onBlur = "Blurred!!!"
-                --                , onReset = ""
-                --                , onEnter = "Entered!!!"
-                --                }
-                --        )
-                --        (Maybe.withDefault "" <| Dict.get 2 state.stringInputValues)
-                --  )
-                --, ( "search"
-                --  , TextInput.view exampleConfig.label
-                --        (TextInput.search SetSearchTerm)
-                --        (TextInput.id "text-input__search-example"
-                --            :: attributes
-                --                { setField = SetSearchTerm
-                --                , onBlur = "Blurred!!!"
-                --                , onReset = ""
-                --                , onEnter = "Entered!!!"
-                --                }
-                --        )
-                --        state.searchInputValue
-                --  )
+                , ( "number"
+                  , TextInput.view exampleConfig.label
+                        (TextInput.id "text-input__number-example"
+                            :: TextInput.number
+                            :: TextInput.onInput SetNumberInput
+                            :: TextInput.value state.numberInputValue
+                            :: attributes
+                                { setField = SetNumberInput
+                                , onBlur = Just 10000000
+                                , onReset = Nothing
+                                , onEnter = Just 20000000
+                                }
+                        )
+                  )
+                , ( "float"
+                  , TextInput.view exampleConfig.label
+                        (TextInput.id "text-input__float-example"
+                            :: TextInput.float
+                            :: TextInput.onInput SetFloatInput
+                            :: TextInput.value state.floatInputValue
+                            :: attributes
+                                { setField = SetFloatInput
+                                , onBlur = Just 1.00000001
+                                , onReset = Nothing
+                                , onEnter = Just 100000001.1
+                                }
+                        )
+                  )
+                , ( "password"
+                  , TextInput.view exampleConfig.label
+                        (TextInput.id "text-input__password-example"
+                            :: TextInput.password
+                            :: TextInput.onInput SetPassword
+                            :: TextInput.value state.passwordInputValue
+                            :: attributes
+                                { setField = SetPassword
+                                , onBlur = "Blurred!!!"
+                                , onReset = ""
+                                , onEnter = "Entered!!!"
+                                }
+                        )
+                  )
+                , ( "email"
+                  , TextInput.view exampleConfig.label
+                        (TextInput.id "text-input__email-example"
+                            :: TextInput.email
+                            :: TextInput.onInput (SetTextInput 2)
+                            :: TextInput.value (Maybe.withDefault "" <| Dict.get 2 state.stringInputValues)
+                            :: attributes
+                                { setField = SetTextInput 2
+                                , onBlur = "Blurred!!!"
+                                , onReset = ""
+                                , onEnter = "Entered!!!"
+                                }
+                        )
+                  )
+                , ( "search"
+                  , TextInput.view exampleConfig.label
+                        (TextInput.id "text-input__search-example"
+                            :: TextInput.search
+                            :: TextInput.onInput SetSearchTerm
+                            :: TextInput.value state.searchInputValue
+                            :: attributes
+                                { setField = SetSearchTerm
+                                , onBlur = "Blurred!!!"
+                                , onReset = ""
+                                , onEnter = "Entered!!!"
+                                }
+                        )
+                  )
                 ]
             ]
     }
@@ -173,7 +182,7 @@ init =
 
 type alias ExampleConfig =
     { label : String
-    , attributes : List (TextInput.Attribute String Msg)
+    , attributes : List (TextInput.Attribute Never Msg)
     , onBlur : Bool
     , onReset : Bool
     , onEnter : Bool
@@ -190,7 +199,7 @@ initControl =
         |> Control.field "onEnter" (Control.bool False)
 
 
-controlAttributes : Control (List (TextInput.Attribute String msg))
+controlAttributes : Control (List (TextInput.Attribute Never msg))
 controlAttributes =
     ControlExtra.list
         |> ControlExtra.optionalListItem "placeholder"
@@ -223,6 +232,7 @@ type Msg
     | SetPassword String
     | SetSearchTerm String
     | UpdateControl (Control ExampleConfig)
+    | NoOp
 
 
 {-| -}
@@ -246,6 +256,9 @@ update msg state =
 
         UpdateControl newControl ->
             ( { state | control = newControl }, Cmd.none )
+
+        NoOp ->
+            ( state, Cmd.none )
 
 
 

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -38,129 +38,92 @@ example =
                 exampleConfig =
                     Control.currentValue state.control
 
-                attributes { setField, onBlur, onReset, onEnter } =
-                    exampleConfig.attributes
-                        ++ List.filterMap identity
-                            [ if exampleConfig.onBlur then
-                                Just (TextInput.onBlur (setField onBlur))
+                toExample { name, toString, inputType, onBlur, onReset, onEnter } index =
+                    ( name
+                    , TextInput.view exampleConfig.label
+                        (TextInput.id ("text-input__" ++ name ++ "-example")
+                            :: TextInput.map
+                                toString
+                                identity
+                                (SetInput index)
+                                inputType
+                            :: TextInput.onInput (SetInput index)
+                            :: TextInput.value
+                                (Maybe.withDefault "" <|
+                                    Dict.get index state.inputValues
+                                )
+                            :: exampleConfig.attributes
+                            ++ List.filterMap identity
+                                [ if exampleConfig.onBlur then
+                                    Just (TextInput.onBlur (SetInput index onBlur))
 
-                              else
-                                Nothing
-                            , if exampleConfig.onReset then
-                                Just (TextInput.onReset (setField onReset))
+                                  else
+                                    Nothing
+                                , if exampleConfig.onReset then
+                                    Just (TextInput.onReset (SetInput index onReset))
 
-                              else
-                                Nothing
-                            , if exampleConfig.onEnter then
-                                Just (TextInput.onEnter (setField onEnter))
+                                  else
+                                    Nothing
+                                , if exampleConfig.onEnter then
+                                    Just (TextInput.onEnter (SetInput index onEnter))
 
-                              else
-                                Nothing
-                            ]
+                                  else
+                                    Nothing
+                                ]
+                        )
+                    )
             in
             [ Control.view UpdateControl state.control
                 |> Html.fromUnstyled
-            , viewExamples
-                [ ( "text"
-                  , TextInput.view exampleConfig.label
-                        (TextInput.id "text-input__text-example"
-                            :: TextInput.text
-                            :: TextInput.onInput (SetInput 1)
-                            :: (TextInput.value <|
-                                    (Maybe.withDefault "" <| Dict.get 1 state.inputValues)
-                               )
-                            :: attributes
-                                { setField = SetInput 1
-                                , onBlur = "Blurred!!!"
-                                , onReset = ""
-                                , onEnter = "Entered!!!"
-                                }
-                        )
-                  )
-                , ( "number"
-                  , TextInput.view exampleConfig.label
-                        (TextInput.id "text-input__number-example"
-                            :: TextInput.map
-                                (Maybe.map String.fromInt >> Maybe.withDefault "")
-                                identity
-                                (SetInput 100)
-                                TextInput.number
-                            :: TextInput.onInput (SetInput 100)
-                            :: TextInput.value
-                                (Maybe.withDefault "" <|
-                                    Dict.get 100 state.inputValues
-                                )
-                            :: attributes
-                                { setField = SetInput 100
-                                , onBlur = "10000000"
-                                , onReset = ""
-                                , onEnter = "20000000"
-                                }
-                        )
-                  )
-                , ( "float"
-                  , TextInput.view exampleConfig.label
-                        (TextInput.id "text-input__float-example"
-                            :: TextInput.map
-                                (Maybe.map String.fromFloat >> Maybe.withDefault "")
-                                identity
-                                (SetInput 1000)
-                                TextInput.float
-                            :: TextInput.onInput (SetInput 1000)
-                            :: TextInput.value
-                                (Maybe.withDefault "" <|
-                                    Dict.get 1000 state.inputValues
-                                )
-                            :: attributes
-                                { setField = SetInput 1000
-                                , onBlur = "1.00000001"
-                                , onReset = ""
-                                , onEnter = "100000001.1"
-                                }
-                        )
-                  )
-                , ( "password"
-                  , TextInput.view exampleConfig.label
-                        (TextInput.id "text-input__password-example"
-                            :: TextInput.password
-                            :: TextInput.onInput (SetInput 10)
-                            :: TextInput.value (Maybe.withDefault "" <| Dict.get 10 state.inputValues)
-                            :: attributes
-                                { setField = SetInput 10
-                                , onBlur = "Blurred!!!"
-                                , onReset = ""
-                                , onEnter = "Entered!!!"
-                                }
-                        )
-                  )
-                , ( "email"
-                  , TextInput.view exampleConfig.label
-                        (TextInput.id "text-input__email-example"
-                            :: TextInput.email
-                            :: TextInput.onInput (SetInput 2)
-                            :: TextInput.value (Maybe.withDefault "" <| Dict.get 2 state.inputValues)
-                            :: attributes
-                                { setField = SetInput 2
-                                , onBlur = "Blurred!!!"
-                                , onReset = ""
-                                , onEnter = "Entered!!!"
-                                }
-                        )
-                  )
-                , ( "search"
-                  , TextInput.view exampleConfig.label
-                        (TextInput.id "text-input__search-example"
-                            :: TextInput.search
-                            :: TextInput.onInput (SetInput 11)
-                            :: TextInput.value (Maybe.withDefault "" <| Dict.get 11 state.inputValues)
-                            :: attributes
-                                { setField = SetInput 11
-                                , onBlur = "Blurred!!!"
-                                , onReset = ""
-                                , onEnter = "Entered!!!"
-                                }
-                        )
-                  )
+            , (viewExamples << List.indexedMap (\i toView -> toView i))
+                [ toExample
+                    { name = "text"
+                    , toString = identity
+                    , inputType = TextInput.text
+                    , onBlur = "Blurred!!!"
+                    , onReset = ""
+                    , onEnter = "Entered!!!"
+                    }
+                , toExample
+                    { name = "number"
+                    , toString = Maybe.map String.fromInt >> Maybe.withDefault ""
+                    , inputType = TextInput.number
+                    , onBlur = "10000000"
+                    , onReset = ""
+                    , onEnter = "20000000"
+                    }
+                , toExample
+                    { name = "float"
+                    , toString = Maybe.map String.fromFloat >> Maybe.withDefault ""
+                    , inputType = TextInput.float
+                    , onBlur = "1.00000001"
+                    , onReset = ""
+                    , onEnter = "100000001.1"
+                    }
+                , toExample
+                    { name = "password"
+                    , toString = identity
+                    , inputType = TextInput.password
+                    , onBlur = "Blurred!!!"
+                    , onReset = ""
+                    , onEnter = "Entered!!!"
+                    }
+                , toExample
+                    { name = "email"
+                    , toString = identity
+                    , inputType = TextInput.email
+                    , onBlur = "Blurred!!!"
+                    , onReset = ""
+                    , onEnter = "Entered!!!"
+                    }
+                , toExample
+                    { name = "search"
+                    , toString = identity
+                    , inputType = TextInput.search
+                    , onBlur = "Blurred!!!"
+                    , onReset = ""
+                    , onEnter = "Entered!!!"
+                    }
                 ]
             ]
     }

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -19,6 +19,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Message.V3 as Message
 import Nri.Ui.TextInput.V7 as TextInput
+import ViewHelpers exposing (viewExamples)
 
 
 {-| -}
@@ -75,109 +76,99 @@ example =
             in
             [ Control.view UpdateControl state.control
                 |> Html.fromUnstyled
-            , Html.div
-                [ css
-                    [ property "display" "grid"
-                    , property "grid-template-columns" "auto 1fr"
-                    , property "grid-gap" "10px"
-                    ]
-                ]
-                [ Heading.h3 [] [ text "TextInput.text" ]
-                , TextInput.view (exampleConfig.label ++ " (text)")
-                    (TextInput.text (SetTextInput 1))
-                    (attributes
-                        { setField = SetTextInput 1
-                        , onBlur = "Blurred!!!"
-                        , onReset = ""
-                        , onEnter = HitEnter
-                        }
-                    )
-                    (Maybe.withDefault "" <| Dict.get 1 state.stringInputValues)
-                , Heading.h3 [] [ text "TextInput.number" ]
-                , TextInput.view (exampleConfig.label ++ " (number)")
-                    (TextInput.number SetNumberInput)
-                    (TextInput.id "hey-this-is-a-test-id"
-                        :: attributes
-                            { setField = SetNumberInput
-                            , onBlur = Just 10000000
+            , viewExamples
+                [ ( "TextInput.text"
+                  , TextInput.view (exampleConfig.label ++ " (text)")
+                        (TextInput.text (SetTextInput 1))
+                        (attributes
+                            { setField = SetTextInput 1
+                            , onBlur = "Blurred!!!"
+                            , onReset = ""
+                            , onEnter = HitEnter
+                            }
+                        )
+                        (Maybe.withDefault "" <| Dict.get 1 state.stringInputValues)
+                  )
+                , ( "TextInput.number"
+                  , TextInput.view (exampleConfig.label ++ " (number)")
+                        (TextInput.number SetNumberInput)
+                        (TextInput.id "hey-this-is-a-test-id"
+                            :: attributes
+                                { setField = SetNumberInput
+                                , onBlur = Just 10000000
+                                , onReset = Nothing
+                                , onEnter = HitEnter
+                                }
+                        )
+                        state.numberInputValue
+                  )
+                , ( "TextInput.float"
+                  , TextInput.view (exampleConfig.label ++ " (float)")
+                        (TextInput.float SetFloatInput)
+                        (attributes
+                            { setField = SetFloatInput
+                            , onBlur = Just 1.00000001
                             , onReset = Nothing
                             , onEnter = HitEnter
                             }
-                    )
-                    state.numberInputValue
-                , Heading.h3 [] [ text "TextInput.float" ]
-                , TextInput.view (exampleConfig.label ++ " (float)")
-                    (TextInput.float SetFloatInput)
-                    (attributes
-                        { setField = SetFloatInput
-                        , onBlur = Just 1.00000001
-                        , onReset = Nothing
-                        , onEnter = HitEnter
-                        }
-                    )
-                    state.floatInputValue
-                , Heading.h3 [] [ text "TextInput.password" ]
-                , TextInput.view (exampleConfig.label ++ " (password)")
-                    (TextInput.password SetPassword)
-                    (attributes
-                        { setField = SetPassword
-                        , onBlur = "Blurred!!!"
-                        , onReset = ""
-                        , onEnter = HitEnter
-                        }
-                    )
-                    state.passwordInputValue
-                , Heading.h3 [] [ text "TextInput.email" ]
-                , TextInput.view (exampleConfig.label ++ " (email)")
-                    (TextInput.email (SetTextInput 2))
-                    (attributes
-                        { setField = SetTextInput 2
-                        , onBlur = "Blurred!!!"
-                        , onReset = ""
-                        , onEnter = HitEnter
-                        }
-                    )
-                    (Maybe.withDefault "" <| Dict.get 2 state.stringInputValues)
-                , Heading.h3 [] [ Html.text "TextInput.writing" ]
-                , TextInput.view (exampleConfig.label ++ " (writing)")
-                    (TextInput.text (SetTextInput 4))
-                    (TextInput.writing
-                        :: attributes
-                            { setField = SetTextInput 4
+                        )
+                        state.floatInputValue
+                  )
+                , ( "TextInput.email"
+                  , TextInput.view (exampleConfig.label ++ " (email)")
+                        (TextInput.email (SetTextInput 2))
+                        (attributes
+                            { setField = SetTextInput 2
                             , onBlur = "Blurred!!!"
                             , onReset = ""
                             , onEnter = HitEnter
                             }
-                    )
-                    (Maybe.withDefault "" <| Dict.get 4 state.stringInputValues)
-                , Heading.h3 [] [ Html.text "TextInput.search" ]
-                , TextInput.view (exampleConfig.label ++ " (search)")
-                    (TextInput.search SetSearchTerm)
-                    (attributes
-                        { setField = SetSearchTerm
-                        , onBlur = "Blurred!!!"
-                        , onReset = ""
-                        , onEnter = HitEnter
-                        }
-                    )
-                    state.searchInputValue
-                , Heading.h3 [] [ text "TextInput.css" ]
-                , TextInput.view (exampleConfig.label ++ " (custom CSS)")
-                    (TextInput.text (SetTextInput 8))
-                    (TextInput.css [ Css.backgroundColor Colors.azure ]
-                        :: attributes
-                            { setField = SetTextInput 8
+                        )
+                        (Maybe.withDefault "" <| Dict.get 2 state.stringInputValues)
+                  )
+                , ( "TextInput.writing"
+                  , TextInput.view (exampleConfig.label ++ " (writing)")
+                        (TextInput.text (SetTextInput 4))
+                        (TextInput.writing
+                            :: attributes
+                                { setField = SetTextInput 4
+                                , onBlur = "Blurred!!!"
+                                , onReset = ""
+                                , onEnter = HitEnter
+                                }
+                        )
+                        (Maybe.withDefault "" <| Dict.get 4 state.stringInputValues)
+                  )
+                , ( "TextInput.search"
+                  , TextInput.view (exampleConfig.label ++ " (search)")
+                        (TextInput.search SetSearchTerm)
+                        (attributes
+                            { setField = SetSearchTerm
                             , onBlur = "Blurred!!!"
                             , onReset = ""
                             , onEnter = HitEnter
                             }
-                    )
-                    (Maybe.withDefault "" <| Dict.get 8 state.stringInputValues)
-                , Message.view
-                    [ Message.tiny
-                    , Message.tip
-                    , Message.plaintext <| "Hit enter " ++ String.fromInt state.enterCount ++ " times"
-                    ]
+                        )
+                        state.searchInputValue
+                  )
+                , ( "TextInput.css"
+                  , TextInput.view (exampleConfig.label ++ " (custom CSS)")
+                        (TextInput.text (SetTextInput 8))
+                        (TextInput.css [ Css.backgroundColor Colors.azure ]
+                            :: attributes
+                                { setField = SetTextInput 8
+                                , onBlur = "Blurred!!!"
+                                , onReset = ""
+                                , onEnter = HitEnter
+                                }
+                        )
+                        (Maybe.withDefault "" <| Dict.get 8 state.stringInputValues)
+                  )
+                ]
+            , Message.view
+                [ Message.tiny
+                , Message.tip
+                , Message.plaintext <| "Hit enter " ++ String.fromInt state.enterCount ++ " times"
                 ]
             ]
     }

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -135,19 +135,6 @@ example =
                         )
                         state.searchInputValue
                   )
-                , ( "TextInput.css"
-                  , TextInput.view (exampleConfig.label ++ " (custom CSS)")
-                        (TextInput.text (SetTextInput 8))
-                        (TextInput.css [ Css.backgroundColor Colors.azure ]
-                            :: attributes
-                                { setField = SetTextInput 8
-                                , onBlur = "Blurred!!!"
-                                , onReset = ""
-                                , onEnter = "Entered!!!"
-                                }
-                        )
-                        (Maybe.withDefault "" <| Dict.get 8 state.stringInputValues)
-                  )
                 ]
             ]
     }
@@ -214,6 +201,8 @@ controlAttributes =
             (Control.value TextInput.loading)
         |> ControlExtra.listItem "TextInput.noMargin"
             (Control.map TextInput.noMargin (Control.bool False))
+        |> ControlExtra.optionalListItem "TextInput.css"
+            (Control.value (TextInput.css [ Css.backgroundColor Colors.azure ]))
 
 
 {-| -}

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -62,21 +62,22 @@ example =
                 |> Html.fromUnstyled
             , viewExamples
                 [ ( "text"
-                  , TextInput.view (exampleConfig.label ++ " (text)")
+                  , TextInput.view exampleConfig.label
                         (TextInput.text (SetTextInput 1))
-                        (attributes
-                            { setField = SetTextInput 1
-                            , onBlur = "Blurred!!!"
-                            , onReset = ""
-                            , onEnter = "Entered!!!"
-                            }
+                        (TextInput.id "text-input__text-example"
+                            :: attributes
+                                { setField = SetTextInput 1
+                                , onBlur = "Blurred!!!"
+                                , onReset = ""
+                                , onEnter = "Entered!!!"
+                                }
                         )
                         (Maybe.withDefault "" <| Dict.get 1 state.stringInputValues)
                   )
                 , ( "number"
-                  , TextInput.view (exampleConfig.label ++ " (number)")
+                  , TextInput.view exampleConfig.label
                         (TextInput.number SetNumberInput)
-                        (TextInput.id "hey-this-is-a-test-id"
+                        (TextInput.id "text-input__number-example"
                             :: attributes
                                 { setField = SetNumberInput
                                 , onBlur = Just 10000000
@@ -87,45 +88,49 @@ example =
                         state.numberInputValue
                   )
                 , ( "float"
-                  , TextInput.view (exampleConfig.label ++ " (float)")
+                  , TextInput.view exampleConfig.label
                         (TextInput.float SetFloatInput)
-                        (attributes
-                            { setField = SetFloatInput
-                            , onBlur = Just 1.00000001
-                            , onReset = Nothing
-                            , onEnter = Just 100000001.1
-                            }
+                        (TextInput.id "text-input__float-example"
+                            :: attributes
+                                { setField = SetFloatInput
+                                , onBlur = Just 1.00000001
+                                , onReset = Nothing
+                                , onEnter = Just 100000001.1
+                                }
                         )
                         state.floatInputValue
                   )
                 , ( "password"
-                  , TextInput.view (exampleConfig.label ++ " (password)")
+                  , TextInput.view exampleConfig.label
                         (TextInput.password SetPassword)
-                        (attributes
-                            { setField = SetPassword
-                            , onBlur = "Blurred!!!"
-                            , onReset = ""
-                            , onEnter = "Entered!!!"
-                            }
+                        (TextInput.id "text-input__password-example"
+                            :: attributes
+                                { setField = SetPassword
+                                , onBlur = "Blurred!!!"
+                                , onReset = ""
+                                , onEnter = "Entered!!!"
+                                }
                         )
                         state.passwordInputValue
                   )
                 , ( "email"
-                  , TextInput.view (exampleConfig.label ++ " (email)")
+                  , TextInput.view exampleConfig.label
                         (TextInput.email (SetTextInput 2))
-                        (attributes
-                            { setField = SetTextInput 2
-                            , onBlur = "Blurred!!!"
-                            , onReset = ""
-                            , onEnter = "Entered!!!"
-                            }
+                        (TextInput.id "text-input__email-example"
+                            :: attributes
+                                { setField = SetTextInput 2
+                                , onBlur = "Blurred!!!"
+                                , onReset = ""
+                                , onEnter = "Entered!!!"
+                                }
                         )
                         (Maybe.withDefault "" <| Dict.get 2 state.stringInputValues)
                   )
                 , ( "writing"
-                  , TextInput.view (exampleConfig.label ++ " (writing)")
+                  , TextInput.view exampleConfig.label
                         (TextInput.text (SetTextInput 4))
                         (TextInput.writing
+                            :: TextInput.id "text-input__writing-example"
                             :: attributes
                                 { setField = SetTextInput 4
                                 , onBlur = "Blurred!!!"
@@ -136,14 +141,15 @@ example =
                         (Maybe.withDefault "" <| Dict.get 4 state.stringInputValues)
                   )
                 , ( "search"
-                  , TextInput.view (exampleConfig.label ++ " (search)")
+                  , TextInput.view exampleConfig.label
                         (TextInput.search SetSearchTerm)
-                        (attributes
-                            { setField = SetSearchTerm
-                            , onBlur = "Blurred!!!"
-                            , onReset = ""
-                            , onEnter = "Entered!!!"
-                            }
+                        (TextInput.id "text-input__search-example"
+                            :: attributes
+                                { setField = SetSearchTerm
+                                , onBlur = "Blurred!!!"
+                                , onReset = ""
+                                , onEnter = "Entered!!!"
+                                }
                         )
                         state.searchInputValue
                   )

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -61,7 +61,7 @@ example =
             [ Control.view UpdateControl state.control
                 |> Html.fromUnstyled
             , viewExamples
-                [ ( "TextInput.text"
+                [ ( "text"
                   , TextInput.view (exampleConfig.label ++ " (text)")
                         (TextInput.text (SetTextInput 1))
                         (attributes
@@ -73,7 +73,7 @@ example =
                         )
                         (Maybe.withDefault "" <| Dict.get 1 state.stringInputValues)
                   )
-                , ( "TextInput.number"
+                , ( "number"
                   , TextInput.view (exampleConfig.label ++ " (number)")
                         (TextInput.number SetNumberInput)
                         (TextInput.id "hey-this-is-a-test-id"
@@ -86,7 +86,7 @@ example =
                         )
                         state.numberInputValue
                   )
-                , ( "TextInput.float"
+                , ( "float"
                   , TextInput.view (exampleConfig.label ++ " (float)")
                         (TextInput.float SetFloatInput)
                         (attributes
@@ -98,7 +98,7 @@ example =
                         )
                         state.floatInputValue
                   )
-                , ( "TextInput.email"
+                , ( "email"
                   , TextInput.view (exampleConfig.label ++ " (email)")
                         (TextInput.email (SetTextInput 2))
                         (attributes
@@ -110,7 +110,7 @@ example =
                         )
                         (Maybe.withDefault "" <| Dict.get 2 state.stringInputValues)
                   )
-                , ( "TextInput.writing"
+                , ( "writing"
                   , TextInput.view (exampleConfig.label ++ " (writing)")
                         (TextInput.text (SetTextInput 4))
                         (TextInput.writing
@@ -123,7 +123,7 @@ example =
                         )
                         (Maybe.withDefault "" <| Dict.get 4 state.stringInputValues)
                   )
-                , ( "TextInput.search"
+                , ( "search"
                   , TextInput.view (exampleConfig.label ++ " (search)")
                         (TextInput.search SetSearchTerm)
                         (attributes
@@ -177,31 +177,31 @@ initControl =
     Control.record ExampleConfig
         |> Control.field "label" (Control.string "Assignment name")
         |> Control.field "attributes" controlAttributes
-        |> Control.field "TextInput.onBlur" (Control.bool False)
-        |> Control.field "TextInput.onReset" (Control.bool False)
-        |> Control.field "TextInput.onEnter" (Control.bool False)
+        |> Control.field "onBlur" (Control.bool False)
+        |> Control.field "onReset" (Control.bool False)
+        |> Control.field "onEnter" (Control.bool False)
 
 
 controlAttributes : Control (List (TextInput.Attribute msg))
 controlAttributes =
     ControlExtra.list
-        |> ControlExtra.optionalListItem "TextInput.placeholder"
+        |> ControlExtra.optionalListItem "placeholder"
             (Control.map TextInput.placeholder <|
                 Control.string "Learning with commas"
             )
-        |> ControlExtra.optionalListItem "TextInput.hiddenLabel"
+        |> ControlExtra.optionalListItem "hiddenLabel"
             (Control.value TextInput.hiddenLabel)
-        |> ControlExtra.optionalListItem "TextInput.errorIf"
+        |> ControlExtra.optionalListItem "errorIf"
             (Control.map TextInput.errorIf <| Control.bool True)
-        |> ControlExtra.optionalListItem "TextInput.errorMessage"
+        |> ControlExtra.optionalListItem "errorMessage"
             (Control.map TextInput.errorMessage <| Control.maybe True <| Control.string "The statement must be true.")
-        |> ControlExtra.optionalListItem "TextInput.disabled"
+        |> ControlExtra.optionalListItem "disabled"
             (Control.value TextInput.disabled)
-        |> ControlExtra.optionalListItem "TextInput.loading"
+        |> ControlExtra.optionalListItem "loading"
             (Control.value TextInput.loading)
-        |> ControlExtra.listItem "TextInput.noMargin"
+        |> ControlExtra.listItem "noMargin"
             (Control.map TextInput.noMargin (Control.bool False))
-        |> ControlExtra.optionalListItem "TextInput.css"
+        |> ControlExtra.optionalListItem "css"
             (Control.value (TextInput.css [ Css.backgroundColor Colors.azure ]))
 
 

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -43,8 +43,8 @@ example =
                     , TextInput.view exampleConfig.label
                         (exampleConfig.attributes
                             ++ [ TextInput.id ("text-input__" ++ name ++ "-example")
-                               , TextInput.map toString identity (SetInput index) inputType
-                               , TextInput.onInput (SetInput index)
+                               , inputType (toString >> SetInput index)
+                                    |> TextInput.map toString identity
                                , TextInput.value (Maybe.withDefault "" (Dict.get index state.inputValues))
                                ]
                             ++ List.filterMap identity

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -89,7 +89,13 @@ example =
                 , toExample
                     { name = "password"
                     , toString = identity
-                    , inputType = TextInput.password
+                    , inputType =
+                        \onInput ->
+                            TextInput.password
+                                { onInput = onInput
+                                , showPassword = state.showPassword
+                                , setShowPassword = SetShowPassword
+                                }
                     , onBlur = "Blurred!!!"
                     , onEnter = "Entered!!!"
                     }
@@ -115,6 +121,7 @@ example =
 {-| -}
 type alias State =
     { inputValues : Dict Int String
+    , showPassword : Bool
     , control : Control ExampleConfig
     }
 
@@ -123,6 +130,7 @@ type alias State =
 init : State
 init =
     { inputValues = Dict.empty
+    , showPassword = False
     , control = initControl
     }
 
@@ -172,6 +180,7 @@ controlAttributes =
 {-| -}
 type Msg
     = SetInput Int String
+    | SetShowPassword Bool
     | UpdateControl (Control ExampleConfig)
 
 
@@ -181,6 +190,11 @@ update msg state =
     case msg of
         SetInput id string ->
             ( { state | inputValues = Dict.insert id string state.inputValues }
+            , Cmd.none
+            )
+
+        SetShowPassword showPassword ->
+            ( { state | showPassword = showPassword }
             , Cmd.none
             )
 

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -10,6 +10,7 @@ import Accessibility.Styled as Html exposing (..)
 import Category exposing (Category(..))
 import Css exposing (..)
 import Debug.Control as Control exposing (Control)
+import Debug.Control.Extra as ControlExtra
 import Dict exposing (Dict)
 import Example exposing (Example)
 import Html.Styled.Attributes exposing (css)
@@ -18,17 +19,6 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Message.V3 as Message
 import Nri.Ui.TextInput.V7 as TextInput
-
-
-{-| -}
-type Msg
-    = SetTextInput Id String
-    | SetNumberInput (Maybe Int)
-    | SetFloatInput (Maybe Float)
-    | SetPassword String
-    | SetSearchTerm String
-    | UpdateControl (Control ExampleConfig)
-    | HitEnter
 
 
 {-| -}
@@ -45,13 +35,7 @@ type alias State =
 
 type alias ExampleConfig =
     { label : String
-    , maybePlaceholderAttribute : Maybe (TextInput.Attribute Msg)
-    , maybeErrorAttribute1 : Maybe (TextInput.Attribute Msg)
-    , maybeErrorAttribute2 : Maybe (TextInput.Attribute Msg)
-    , maybeShowLabelAttribute : Maybe (TextInput.Attribute Msg)
-    , maybeDisabledAttribute : Maybe (TextInput.Attribute Msg)
-    , maybeLoadingAttribute : Maybe (TextInput.Attribute Msg)
-    , noMarginAttribute : TextInput.Attribute Msg
+    , attributes : List (TextInput.Attribute Msg)
     , onBlur : Bool
     , onReset : Bool
     }
@@ -74,26 +58,20 @@ example =
                     Control.currentValue state.control
 
                 attributes { setField, onBlur, onReset, onEnter } =
-                    List.filterMap identity
-                        [ exampleConfig.maybeErrorAttribute1
-                        , exampleConfig.maybeErrorAttribute2
-                        , exampleConfig.maybePlaceholderAttribute
-                        , exampleConfig.maybeShowLabelAttribute
-                        , exampleConfig.maybeDisabledAttribute
-                        , exampleConfig.maybeLoadingAttribute
-                        , Just exampleConfig.noMarginAttribute
-                        , if exampleConfig.onBlur then
-                            Just (TextInput.onBlur (setField onBlur))
+                    exampleConfig.attributes
+                        ++ List.filterMap identity
+                            [ if exampleConfig.onBlur then
+                                Just (TextInput.onBlur (setField onBlur))
 
-                          else
-                            Nothing
-                        , if exampleConfig.onReset then
-                            Just (TextInput.onReset (setField onReset))
+                              else
+                                Nothing
+                            , if exampleConfig.onReset then
+                                Just (TextInput.onReset (setField onReset))
 
-                          else
-                            Nothing
-                        , Just <| TextInput.onEnter onEnter
-                        ]
+                              else
+                                Nothing
+                            , Just <| TextInput.onEnter onEnter
+                            ]
             in
             [ Control.view UpdateControl state.control
                 |> Html.fromUnstyled
@@ -216,29 +194,43 @@ init =
     , control =
         Control.record ExampleConfig
             |> Control.field "label" (Control.string "Assignment name")
-            |> Control.field "TextInput.placeholder"
-                (Control.maybe True <|
-                    Control.map TextInput.placeholder <|
-                        Control.string "Learning with commas"
-                )
-            |> Control.field "TextInput.hiddenLabel"
-                (Control.maybe False (Control.value TextInput.hiddenLabel))
-            |> Control.field "TextInput.errorIf"
-                (Control.maybe False (Control.map TextInput.errorIf <| Control.bool True))
-            |> Control.field "TextInput.errorMessage"
-                (Control.maybe False (Control.map TextInput.errorMessage <| Control.maybe True <| Control.string "The statement must be true."))
-            |> Control.field "TextInput.disabled"
-                (Control.maybe False (Control.value TextInput.disabled))
-            |> Control.field "TextInput.loading"
-                (Control.maybe False (Control.value TextInput.loading))
-            |> Control.field "TextInput.noMargin"
-                (Control.map TextInput.noMargin (Control.bool False))
-            |> Control.field "TextInput.onBlur"
-                (Control.bool False)
-            |> Control.field "TextInput.onReset"
-                (Control.bool False)
+            |> Control.field "attributes" controlAttributes
+            |> Control.field "TextInput.onBlur" (Control.bool False)
+            |> Control.field "TextInput.onReset" (Control.bool False)
     , enterCount = 0
     }
+
+
+controlAttributes : Control (List (TextInput.Attribute msg))
+controlAttributes =
+    ControlExtra.list
+        |> ControlExtra.optionalListItem "TextInput.placeholder"
+            (Control.map TextInput.placeholder <|
+                Control.string "Learning with commas"
+            )
+        |> ControlExtra.optionalListItem "TextInput.hiddenLabel"
+            (Control.value TextInput.hiddenLabel)
+        |> ControlExtra.optionalListItem "TextInput.errorIf"
+            (Control.map TextInput.errorIf <| Control.bool True)
+        |> ControlExtra.optionalListItem "TextInput.errorMessage"
+            (Control.map TextInput.errorMessage <| Control.maybe True <| Control.string "The statement must be true.")
+        |> ControlExtra.optionalListItem "TextInput.disabled"
+            (Control.value TextInput.disabled)
+        |> ControlExtra.optionalListItem "TextInput.loading"
+            (Control.value TextInput.loading)
+        |> ControlExtra.listItem "TextInput.noMargin"
+            (Control.map TextInput.noMargin (Control.bool False))
+
+
+{-| -}
+type Msg
+    = SetTextInput Id String
+    | SetNumberInput (Maybe Int)
+    | SetFloatInput (Maybe Float)
+    | SetPassword String
+    | SetSearchTerm String
+    | UpdateControl (Control ExampleConfig)
+    | HitEnter
 
 
 {-| -}

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -41,18 +41,12 @@ example =
                 toExample { name, toString, inputType, onBlur, onReset, onEnter } index =
                     ( name
                     , TextInput.view exampleConfig.label
-                        (TextInput.id ("text-input__" ++ name ++ "-example")
-                            :: TextInput.map
-                                toString
-                                identity
-                                (SetInput index)
-                                inputType
-                            :: TextInput.onInput (SetInput index)
-                            :: TextInput.value
-                                (Maybe.withDefault "" <|
-                                    Dict.get index state.inputValues
-                                )
-                            :: exampleConfig.attributes
+                        (exampleConfig.attributes
+                            ++ [ TextInput.id ("text-input__" ++ name ++ "-example")
+                               , TextInput.map toString identity (SetInput index) inputType
+                               , TextInput.onInput (SetInput index)
+                               , TextInput.value (Maybe.withDefault "" (Dict.get index state.inputValues))
+                               ]
                             ++ List.filterMap identity
                                 [ if exampleConfig.onBlur then
                                     Just (TextInput.onBlur (SetInput index onBlur))

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -23,26 +23,6 @@ import ViewHelpers exposing (viewExamples)
 
 
 {-| -}
-type alias State =
-    { numberInputValue : Maybe Int
-    , floatInputValue : Maybe Float
-    , stringInputValues : Dict Id String
-    , passwordInputValue : String
-    , searchInputValue : String
-    , control : Control ExampleConfig
-    , enterCount : Int
-    }
-
-
-type alias ExampleConfig =
-    { label : String
-    , attributes : List (TextInput.Attribute Msg)
-    , onBlur : Bool
-    , onReset : Bool
-    }
-
-
-{-| -}
 example : Example State Msg
 example =
     { name = "TextInput"
@@ -71,7 +51,11 @@ example =
 
                               else
                                 Nothing
-                            , Just <| TextInput.onEnter onEnter
+                            , if exampleConfig.onEnter then
+                                Just (TextInput.onEnter (setField onEnter))
+
+                              else
+                                Nothing
                             ]
             in
             [ Control.view UpdateControl state.control
@@ -84,7 +68,7 @@ example =
                             { setField = SetTextInput 1
                             , onBlur = "Blurred!!!"
                             , onReset = ""
-                            , onEnter = HitEnter
+                            , onEnter = "Entered!!!"
                             }
                         )
                         (Maybe.withDefault "" <| Dict.get 1 state.stringInputValues)
@@ -97,7 +81,7 @@ example =
                                 { setField = SetNumberInput
                                 , onBlur = Just 10000000
                                 , onReset = Nothing
-                                , onEnter = HitEnter
+                                , onEnter = Just 20000000
                                 }
                         )
                         state.numberInputValue
@@ -109,7 +93,7 @@ example =
                             { setField = SetFloatInput
                             , onBlur = Just 1.00000001
                             , onReset = Nothing
-                            , onEnter = HitEnter
+                            , onEnter = Just 100000001.1
                             }
                         )
                         state.floatInputValue
@@ -121,7 +105,7 @@ example =
                             { setField = SetTextInput 2
                             , onBlur = "Blurred!!!"
                             , onReset = ""
-                            , onEnter = HitEnter
+                            , onEnter = "Entered!!!"
                             }
                         )
                         (Maybe.withDefault "" <| Dict.get 2 state.stringInputValues)
@@ -134,7 +118,7 @@ example =
                                 { setField = SetTextInput 4
                                 , onBlur = "Blurred!!!"
                                 , onReset = ""
-                                , onEnter = HitEnter
+                                , onEnter = "Entered!!!"
                                 }
                         )
                         (Maybe.withDefault "" <| Dict.get 4 state.stringInputValues)
@@ -146,7 +130,7 @@ example =
                             { setField = SetSearchTerm
                             , onBlur = "Blurred!!!"
                             , onReset = ""
-                            , onEnter = HitEnter
+                            , onEnter = "Entered!!!"
                             }
                         )
                         state.searchInputValue
@@ -159,18 +143,24 @@ example =
                                 { setField = SetTextInput 8
                                 , onBlur = "Blurred!!!"
                                 , onReset = ""
-                                , onEnter = HitEnter
+                                , onEnter = "Entered!!!"
                                 }
                         )
                         (Maybe.withDefault "" <| Dict.get 8 state.stringInputValues)
                   )
                 ]
-            , Message.view
-                [ Message.tiny
-                , Message.tip
-                , Message.plaintext <| "Hit enter " ++ String.fromInt state.enterCount ++ " times"
-                ]
             ]
+    }
+
+
+{-| -}
+type alias State =
+    { numberInputValue : Maybe Int
+    , floatInputValue : Maybe Float
+    , stringInputValues : Dict Id String
+    , passwordInputValue : String
+    , searchInputValue : String
+    , control : Control ExampleConfig
     }
 
 
@@ -182,14 +172,27 @@ init =
     , stringInputValues = Dict.empty
     , passwordInputValue = ""
     , searchInputValue = ""
-    , control =
-        Control.record ExampleConfig
-            |> Control.field "label" (Control.string "Assignment name")
-            |> Control.field "attributes" controlAttributes
-            |> Control.field "TextInput.onBlur" (Control.bool False)
-            |> Control.field "TextInput.onReset" (Control.bool False)
-    , enterCount = 0
+    , control = initControl
     }
+
+
+type alias ExampleConfig =
+    { label : String
+    , attributes : List (TextInput.Attribute Msg)
+    , onBlur : Bool
+    , onReset : Bool
+    , onEnter : Bool
+    }
+
+
+initControl : Control ExampleConfig
+initControl =
+    Control.record ExampleConfig
+        |> Control.field "label" (Control.string "Assignment name")
+        |> Control.field "attributes" controlAttributes
+        |> Control.field "TextInput.onBlur" (Control.bool False)
+        |> Control.field "TextInput.onReset" (Control.bool False)
+        |> Control.field "TextInput.onEnter" (Control.bool False)
 
 
 controlAttributes : Control (List (TextInput.Attribute msg))
@@ -221,7 +224,6 @@ type Msg
     | SetPassword String
     | SetSearchTerm String
     | UpdateControl (Control ExampleConfig)
-    | HitEnter
 
 
 {-| -}
@@ -245,9 +247,6 @@ update msg state =
 
         UpdateControl newControl ->
             ( { state | control = newControl }, Cmd.none )
-
-        HitEnter ->
-            ( { state | enterCount = state.enterCount + 1 }, Cmd.none )
 
 
 

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -87,11 +87,11 @@ example =
                     , onEnter = "100000001.1"
                     }
                 , toExample
-                    { name = "password"
+                    { name = "newPassword"
                     , toString = identity
                     , inputType =
                         \onInput ->
-                            TextInput.password
+                            TextInput.newPassword
                                 { onInput = onInput
                                 , showPassword = state.showPassword
                                 , setShowPassword = SetShowPassword

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -98,6 +98,18 @@ example =
                         )
                         state.floatInputValue
                   )
+                , ( "password"
+                  , TextInput.view (exampleConfig.label ++ " (password)")
+                        (TextInput.password SetPassword)
+                        (attributes
+                            { setField = SetPassword
+                            , onBlur = "Blurred!!!"
+                            , onReset = ""
+                            , onEnter = "Entered!!!"
+                            }
+                        )
+                        state.passwordInputValue
+                  )
                 , ( "email"
                   , TextInput.view (exampleConfig.label ++ " (email)")
                         (TextInput.email (SetTextInput 2))

--- a/styleguide-app/ViewHelpers.elm
+++ b/styleguide-app/ViewHelpers.elm
@@ -1,0 +1,19 @@
+module ViewHelpers exposing (viewExamples)
+
+import Css
+import Html.Styled as Html exposing (Html)
+import Html.Styled.Attributes as Attributes exposing (css)
+
+
+viewExamples : List ( String, Html msg ) -> Html msg
+viewExamples examples =
+    let
+        viewExample ( name, view ) =
+            Html.tr []
+                [ Html.th [] [ Html.text name ]
+                , Html.td [] [ view ]
+                ]
+    in
+    Html.table [ css [ Css.width (Css.pct 100) ] ]
+        [ Html.tbody [] (List.map viewExample examples)
+        ]

--- a/tests/Spec/Nri/Ui/TextInput.elm
+++ b/tests/Spec/Nri/Ui/TextInput.elm
@@ -1,7 +1,7 @@
 module Spec.Nri.Ui.TextInput exposing (spec)
 
 import Html.Styled
-import Nri.Ui.TextInput.V6 as TextInput
+import Nri.Ui.TextInput.V7 as TextInput
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (..)
@@ -9,7 +9,7 @@ import Test.Html.Selector exposing (..)
 
 spec : Test
 spec =
-    describe "Nri.Ui.TextInput.V6"
+    describe "Nri.Ui.TextInput.V7"
         [ test "it uses the same DOM id that generateId produces" <|
             \() ->
                 TextInput.view "myLabel"

--- a/tests/Spec/Nri/Ui/TextInput.elm
+++ b/tests/Spec/Nri/Ui/TextInput.elm
@@ -13,9 +13,7 @@ spec =
         [ test "it uses the same DOM id that generateId produces" <|
             \() ->
                 TextInput.view "myLabel"
-                    (TextInput.text identity)
-                    []
-                    ""
+                    [ TextInput.text identity ]
                     |> Html.Styled.toUnstyled
                     |> Query.fromHtml
                     |> Query.has

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -61,6 +61,7 @@
         "Nri.Ui.Text.Writing.V1",
         "Nri.Ui.TextArea.V4",
         "Nri.Ui.TextInput.V6",
+        "Nri.Ui.TextInput.V7",
         "Nri.Ui.Tooltip.V1",
         "Nri.Ui.Tooltip.V2",
         "Nri.Ui.UiIcon.V1"


### PR DESCRIPTION
New version of TextInput that adds first class support for:
- Password input show/hide PW functionality
- Guidance that can be attached to the input when the error isn't showing

## For reviewer

Instead of looking at the whole diff, I recommend ignoring the first commit (see https://github.com/NoRedInk/noredink-ui/pull/759/files/f00b1a8e9b935eae76b46787d0802c44e6b8b217..c9da21b1cd1bb6901531ab4f5d10482ede096943). This will give you a much cleaner (although still large) view!

## Visual changes

(Note: I renamed `password` to `newPassword` in the styleguide -- see deploy preview for most-up-to-date version)

**With no guidance, no error message, and no chars**

<img width="1084" alt="" src="https://user-images.githubusercontent.com/8811312/139485441-6f7aecc8-d4ee-44a5-a43d-b3cd1736b05a.png">

**With guidance, no error message, and no chars**
<img width="1059" alt="" src="https://user-images.githubusercontent.com/8811312/139485448-cb94969d-7c58-4143-8b2a-4b3284efec4a.png">

**With guidance, error message, and no chars**
<img width="1070" alt="" src="https://user-images.githubusercontent.com/8811312/139485447-ef70cba0-7b09-413b-9ef1-f079294bbc0b.png">

**With guidance, no error message, and chars**
<img width="1071" alt="" src="https://user-images.githubusercontent.com/8811312/139485445-40e57df1-c593-4b59-a3b8-ecdd0d322d6e.png">

**With guidance, no error message, chars, and user hit "Show password"**
<img width="1065" alt="" src="https://user-images.githubusercontent.com/8811312/139485443-08c29dff-bd85-4e35-8046-db665cd3e613.png">

cc @NoRedInk/design 

## Accessibility notes

I looked around a bit online for instructions on show/hide password behavior. It seems like often folks use a checkbox or a "toggle" button. Both of these options seems strange to me since we're changing the text of the button from "Show" to "Hide".

Would love to talk through some options at some point! (I don't think this is blocking -- we should be able to merge & release and continue to iterate on the underlying implementation without changing the API) cc @krinhorn 