### PR TITLE
Tessa/select with label

### DIFF
--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -5,7 +5,8 @@ Nri.Ui.Menu.V1,upgrade to V3
 Nri.Ui.Menu.V2,upgrade to V3
 Nri.Ui.Modal.V10,upgrade to V11
 Nri.Ui.RadioButton.V1,upgrade to V2
-Nri.Ui.Select.V5,upgrade to V7
+Nri.Ui.Select.V5,upgrade to V8
+Nri.Ui.Select.V7,upgrade to V8
 Nri.Ui.Table.V4,upgrade to V5
 Nri.Ui.Tabs.V6,upgrade to V7
 Nri.Ui.Text.V5,upgrade to V6

--- a/elm.json
+++ b/elm.json
@@ -51,6 +51,7 @@
         "Nri.Ui.SegmentedControl.V14",
         "Nri.Ui.Select.V5",
         "Nri.Ui.Select.V7",
+        "Nri.Ui.Select.V8",
         "Nri.Ui.Slide.V1",
         "Nri.Ui.SlideModal.V2",
         "Nri.Ui.SortableTable.V2",

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -95,7 +95,10 @@ hint = 'upgrade to V14'
 hint = 'upgrade to V14'
 
 [forbidden."Nri.Ui.Select.V5"]
-hint = 'upgrade to V7'
+hint = 'upgrade to V8'
+
+[forbidden."Nri.Ui.Select.V7"]
+hint = 'upgrade to V8'
 
 [forbidden."Nri.Ui.Table.V4"]
 hint = 'upgrade to V5'

--- a/src/InputErrorInternal.elm
+++ b/src/InputErrorInternal.elm
@@ -1,0 +1,74 @@
+module InputErrorInternal exposing
+    ( ErrorState, init
+    , setErrorIf, setErrorMessage
+    , getIsInError, getErrorMessage
+    )
+
+{-|
+
+@docs ErrorState, init
+@docs setErrorIf, setErrorMessage
+@docs getIsInError, getErrorMessage
+
+-}
+
+
+{-| -}
+type ErrorState
+    = NoError
+    | Error { message : Maybe String }
+
+
+{-| -}
+init : ErrorState
+init =
+    NoError
+
+
+{-| -}
+setErrorIf : Bool -> { config | error : ErrorState } -> { config | error : ErrorState }
+setErrorIf isInError_ config =
+    { config
+        | error =
+            if isInError_ then
+                Error { message = Nothing }
+
+            else
+                NoError
+    }
+
+
+{-| -}
+setErrorMessage : Maybe String -> { config | error : ErrorState } -> { config | error : ErrorState }
+setErrorMessage maybeMessage config =
+    { config
+        | error =
+            case maybeMessage of
+                Nothing ->
+                    NoError
+
+                Just message ->
+                    Error { message = Just message }
+    }
+
+
+{-| -}
+getIsInError : ErrorState -> Bool
+getIsInError error =
+    case error of
+        NoError ->
+            False
+
+        Error _ ->
+            True
+
+
+{-| -}
+getErrorMessage : ErrorState -> Maybe String
+getErrorMessage error =
+    case error of
+        NoError ->
+            Nothing
+
+        Error { message } ->
+            message

--- a/src/InputLabelInternal.elm
+++ b/src/InputLabelInternal.elm
@@ -1,0 +1,45 @@
+module InputLabelInternal exposing (view)
+
+{-|
+
+@docs view
+
+-}
+
+import Accessibility.Styled as Html exposing (Html)
+import Accessibility.Styled.Style as Accessibility
+import Css
+import Html.Styled.Attributes as Attributes
+import InputErrorInternal exposing (ErrorState)
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.InputStyles.V3 as InputStyles exposing (Theme)
+
+
+{-| -}
+view :
+    { for : String, label : String, theme : Theme }
+    -> { config | error : ErrorState, noMarginTop : Bool, hideLabel : Bool }
+    -> Html msg
+view { for, label, theme } config =
+    let
+        extraStyles =
+            if config.hideLabel then
+                Accessibility.invisible
+
+            else
+                []
+    in
+    Html.label
+        ([ Attributes.for for
+         , Attributes.css
+            [ InputStyles.label theme (InputErrorInternal.getIsInError config.error)
+            , if config.noMarginTop then
+                Css.top (Css.px -InputStyles.defaultMarginTop)
+
+              else
+                Css.batch []
+            ]
+         ]
+            ++ extraStyles
+        )
+        [ Html.text label ]

--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -46,7 +46,9 @@ import Nri.Ui.Colors.Extra as ColorsExtra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.CssVendorPrefix.V1 as VendorPrefixed
 import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.InputStyles.V3 as InputStyles exposing (defaultMarginTop)
+import Nri.Ui.Message.V3 as Message
 import Nri.Ui.Util
 import SolidColor
 
@@ -156,6 +158,16 @@ view label config attributes =
             , defaultDisplayText = config.defaultDisplayText
             , isInError = isInError_
             }
+        , viewJust
+            (\m ->
+                Message.view
+                    [ Message.tiny
+                    , Message.error
+                    , Message.plaintext m
+                    , Message.alertRole
+                    ]
+            )
+            (InputErrorInternal.getErrorMessage config_.error)
         ]
 
 

--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -16,7 +16,7 @@ module Nri.Ui.Select.V8 exposing
 
     - view adds a label
     - adds standard custom, nriDescription, etc. attributes
-    - switches to a list-based attribuet API from a record-based API
+    - switches to a list-based attribute API from a record-based API
 
 @docs view, generateId
 

