### PR TITLE
Hack/tessa/browse mode

### DIFF
--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -33,11 +33,7 @@ hint = 'Use Accessibility.Widgetd.Widget'
 
 [forbidden.Html]
 hint = 'Use Html.Styled'
-usages = [
-    'styleguide-app/../src/Nri/Ui/Button/V8.elm',
-    'styleguide-app/Examples/Modal.elm',
-    'styleguide-app/Main.elm',
-]
+usages = ['styleguide-app/../src/Nri/Ui/Button/V8.elm']
 
 [forbidden."Nri.Ui.Accordion.V1"]
 hint = 'upgrade to V3'

--- a/src/Nri/Ui/Page/V3.elm
+++ b/src/Nri/Ui/Page/V3.elm
@@ -23,7 +23,7 @@ import Nri.Ui.Html.V3 exposing (viewIf)
 
 {-| The default page information is for the button
 which will direct the user back to the main page of
-the SPA. Specify it's name and the message which will
+the SPA. Specify its name and the message which will
 navigate to the page.
 -}
 type alias DefaultPage msg =

--- a/src/Nri/Ui/Switch/V1.elm
+++ b/src/Nri/Ui/Switch/V1.elm
@@ -1,8 +1,8 @@
-module Nri.Ui.Switch.V1 exposing (view, Attribute, onSwitch, disabled, id, label)
+module Nri.Ui.Switch.V1 exposing (view, Attribute, onSwitch, disabled, id, label, custom)
 
 {-|
 
-@docs view, Attribute, onSwitch, disabled, id, label
+@docs view, Attribute, onSwitch, disabled, id, label, custom
 
 -}
 
@@ -27,6 +27,7 @@ type Attribute msg
     | Id String
     | Label (Html msg)
     | Disabled
+    | Custom (List (Html.Attribute Never))
 
 
 {-| Specify what happens when the switch is toggled.
@@ -63,10 +64,18 @@ label =
     Label
 
 
+{-| Pass custom attributes through to be attached to the underlying input.
+-}
+custom : List (Html.Attribute Never) -> Attribute msg
+custom =
+    Custom
+
+
 type alias Config msg =
     { onSwitch : Maybe (Bool -> msg)
     , id : String
     , label : Maybe (Html msg)
+    , attributes : List (Html.Attribute Never)
     }
 
 
@@ -75,6 +84,7 @@ defaultConfig =
     { onSwitch = Nothing
     , id = "nri-ui-switch-with-default-id"
     , label = Nothing
+    , attributes = []
     }
 
 
@@ -92,6 +102,9 @@ customize attr config =
 
         Label label_ ->
             { config | label = Just label_ }
+
+        Custom custom_ ->
+            { config | attributes = custom_ }
 
 
 {-| Render a switch. The boolean here indicates whether the switch is on
@@ -133,6 +146,7 @@ view attrs isOn =
             { id = config.id
             , onCheck = config.onSwitch
             , checked = isOn
+            , attributes = config.attributes
             }
         , Nri.Ui.Svg.V1.toHtml
             (viewSwitch
@@ -162,26 +176,29 @@ viewCheckbox :
     { id : String
     , onCheck : Maybe (Bool -> msg)
     , checked : Bool
+    , attributes : List (Html.Attribute Never)
     }
     -> Html msg
 viewCheckbox config =
     Html.checkbox config.id
         (Just config.checked)
-        [ Attributes.id config.id
-        , Attributes.css
+        ([ Attributes.id config.id
+         , Attributes.css
             [ Css.position Css.absolute
             , Css.top (Css.px 10)
             , Css.left (Css.px 10)
             , Css.zIndex (Css.int 0)
             , Css.opacity (Css.num 0)
             ]
-        , case config.onCheck of
+         , case config.onCheck of
             Just onCheck ->
                 Events.onCheck onCheck
 
             Nothing ->
                 Widget.disabled True
-        ]
+         ]
+            ++ List.map (Attributes.map never) config.attributes
+        )
 
 
 viewSwitch :

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -14,6 +14,7 @@ import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Html.Attributes.V2 as AttributeExtras exposing (targetBlank)
+import Routes exposing (Route)
 
 
 type alias Example state msg =
@@ -92,12 +93,12 @@ wrapState wrapState_ unwrapState example =
     }
 
 
-preview : (String -> msg2) -> Example state msg -> Html msg2
+preview : (Route -> msg2) -> Example state msg -> Html msg2
 preview navigate =
     Lazy.lazy (preview_ navigate)
 
 
-preview_ : (String -> msg2) -> Example state msg -> Html msg2
+preview_ : (Route -> msg2) -> Example state msg -> Html msg2
 preview_ navigate example =
     Container.view
         [ Container.gray
@@ -108,7 +109,7 @@ preview_ navigate example =
                 , Css.cursor Css.pointer
                 ]
             ]
-        , Container.custom [ Events.onClick (navigate (exampleHref example)) ]
+        , Container.custom [ Events.onClick (navigate (Routes.Doodad example.name)) ]
         , Container.html
             (ClickableText.link example.name
                 [ ClickableText.href (exampleHref example)
@@ -169,7 +170,7 @@ view_ example =
 
 exampleHref : Example state msg -> String
 exampleHref example =
-    "#/doodad/" ++ example.name
+    Routes.toString (Routes.Doodad example.name)
 
 
 exampleLink : Example state msg -> Html msg

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -130,12 +130,36 @@ preview_ navigate example =
 
 
 view : Maybe Route -> Example state msg -> Html msg
-view =
-    Lazy.lazy2 view_
+view previousRoute example =
+    Container.view
+        [ Container.pillow
+        , Container.css
+            [ Css.position Css.relative
+            , Css.margin (Css.px 10)
+            , Css.minHeight (Css.calc (Css.vh 100) Css.minus (Css.px 20))
+            , Css.boxSizing Css.borderBox
+            ]
+        , Container.html
+            [ Lazy.lazy view_ example
+            , ClickableSvg.link ("Close " ++ example.name ++ " example")
+                UiIcon.x
+                [ ClickableSvg.href
+                    (Maybe.withDefault Routes.All previousRoute
+                        |> Routes.toString
+                    )
+                , ClickableSvg.small
+                , ClickableSvg.css
+                    [ Css.position Css.absolute
+                    , Css.top (Css.px 15)
+                    , Css.right (Css.px 15)
+                    ]
+                ]
+            ]
+        ]
 
 
-view_ : Maybe Route -> Example state msg -> Html msg
-view_ previousRoute example =
+view_ : Example state msg -> Html msg
+view_ example =
     Html.div
         [ -- this class makes the axe accessibility checking output easier to parse
           String.replace "." "-" example.name
@@ -159,13 +183,6 @@ view_ previousRoute example =
             ]
         , KeyboardSupport.view example.keyboardSupport
         , Html.div [] (example.view example.state)
-        , ClickableSvg.link ("Close " ++ example.name ++ " example")
-            UiIcon.x
-            [ ClickableSvg.href
-                (Maybe.withDefault Routes.All previousRoute
-                    |> Routes.toString
-                )
-            ]
         ]
 
 

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -5,6 +5,7 @@ import Css exposing (..)
 import Css.Global exposing (a, descendants)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
+import Html.Styled.Events as Events
 import Html.Styled.Lazy as Lazy
 import KeyboardSupport exposing (KeyboardSupport)
 import Nri.Ui.ClickableText.V3 as ClickableText
@@ -88,13 +89,13 @@ wrapState wrapState_ unwrapState example =
     }
 
 
-preview : Example state msg -> Html msg
-preview =
-    Lazy.lazy preview_
+preview : (String -> msg2) -> Example state msg -> Html msg2
+preview navigate =
+    Lazy.lazy (preview_ navigate)
 
 
-preview_ : Example state msg -> Html msg
-preview_ example =
+preview_ : (String -> msg2) -> Example state msg -> Html msg2
+preview_ navigate example =
     Container.view
         [ Container.gray
         , Container.css
@@ -104,6 +105,7 @@ preview_ example =
                 , Css.cursor Css.pointer
                 ]
             ]
