### PR TITLE
Extract modal helpers for Button and ClickableText, update styleguide Modal example

### DIFF
--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -4,7 +4,7 @@ module Nri.Ui.Button.V10 exposing
     , icon, custom, css, nriDescription, testId, id
     , onClick
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
-    , small, medium, large
+    , small, medium, large, modal
     , exactWidth, boundedWidth, unboundedWidth, fillContainerWidth
     , primary, secondary, danger, premium
     , enabled, unfulfilled, disabled, error, loading, success
@@ -19,6 +19,7 @@ module Nri.Ui.Button.V10 exposing
 
   - uses ClickableAttributes
   - adds `nriDescription`, `testId`, and `id` helpers
+  - adds `modal` helper, an alias for `large` size
 
 
 # Changes from V9:
@@ -42,7 +43,7 @@ module Nri.Ui.Button.V10 exposing
 
 ## Sizing
 
-@docs small, medium, large
+@docs small, medium, large, modal
 @docs exactWidth, boundedWidth, unboundedWidth, fillContainerWidth
 
 
@@ -263,6 +264,13 @@ medium =
 large : Attribute msg
 large =
     set (\attributes -> { attributes | size = Large })
+
+
+{-| Alias for Button.large
+-}
+modal : Attribute msg
+modal =
+    large
 
 
 

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -2,7 +2,7 @@ module Nri.Ui.ClickableText.V3 exposing
     ( button
     , link
     , Attribute
-    , small, medium, large
+    , small, medium, large, modal
     , onClick
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     , icon
@@ -19,6 +19,7 @@ module Nri.Ui.ClickableText.V3 exposing
   - removes underline on hover and recolors to azureDark
   - removes bottom border
   - adds `nriDescription`, `testId`, and `id` helpers
+  - adds `modal` helper, for use in modal footers, same as applying large and Css.marginTop (Css.px 15)
 
 
 # Changes from V2
@@ -54,7 +55,7 @@ HTML `<a>` elements and are created here with `*Link` functions.
 
 ## Sizing
 
-@docs small, medium, large
+@docs small, medium, large, modal
 
 
 ## Behavior
@@ -99,6 +100,19 @@ medium =
 large : Attribute msg
 large =
     set (\attributes -> { attributes | size = Large })
+
+
+{-| For use in Modal footers (adds `large` and `Css.marginTop (Css.px 15)`)
+-}
+modal : Attribute msg
+modal =
+    set
+        (\attributes ->
+            { attributes
+                | size = Large
+                , customStyles = List.append attributes.customStyles [ Css.marginTop (Css.px 15) ]
+            }
+        )
 
 
 type Size

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -242,10 +242,9 @@ continueButtonId =
 continueButton : Html Msg
 continueButton =
     Button.button "Continue"
-        [ Button.primary
-        , Button.onClick CloseModal
-        , Button.custom [ Attributes.id continueButtonId ]
-        , Button.large
+        [ Button.onClick CloseModal
+        , Button.id continueButtonId
+        , Button.modal
         ]
 
 
@@ -258,9 +257,8 @@ closeClickableText : Html Msg
 closeClickableText =
     ClickableText.button "Close"
         [ ClickableText.onClick CloseModal
-        , ClickableText.large
-        , ClickableText.custom [ Attributes.id closeClickableTextId ]
-        , ClickableText.css [ Css.marginTop (Css.px 15) ]
+        , ClickableText.modal
+        , ClickableText.id closeClickableTextId
         ]
 
 


### PR DESCRIPTION
Extracts helpers for these styles in the modal footer buttons:
![image](https://user-images.githubusercontent.com/1555022/139719573-352809fd-7df7-490c-828b-dfd086b00364.png)
