### PR TITLE
Tessa/use control extras

### DIFF
--- a/styleguide-app/Examples/Balloon.elm
+++ b/styleguide-app/Examples/Balloon.elm
@@ -35,26 +35,25 @@ example =
 
 {-| -}
 type alias State =
-    Control Settings
-
-
-type alias Settings =
-    { copy : String
-    , theme : Maybe ( String, Balloon.Attribute )
-    , position : Maybe ( String, Balloon.Attribute )
-    , width : Maybe ( String, Balloon.Attribute )
-    , padding : Maybe ( String, Balloon.Attribute )
+    { copy : Control String
+    , attributes : Control (List ( String, Balloon.Attribute ))
     }
 
 
-init : Control Settings
+init : State
 init =
-    Control.record Settings
-        |> Control.field "copy" (Control.string "Hello, world!")
-        |> Control.field "theme" (Control.maybe False themeOptions)
-        |> Control.field "position" (Control.maybe False positionOptions)
-        |> Control.field "width" (Control.maybe False widthOptions)
-        |> Control.field "padding" (Control.maybe False paddingOptions)
+    { copy = Control.string "Hello, world!"
+    , attributes = controlAttributes
+    }
+
+
+controlAttributes : Control (List ( String, Balloon.Attribute ))
+controlAttributes =
+    ControlExtra.list
+        |> ControlExtra.optionalListItem "theme" themeOptions
+        |> ControlExtra.optionalListItem "position" positionOptions
+        |> ControlExtra.optionalListItem "width" widthOptions
+        |> ControlExtra.optionalListItem "padding" paddingOptions
 
 
 themeOptions : Control ( String, Balloon.Attribute )
@@ -103,14 +102,20 @@ paddingOptions =
 
 {-| -}
 type Msg
-    = SetDebugControlsState (Control Settings)
+    = SetCopy (Control String)
+    | SetAttributes (Control (List ( String, Balloon.Attribute )))
 
 
 update : Msg -> State -> ( State, Cmd Msg )
 update msg state =
     case msg of
-        SetDebugControlsState newDebugControlsState ->
-            ( newDebugControlsState
+        SetCopy copy ->
+            ( { state | copy = copy }
+            , Cmd.none
+            )
+
+        SetAttributes attributes ->
+            ( { state | attributes = attributes }
             , Cmd.none
             )
 
@@ -118,26 +123,22 @@ update msg state =
 view : State -> List (Html Msg)
 view state =
     let
-        settings =
-            Control.currentValue state
+        copy =
+            Control.currentValue state.copy
 
         attributes =
-            List.filterMap identity
-                [ settings.theme
-                , settings.position
-                , settings.width
-                , settings.padding
-                ]
+            Control.currentValue state.attributes
     in
-    [ Control.view SetDebugControlsState state |> fromUnstyled
+    [ Control.view SetCopy state.copy |> fromUnstyled
+    , Control.view SetAttributes state.attributes |> fromUnstyled
     , Html.Styled.code [ css [ Css.display Css.block, Css.margin2 (Css.px 20) Css.zero ] ]
         [ text <|
             "Balloon.balloon [ "
                 ++ String.join ", " (List.map Tuple.first attributes)
                 ++ " ] "
                 ++ "\""
-                ++ settings.copy
+                ++ copy
                 ++ "\""
         ]
-    , Balloon.balloon (List.map Tuple.second attributes) (text settings.copy)
+    , Balloon.balloon (List.map Tuple.second attributes) (text copy)
     ]

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -5,6 +5,7 @@ import Category exposing (Category(..))
 import CommonControls
 import Css exposing (..)
 import Debug.Control as Control exposing (Control)
+import Debug.Control.Extra as ControlExtra
 import Example exposing (Example)
 import Html.Styled.Attributes as Attributes exposing (css, href)
 import KeyboardSupport exposing (Direction(..), Key(..))
@@ -26,26 +27,24 @@ init : State
 init =
     { show = True
     , control =
-        Control.record
-            (\a b c d e f -> List.filterMap identity [ a, b, c, d, e, f ])
-            |> Control.field "theme" controlTheme
-            |> Control.field "content" (Control.map Just controlContent)
-            |> Control.field "role" controlRole
-            |> Control.field "dismissable" controlDismissable
-            |> Control.field "css" controlCss
-            |> Control.field "icon" controlIcon
+        ControlExtra.list
+            |> ControlExtra.optionalListItem "theme" controlTheme
+            |> ControlExtra.listItem "content" controlContent
+            |> ControlExtra.optionalListItem "role" controlRole
+            |> ControlExtra.optionalListItem "dismissable" controlDismissable
+            |> ControlExtra.optionalListItem "css" controlCss
+            |> ControlExtra.optionalListItem "icon" controlIcon
     }
 
 
-controlTheme : Control (Maybe (Message.Attribute msg))
+controlTheme : Control (Message.Attribute msg)
 controlTheme =
     Control.choice
-        [ ( "not set", Control.value Nothing )
-        , ( "tip", Control.value (Just Message.tip) )
-        , ( "error", Control.value (Just Message.error) )
-        , ( "alert", Control.value (Just Message.alert) )
-        , ( "success", Control.value (Just Message.success) )
-        , ( "customTheme", Control.map Just controlCustomTheme )
+        [ ( "tip", Control.value Message.tip )
+        , ( "error", Control.value Message.error )
+        , ( "alert", Control.value Message.alert )
+        , ( "success", Control.value Message.success )
+        , ( "customTheme", controlCustomTheme )
         ]
 
 
@@ -64,13 +63,12 @@ controlCustomTheme =
             )
 
 
-controlIcon : Control (Maybe (Message.Attribute msg))
+controlIcon : Control (Message.Attribute msg)
 controlIcon =
     Control.choice
-        [ ( "not set", Control.value Nothing )
-        , ( "premiumFlag", Control.value (Just (Message.icon Pennant.premiumFlag)) )
-        , ( "lock", Control.value (Just (Message.icon UiIcon.lock)) )
-        , ( "clock", Control.value (Just (Message.icon UiIcon.clock)) )
+        [ ( "premiumFlag", Control.value (Message.icon Pennant.premiumFlag) )
+        , ( "lock", Control.value (Message.icon UiIcon.lock) )
+        , ( "clock", Control.value (Message.icon UiIcon.clock) )
         ]
 
 
@@ -123,37 +121,32 @@ controlContent =
         ]
 
 
-controlRole : Control (Maybe (Message.Attribute msg))
+controlRole : Control (Message.Attribute msg)
 controlRole =
     Control.choice
-        [ ( "not set", Control.value Nothing )
-        , ( "alertRole", Control.value (Just Message.alertRole) )
-        , ( "alertDialogRole", Control.value (Just Message.alertDialogRole) )
+        [ ( "alertRole", Control.value Message.alertRole )
+        , ( "alertDialogRole", Control.value Message.alertDialogRole )
         ]
 
 
-controlDismissable : Control (Maybe (Message.Attribute Msg))
+controlDismissable : Control (Message.Attribute Msg)
 controlDismissable =
-    Control.maybe False <|
-        Control.value (Message.onDismiss Dismiss)
+    Control.value (Message.onDismiss Dismiss)
 
 
-controlCss : Control (Maybe (Message.Attribute Msg))
+controlCss : Control (Message.Attribute Msg)
 controlCss =
     Control.choice
-        [ ( "not set", Control.value Nothing )
-        , ( "css [ border3 (px 1) dashed red ]"
+        [ ( "css [ border3 (px 1) dashed red ]"
           , Control.value
-                (Just (Message.css [ Css.border3 (Css.px 1) Css.dashed Colors.red ]))
+                (Message.css [ Css.border3 (Css.px 1) Css.dashed Colors.red ])
           )
         , ( "css [ border3 (px 2) solid purple, borderRadius4 (px 8) (px 8) zero zero ]"
           , Control.value
-                (Just
-                    (Message.css
-                        [ Css.border3 (Css.px 2) Css.solid Colors.purple
-                        , Css.borderRadius4 (Css.px 8) (Css.px 8) Css.zero Css.zero
-                        ]
-                    )
+                (Message.css
+                    [ Css.border3 (Css.px 2) Css.solid Colors.purple
+                    , Css.borderRadius4 (Css.px 8) (Css.px 8) Css.zero Css.zero
+                    ]
                 )
           )
         ]

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -11,6 +11,7 @@ import Browser.Dom as Dom
 import Category exposing (Category(..))
 import Css exposing (..)
 import Debug.Control as Control exposing (Control)
+import Debug.Control.Extra as ControlExtra
 import Example exposing (Example)
 import Html as Root
 import Html.Styled.Attributes as Attributes exposing (css)
@@ -44,10 +45,10 @@ init =
 
 controlAttributes : Control (List Modal.Attribute)
 controlAttributes =
-    Control.record (\a b c -> a :: b :: c :: [])
-        |> Control.field "Theme" controlTheme
-        |> Control.field "Title visibility" controlTitleVisibility
-        |> Control.field "Custom css" controlCss
+    ControlExtra.list
+        |> ControlExtra.listItem "Theme" controlTheme
+        |> ControlExtra.listItem "Title visibility" controlTitleVisibility
+        |> ControlExtra.listItem "Custom css" controlCss
 
 
 type alias ViewSettings =

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -154,9 +154,9 @@ initStaticExampleSettings : Control (List (Tooltip.Attribute Never))
 initStaticExampleSettings =
     ControlExtra.list
         |> ControlExtra.listItem "content" controlContent
-        |> ControlExtra.listItem "withoutTail" controlTail
         |> ControlExtra.listItem "direction" controlDirection
         |> ControlExtra.listItem "alignment" controlAlignment
+        |> ControlExtra.listItem "withoutTail" controlTail
         |> ControlExtra.listItem "width" controlWidth
         |> ControlExtra.listItem "padding" controlPadding
 

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -201,7 +201,7 @@ controlTail : Control (Tooltip.Attribute Never)
 controlTail =
     Control.map
         (\bool ->
-            if True then
+            if bool then
                 Tooltip.withoutTail
 
             else


### PR DESCRIPTION
Use `Debug.Control.Extra` list in many of the styleguide examples to make adding new attributes/settings less involved.

Updates styleguide example for:
- Balloon
- Message
- Modal
- Tooltip