+        , Container.custom [ Events.onClick (navigate (exampleHref example)) ]
         , Container.html
             [ ClickableText.link example.name
                 [ ClickableText.href (exampleHref example)

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -22,6 +22,7 @@ type alias Example state msg =
     , state : state
     , update : msg -> state -> ( state, Cmd msg )
     , subscriptions : state -> Sub msg
+    , preview : List (Html Never)
     , view : state -> List (Html msg)
     , categories : List Category
     , keyboardSupport : List KeyboardSupport
@@ -52,6 +53,7 @@ wrapMsg wrapMsg_ unwrapMsg example =
                 Nothing ->
                     ( state, Cmd.none )
     , subscriptions = \state -> Sub.map wrapMsg_ (example.subscriptions state)
+    , preview = []
     , view = \state -> List.map (Html.map wrapMsg_) (example.view state)
     , categories = example.categories
     , keyboardSupport = example.keyboardSupport
@@ -80,6 +82,7 @@ wrapState wrapState_ unwrapState example =
         unwrapState
             >> Maybe.map example.subscriptions
             >> Maybe.withDefault Sub.none
+    , preview = []
     , view =
         unwrapState
             >> Maybe.map example.view
@@ -107,10 +110,11 @@ preview_ navigate example =
             ]
         , Container.custom [ Events.onClick (navigate (exampleHref example)) ]
         , Container.html
-            [ ClickableText.link example.name
+            (ClickableText.link example.name
                 [ ClickableText.href (exampleHref example)
                 ]
-            ]
+                :: List.map (Html.map never) example.preview
+            )
         ]
 
 

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -8,12 +8,14 @@ import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Html.Styled.Lazy as Lazy
 import KeyboardSupport exposing (KeyboardSupport)
+import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors exposing (..)
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Html.Attributes.V2 as AttributeExtras exposing (targetBlank)
+import Nri.Ui.UiIcon.V1 as UiIcon
 import Routes exposing (Route)
 
 
@@ -127,18 +129,19 @@ preview_ navigate example =
         ]
 
 
-view : Example state msg -> Html msg
+view : Maybe Route -> Example state msg -> Html msg
 view =
-    Lazy.lazy view_
+    Lazy.lazy2 view_
 
 
-view_ : Example state msg -> Html msg
-view_ example =
+view_ : Maybe Route -> Example state msg -> Html msg
+view_ previousRoute example =
     Html.div
         [ -- this class makes the axe accessibility checking output easier to parse
           String.replace "." "-" example.name
             |> (++) "module-example__"
             |> Attributes.class
+        , Attributes.id (String.replace "." "-" example.name)
         ]
         [ Html.div
             [ Attributes.css
@@ -155,16 +158,14 @@ view_ example =
             , srcLink example
             ]
         , KeyboardSupport.view example.keyboardSupport
-        , Html.div
-            [ Attributes.css
-                [ padding (px 40)
-                , boxShadow5 zero (px 2) (px 4) zero (rgba 0 0 0 0.25)
-                , border3 (px 1) solid gray92
-                , borderRadius (px 20)
-                , margin3 (px 10) zero (px 40)
-                ]
+        , Html.div [] (example.view example.state)
+        , ClickableSvg.link ("Close " ++ example.name ++ " example")
+            UiIcon.x
+            [ ClickableSvg.href
+                (Maybe.withDefault Routes.All previousRoute
+                    |> Routes.toString
+                )
             ]
-            (example.view example.state)
         ]
 
 

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -7,9 +7,11 @@ import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Lazy as Lazy
 import KeyboardSupport exposing (KeyboardSupport)
+import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 exposing (..)
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Html.Attributes.V2 as AttributeExtras exposing (targetBlank)
 
 
@@ -94,7 +96,7 @@ preview =
 preview_ : Example state msg -> Html msg
 preview_ example =
     Container.view
-        [ Container.html [ exampleName example ]
+        [ Container.html [ exampleLink example ]
         ]
 
 
@@ -121,14 +123,9 @@ view_ example =
                 , descendants [ Css.Global.a [ textDecoration none ] ]
                 ]
             ]
-            [ exampleName example
-            , String.replace "." "-" (fullName example)
-                |> (++) "https://package.elm-lang.org/packages/NoRedInk/noredink-ui/latest/"
-                |> viewLink "Docs"
-            , String.replace "." "/" (fullName example)
-                ++ ".elm"
-                |> (++) "https://github.com/NoRedInk/noredink-ui/blob/master/src/"
-                |> viewLink "Source"
+            [ exampleLink example
+            , docsLink example
+            , srcLink example
             ]
         , KeyboardSupport.view example.keyboardSupport
         , Html.div
@@ -144,34 +141,43 @@ view_ example =
         ]
 
 
-exampleName : Example state msg -> Html msg
-exampleName example =
-    Html.styled Html.h2
-        [ color navy
-        , fontSize (px 20)
-        , marginTop zero
-        , marginBottom zero
-        , Fonts.baseFont
-        ]
-        []
-        [ Html.a
-            [ Attributes.href ("#/doodad/" ++ example.name)
-            , Attributes.class "module-example__doodad-link"
-            , -- this data attribute is used to name the Percy screenshots
-              String.replace "." "-" example.name
-                |> Attributes.attribute "data-percy-name"
+exampleLink : Example state msg -> Html msg
+exampleLink example =
+    Heading.h2 []
+        [ ClickableText.link (fullName example)
+            [ ClickableText.href ("#/doodad/" ++ example.name)
+            , ClickableText.large
+            , ClickableText.custom
+                [ -- this data attribute is used to name the Percy screenshots
+                  String.replace "." "-" example.name
+                    |> Attributes.attribute "data-percy-name"
+                ]
             ]
-            [ Html.text (fullName example) ]
         ]
 
 
-viewLink : String -> String -> Html msg
-viewLink text href =
-    Html.a
-        ([ Attributes.href href
-         , Attributes.css [ Css.display Css.block, marginLeft (px 20) ]
-         ]
-            ++ targetBlank
-        )
-        [ Html.text text
+docsLink : Example state msg -> Html msg
+docsLink example =
+    let
+        link =
+            "https://package.elm-lang.org/packages/NoRedInk/noredink-ui/latest/"
+                ++ String.replace "." "-" (fullName example)
+    in
+    ClickableText.link "Docs"
+        [ ClickableText.linkExternal link
+        , ClickableText.css [ Css.marginLeft (Css.px 20) ]
+        ]
+
+
+srcLink : Example state msg -> Html msg
+srcLink example =
+    let
+        link =
+            String.replace "." "/" (fullName example)
+                ++ ".elm"
+                |> (++) "https://github.com/NoRedInk/noredink-ui/blob/master/src/"
+    in
+    ClickableText.link "Source"
+        [ ClickableText.linkExternal link
+        , ClickableText.css [ Css.marginLeft (Css.px 20) ]
         ]

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -53,7 +53,7 @@ wrapMsg wrapMsg_ unwrapMsg example =
                 Nothing ->
                     ( state, Cmd.none )
     , subscriptions = \state -> Sub.map wrapMsg_ (example.subscriptions state)
-    , preview = []
+    , preview = example.preview
     , view = \state -> List.map (Html.map wrapMsg_) (example.view state)
     , categories = example.categories
     , keyboardSupport = example.keyboardSupport
@@ -82,7 +82,7 @@ wrapState wrapState_ unwrapState example =
         unwrapState
             >> Maybe.map example.subscriptions
             >> Maybe.withDefault Sub.none
-    , preview = []
+    , preview = example.preview
     , view =
         unwrapState
             >> Maybe.map example.view

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -114,7 +114,14 @@ preview_ navigate example =
                 [ ClickableText.href (exampleHref example)
                 , ClickableText.css [ Css.marginBottom (Css.px 10) ]
                 ]
-                :: List.map (Html.map never) example.preview
+                :: [ Html.div
+                        [ Attributes.css
+                            [ Css.displayFlex
+                            , Css.flexDirection Css.column
+                            ]
+                        ]
+                        (List.map (Html.map never) example.preview)
+                   ]
             )
         ]
 

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -112,6 +112,7 @@ preview_ navigate example =
         , Container.html
             (ClickableText.link example.name
                 [ ClickableText.href (exampleHref example)
+                , ClickableText.css [ Css.marginBottom (Css.px 10) ]
                 ]
                 :: List.map (Html.map never) example.preview
             )

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -1,4 +1,4 @@
-module Example exposing (Example, view, wrapMsg, wrapState)
+module Example exposing (Example, preview, view, wrapMsg, wrapState)
 
 import Category exposing (Category)
 import Css exposing (..)
@@ -8,6 +8,7 @@ import Html.Styled.Attributes as Attributes
 import Html.Styled.Lazy as Lazy
 import KeyboardSupport exposing (KeyboardSupport)
 import Nri.Ui.Colors.V1 exposing (..)
+import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as AttributeExtras exposing (targetBlank)
 
@@ -22,6 +23,11 @@ type alias Example state msg =
     , categories : List Category
     , keyboardSupport : List KeyboardSupport
     }
+
+
+fullName : Example state msg -> String
+fullName example =
+    "Nri.Ui." ++ example.name ++ ".V" ++ String.fromInt example.version
 
 
 wrapMsg :
@@ -80,6 +86,18 @@ wrapState wrapState_ unwrapState example =
     }
 
 
+preview : Example state msg -> Html msg
+preview =
+    Lazy.lazy preview_
+
+
+preview_ : Example state msg -> Html msg
+preview_ example =
+    Container.view
+        [ Container.html [ exampleName example ]
+        ]
+
+
 view : Example state msg -> Html msg
 view =
     Lazy.lazy view_
