### PR TITLE
Elm style helpers for working with conditional styles

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -21,6 +21,7 @@
         "Nri.Ui.Colors.Extra",
         "Nri.Ui.Colors.V1",
         "Nri.Ui.Confetti.V2",
+        "Nri.Ui.Css.V1",
         "Nri.Ui.CssVendorPrefix.V1",
         "Nri.Ui.Data.PremiumLevel",
         "Nri.Ui.DisclosureIndicator.V2",

--- a/src/Nri/Ui/Css/V1.elm
+++ b/src/Nri/Ui/Css/V1.elm
@@ -6,7 +6,7 @@ module Nri.Ui.Css.V1 exposing (styleIf, styleJust)
 
 -}
 
-import Css exposing (Style, property)
+import Css exposing (Style, batch)
 
 
 {-| Apply a style only if a condition is `True`.
@@ -17,7 +17,7 @@ styleIf view condition =
         view ()
 
     else
-        property "-nri" "noop"
+        batch []
 
 
 {-| Apply a style if the `Maybe` is a `Just`, otherwise apply nothing.
@@ -29,4 +29,4 @@ styleJust view maybe =
             view whatever
 
         Nothing ->
-            property "-nri" "noop"
+            batch []

--- a/src/Nri/Ui/Css/V1.elm
+++ b/src/Nri/Ui/Css/V1.elm
@@ -11,10 +11,10 @@ import Css exposing (Style, batch)
 
 {-| Apply a style only if a condition is `True`.
 -}
-styleIf : (() -> Style) -> Bool -> Style
-styleIf view condition =
+styleIf : Bool -> Style -> Style
+styleIf condition view =
     if condition then
-        view ()
+        view
 
     else
         batch []

--- a/src/Nri/Ui/Css/V1.elm
+++ b/src/Nri/Ui/Css/V1.elm
@@ -1,0 +1,26 @@
+module Nri.Ui.Css.V1 exposing (..)
+
+import Css exposing (Style, property)
+
+
+{-| Apply a style only if a condition is `True`.
+-}
+styleIf : (() -> Style) -> Bool -> Style
+styleIf view condition =
+    if condition then
+        view ()
+
+    else
+        property "-nri" "noop"
+
+
+{-| View value of if `Maybe` is a `Just`, otherwise show nothing.
+-}
+styleJust : (a -> Style) -> Maybe a -> Style
+styleJust view maybe =
+    case maybe of
+        Just whatever ->
+            view whatever
+
+        Nothing ->
+            property "-nri" "noop"

--- a/src/Nri/Ui/Css/V1.elm
+++ b/src/Nri/Ui/Css/V1.elm
@@ -1,5 +1,11 @@
 module Nri.Ui.Css.V1 exposing (styleIf, styleJust)
 
+{-|
+
+@docs styleIf, styleJust
+
+-}
+
 import Css exposing (Style, property)
 
 
@@ -14,7 +20,7 @@ styleIf view condition =
         property "-nri" "noop"
 
 
-{-| View value of if `Maybe` is a `Just`, otherwise show nothing.
+{-| Apply a style if the `Maybe` is a `Just`, otherwise apply nothing.
 -}
 styleJust : (a -> Style) -> Maybe a -> Style
 styleJust view maybe =

--- a/src/Nri/Ui/Css/V1.elm
+++ b/src/Nri/Ui/Css/V1.elm
@@ -1,4 +1,4 @@
-module Nri.Ui.Css.V1 exposing (..)
+module Nri.Ui.Css.V1 exposing (styleIf, styleJust)
 
 import Css exposing (Style, property)
 

--- a/src/Nri/Ui/Css/V1.elm
+++ b/src/Nri/Ui/Css/V1.elm
@@ -9,15 +9,17 @@ module Nri.Ui.Css.V1 exposing (styleIf, styleJust)
 import Css exposing (Style, batch)
 
 
-{-| Apply a style only if a condition is `True`.
+{-| Apply a list of styles only if a condition is `True`.
 -}
-styleIf : Bool -> Style -> Style
-styleIf condition view =
-    if condition then
-        view
+styleIf : Bool -> List Style -> Style
+styleIf condition stuff =
+    batch
+        (if condition then
+            stuff
 
-    else
-        batch []
+         else
+            []
+        )
 
 
 {-| Apply a style if the `Maybe` is a `Just`, otherwise apply nothing.


### PR DESCRIPTION
Working with conditional styles can be awkward sometimes.  For example I recently needed to make the `backgroundColor` conditional in the following code: 

```
[ flexGrow (num 1)
, flexShrink zero
, displayFlex
, flexDirection column
, bottom zero
, Css.width (pct 100)
, padding2 (px 12) (px 20)
, borderTop3 (px 1) solid Colors.gray92
, backgroundColor Colors.frost
, Css.Media.withMedia
  [ Css.Media.only Css.Media.print [] ]
  [ backgroundColor transparent ]
]
```


Typical approach 1 is handling optional styles separately: 

```
([ flexGrow (num 1)
 , flexShrink zero
 , displayFlex
 , flexDirection column
 , bottom zero
 , Css.width (pct 100)
 , padding2 (px 12) (px 20)
 , borderTop3 (px 1) solid Colors.gray92
 , Css.Media.withMedia
   [ Css.Media.only Css.Media.print [] ]
   [ backgroundColor transparent ]
 ]
   ++ List.filterMap identity
     [ if isEmphasized then
         Just <| backgroundColor Colors.frost

       else
         Nothing
     ]
)
```

Typical approach 2 is making all styles optional: 

```
([ Just <| flexGrow (num 1)
 , Just <| flexShrink zero
 , Just <| displayFlex
 , Just <| flexDirection column
 , Just <| bottom zero
 , Just <| Css.width (pct 100)
 , Just <| padding2 (px 12) (px 20)
 , Just <| borderTop3 (px 1) solid Colors.gray92
 , if isEmphasized then
    Just <| backgroundColor Colors.frost
    
   else
    Nothing
 , Just <|
    Css.Media.withMedia
        [ Css.Media.only Css.Media.print [] ]
        [ backgroundColor transparent ]
 ]
    |> List.filterMap identity
)
```

Both of these feel rather heavy to me and not ideal.  

This PR adds two new functions `styleIf` and `styleJust` which are modeled after `viewIf` and `viewJust`. 

```
[ flexGrow (num 1)
, flexShrink zero
, displayFlex
, flexDirection column
, bottom zero
, Css.width (pct 100)
, padding2 (px 12) (px 20)
, borderTop3 (px 1) solid Colors.gray92
, styleIf isEmphasized [ backgroundColor Colors.frost ]
, Css.Media.withMedia
    [ Css.Media.only Css.Media.print [] ]
    [ backgroundColor transparent ]
]
```

~This is accomplished by using an unrecognized vendor-prefix property as a css no-op (-nri: noop;).~

~The downside, of course, with this approach is that we will be injecting extra css into our application.~

Curious for thoughts on if this is a good idea or not 😃 