--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -1,5 +1,6 @@
 module Nri.Ui.Select.V8 exposing
     ( view, generateId
+    , Choice, choices
     , value
     , Attribute, defaultDisplayText
     , custom, nriDescription, id, testId
@@ -11,14 +12,15 @@ module Nri.Ui.Select.V8 exposing
 
 # Changes from V5
 
-    -  view adds a label
-    - `Choice` is no longer exposed
-    - adds `generateId`
+    - view adds a label
+    - adds standard custom, nriDescription, etc. attributes
 
 @docs view, generateId
 
 
 ### Input types
+
+@docs Choice, choices
 
 
 ### Input content
@@ -121,6 +123,18 @@ testId id_ =
     custom [ Extra.testId id_ ]
 
 
+{-| A single possible choice.
+-}
+type alias Choice value =
+    { label : String, value : value }
+
+
+{-| -}
+choices : List (Choice value) -> Attribute value
+choices choices_ =
+    Attribute (\config -> { config | choices = choices_ })
+
+
 {-| Customizations for the Select.
 -}
 type Attribute value
@@ -137,6 +151,7 @@ applyConfig attributes =
 type alias Config value =
     { id : Maybe String
     , value : Maybe value
+    , choices : List (Choice value)
     , defaultDisplayText : Maybe String
     , error : ErrorState
     , custom : List (Html.Attribute Never)
@@ -147,16 +162,11 @@ defaultConfig : Config value
 defaultConfig =
     { id = Nothing
     , value = Nothing
+    , choices = []
     , defaultDisplayText = Nothing
     , error = InputErrorInternal.init
     , custom = []
     }
-
-
-{-| A single possible choice.
--}
-type alias Choice a =
-    { label : String, value : a }
 
 
 {-| A select dropdown. Remember to add a label!
@@ -164,8 +174,7 @@ type alias Choice a =
 view :
     String
     ->
-        { choices : List (Choice a)
-        , valueToString : a -> String
+        { valueToString : a -> String
         }
     -> List (Attribute a)
     -> Html a
@@ -195,7 +204,7 @@ view label config attributes =
             ]
             [ Html.text label ]
         , viewSelect
-            { choices = config.choices
+            { choices = config_.choices
             , current = config_.value
             , id = id_
             , custom = config_.custom

--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -1,0 +1,176 @@
+module Nri.Ui.Select.V7 exposing (Choice, view)
+
+{-| Build a select input.
+
+@docs Choice, view
+
+-}
+
+import Css
+import Dict
+import Html.Styled as Html exposing (Html)
+import Html.Styled.Attributes as Attributes
+import Html.Styled.Events as Events
+import Json.Decode exposing (Decoder)
+import Nri.Ui
+import Nri.Ui.Colors.Extra as ColorsExtra
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.CssVendorPrefix.V1 as VendorPrefixed
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Util
+import SolidColor
+
+
+{-| A single possible choice.
+-}
+type alias Choice a =
+    { label : String, value : a }
+
+
+{-| A select dropdown. Remember to add a label!
+-}
+view :
+    { choices : List (Choice a)
+    , current : Maybe a
+    , id : String
+    , valueToString : a -> String
+    , defaultDisplayText : Maybe String
+    , isInError : Bool
+    }
+    -> Html a
+view config =
+    let
+        valueLookup =
+            config.choices
+                |> List.map (\x -> ( niceId (config.valueToString x.value), x.value ))
+                |> Dict.fromList
+
+        decodeValue string =
+            Dict.get string valueLookup
+                |> Maybe.map Json.Decode.succeed
+                |> Maybe.withDefault
+                    -- At present, elm/virtual-dom throws this failure away.
+                    (Json.Decode.fail
+                        ("Nri.Select: could not decode the value: "
+                            ++ string
+                            ++ "\nexpected one of: "
+                            ++ String.join ", " (Dict.keys valueLookup)
+                        )
+                    )
+
+        onSelectHandler =
+            Events.on "change" (Events.targetValue |> Json.Decode.andThen decodeValue)
+
+        defaultOption =
+            config.defaultDisplayText
+                |> Maybe.map (viewDefaultChoice config.current >> List.singleton)
+                |> Maybe.withDefault []
+
+        currentVal =
+            if config.current == Nothing && config.defaultDisplayText == Nothing then
+                config.choices
+                    |> List.head
+                    |> Maybe.map .value
+
+            else
+                config.current
+    in
+    config.choices
+        |> List.map (viewChoice currentVal config.valueToString)
+        |> (++) defaultOption
+        |> Nri.Ui.styled Html.select
+            "nri-select-menu"
+            [ -- border
+              Css.border3 (Css.px 1)
+                Css.solid
+                (if config.isInError then
+                    Colors.purple
+
+                 else
+                    Colors.gray75
+                )
+            , Css.borderBottomWidth (Css.px 3)
+            , Css.borderRadius (Css.px 8)
+            , Css.focus [ Css.borderColor Colors.azure ]
+
+            -- Font and color
+            , Css.color Colors.gray20
+            , Fonts.baseFont
+            , Css.fontSize (Css.px 15)
+            , Css.fontWeight (Css.int 600)
+            , Css.textOverflow Css.ellipsis
+            , Css.overflow Css.hidden
+            , Css.whiteSpace Css.noWrap
+
+            -- Interaction
+            , Css.cursor Css.pointer
+
+            -- Size and spacing
+            , Css.height (Css.px 45)
+            , Css.width (Css.pct 100)
+            , Css.paddingLeft (Css.px 15)
+            , Css.paddingRight (Css.px 30)
+
+            -- Icons
+            , selectArrowsCss
+            ]
+            [ onSelectHandler
+            , Attributes.id config.id
+            ]
+
+
+viewDefaultChoice : Maybe a -> String -> Html a
+viewDefaultChoice current displayText =
+    Html.option
+        [ Attributes.selected (current == Nothing)
+        , Attributes.disabled True
+        ]
+        [ Html.text displayText ]
+
+
+viewChoice : Maybe a -> (a -> String) -> Choice a -> Html a
+viewChoice current toString choice =
+    let
+        isSelected =
+            current
+                |> Maybe.map ((==) choice.value)
+                |> Maybe.withDefault False
+    in
+    Html.option
+        [ Attributes.id (niceId (toString choice.value))
+        , Attributes.value (niceId (toString choice.value))
+        , Attributes.selected isSelected
+        ]
+        [ Html.text choice.label ]
+
+
+niceId : String -> String
+niceId x =
+    "nri-select-" ++ Nri.Ui.Util.dashify (Nri.Ui.Util.removePunctuation x)
+
+
+selectArrowsCss : Css.Style
+selectArrowsCss =
+    let
+        color =
+            SolidColor.toRGBString (ColorsExtra.fromCssColor Colors.azure)
+    in
+    Css.batch
+        [ """<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="12px" height="16px" viewBox="0 0 12 16"><g fill=" """
+            ++ color
+            ++ """ "><path d="M2.10847,9.341803 C1.65347,8.886103 0.91427,8.886103 0.45857,9.341803 C0.23107,9.570003 0.11697,9.868203 0.11697,10.167103 C0.11697,10.465303 0.23107,10.763503 0.45857,10.991703 L5.12547,15.657903 C5.57977,16.114303 6.31897,16.114303 6.77537,15.657903 L11.44157,10.991703 C11.89727,10.536003 11.89727,9.797503 11.44157,9.341803 C10.98657,8.886103 10.24667,8.886103 9.79167,9.341803 L5.95007,13.182703 L2.10847,9.341803 Z"/><path d="M1.991556,6.658179 C1.536659,7.11394 0.797279,7.11394 0.3416911,6.658179 C0.1140698,6.43004 0,6.13173 0,5.83325 C0,5.53476 0.1140698,5.23645 0.3416911,5.00831 L5.008185,0.34182 C5.463081,-0.11394 6.202461,-0.11394 6.65805,0.34182 L11.32454,5.00831 C11.78031,5.4639 11.78031,6.202592 11.32454,6.658179 C10.86965,7.11394 10.13027,7.11394 9.674679,6.658179 L5.833118,2.81679 L1.991556,6.658179 Z"/></g></svg> """
+            |> urlUtf8
+            |> Css.property "background"
+        , Css.backgroundColor Colors.white
+
+        -- "appearance: none" removes the default dropdown arrows
+        , VendorPrefixed.property "appearance" "none"
+        , Css.backgroundRepeat Css.noRepeat
+        , Css.property "background-position" "center right -20px"
+        , Css.backgroundOrigin Css.contentBox
+        ]
+
+
+urlUtf8 : String -> String
+urlUtf8 content =
+    """url('data:image/svg+xml;utf8,""" ++ content ++ """')"""

--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -1,5 +1,6 @@
 module Nri.Ui.Select.V8 exposing
     ( view, generateId
+    , Attribute
     , id
     , errorIf, errorMessage
     )

--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -1,6 +1,6 @@
-module Nri.Ui.Select.V7 exposing (Choice, view)
+module Nri.Ui.Select.V8 exposing (Choice, view)
 
-{-| Build a select input.
+{-| Build a select input with a label, optional guidance, and error messaging.
 
 @docs Choice, view
 

--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -1,5 +1,6 @@
 module Nri.Ui.Select.V8 exposing
     ( view, generateId
+    , value
     , Attribute
     , id
     , errorIf, errorMessage
@@ -21,6 +22,8 @@ module Nri.Ui.Select.V8 exposing
 
 
 ### Input content
+
+@docs value
 
 
 ### Input handlers
@@ -58,9 +61,15 @@ we'll automatically generate one from the label you pass in, but this can
 cause problems if you have more than one text input with the same label on
 the page. Use this to be more specific and avoid issues with duplicate IDs!
 -}
-id : String -> Attribute
+id : String -> Attribute value
 id id_ =
     Attribute (\config -> { config | id = Just id_ })
+
+
+{-| -}
+value : Maybe value -> Attribute value
+value value_ =
+    Attribute (\config -> { config | value = value_ })
 
 
 {-| Sets whether or not the field will be highlighted as having a validation error.
@@ -68,7 +77,7 @@ id id_ =
 If you have an error message to display, use `errorMessage` instead.
 
 -}
-errorIf : Bool -> Attribute
+errorIf : Bool -> Attribute value
 errorIf =
     Attribute << InputErrorInternal.setErrorIf
 
@@ -76,33 +85,35 @@ errorIf =
 {-| If `Just`, the field will be highlighted as having a validation error,
 and the given error message will be shown.
 -}
-errorMessage : Maybe String -> Attribute
+errorMessage : Maybe String -> Attribute value
 errorMessage =
     Attribute << InputErrorInternal.setErrorMessage
 
 
 {-| Customizations for the Select.
 -}
-type Attribute
-    = Attribute (Config -> Config)
+type Attribute value
+    = Attribute (Config value -> Config value)
 
 
-applyConfig : List Attribute -> Config
+applyConfig : List (Attribute value) -> Config value
 applyConfig attributes =
     List.foldl (\(Attribute update) config -> update config)
         defaultConfig
         attributes
 
 
-type alias Config =
+type alias Config value =
     { id : Maybe String
+    , value : Maybe value
     , error : ErrorState
     }
 
 
-defaultConfig : Config
+defaultConfig : Config value
 defaultConfig =
     { id = Nothing
+    , value = Nothing
     , error = InputErrorInternal.init
     }
 
@@ -119,11 +130,10 @@ view :
     String
     ->
         { choices : List (Choice a)
-        , current : Maybe a
         , valueToString : a -> String
         , defaultDisplayText : Maybe String
         }
-    -> List Attribute
+    -> List (Attribute a)
     -> Html a
 view label config attributes =
     let
@@ -152,7 +162,7 @@ view label config attributes =
             [ Html.text label ]
         , viewSelect
             { choices = config.choices
-            , current = config.current
+            , current = config_.value
             , id = id_
             , valueToString = config.valueToString
             , defaultDisplayText = config.defaultDisplayText

--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -6,6 +6,7 @@ module Nri.Ui.Select.V8 exposing
     , hiddenLabel, visibleLabel
     , errorIf, errorMessage
     , custom, nriDescription, id, testId
+    , containerCss, noMargin
     )
 
 {-| Build a select input with a label, optional guidance, and error messaging.
@@ -37,7 +38,8 @@ module Nri.Ui.Select.V8 exposing
 @docs Attribute, defaultDisplayText, autofocus
 @docs hiddenLabel, visibleLabel
 @docs errorIf, errorMessage
-@docs css, custom, nriDescription, id, testId, noMargin
+@docs custom, nriDescription, id, testId
+@docs containerCss, noMargin
 @docs disabled, loading, guidance
 
 -}
@@ -141,6 +143,21 @@ testId id_ =
     custom [ Extra.testId id_ ]
 
 
+{-| Adds CSS to the element containing the input.
+-}
+containerCss : List Css.Style -> Attribute value
+containerCss styles =
+    Attribute <|
+        \config -> { config | containerCss = config.containerCss ++ styles }
+
+
+{-| Remove default spacing from the Input.
+-}
+noMargin : Bool -> Attribute value
+noMargin removeMargin =
+    Attribute <| \config -> { config | noMarginTop = removeMargin }
+
+
 {-| A single possible choice.
 -}
 type alias Choice value =
@@ -181,6 +198,7 @@ type alias Config value =
     , error : ErrorState
     , hideLabel : Bool
     , noMarginTop : Bool
+    , containerCss : List Css.Style
     , custom : List (Html.Attribute Never)
     }
 
@@ -195,6 +213,7 @@ defaultConfig =
     , error = InputErrorInternal.init
     , hideLabel = False
     , noMarginTop = False
+    , containerCss = []
     , custom = []
     }
 
@@ -214,9 +233,15 @@ view label attributes =
     in
     Html.div
         [ css
-            [ Css.position Css.relative
-            , Css.marginTop (Css.px InputStyles.defaultMarginTop)
-            ]
+            ([ Css.position Css.relative
+             , if config.noMarginTop then
+                Css.batch []
+
+               else
+                Css.paddingTop (Css.px InputStyles.defaultMarginTop)
+             ]
+                ++ config.containerCss
+            )
         ]
         [ InputLabelInternal.view
             { for = id_

--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -12,10 +12,11 @@ module Nri.Ui.Select.V8 exposing
 {-| Build a select input with a label, optional guidance, and error messaging.
 
 
-# Changes from V5
+# Changes from V7
 
     - view adds a label
     - adds standard custom, nriDescription, etc. attributes
+    - switches to a list-based attribuet API from a record-based API
 
 @docs view, generateId
 
@@ -30,17 +31,13 @@ module Nri.Ui.Select.V8 exposing
 @docs value
 
 
-### Input handlers
-
-
 ### Attributes
 
-@docs Attribute, defaultDisplayText, autofocus
+@docs Attribute, defaultDisplayText
 @docs hiddenLabel, visibleLabel
 @docs errorIf, errorMessage
 @docs custom, nriDescription, id, testId
 @docs containerCss, noMargin
-@docs disabled, loading, guidance
 
 -}
 

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -3,7 +3,8 @@ module Nri.Ui.TextInput.V7 exposing
     , number, float, text, newPassword, currentPassword, email, search
     , value, map
     , onFocus, onBlur, onEnter
-    , Attribute, placeholder, hiddenLabel, autofocus
+    , Attribute, placeholder, autofocus
+    , hiddenLabel
     , css, custom, nriDescription, id, testId, noMargin
     , disabled, loading, errorIf, errorMessage, guidance
     , writing
@@ -40,7 +41,8 @@ module Nri.Ui.TextInput.V7 exposing
 
 ### Attributes
 
-@docs Attribute, placeholder, hiddenLabel, autofocus
+@docs Attribute, placeholder, autofocus
+@docs hiddenLabel, visibleLabel
 @docs css, custom, nriDescription, id, testId, noMargin
 @docs disabled, loading, errorIf, errorMessage, guidance
 @docs writing
@@ -55,6 +57,7 @@ import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes as Attributes exposing (..)
 import Html.Styled.Events as Events
 import InputErrorInternal exposing (ErrorState)
+import InputLabelInternal
 import Keyboard.Event exposing (KeyboardEvent)
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.ClickableText.V3 as ClickableText
@@ -307,6 +310,14 @@ hiddenLabel : Attribute value msg
 hiddenLabel =
     Attribute emptyEventsAndValues <|
         \config -> { config | hideLabel = True }
+
+
+{-| Default behavior.
+-}
+visibleLabel : Attribute value msg
+visibleLabel =
+    Attribute emptyEventsAndValues <|
+        \config -> { config | hideLabel = False }
 
 
 {-| Causes the TextInput to produce the given `msg` when the field is focused.
@@ -656,28 +667,12 @@ view label attributes =
                    ]
             )
             []
-        , let
-            extraStyles =
-                if config.hideLabel then
-                    Accessibility.invisible
-
-                else
-                    []
-          in
-          Html.label
-            ([ for idValue
-             , Attributes.css
-                [ InputStyles.label config.inputStyle isInError
-                , if config.noMarginTop then
-                    Css.top (Css.px -defaultMarginTop)
-
-                  else
-                    Css.batch []
-                ]
-             ]
-                ++ extraStyles
-            )
-            [ Html.text label ]
+        , InputLabelInternal.view
+            { for = idValue
+            , label = label
+            , theme = config.inputStyle
+            }
+            config
         , Maybe.map2
             (\view_ onStringInput_ ->
                 view_

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -38,7 +38,7 @@ module Nri.Ui.TextInput.V7 exposing
 @docs onFocus, onBlur, onEnter
 
 
-## Attributes
+### Attributes
 
 @docs Attribute, placeholder, hiddenLabel, autofocus
 @docs css, custom, nriDescription, id, testId, noMargin
@@ -742,7 +742,7 @@ view label attributes =
         ]
 
 
-{-| Gives you the DOM element id that will be used by a `TextInput.view` with the given label.
+{-| Gives you the default DOM element id that will be used by a `TextInput.view` with the given label.
 This is for use when you need the DOM element id for use in javascript (such as trigger an event to focus a particular text input)
 -}
 generateId : String -> String

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -4,7 +4,7 @@ module Nri.Ui.TextInput.V7 exposing
     , value, map
     , onFocus, onBlur, onEnter
     , Attribute, placeholder, autofocus
-    , hiddenLabel
+    , hiddenLabel, visibleLabel
     , css, custom, nriDescription, id, testId, noMargin
     , disabled, loading, errorIf, errorMessage, guidance
     , writing

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -20,7 +20,7 @@ import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Colors.Extra exposing (fromCssColor, toCssColor)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
-import Nri.Ui.Select.V7 as Select
+import Nri.Ui.Select.V8 as Select
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Tooltip.V2 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -20,7 +20,6 @@ import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Colors.Extra exposing (fromCssColor, toCssColor)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
-import Nri.Ui.Select.V8 as Select
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Tooltip.V2 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -30,14 +30,12 @@ example =
     , keyboardSupport = []
     , view =
         \state ->
-            let
-                attributes : Settings
-                attributes =
-                    Control.currentValue state.attributes
-            in
-            [ Control.view UpdateAttributes state.attributes
+            [ Control.view UpdateLabel state.label
                 |> Html.Styled.fromUnstyled
-            , Select.view "Tortilla Selector" attributes
+            , Control.view UpdateAttributes state.attributes
+                |> Html.Styled.fromUnstyled
+            , Select.view (Control.currentValue state.label)
+                (Control.currentValue state.attributes)
                 |> Html.Styled.map ConsoleLog
             ]
     }
@@ -45,14 +43,16 @@ example =
 
 {-| -}
 type alias State =
-    { attributes : Control Settings
+    { label : Control String
+    , attributes : Control Settings
     }
 
 
 {-| -}
 init : State
 init =
-    { attributes = initControls
+    { label = Control.string "Tortilla Selector"
+    , attributes = initControls
     }
 
 
@@ -98,6 +98,7 @@ initChoices =
 {-| -}
 type Msg
     = ConsoleLog String
+    | UpdateLabel (Control String)
     | UpdateAttributes (Control Settings)
 
 
@@ -111,6 +112,11 @@ update msg state =
                     Debug.log "SelectExample" message
             in
             ( state, Cmd.none )
+
+        UpdateLabel label ->
+            ( { state | label = label }
+            , Cmd.none
+            )
 
         UpdateAttributes attributes ->
             ( { state | attributes = attributes }

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -12,7 +12,7 @@ import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Example exposing (Example)
 import Html.Styled
-import Html.Styled.Attributes
+import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Select.V8 as Select exposing (Choice)
@@ -30,12 +30,33 @@ example =
     , keyboardSupport = []
     , view =
         \state ->
+            let
+                label =
+                    Control.currentValue state.label
+
+                ( attributesCode, attributes ) =
+                    List.unzip (Control.currentValue state.attributes)
+            in
             [ Control.view UpdateLabel state.label
                 |> Html.Styled.fromUnstyled
             , Control.view UpdateAttributes state.attributes
                 |> Html.Styled.fromUnstyled
-            , Select.view (Control.currentValue state.label)
-                (Control.currentValue state.attributes)
+            , Html.Styled.code
+                [ css
+                    [ Css.display Css.block
+                    , Css.margin2 (Css.px 20) Css.zero
+                    , Css.whiteSpace Css.preWrap
+                    ]
+                ]
+                [ Html.Styled.text <|
+                    "Select.view \""
+                        ++ label
+                        ++ "\""
+                        ++ "\n    [ "
+                        ++ String.join "\n    , " attributesCode
+                        ++ "\n    ] "
+                ]
+            , Select.view label attributes
                 |> Html.Styled.map ConsoleLog
             ]
     }
@@ -57,39 +78,73 @@ init =
 
 
 type alias Settings =
-    List (Select.Attribute String)
+    List ( String, Select.Attribute String )
 
 
 initControls : Control Settings
 initControls =
     ControlExtra.list
         |> ControlExtra.listItem "choices"
-            (Control.map (Select.choices identity) initChoices)
+            (Control.map
+                (\( code, choices ) ->
+                    ( "Select.choices identity" ++ code
+                    , Select.choices identity choices
+                    )
+                )
+                initChoices
+            )
         |> ControlExtra.optionalListItem "defaultDisplayText"
-            (Control.map Select.defaultDisplayText <|
-                Control.string "Select a tasty tortilla based treat!"
+            (Control.map
+                (\str ->
+                    ( "Select.defaultDisplayText \"" ++ str ++ "\""
+                    , Select.defaultDisplayText str
+                    )
+                )
+                (Control.string "Select a tasty tortilla based treat!")
             )
-        |> ControlExtra.optionalListItem "errorIf"
-            (Control.map Select.errorIf <| Control.bool True)
+        |> ControlExtra.listItem "errorIf"
+            (Control.map
+                (\bool ->
+                    ( "Select.errorIf " ++ Debug.toString bool
+                    , Select.errorIf bool
+                    )
+                )
+                (Control.bool False)
+            )
         |> ControlExtra.optionalListItem "errorMessage"
-            (Control.map (Just >> Select.errorMessage) <|
-                Control.string "The right item must be selected."
+            (Control.map
+                (\str ->
+                    ( "Select.errorMessage (Just \"" ++ str ++ "\")"
+                    , Select.errorMessage (Just str)
+                    )
+                )
+                (Control.string "The right item must be selected.")
             )
 
 
-initChoices : Control (List (Choice String))
+initChoices : Control ( String, List (Choice String) )
 initChoices =
     Control.choice
         [ ( "Short choices"
-          , [ { label = "Tacos", value = "tacos" }
-            , { label = "Burritos", value = "burritos" }
-            , { label = "Enchiladas", value = "enchiladas" }
-            ]
+          , ( """
+        [ { label = "Tacos", value = "tacos" }
+        , { label = "Burritos", value = "burritos" }
+        , { label = "Enchiladas", value = "enchiladas" }
+        ]"""
+            , [ { label = "Tacos", value = "tacos" }
+              , { label = "Burritos", value = "burritos" }
+              , { label = "Enchiladas", value = "enchiladas" }
+              ]
+            )
                 |> Control.value
           )
         , ( "Overflowing text choices"
-          , [ { label = "Look at me, I design coastlines, I got an award for Norway. Where's the sense in that? My mistress' eyes are nothing like the sun. Coral be far more red than her lips red.", value = "design-coastlines" }
-            ]
+          , ( """
+        [ { label = "Look at me, I design coastlines, I got an award for Norway. Where's the sense in that? My mistress' eyes are nothing like the sun. Coral be far more red than her lips red.", value = "design-coastlines" }
+        ]"""
+            , [ { label = "Look at me, I design coastlines, I got an award for Norway. Where's the sense in that? My mistress' eyes are nothing like the sun. Coral be far more red than her lips red.", value = "design-coastlines" }
+              ]
+            )
                 |> Control.value
           )
         ]

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -44,7 +44,6 @@ example =
                     , { label = "Enchiladas", value = "Enchiladas" }
                     ]
                 , valueToString = identity
-                , defaultDisplayText = Just "Select a tasty tortilla based treat!"
                 }
                 attributes
                 |> Html.Styled.map ConsoleLog
@@ -53,9 +52,9 @@ example =
                 [ Select.view "Selector with Overflowed Text"
                     { choices = []
                     , valueToString = identity
-                    , defaultDisplayText = Just "Look at me, I design coastlines, I got an award for Norway. Where's the sense in that?"
                     }
-                    []
+                    [ Select.defaultDisplayText "Look at me, I design coastlines, I got an award for Norway. Where's the sense in that?"
+                    ]
                     |> Html.Styled.map ConsoleLog
                 ]
             ]
@@ -82,10 +81,16 @@ type alias Settings =
 initControls : Control Settings
 initControls =
     ControlExtra.list
+        |> ControlExtra.optionalListItem "defaultDisplayText"
+            (Control.map Select.defaultDisplayText <|
+                Control.string "Select a tasty tortilla based treat!"
+            )
         |> ControlExtra.optionalListItem "errorIf"
             (Control.map Select.errorIf <| Control.bool True)
         |> ControlExtra.optionalListItem "errorMessage"
-            (Control.map (Just >> Select.errorMessage) <| Control.string "The right item must be selected.")
+            (Control.map (Just >> Select.errorMessage) <|
+                Control.string "The right item must be selected."
+            )
 
 
 {-| -}

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -28,47 +28,38 @@ example =
     , keyboardSupport = []
     , view =
         \state ->
-            [ Html.Styled.label
-                [ Html.Styled.Attributes.for "tortilla-selector" ]
-                [ Heading.h3 [] [ Html.Styled.text "Tortilla Selector" ] ]
-            , Select.view
+            [ Select.view "Tortilla Selector"
                 { current = Nothing
                 , choices =
                     [ { label = "Tacos", value = "Tacos" }
                     , { label = "Burritos", value = "Burritos" }
                     , { label = "Enchiladas", value = "Enchiladas" }
                     ]
-                , id = "tortilla-selector"
                 , valueToString = identity
                 , defaultDisplayText = Just "Select a tasty tortilla based treat!"
                 , isInError = False
                 }
+                []
                 |> Html.Styled.map ConsoleLog
-            , Html.Styled.label
-                [ Html.Styled.Attributes.for "errored-selector" ]
-                [ Heading.h3 [] [ Html.Styled.text "Errored Selector" ] ]
-            , Select.view
+            , Select.view "Errored Selector"
                 { current = Nothing
                 , choices = []
-                , id = "errored-selector"
                 , valueToString = identity
                 , defaultDisplayText = Just "Please select an option"
                 , isInError = True
                 }
+                []
                 |> Html.Styled.map ConsoleLog
-            , Html.Styled.label
-                [ Html.Styled.Attributes.for "overflowed-selector" ]
-                [ Heading.h3 [] [ Html.Styled.text "Selector with Overflowed Text" ] ]
             , Html.Styled.div
                 [ Html.Styled.Attributes.css [ Css.maxWidth (Css.px 400) ] ]
-                [ Select.view
+                [ Select.view "Selector with Overflowed Text"
                     { current = Nothing
                     , choices = []
-                    , id = "overflowed-selector"
                     , valueToString = identity
                     , defaultDisplayText = Just "Look at me, I design coastlines, I got an award for Norway. Where's the sense in that?"
                     , isInError = False
                     }
+                    []
                     |> Html.Styled.map ConsoleLog
                 ]
             ]

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -14,6 +14,7 @@ import Example exposing (Example)
 import Html.Styled
 import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Direction(..), Key(..))
+import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Select.V8 as Select exposing (Choice)
 
@@ -41,23 +42,28 @@ example =
                 |> Html.Styled.fromUnstyled
             , Control.view UpdateAttributes state.attributes
                 |> Html.Styled.fromUnstyled
-            , Html.Styled.code
-                [ css
-                    [ Css.display Css.block
-                    , Css.margin2 (Css.px 20) Css.zero
-                    , Css.whiteSpace Css.preWrap
+            , Html.Styled.div
+                [ css [ Css.displayFlex, Css.alignItems Css.flexStart ]
+                ]
+                [ Html.Styled.code
+                    [ css
+                        [ Css.display Css.block
+                        , Css.margin2 (Css.px 20) Css.zero
+                        , Css.whiteSpace Css.preWrap
+                        , Css.maxWidth (Css.px 500)
+                        ]
                     ]
+                    [ Html.Styled.text <|
+                        "Select.view \""
+                            ++ label
+                            ++ "\""
+                            ++ "\n    [ "
+                            ++ String.join "\n    , " attributesCode
+                            ++ "\n    ] "
+                    ]
+                , Select.view label attributes
+                    |> Html.Styled.map ConsoleLog
                 ]
-                [ Html.Styled.text <|
-                    "Select.view \""
-                        ++ label
-                        ++ "\""
-                        ++ "\n    [ "
-                        ++ String.join "\n    , " attributesCode
-                        ++ "\n    ] "
-                ]
-            , Select.view label attributes
-                |> Html.Styled.map ConsoleLog
             ]
     }
 
@@ -104,14 +110,39 @@ initControls =
                 )
                 (Control.string "Select a tasty tortilla based treat!")
             )
-        |> ControlExtra.listItem "errorIf"
+        |> ControlExtra.optionalListItem "containerCss"
+            (Control.choice
+                [ ( "flex-basis: 300px"
+                  , Control.value
+                        ( "Select.containerCss [ Css.flexBasis (Css.px 300) ]"
+                        , Select.containerCss [ Css.flexBasis (Css.px 300) ]
+                        )
+                  )
+                , ( "background-color: lichen"
+                  , Control.value
+                        ( "Select.containerCss [ Css.backgroundColor Colors.lichen ]"
+                        , Select.containerCss [ Css.backgroundColor Colors.lichen ]
+                        )
+                  )
+                ]
+            )
+        |> ControlExtra.optionalListItem "noMargin"
+            (Control.map
+                (\bool ->
+                    ( "Select.noMargin " ++ Debug.toString bool
+                    , Select.noMargin bool
+                    )
+                )
+                (Control.bool True)
+            )
+        |> ControlExtra.optionalListItem "errorIf"
             (Control.map
                 (\bool ->
                     ( "Select.errorIf " ++ Debug.toString bool
                     , Select.errorIf bool
                     )
                 )
-                (Control.bool False)
+                (Control.bool True)
             )
         |> ControlExtra.optionalListItem "errorMessage"
             (Control.map

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -37,7 +37,6 @@ example =
                     ]
                 , valueToString = identity
                 , defaultDisplayText = Just "Select a tasty tortilla based treat!"
-                , isInError = False
                 }
                 []
                 |> Html.Styled.map ConsoleLog
@@ -46,9 +45,9 @@ example =
                 , choices = []
                 , valueToString = identity
                 , defaultDisplayText = Just "Please select an option"
-                , isInError = True
                 }
-                []
+                [ Select.errorIf True
+                ]
                 |> Html.Styled.map ConsoleLog
             , Html.Styled.div
                 [ Html.Styled.Attributes.css [ Css.maxWidth (Css.px 400) ] ]
@@ -57,7 +56,6 @@ example =
                     , choices = []
                     , valueToString = identity
                     , defaultDisplayText = Just "Look at me, I design coastlines, I got an award for Norway. Where's the sense in that?"
-                    , isInError = False
                     }
                     []
                     |> Html.Styled.map ConsoleLog

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -39,13 +39,6 @@ example =
                 |> Html.Styled.fromUnstyled
             , Select.view "Tortilla Selector" attributes
                 |> Html.Styled.map ConsoleLog
-            , Html.Styled.div
-                [ Html.Styled.Attributes.css [ Css.maxWidth (Css.px 400) ] ]
-                [ Select.view "Selector with Overflowed Text"
-                    [ Select.defaultDisplayText "Look at me, I design coastlines, I got an award for Norway. Where's the sense in that?"
-                    ]
-                    |> Html.Styled.map ConsoleLog
-                ]
             ]
     }
 
@@ -86,19 +79,20 @@ initControls =
 
 initChoices : Control (List (Choice String))
 initChoices =
-    ControlExtra.list
-        |> initChoice "value-1" "Tacos"
-        |> initChoice "value-2" "Burritos"
-        |> initChoice "value-3" "Enchiladas"
-
-
-initChoice : String -> String -> Control (List (Choice String)) -> Control (List (Choice String))
-initChoice value default =
-    let
-        toChoice label =
-            { label = label, value = value }
-    in
-    ControlExtra.listItem value (Control.map toChoice (Control.string default))
+    Control.choice
+        [ ( "Short choices"
+          , [ { label = "Tacos", value = "tacos" }
+            , { label = "Burritos", value = "burritos" }
+            , { label = "Enchiladas", value = "enchiladas" }
+            ]
+                |> Control.value
+          )
+        , ( "Overflowing text choices"
+          , [ { label = "Look at me, I design coastlines, I got an award for Norway. Where's the sense in that? My mistress' eyes are nothing like the sun. Coral be far more red than her lips red.", value = "design-coastlines" }
+            ]
+                |> Control.value
+          )
+        ]
 
 
 {-| -}

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -37,16 +37,11 @@ example =
             in
             [ Control.view UpdateAttributes state.attributes
                 |> Html.Styled.fromUnstyled
-            , Select.view "Tortilla Selector"
-                { valueToString = identity
-                }
-                attributes
+            , Select.view "Tortilla Selector" attributes
                 |> Html.Styled.map ConsoleLog
             , Html.Styled.div
                 [ Html.Styled.Attributes.css [ Css.maxWidth (Css.px 400) ] ]
                 [ Select.view "Selector with Overflowed Text"
-                    { valueToString = identity
-                    }
                     [ Select.defaultDisplayText "Look at me, I design coastlines, I got an award for Norway. Where's the sense in that?"
                     ]
                     |> Html.Styled.map ConsoleLog
@@ -76,7 +71,7 @@ initControls : Control Settings
 initControls =
     ControlExtra.list
         |> ControlExtra.listItem "choices"
-            (Control.map Select.choices initChoices)
+            (Control.map (Select.choices identity) initChoices)
         |> ControlExtra.optionalListItem "defaultDisplayText"
             (Control.map Select.defaultDisplayText <|
                 Control.string "Select a tasty tortilla based treat!"

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -6,6 +6,7 @@ module Examples.Select exposing (Msg, State, example)
 
 -}
 
+import Accessibility.Styled.Key as Key
 import Category exposing (Category(..))
 import Css
 import Debug.Control as Control exposing (Control)
@@ -29,7 +30,14 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Inputs ]
     , keyboardSupport = []
-    , preview = []
+    , preview =
+        [ Select.view "Label" [ Select.custom [ Key.tabbable False ] ]
+        , Select.view "Hidden label"
+            [ Select.hiddenLabel
+            , Select.defaultDisplayText "Hidden label"
+            , Select.custom [ Key.tabbable False ]
+            ]
+        ]
     , view =
         \state ->
             let

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -15,7 +15,7 @@ import Html.Styled
 import Html.Styled.Attributes
 import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Heading.V2 as Heading
-import Nri.Ui.Select.V8 as Select
+import Nri.Ui.Select.V8 as Select exposing (Choice)
 
 
 {-| -}
@@ -38,20 +38,14 @@ example =
             [ Control.view UpdateAttributes state.attributes
                 |> Html.Styled.fromUnstyled
             , Select.view "Tortilla Selector"
-                { choices =
-                    [ { label = "Tacos", value = "Tacos" }
-                    , { label = "Burritos", value = "Burritos" }
-                    , { label = "Enchiladas", value = "Enchiladas" }
-                    ]
-                , valueToString = identity
+                { valueToString = identity
                 }
                 attributes
                 |> Html.Styled.map ConsoleLog
             , Html.Styled.div
                 [ Html.Styled.Attributes.css [ Css.maxWidth (Css.px 400) ] ]
                 [ Select.view "Selector with Overflowed Text"
-                    { choices = []
-                    , valueToString = identity
+                    { valueToString = identity
                     }
                     [ Select.defaultDisplayText "Look at me, I design coastlines, I got an award for Norway. Where's the sense in that?"
                     ]
@@ -81,6 +75,8 @@ type alias Settings =
 initControls : Control Settings
 initControls =
     ControlExtra.list
+        |> ControlExtra.listItem "choices"
+            (Control.map Select.choices initChoices)
         |> ControlExtra.optionalListItem "defaultDisplayText"
             (Control.map Select.defaultDisplayText <|
                 Control.string "Select a tasty tortilla based treat!"
@@ -91,6 +87,23 @@ initControls =
             (Control.map (Just >> Select.errorMessage) <|
                 Control.string "The right item must be selected."
             )
+
+
+initChoices : Control (List (Choice String))
+initChoices =
+    ControlExtra.list
+        |> initChoice "value-1" "Tacos"
+        |> initChoice "value-2" "Burritos"
+        |> initChoice "value-3" "Enchiladas"
+
+
+initChoice : String -> String -> Control (List (Choice String)) -> Control (List (Choice String))
+initChoice value default =
+    let
+        toChoice label =
+            { label = label, value = value }
+    in
+    ControlExtra.listItem value (Control.map toChoice (Control.string default))
 
 
 {-| -}

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -93,6 +93,8 @@ initControls =
                 )
                 initChoices
             )
+        |> ControlExtra.optionalListItem "hiddenLabel"
+            (Control.value ( "Select.hiddenLabel", Select.hiddenLabel ))
         |> ControlExtra.optionalListItem "defaultDisplayText"
             (Control.map
                 (\str ->

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -13,14 +13,14 @@ import Html.Styled
 import Html.Styled.Attributes
 import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Heading.V2 as Heading
-import Nri.Ui.Select.V7 as Select
+import Nri.Ui.Select.V8 as Select
 
 
 {-| -}
 example : Example State Msg
 example =
     { name = "Select"
-    , version = 7
+    , version = 8
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -31,14 +31,14 @@ example =
     , view =
         \state ->
             let
+                attributes : Settings
                 attributes =
                     Control.currentValue state.attributes
             in
             [ Control.view UpdateAttributes state.attributes
                 |> Html.Styled.fromUnstyled
             , Select.view "Tortilla Selector"
-                { current = Nothing
-                , choices =
+                { choices =
                     [ { label = "Tacos", value = "Tacos" }
                     , { label = "Burritos", value = "Burritos" }
                     , { label = "Enchiladas", value = "Enchiladas" }
@@ -51,8 +51,7 @@ example =
             , Html.Styled.div
                 [ Html.Styled.Attributes.css [ Css.maxWidth (Css.px 400) ] ]
                 [ Select.view "Selector with Overflowed Text"
-                    { current = Nothing
-                    , choices = []
+                    { choices = []
                     , valueToString = identity
                     , defaultDisplayText = Just "Look at me, I design coastlines, I got an award for Norway. Where's the sense in that?"
                     }
@@ -65,7 +64,7 @@ example =
 
 {-| -}
 type alias State =
-    { attributes : Control (List Select.Attribute)
+    { attributes : Control Settings
     }
 
 
@@ -76,7 +75,11 @@ init =
     }
 
 
-initControls : Control (List Select.Attribute)
+type alias Settings =
+    List (Select.Attribute String)
+
+
+initControls : Control Settings
 initControls =
     ControlExtra.list
         |> ControlExtra.optionalListItem "errorIf"
@@ -88,7 +91,7 @@ initControls =
 {-| -}
 type Msg
     = ConsoleLog String
-    | UpdateAttributes (Control (List Select.Attribute))
+    | UpdateAttributes (Control Settings)
 
 
 {-| -}

--- a/styleguide-app/Examples/Svg.elm
+++ b/styleguide-app/Examples/Svg.elm
@@ -17,7 +17,7 @@ import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.Extra exposing (fromCssColor, toCssColor)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
-import Nri.Ui.Select.V7 as Select
+import Nri.Ui.Select.V8 as Select
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.UiIcon.V1 as UiIcon
 import SolidColor exposing (SolidColor)

--- a/styleguide-app/Examples/Svg.elm
+++ b/styleguide-app/Examples/Svg.elm
@@ -17,7 +17,6 @@ import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.Extra exposing (fromCssColor, toCssColor)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
-import Nri.Ui.Select.V8 as Select
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.UiIcon.V1 as UiIcon
 import SolidColor exposing (SolidColor)

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -47,6 +47,7 @@
         "Nri.Ui.SegmentedControl.V14",
         "Nri.Ui.Select.V5",
         "Nri.Ui.Select.V7",
+        "Nri.Ui.Select.V8",
         "Nri.Ui.Slide.V1",
         "Nri.Ui.SlideModal.V2",
         "Nri.Ui.SortableTable.V2",


### PR DESCRIPTION
Fixes https://github.com/NoRedInk/noredink-ui/issues/680. 

Relevant to work in https://github.com/NoRedInk/NoRedInk/pull/36205 (I was really struggling to get the elements to line up, and I think the problem stemmed from inconsistent labels in noredink-ui!)

Adds more fully-featured Select.V8 that includes a label.


<img width="1198" alt="Screen Shot 2021-11-04 at 12 51 52 PM" src="https://user-images.githubusercontent.com/8811312/140410574-b1fc5ac6-5987-4420-984b-f74f60edd550.png">

@NoRedInk/design 


---

For reviewer -- I suggest ignoring the first commit! it's a straight copy, no changes. https://github.com/NoRedInk/noredink-ui/pull/773/files/efa89877ec90ee2f780cef21b7f7c51d270d0118..2e7a95a8224a222112ecc286818d77424ecfffa8