@@ -87,10 +105,6 @@ view =
 
 view_ : Example state msg -> Html msg
 view_ example =
-    let
-        fullName =
-            "Nri.Ui." ++ example.name ++ ".V" ++ String.fromInt example.version
-    in
     Html.div
         [ -- this class makes the axe accessibility checking output easier to parse
           String.replace "." "-" example.name
@@ -107,27 +121,11 @@ view_ example =
                 , descendants [ Css.Global.a [ textDecoration none ] ]
                 ]
             ]
-            [ Html.styled Html.h2
-                [ color navy
-                , fontSize (px 20)
-                , marginTop zero
-                , marginBottom zero
-                , Fonts.baseFont
-                ]
-                []
-                [ Html.a
-                    [ Attributes.href ("#/doodad/" ++ example.name)
-                    , Attributes.class "module-example__doodad-link"
-                    , -- this data attribute is used to name the Percy screenshots
-                      String.replace "." "-" example.name
-                        |> Attributes.attribute "data-percy-name"
-                    ]
-                    [ Html.text fullName ]
-                ]
-            , String.replace "." "-" fullName
+            [ exampleName example
+            , String.replace "." "-" (fullName example)
                 |> (++) "https://package.elm-lang.org/packages/NoRedInk/noredink-ui/latest/"
                 |> viewLink "Docs"
-            , String.replace "." "/" fullName
+            , String.replace "." "/" (fullName example)
                 ++ ".elm"
                 |> (++) "https://github.com/NoRedInk/noredink-ui/blob/master/src/"
                 |> viewLink "Source"
@@ -143,6 +141,27 @@ view_ example =
                 ]
             ]
             (example.view example.state)
+        ]
+
+
+exampleName : Example state msg -> Html msg
+exampleName example =
+    Html.styled Html.h2
+        [ color navy
+        , fontSize (px 20)
+        , marginTop zero
+        , marginBottom zero
+        , Fonts.baseFont
+        ]
+        []
+        [ Html.a
+            [ Attributes.href ("#/doodad/" ++ example.name)
+            , Attributes.class "module-example__doodad-link"
+            , -- this data attribute is used to name the Percy screenshots
+              String.replace "." "-" example.name
+                |> Attributes.attribute "data-percy-name"
+            ]
+            [ Html.text (fullName example) ]
         ]
 
 

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -8,7 +8,7 @@ import Html.Styled.Attributes as Attributes
 import Html.Styled.Lazy as Lazy
 import KeyboardSupport exposing (KeyboardSupport)
 import Nri.Ui.ClickableText.V3 as ClickableText
-import Nri.Ui.Colors.V1 exposing (..)
+import Nri.Ui.Colors.V1 as Colors exposing (..)
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V2 as Heading
@@ -96,7 +96,19 @@ preview =
 preview_ : Example state msg -> Html msg
 preview_ example =
     Container.view
-        [ Container.html [ exampleLink example ]
+        [ Container.gray
+        , Container.css
+            [ Css.flexBasis (Css.px 150)
+            , Css.hover
+                [ Css.backgroundColor Colors.glacier
+                , Css.cursor Css.pointer
+                ]
+            ]
+        , Container.html
+            [ ClickableText.link example.name
+                [ ClickableText.href (exampleHref example)
+                ]
+            ]
         ]
 
 
@@ -141,11 +153,16 @@ view_ example =
         ]
 
 
+exampleHref : Example state msg -> String
+exampleHref example =
+    "#/doodad/" ++ example.name
+
+
 exampleLink : Example state msg -> Html msg
 exampleLink example =
     Heading.h2 []
         [ ClickableText.link (fullName example)
-            [ ClickableText.href ("#/doodad/" ++ example.name)
+            [ ClickableText.href (exampleHref example)
             , ClickableText.large
             , ClickableText.custom
                 [ -- this data attribute is used to name the Percy screenshots

--- a/styleguide-app/Examples/Accordion.elm
+++ b/styleguide-app/Examples/Accordion.elm
@@ -38,6 +38,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view = view
     , categories = [ Layout ]
     , keyboardSupport =

--- a/styleguide-app/Examples/Accordion.elm
+++ b/styleguide-app/Examples/Accordion.elm
@@ -25,6 +25,7 @@ import Nri.Ui.DisclosureIndicator.V2 as DisclosureIndicator
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Set exposing (Set)
 import Task
@@ -38,7 +39,21 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ -- faking a mini version of the Accordion component to give styleguide users a sense of what the
+          -- component might look like
+          Html.div []
+            [ Html.div [ css [ Css.displayFlex, Css.alignItems Css.center ] ]
+                [ defaultCaret False
+                , Text.smallBody [ Text.plaintext "Closed" ]
+                ]
+            , Html.div [ css [ Css.displayFlex, Css.alignItems Css.center ] ]
+                [ defaultCaret True
+                , Text.smallBody [ Text.plaintext "Open" ]
+                ]
+            , Text.caption [ Text.plaintext "Accordion content." ]
+            ]
+        ]
     , view = view
     , categories = [ Layout ]
     , keyboardSupport =
@@ -58,13 +73,14 @@ example =
     }
 
 
+defaultCaret : Bool -> Html msg
+defaultCaret =
+    DisclosureIndicator.large [ Css.marginRight (Css.px 8) ]
+
+
 {-| -}
 view : State -> List (Html Msg)
 view model =
-    let
-        defaultCaret =
-            DisclosureIndicator.large [ Css.marginRight (Css.px 8) ]
-    in
     [ Heading.h3 [] [ Html.text "Accordion.view" ]
     , Accordion.view
         { entries =

--- a/styleguide-app/Examples/AssignmentIcon.elm
+++ b/styleguide-app/Examples/AssignmentIcon.elm
@@ -35,11 +35,18 @@ example =
     , subscriptions = \_ -> Sub.none
     , preview =
         IconExamples.preview
-            [ AssignmentIcon.diagnostic
-            , AssignmentIcon.practice
-            , AssignmentIcon.quiz
-            , AssignmentIcon.quickWrite
-            , AssignmentIcon.guidedDraft
+            [ AssignmentIcon.planningDiagnosticCircled
+            , AssignmentIcon.unitDiagnosticCircled
+            , AssignmentIcon.practiceCircled
+            , AssignmentIcon.quizCircled
+            , AssignmentIcon.quickWriteCircled
+            , AssignmentIcon.guidedDraftCircled
+            , AssignmentIcon.peerReviewCircled
+            , AssignmentIcon.selfReviewCircled
+            , AssignmentIcon.startPrimary
+            , AssignmentIcon.assessment
+            , AssignmentIcon.standards
+            , AssignmentIcon.writing
             ]
     , view =
         \_ ->

--- a/styleguide-app/Examples/AssignmentIcon.elm
+++ b/styleguide-app/Examples/AssignmentIcon.elm
@@ -33,6 +33,7 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \_ ->
             [ IconExamples.view "Diagnostic"

--- a/styleguide-app/Examples/AssignmentIcon.elm
+++ b/styleguide-app/Examples/AssignmentIcon.elm
@@ -33,7 +33,14 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        IconExamples.preview
+            [ AssignmentIcon.diagnostic
+            , AssignmentIcon.practice
+            , AssignmentIcon.quiz
+            , AssignmentIcon.quickWrite
+            , AssignmentIcon.guidedDraft
+            ]
     , view =
         \_ ->
             [ IconExamples.view "Diagnostic"

--- a/styleguide-app/Examples/Balloon.elm
+++ b/styleguide-app/Examples/Balloon.elm
@@ -29,6 +29,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view = view
     }
 

--- a/styleguide-app/Examples/Balloon.elm
+++ b/styleguide-app/Examples/Balloon.elm
@@ -33,7 +33,7 @@ example =
         [ Balloon.balloon
             [ Balloon.onTop
             , Balloon.navy
-            , Balloon.paddingPx 4
+            , Balloon.paddingPx 15
             ]
             (text "This is a balloon.")
         ]

--- a/styleguide-app/Examples/Balloon.elm
+++ b/styleguide-app/Examples/Balloon.elm
@@ -29,7 +29,14 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ Balloon.balloon
+            [ Balloon.onTop
+            , Balloon.navy
+            , Balloon.paddingPx 4
+            ]
+            (text "This is a balloon.")
+        ]
     , view = view
     }
 

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -6,6 +6,7 @@ module Examples.Button exposing (Msg, State, example)
 
 -}
 
+import Accessibility.Styled.Key as Key
 import Category exposing (Category(..))
 import Css exposing (middle, verticalAlign)
 import Debug.Control as Control exposing (Control)
@@ -32,18 +33,21 @@ example =
         [ Button.link "Primary"
             [ Button.small
             , Button.fillContainerWidth
+            , Button.custom [ Key.tabbable False ]
             ]
         , Button.link "Secondary"
             [ Button.small
             , Button.fillContainerWidth
             , Button.secondary
             , Button.css [ Css.marginTop (Css.px 8) ]
+            , Button.custom [ Key.tabbable False ]
             ]
         , Button.link "Premium"
             [ Button.small
             , Button.fillContainerWidth
             , Button.premium
             , Button.css [ Css.marginTop (Css.px 8) ]
+            , Button.custom [ Key.tabbable False ]
             ]
         ]
     , view = \state -> [ viewButtonExamples state ]

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -29,7 +29,10 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , preview =
-        [ Button.link "Primary" [ Button.small, Button.fillContainerWidth ]
+        [ Button.link "Primary"
+            [ Button.small
+            , Button.fillContainerWidth
+            ]
         , Button.link "Secondary"
             [ Button.small
             , Button.fillContainerWidth

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -28,6 +28,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view = \state -> [ viewButtonExamples state ]
     , categories = [ Buttons ]
     , keyboardSupport = []

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -28,7 +28,21 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ Button.link "Primary" [ Button.small, Button.fillContainerWidth ]
+        , Button.link "Secondary"
+            [ Button.small
+            , Button.fillContainerWidth
+            , Button.secondary
+            , Button.css [ Css.marginTop (Css.px 8) ]
+            ]
+        , Button.link "Premium"
+            [ Button.small
+            , Button.fillContainerWidth
+            , Button.premium
+            , Button.css [ Css.marginTop (Css.px 8) ]
+            ]
+        ]
     , view = \state -> [ viewButtonExamples state ]
     , categories = [ Buttons ]
     , keyboardSupport = []

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -38,6 +38,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \state ->
             [ viewInteractableCheckbox "styleguide-checkbox-interactable" state

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -36,6 +36,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \state ->
             let

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -6,6 +6,7 @@ module Examples.ClickableSvg exposing (Msg, State, example)
 
 -}
 
+import Accessibility.Styled.Key as Key
 import Category exposing (Category(..))
 import Css
 import Debug.Control as Control exposing (Control)
@@ -37,9 +38,21 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , preview =
-        [ ClickableSvg.link "ClickableSvg small" UiIcon.link [ ClickableSvg.small ]
-        , ClickableSvg.link "ClickableSvg medium" UiIcon.link [ ClickableSvg.medium ]
-        , ClickableSvg.link "ClickableSvg large" UiIcon.link [ ClickableSvg.large ]
+        [ ClickableSvg.link "ClickableSvg small"
+            UiIcon.link
+            [ ClickableSvg.small
+            , ClickableSvg.custom [ Key.tabbable False ]
+            ]
+        , ClickableSvg.link "ClickableSvg medium"
+            UiIcon.link
+            [ ClickableSvg.medium
+            , ClickableSvg.custom [ Key.tabbable False ]
+            ]
+        , ClickableSvg.link "ClickableSvg large"
+            UiIcon.link
+            [ ClickableSvg.large
+            , ClickableSvg.custom [ Key.tabbable False ]
+            ]
         ]
     , view =
         \state ->

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -36,7 +36,11 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ ClickableSvg.link "ClickableSvg small" UiIcon.link [ ClickableSvg.small ]
+        , ClickableSvg.link "ClickableSvg medium" UiIcon.link [ ClickableSvg.medium ]
+        , ClickableSvg.link "ClickableSvg large" UiIcon.link [ ClickableSvg.large ]
+        ]
     , view =
         \state ->
             let

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -32,7 +32,20 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ ClickableText.link "Small"
+            [ ClickableText.icon UiIcon.link
+            , ClickableText.small
+            ]
+        , ClickableText.link "Medium"
+            [ ClickableText.icon UiIcon.link
+            , ClickableText.medium
+            ]
+        , ClickableText.link "Large"
+            [ ClickableText.icon UiIcon.link
+            , ClickableText.large
+            ]
+        ]
     , view = \state -> [ viewExamples state ]
     , categories = [ Buttons ]
     , keyboardSupport = []

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -6,6 +6,7 @@ module Examples.ClickableText exposing (Msg, State, example)
 
 -}
 
+import Accessibility.Styled.Key as Key
 import Category exposing (Category(..))
 import Css exposing (middle, verticalAlign)
 import Debug.Control as Control exposing (Control)
@@ -36,14 +37,17 @@ example =
         [ ClickableText.link "Small"
             [ ClickableText.icon UiIcon.link
             , ClickableText.small
+            , ClickableText.custom [ Key.tabbable False ]
             ]
         , ClickableText.link "Medium"
             [ ClickableText.icon UiIcon.link
             , ClickableText.medium
+            , ClickableText.custom [ Key.tabbable False ]
             ]
         , ClickableText.link "Large"
             [ ClickableText.icon UiIcon.link
             , ClickableText.large
+            , ClickableText.custom [ Key.tabbable False ]
             ]
         ]
     , view = \state -> [ viewExamples state ]

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -32,6 +32,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view = \state -> [ viewExamples state ]
     , categories = [ Buttons ]
     , keyboardSupport = []

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -14,6 +14,7 @@ import Html.Styled.Attributes as Attributes exposing (css)
 import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V2 as Heading
 import SolidColor exposing (highContrast)
 
@@ -132,10 +133,8 @@ viewPreviewSwatch ( name, color ) =
             , Css.margin2 (Css.px 4) Css.zero
             , Css.borderRadius (Css.px 4)
             , Css.backgroundColor color
-            , Nri.Ui.Colors.Extra.fromCssColor color
-                |> highContrast
-                |> Nri.Ui.Colors.Extra.toCssColor
-                |> Css.color
+            , Css.color color
+            , Css.fontSize (Css.px 14)
             ]
         ]
         [ Html.text name ]

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -41,7 +41,12 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ ( "green", Colors.green )
+        , ( "purple", Colors.purple )
+        , ( "mustard", Colors.mustard )
+        ]
+            |> List.map viewPreviewSwatch
     , view =
         \_ ->
             [ [ ( "gray20", Colors.gray20, "Main text" )
@@ -116,6 +121,24 @@ example =
                 |> viewColors
             ]
     }
+
+
+viewPreviewSwatch : ( String, Css.Color ) -> Html.Html msg
+viewPreviewSwatch ( name, color ) =
+    Html.div
+        [ Attributes.css
+            [ Css.textAlign Css.center
+            , Css.padding2 (Css.px 8) Css.zero
+            , Css.margin2 (Css.px 4) Css.zero
+            , Css.borderRadius (Css.px 4)
+            , Css.backgroundColor color
+            , Nri.Ui.Colors.Extra.fromCssColor color
+                |> highContrast
+                |> Nri.Ui.Colors.Extra.toCssColor
+                |> Css.color
+            ]
+        ]
+        [ Html.text name ]
 
 
 viewColors : List ColorExample -> Html.Html msg

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -41,6 +41,7 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \_ ->
             [ [ ( "gray20", Colors.gray20, "Main text" )

--- a/styleguide-app/Examples/Confetti.elm
+++ b/styleguide-app/Examples/Confetti.elm
@@ -33,6 +33,7 @@ example =
                 [ Browser.Events.onResize WindowResized
                 , Confetti.subscriptions ConfettiMsg state
                 ]
+    , preview = []
     , view =
         \state ->
             [ Button.button "Launch confetti!"

--- a/styleguide-app/Examples/Container.elm
+++ b/styleguide-app/Examples/Container.elm
@@ -35,7 +35,17 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ Container.view []
+        , Container.view
+            [ Container.invalid
+            , Container.css [ Css.marginTop (Css.px 8) ]
+            ]
+        , Container.view
+            [ Container.disabled
+            , Container.css [ Css.marginTop (Css.px 8) ]
+            ]
+        ]
     , view =
         \state ->
             let

--- a/styleguide-app/Examples/Container.elm
+++ b/styleguide-app/Examples/Container.elm
@@ -35,6 +35,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \state ->
             let

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -36,6 +36,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \state ->
             [ Text.smallBodyGray [ Text.plaintext "The disclosure indicator is only the caret. It is NOT a button -- you must create a button or clickabletext yourself!" ]

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -36,7 +36,12 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ DisclosureIndicator.medium [] False
+        , DisclosureIndicator.medium [] True
+        , DisclosureIndicator.large [] False
+        , DisclosureIndicator.large [] True
+        ]
     , view =
         \state ->
             [ Text.smallBodyGray [ Text.plaintext "The disclosure indicator is only the caret. It is NOT a button -- you must create a button or clickabletext yourself!" ]

--- a/styleguide-app/Examples/Divider.elm
+++ b/styleguide-app/Examples/Divider.elm
@@ -35,6 +35,6 @@ example =
     , state = {}
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview = [ Divider.view "Dividing Line" ]
     , view = \state -> [ Divider.view "Dividing Line" ]
     }

--- a/styleguide-app/Examples/Divider.elm
+++ b/styleguide-app/Examples/Divider.elm
@@ -35,5 +35,6 @@ example =
     , state = {}
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view = \state -> [ Divider.view "Dividing Line" ]
     }

--- a/styleguide-app/Examples/Fonts.elm
+++ b/styleguide-app/Examples/Fonts.elm
@@ -7,8 +7,9 @@ module Examples.Fonts exposing (example, State, Msg)
 -}
 
 import Category exposing (Category(..))
+import Css exposing (Style)
 import Example exposing (Example)
-import Html.Styled as Html
+import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Fonts.V1 as Fonts
@@ -35,7 +36,12 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ ( "baseFont", Fonts.baseFont )
+        , ( "quizFont", Fonts.quizFont )
+        , ( "ugFont", Fonts.ugFont )
+        ]
+            |> List.map viewPreview
     , view =
         \_ ->
             [ Heading.h3 [] [ Html.text "baseFont" ]
@@ -49,3 +55,20 @@ example =
                 [ Html.text "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz" ]
             ]
     }
+
+
+viewPreview : ( String, Style ) -> Html msg
+viewPreview ( name, font ) =
+    Html.div
+        [ css
+            [ Css.displayFlex
+            , Css.justifyContent Css.spaceBetween
+            , font
+            , Css.fontSize (Css.px 14)
+            ]
+        ]
+        [ Html.p [ css [ Css.margin2 (Css.px 8) Css.zero ] ]
+            [ Html.text name ]
+        , Html.p [ css [ Css.margin2 (Css.px 8) Css.zero ] ]
+            [ Html.text "AaBbCc" ]
+        ]

--- a/styleguide-app/Examples/Fonts.elm
+++ b/styleguide-app/Examples/Fonts.elm
@@ -35,6 +35,7 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \_ ->
             [ Heading.h3 [] [ Html.text "baseFont" ]

--- a/styleguide-app/Examples/Heading.elm
+++ b/styleguide-app/Examples/Heading.elm
@@ -35,6 +35,7 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \_ ->
             [ Heading.h1 [] [ Html.text "This is the main page heading." ]

--- a/styleguide-app/Examples/Heading.elm
+++ b/styleguide-app/Examples/Heading.elm
@@ -35,7 +35,12 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ Heading.h1 [] [ Html.text "h1" ]
+        , Heading.h2 [] [ Html.text "h2" ]
+        , Heading.h3 [] [ Html.text "h3" ]
+        , Heading.h4 [] [ Html.text "h4" ]
+        ]
     , view =
         \_ ->
             [ Heading.h1 [] [ Html.text "This is the main page heading." ]

--- a/styleguide-app/Examples/IconExamples.elm
+++ b/styleguide-app/Examples/IconExamples.elm
@@ -15,7 +15,6 @@ preview icons =
         [ css
             [ Css.displayFlex
             , Css.justifyContent Css.spaceBetween
-            , Css.marginTop (Css.px 8)
             , Css.color Colors.gray45
             ]
         ]

--- a/styleguide-app/Examples/IconExamples.elm
+++ b/styleguide-app/Examples/IconExamples.elm
@@ -14,12 +14,13 @@ preview icons =
     [ Html.div
         [ css
             [ Css.displayFlex
-            , Css.justifyContent Css.spaceBetween
+            , Css.flexWrap Css.wrap
+            , Css.property "gap" "10px"
             , Css.color Colors.gray45
             ]
         ]
         (List.map
-            (Svg.withWidth (Css.px 18) >> Svg.withHeight (Css.px 18) >> Svg.toHtml)
+            (Svg.withWidth (Css.px 30) >> Svg.withHeight (Css.px 30) >> Svg.toHtml)
             icons
         )
     ]

--- a/styleguide-app/Examples/IconExamples.elm
+++ b/styleguide-app/Examples/IconExamples.elm
@@ -1,4 +1,4 @@
-module Examples.IconExamples exposing (view, viewWithCustomStyles)
+module Examples.IconExamples exposing (preview, view, viewWithCustomStyles)
 
 import Css
 import Html.Styled as Html exposing (Html)
@@ -7,6 +7,23 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Text.V6 as Text
+
+
+preview : List Svg.Svg -> List (Html msg)
+preview icons =
+    [ Html.div
+        [ css
+            [ Css.displayFlex
+            , Css.justifyContent Css.spaceBetween
+            , Css.marginTop (Css.px 8)
+            , Css.color Colors.gray45
+            ]
+        ]
+        (List.map
+            (Svg.withWidth (Css.px 18) >> Svg.withHeight (Css.px 18) >> Svg.toHtml)
+            icons
+        )
+    ]
 
 
 view : String -> List ( String, Svg.Svg ) -> Html msg

--- a/styleguide-app/Examples/Loading.elm
+++ b/styleguide-app/Examples/Loading.elm
@@ -94,6 +94,7 @@ example =
     , state = init
     , update = update
     , subscriptions = subscriptions
+    , preview = []
     , view =
         \{ showLoadingFadeIn, showLoading, showSpinners } ->
             [ if showLoading then

--- a/styleguide-app/Examples/Logo.elm
+++ b/styleguide-app/Examples/Logo.elm
@@ -35,6 +35,7 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \_ ->
             [ IconExamples.viewWithCustomStyles "NRI"

--- a/styleguide-app/Examples/Logo.elm
+++ b/styleguide-app/Examples/Logo.elm
@@ -10,9 +10,12 @@ import Category exposing (Category(..))
 import Css
 import Example exposing (Example)
 import Examples.IconExamples as IconExamples
+import Html.Styled as Html exposing (Html)
+import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Logo.V1 as Logo
+import Nri.Ui.Svg.V1 as Svg
 
 
 {-| -}
@@ -35,7 +38,14 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        Html.div [ css [ Css.marginBottom (Css.px 8) ] ] [ Svg.toHtml Logo.noredink ]
+            :: IconExamples.preview
+                [ Logo.facebook
+                , Logo.twitter
+                , Logo.cleverC
+                , Logo.googleG
+                ]
     , view =
         \_ ->
             [ IconExamples.viewWithCustomStyles "NRI"

--- a/styleguide-app/Examples/MasteryIcon.elm
+++ b/styleguide-app/Examples/MasteryIcon.elm
@@ -34,6 +34,7 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \_ ->
             [ IconExamples.view "Levels"

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -47,6 +47,7 @@ example =
           }
         , { keys = [ Esc ], result = "Closes the menu" }
         ]
+    , preview = []
     , view = view
     }
 

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -177,6 +177,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \state ->
             let

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -177,7 +177,11 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ Message.view [ Message.plaintext "Tiny tip" ]
+        , Message.view [ Message.success, Message.plaintext "Tiny success" ]
+        , Message.view [ Message.error, Message.plaintext "Tiny error" ]
+        ]
     , view =
         \state ->
             let

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -14,7 +14,6 @@ import Css exposing (..)
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Example exposing (Example)
-import Html as Root
 import Html.Styled.Attributes as Attributes exposing (css)
 import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V10 as Button

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -7,6 +7,7 @@ module Examples.Modal exposing (Msg, State, example)
 -}
 
 import Accessibility.Styled as Html exposing (Html, div, h3, h4, p, span, text)
+import Accessibility.Styled.Key as Key
 import Browser.Dom as Dom
 import Category exposing (Category(..))
 import Css exposing (..)
@@ -160,7 +161,7 @@ example =
                     ]
                 ]
                 [ text "Modal"
-                , ClickableSvg.button "Close"
+                , ClickableSvg.link "Close"
                     UiIcon.x
                     [ ClickableSvg.exactWidth 10
                     , ClickableSvg.exactHeight 10
@@ -169,6 +170,7 @@ example =
                         , Css.top (Css.px 10)
                         , Css.right (Css.px 10)
                         ]
+                    , ClickableSvg.custom [ Key.tabbable False ]
                     ]
                 ]
             ]

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -125,6 +125,7 @@ example =
     , state = init
     , update = update
     , subscriptions = subscriptions
+    , preview = []
     , view =
         \state ->
             let

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -18,11 +18,15 @@ import Html.Styled.Attributes as Attributes exposing (css)
 import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Checkbox.V5 as Checkbox
+import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.FocusTrap.V1 as FocusTrap
+import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Modal.V11 as Modal
 import Nri.Ui.Text.V6 as Text
+import Nri.Ui.UiIcon.V1 as UiIcon
 import Task
 
 
@@ -125,7 +129,50 @@ example =
     , state = init
     , update = update
     , subscriptions = subscriptions
-    , preview = []
+    , preview =
+        [ -- faking a mini version of the Modal component to give styleguide users a sense of what the
+          -- component might look like
+          div
+            [ css
+                [ Css.backgroundColor (Nri.Ui.Colors.Extra.withAlpha 0.9 Colors.navy)
+                , Css.borderRadius (Css.px 4)
+                , Css.padding2 (Css.px 25) Css.zero
+                , Css.displayFlex
+                , Css.alignItems Css.center
+                , Css.justifyContent Css.center
+                ]
+            ]
+            [ div
+                [ css
+                    [ Css.backgroundColor Colors.white
+                    , Css.padding (Css.px 10)
+                    , Css.borderRadius (Css.px 10)
+                    , Css.boxShadow5 Css.zero (Css.px 1) (Css.px 10) Css.zero (Css.rgba 0 0 0 0.35)
+                    , Css.textAlign Css.center
+                    , Css.color Colors.navy
+                    , Fonts.baseFont
+                    , Css.margin Css.auto
+                    , Css.width (Css.px 100)
+                    , Css.height (Css.px 60)
+                    , Css.fontSize (Css.px 10)
+                    , Css.fontWeight Css.bold
+                    , Css.position Css.relative
+                    ]
+                ]
+                [ text "Modal"
+                , ClickableSvg.button "Close"
+                    UiIcon.x
+                    [ ClickableSvg.exactWidth 10
+                    , ClickableSvg.exactHeight 10
+                    , ClickableSvg.css
+                        [ Css.position absolute
+                        , Css.top (Css.px 10)
+                        , Css.right (Css.px 10)
+                        ]
+                    ]
+                ]
+            ]
+        ]
     , view =
         \state ->
             let

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -17,6 +17,7 @@ import Html.Styled.Attributes exposing (css)
 import Http
 import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Page.V3 as Page exposing (RecoveryText(..))
 
@@ -62,7 +63,32 @@ example =
     , state = { httpError = CommonControls.httpError, recoveryText = initRecoveryText }
     , update = update
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ -- faking a mini version of the Page component to give styleguide users a sense of what the
+          -- component might look like
+          Html.div
+            [ css
+                [ Css.displayFlex
+                , Css.alignItems Css.center
+                , Css.flexDirection Css.column
+                , Css.backgroundColor Colors.white
+                , Css.borderRadius (Css.px 4)
+                , Css.padding (Css.px 20)
+                ]
+            ]
+            [ Html.div [ css [ Css.fontSize (Css.px 40) ] ] [ Html.text "😵" ]
+            , Html.p
+                [ css
+                    [ Css.color Colors.navy
+                    , Fonts.baseFont
+                    , Css.fontWeight Css.bold
+                    , Css.textAlign Css.center
+                    , Css.margin Css.zero
+                    ]
+                ]
+                [ Html.text "There was a problem!" ]
+            ]
+        ]
     , view =
         \model ->
             let

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -62,6 +62,7 @@ example =
     , state = { httpError = CommonControls.httpError, recoveryText = initRecoveryText }
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \model ->
             let

--- a/styleguide-app/Examples/Pennant.elm
+++ b/styleguide-app/Examples/Pennant.elm
@@ -38,6 +38,7 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \_ ->
             [ IconExamples.viewWithCustomStyles "Premium Pennants"

--- a/styleguide-app/Examples/Pennant.elm
+++ b/styleguide-app/Examples/Pennant.elm
@@ -38,7 +38,12 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        IconExamples.preview
+            [ Pennant.premiumFlag
+            , Pennant.expiredPremiumFlag
+            , Pennant.disabledPremiumFlag
+            ]
     , view =
         \_ ->
             [ IconExamples.viewWithCustomStyles "Premium Pennants"

--- a/styleguide-app/Examples/RadioButton.elm
+++ b/styleguide-app/Examples/RadioButton.elm
@@ -34,6 +34,7 @@ example =
     , state = init
     , update = update
     , subscriptions = subscriptions
+    , preview = []
     , view = view
     , categories = [ Inputs ]
     , keyboardSupport =

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -36,6 +36,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \state ->
             let

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -26,6 +26,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Inputs ]
     , keyboardSupport = []
+    , preview = []
     , view =
         \state ->
             [ Html.Styled.label

--- a/styleguide-app/Examples/Slide.elm
+++ b/styleguide-app/Examples/Slide.elm
@@ -42,6 +42,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \state ->
             [ Keyed.node "div"

--- a/styleguide-app/Examples/SlideModal.elm
+++ b/styleguide-app/Examples/SlideModal.elm
@@ -40,6 +40,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \state ->
             [ viewModal state.modal

--- a/styleguide-app/Examples/SortableTable.elm
+++ b/styleguide-app/Examples/SortableTable.elm
@@ -41,6 +41,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \{ sortState } ->
             let

--- a/styleguide-app/Examples/Svg.elm
+++ b/styleguide-app/Examples/Svg.elm
@@ -33,6 +33,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \state ->
             [ viewSettings state

--- a/styleguide-app/Examples/Switch.elm
+++ b/styleguide-app/Examples/Switch.elm
@@ -34,16 +34,12 @@ example =
     , preview =
         [ Switch.view
             [ Switch.label (Html.text "Toggle On")
-
-            -- TODO
-            -- Switch.custom [ Key.tabbable False ]
+            , Switch.custom [ Key.tabbable False ]
             ]
             False
         , Switch.view
             [ Switch.label (Html.text "Toggle Off")
-
-            -- TODO
-            -- Switch.custom [ Key.tabbable False ]
+            , Switch.custom [ Key.tabbable False ]
             ]
             True
         ]

--- a/styleguide-app/Examples/Switch.elm
+++ b/styleguide-app/Examples/Switch.elm
@@ -6,6 +6,7 @@ module Examples.Switch exposing (Msg, State, example)
 
 -}
 
+import Accessibility.Styled.Key as Key
 import Category
 import Example exposing (Example)
 import Html.Styled as Html
@@ -31,8 +32,20 @@ example =
     , update = \(Switch new) _ -> ( new, Cmd.none )
     , subscriptions = \_ -> Sub.none
     , preview =
-        [ Switch.view [ Switch.label (Html.text "Toggle On") ] False
-        , Switch.view [ Switch.label (Html.text "Toggle Off") ] True
+        [ Switch.view
+            [ Switch.label (Html.text "Toggle On")
+
+            -- TODO
+            -- Switch.custom [ Key.tabbable False ]
+            ]
+            False
+        , Switch.view
+            [ Switch.label (Html.text "Toggle Off")
+
+            -- TODO
+            -- Switch.custom [ Key.tabbable False ]
+            ]
+            True
         ]
     , view =
         \interactiveIsOn ->

--- a/styleguide-app/Examples/Switch.elm
+++ b/styleguide-app/Examples/Switch.elm
@@ -11,7 +11,6 @@ import Example exposing (Example)
 import Html.Styled as Html
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Switch.V1 as Switch
-import Nri.Ui.Text.V6 as Text
 
 
 {-| -}
@@ -31,47 +30,39 @@ example =
     , state = True
     , update = \(Switch new) _ -> ( new, Cmd.none )
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ Switch.view [ Switch.label (Html.text "Toggle On") ] False
+        , Switch.view [ Switch.label (Html.text "Toggle Off") ] True
+        ]
     , view =
         \interactiveIsOn ->
             [ Heading.h3 [] [ Html.text "Interactive" ]
-            , Text.mediumBody
-                [ Text.html
-                    [ Switch.view
-                        [ Switch.onSwitch Switch
-                        , Switch.id "switch-interactive"
-                        , Switch.label
-                            (if interactiveIsOn then
-                                Html.text "On"
+            , Switch.view
+                [ Switch.onSwitch Switch
+                , Switch.id "switch-interactive"
+                , Switch.label
+                    (if interactiveIsOn then
+                        Html.text "On"
 
-                             else
-                                Html.text "Off"
-                            )
-                        ]
-                        interactiveIsOn
-                    ]
+                     else
+                        Html.text "Off"
+                    )
                 ]
-            , Heading.h3 [] [ Html.text "Disabled" ]
-            , Text.mediumBody
-                [ Text.html
-                    [ Switch.view
-                        [ Switch.disabled
-                        , Switch.id "switch-disabled-on"
-                        , Switch.label (Html.text "Permanently on")
-                        ]
-                        True
-                    ]
+                interactiveIsOn
+            , Heading.h3 [] [ Html.text "Disabled (On)" ]
+            , Switch.view
+                [ Switch.disabled
+                , Switch.id "switch-disabled-on"
+                , Switch.label (Html.text "Permanently on")
                 ]
-            , Text.mediumBody
-                [ Text.html
-                    [ Switch.view
-                        [ Switch.disabled
-                        , Switch.id "switch-disabled-off"
-                        , Switch.label (Html.text "Permanently off")
-                        ]
-                        False
-                    ]
+                True
+            , Heading.h3 [] [ Html.text "Disabled (Off)" ]
+            , Switch.view
+                [ Switch.disabled
+                , Switch.id "switch-disabled-off"
+                , Switch.label (Html.text "Permanently off")
                 ]
+                False
             ]
     , categories = [ Category.Inputs ]
     , keyboardSupport = [{- TODO -}]

--- a/styleguide-app/Examples/Switch.elm
+++ b/styleguide-app/Examples/Switch.elm
@@ -31,6 +31,7 @@ example =
     , state = True
     , update = \(Switch new) _ -> ( new, Cmd.none )
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \interactiveIsOn ->
             [ Heading.h3 [] [ Html.text "Interactive" ]

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -37,6 +37,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Tables, Layout ]
     , keyboardSupport = []
+    , preview = []
     , view =
         \() ->
             let

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -37,7 +37,29 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Tables, Layout ]
     , keyboardSupport = []
-    , preview = []
+    , preview =
+        [ Table.view
+            [ Table.string
+                { header = "A"
+                , value = .a
+                , width = px 50
+                , cellStyles = always []
+                }
+            , Table.string
+                { header = "B"
+                , value = .b
+                , width = px 50
+                , cellStyles = always []
+                }
+            ]
+            [ { a = "Row 1 A"
+              , b = "Row 1 B"
+              }
+            , { a = "Row 2 A"
+              , b = "Row 2 B"
+              }
+            ]
+        ]
     , view =
         \() ->
             let

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -23,6 +23,7 @@ import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Tabs.V7 as Tabs exposing (Alignment(..), Tab)
 import Nri.Ui.Tooltip.V2 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon
+import Routes
 import Task
 
 
@@ -117,9 +118,14 @@ update msg model =
             )
 
 
+exampleName : String
+exampleName =
+    "Tabs"
+
+
 example : Example State Msg
 example =
-    { name = "Tabs"
+    { name = exampleName
     , version = 7
     , categories = [ Layout ]
     , keyboardSupport =
@@ -168,7 +174,7 @@ allTabs openTooltipId labelledBy =
                 |> Svg.toHtml
     in
     [ Tabs.build { id = First, idString = "tab-0" }
-        ([ Tabs.spaHref "/#/doodad/Tabs"
+        ([ Tabs.spaHref <| Routes.toString (Routes.Doodad exampleName)
          , Tabs.tabString "1"
          , Tabs.withTooltip
             [ Tooltip.plaintext "Link Example"

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -136,6 +136,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \model ->
             let

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -19,8 +19,10 @@ import Html.Styled as Html exposing (Html, fromUnstyled)
 import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Key(..))
 import List.Zipper exposing (Zipper)
+import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Tabs.V7 as Tabs exposing (Alignment(..), Tab)
+import Nri.Ui.Text.V6 as Text
 import Nri.Ui.Tooltip.V2 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Routes
@@ -142,7 +144,49 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ -- faking a mini version of the Tabs component to give styleguide users a sense of what the
+          -- component might look like
+          Html.div [ css [ Css.displayFlex, Css.flexWrap Css.wrap ] ]
+            [ Html.div
+                [ css
+                    [ Css.backgroundColor Colors.white
+                    , Css.padding (Css.px 4)
+                    , Css.borderRadius4 (Css.px 4) (Css.px 4) Css.zero Css.zero
+                    , Css.border3 (Css.px 1) Css.solid Colors.navy
+                    , Css.borderBottomWidth Css.zero
+                    ]
+                ]
+                [ Text.smallBody [ Text.plaintext "Tab 1" ] ]
+            , Html.div
+                [ css [ Css.width (Css.px 4), Css.borderBottom3 (Css.px 1) Css.solid Colors.navy ]
+                ]
+                []
+            , Html.div
+                [ css
+                    [ Css.backgroundColor Colors.frost
+                    , Css.padding (Css.px 4)
+                    , Css.borderRadius4 (Css.px 4) (Css.px 4) Css.zero Css.zero
+                    , Css.border3 (Css.px 1) Css.solid Colors.navy
+                    ]
+                ]
+                [ Text.smallBody [ Text.plaintext "Tab 1" ] ]
+            , Html.div
+                [ css
+                    [ Css.width (Css.px 30)
+                    , Css.borderBottom3 (Css.px 1) Css.solid Colors.navy
+                    ]
+                ]
+                []
+            , Html.div
+                [ css
+                    [ Css.paddingTop (Css.px 4)
+                    , Css.minWidth (Css.px 100)
+                    ]
+                ]
+                [ Text.caption [ Text.plaintext "Tab 1 content" ] ]
+            ]
+        ]
     , view =
         \model ->
             let

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -30,6 +30,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \state ->
             let

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -30,7 +30,13 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ ( "caption", Text.caption )
+        , ( "smallBody", Text.smallBody )
+        , ( "mediumBody", Text.mediumBody )
+        , ( "ugMediumBody", Text.ugMediumBody )
+        ]
+            |> List.map viewPreview
     , view =
         \state ->
             let
@@ -56,6 +62,11 @@ example =
                 attributes
             ]
     }
+
+
+viewPreview : ( String, List (Text.Attribute msg) -> Html msg ) -> Html msg
+viewPreview ( name, view ) =
+    view [ Text.plaintext name ]
 
 
 viewExamples : List ( String, List (Text.Attribute msg) -> Html msg ) -> List (Text.Attribute msg) -> Html msg

--- a/styleguide-app/Examples/Text/Writing.elm
+++ b/styleguide-app/Examples/Text/Writing.elm
@@ -32,6 +32,7 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \_ ->
             let

--- a/styleguide-app/Examples/Text/Writing.elm
+++ b/styleguide-app/Examples/Text/Writing.elm
@@ -32,7 +32,7 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview = [ TextWriting.footnote [ text "This is a footnote. " ] ]
     , view =
         \_ ->
             let

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -44,6 +44,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Inputs ]
     , keyboardSupport = []
+    , preview = []
     , view =
         \state ->
             [ Heading.h1 [] [ Html.text "Textarea controls" ]

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -7,6 +7,7 @@ module Examples.TextInput exposing (Msg, State, example)
 -}
 
 import Accessibility.Styled as Html exposing (..)
+import Accessibility.Styled.Key as Key
 import Category exposing (Category(..))
 import Css exposing (..)
 import Debug.Control as Control exposing (Control)
@@ -33,10 +34,13 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , preview =
-        [ TextInput.view "Text Input" []
+        [ TextInput.view "Text Input"
+            [ TextInput.custom [ Key.tabbable False ]
+            ]
         , TextInput.view "Errored"
             [ TextInput.value "invalid content"
             , TextInput.errorIf True
+            , TextInput.custom [ Key.tabbable False ]
             ]
         ]
     , view =

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -32,7 +32,13 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ TextInput.view "Text Input" []
+        , TextInput.view "Errored"
+            [ TextInput.value "invalid content"
+            , TextInput.errorIf True
+            ]
+        ]
     , view =
         \state ->
             let

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -32,6 +32,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \state ->
             let

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -33,7 +33,31 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ Html.div
+            [ css
+                [ Css.marginTop (Css.px 60)
+                , Css.alignSelf Css.center
+                ]
+            ]
+            [ Tooltip.view
+                { id = "preview-tooltip"
+                , trigger =
+                    \attributes ->
+                        ClickableSvg.button "example-preview-tooltip-icon"
+                            UiIcon.gear
+                            [ ClickableSvg.custom attributes
+                            , ClickableSvg.small
+                            ]
+                }
+                [ Tooltip.plaintext "This is a tooltip."
+                , Tooltip.open True
+                , Tooltip.onTop
+                , Tooltip.smallPadding
+                , Tooltip.fitToContent
+                ]
+            ]
+        ]
     , view = view
     }
 

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -33,6 +33,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view = view
     }
 

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -7,6 +7,7 @@ module Examples.Tooltip exposing (example, State, Msg)
 -}
 
 import Accessibility.Styled as Html exposing (Html)
+import Accessibility.Styled.Key as Key
 import Category exposing (Category(..))
 import Css
 import Debug.Control as Control exposing (Control)
@@ -48,6 +49,7 @@ example =
                             UiIcon.gear
                             [ ClickableSvg.custom attributes
                             , ClickableSvg.small
+                            , ClickableSvg.custom [ Key.tabbable False ]
                             ]
                 }
                 [ Tooltip.plaintext "This is a tooltip."

--- a/styleguide-app/Examples/UiIcon.elm
+++ b/styleguide-app/Examples/UiIcon.elm
@@ -36,10 +36,17 @@ example =
     , preview =
         IconExamples.preview
             [ UiIcon.seeMore
-            , UiIcon.copyToClipboard
+            , UiIcon.archive
+            , UiIcon.share
+            , UiIcon.footsteps
+            , UiIcon.person
+            , UiIcon.calendar
+            , UiIcon.missingDocument
             , UiIcon.speechBalloon
-            , UiIcon.arrowPointingRight
+            , UiIcon.edit
+            , UiIcon.arrowTop
             , UiIcon.checkmark
+            , UiIcon.equals
             ]
     , view =
         \_ ->

--- a/styleguide-app/Examples/UiIcon.elm
+++ b/styleguide-app/Examples/UiIcon.elm
@@ -33,6 +33,7 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
+    , preview = []
     , view =
         \_ ->
             [ IconExamples.view "Interface"

--- a/styleguide-app/Examples/UiIcon.elm
+++ b/styleguide-app/Examples/UiIcon.elm
@@ -33,7 +33,14 @@ example =
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        IconExamples.preview
+            [ UiIcon.seeMore
+            , UiIcon.copyToClipboard
+            , UiIcon.speechBalloon
+            , UiIcon.arrowPointingRight
+            , UiIcon.checkmark
+            ]
     , view =
         \_ ->
             [ IconExamples.view "Interface"

--- a/styleguide-app/Main.elm
+++ b/styleguide-app/Main.elm
@@ -61,6 +61,7 @@ type Msg
     = UpdateModuleStates String Examples.Msg
     | OnUrlRequest Browser.UrlRequest
     | OnUrlChange Url
+    | ChangeUrl String
     | SkipToMainContent
     | NoOp
 
@@ -96,6 +97,9 @@ update action model =
 
         OnUrlChange route ->
             ( { model | route = Routes.fromLocation route }, Cmd.none )
+
+        ChangeUrl url ->
+            ( model, Browser.Navigation.pushUrl model.navigationKey url )
 
         SkipToMainContent ->
             ( model
@@ -177,14 +181,10 @@ view_ model =
         ]
 
 
-viewPreviews : String -> List (Example state Examples.Msg) -> Html Msg
+viewPreviews : String -> List (Example state msg) -> Html Msg
 viewPreviews containerId examples =
     examples
-        |> List.map
-            (\example ->
-                Example.preview example
-                    |> Html.map (UpdateModuleStates example.name)
-            )
+        |> List.map (\example -> Example.preview ChangeUrl example)
         |> Html.div
             [ id containerId
             , css

--- a/styleguide-app/Main.elm
+++ b/styleguide-app/Main.elm
@@ -166,26 +166,33 @@ view_ model =
                                 (Set.fromList Category.sorter doodad.categories)
                                 category
                         )
-                        |> List.map
-                            (\example ->
-                                Example.preview example
-                                    |> Html.map (UpdateModuleStates example.name)
-                            )
-                        |> Html.div [ id (Category.forId category) ]
+                        |> viewPreviews (Category.forId category)
                     ]
 
                 Routes.All ->
                     [ mainContentHeader "All"
-                    , examples (\_ -> True)
-                        |> List.map
-                            (\example ->
-                                Example.preview example
-                                    |> Html.map (UpdateModuleStates example.name)
-                            )
-                        |> Html.div []
+                    , viewPreviews "all" (examples (\_ -> True))
                     ]
             )
         ]
+
+
+viewPreviews : String -> List (Example state Examples.Msg) -> Html Msg
+viewPreviews containerId examples =
+    examples
+        |> List.map
+            (\example ->
+                Example.preview example
+                    |> Html.map (UpdateModuleStates example.name)
+            )
+        |> Html.div
+            [ id containerId
+            , css
+                [ Css.displayFlex
+                , Css.flexWrap Css.wrap
+                , Css.property "gap" "10px"
+                ]
+            ]
 
 
 navigation : Route -> Html Msg

--- a/styleguide-app/Main.elm
+++ b/styleguide-app/Main.elm
@@ -168,7 +168,7 @@ view_ model =
                         )
                         |> List.map
                             (\example ->
-                                Example.view example
+                                Example.preview example
                                     |> Html.map (UpdateModuleStates example.name)
                             )
                         |> Html.div [ id (Category.forId category) ]
@@ -179,7 +179,7 @@ view_ model =
                     , examples (\_ -> True)
                         |> List.map
                             (\example ->
-                                Example.view example
+                                Example.preview example
                                     |> Html.map (UpdateModuleStates example.name)
                             )
                         |> Html.div []

--- a/styleguide-app/Main.elm
+++ b/styleguide-app/Main.elm
@@ -1,6 +1,6 @@
 module Main exposing (init, main)
 
-import Accessibility.Styled as Html exposing (Html, img, text)
+import Accessibility.Styled as Html exposing (Html)
 import Browser exposing (Document, UrlRequest(..))
 import Browser.Dom
 import Browser.Navigation exposing (Key)
@@ -10,10 +10,10 @@ import Css.Media exposing (withMedia)
 import Dict exposing (Dict)
 import Example exposing (Example)
 import Examples
-import Html as RootHtml
 import Html.Attributes
 import Html.Styled.Attributes as Attributes exposing (..)
 import Html.Styled.Events as Events
+import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.CssVendorPrefix.V1 as VendorPrefixed
 import Nri.Ui.Fonts.V1 as Fonts
@@ -143,11 +143,16 @@ view_ model =
             [ displayFlex
             , withMedia [ mobile ] [ flexDirection column, alignItems stretch ]
             , alignItems flexStart
-            , minHeight (vh 100)
             ]
         ]
         [ navigation model.route
-        , Html.main_ [ css [ flexGrow (int 1), sectionStyles ] ]
+        , Html.main_
+            [ css
+                [ flexGrow (int 1)
+                , margin2 (px 40) zero
+                , Css.minHeight (Css.vh 100)
+                ]
+            ]
             (case model.route of
                 Routes.Doodad doodad ->
                     case List.head (examples (\m -> m.name == doodad)) of
@@ -207,21 +212,21 @@ navigation route =
                     False
 
         link active hash displayName =
-            Html.a
-                [ css
-                    [ backgroundColor transparent
-                    , borderStyle none
-                    , textDecoration none
+            ClickableText.link displayName
+                [ ClickableText.small
+                , ClickableText.css
+                    [ Css.color Colors.navy
+                    , Css.display Css.block
+                    , Css.padding (Css.px 8)
+                    , Css.borderRadius (Css.px 8)
                     , if active then
-                        color Colors.navy
+                        Css.backgroundColor Colors.glacier
 
                       else
-                        color Colors.azure
-                    , Fonts.baseFont
+                        Css.batch []
                     ]
-                , Attributes.href hash
+                , ClickableText.href hash
                 ]
-                [ Html.text displayName ]
 
         navLink category =
             link (isActive category)
@@ -231,7 +236,7 @@ navigation route =
         toNavLi element =
             Html.li
                 [ css
-                    [ margin2 (px 10) zero
+                    [ margin zero
                     , listStyle none
                     , textDecoration none
                     ]
@@ -276,18 +281,12 @@ navigation route =
             , id "skip"
             ]
             [ Html.text "Skip to main content" ]
-        , Heading.h4 [] [ Html.text "Categories" ]
         , (link (route == Routes.All) "#/" "All"
             :: List.map navLink Category.all
           )
             |> List.map toNavLi
             |> Html.ul
-                [ css [ margin4 zero zero (px 40) zero, padding zero ]
+                [ css [ margin zero, padding zero ]
                 , id "categories"
                 ]
         ]
-
-
-sectionStyles : Css.Style
-sectionStyles =
-    Css.batch [ margin2 (px 40) zero ]

--- a/styleguide-app/Routes.elm
+++ b/styleguide-app/Routes.elm
@@ -22,7 +22,7 @@ toString route_ =
             "#/category/" ++ Debug.toString c
 
         All ->
-            ""
+            "#/"
 
 
 route : Parser Route

--- a/styleguide-app/Routes.elm
+++ b/styleguide-app/Routes.elm
@@ -1,4 +1,4 @@
-module Routes exposing (Route(..), fromLocation)
+module Routes exposing (Route(..), fromLocation, toString)
 
 import Browser.Navigation as Navigation
 import Category
@@ -10,6 +10,19 @@ type Route
     = Doodad String
     | Category Category.Category
     | All
+
+
+toString : Route -> String
+toString route_ =
+    case route_ of
+        Doodad exampleName ->
+            "#/doodad/" ++ exampleName
+
+        Category c ->
+            "#/category/" ++ Debug.toString c
+
+        All ->
+            ""
 
 
 route : Parser Route


### PR DESCRIPTION
https://trello.com/c/c8tfGJis/483-make-styleguide-more-browse-able-and-usable

# All components view

<img width="1536" alt="Screen Shot 2021-11-05 at 3 54 13 PM" src="https://user-images.githubusercontent.com/8811312/140587050-a63bc8b7-a40b-4efa-9b65-6a9f935ec297.png">

Some of the previews are faked-out because for one reason or another, it wasn't straight forward to put an example use in place. My hope is that over time the fake versions will be replaced by real uses.

I zoomed out to take a comprehensive screenshot.

# Category view

![image](https://user-images.githubusercontent.com/8811312/140587213-15f16c46-7899-41e7-afc9-aeac8726ff64.png)


# Single component view

<img width="1536" alt="Screen Shot 2021-11-05 at 3 54 46 PM" src="https://user-images.githubusercontent.com/8811312/140587045-41704ab8-2133-4d16-b469-a4f1a15a87f2.png">

---

cc @NoRedInk/design 