### PR TITLE
Modify shell.nix to work properly on M1

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,8 @@
 let
   sources = import ./nix/sources.nix;
-  nixpkgs = import sources.nixpkgs { };
-  niv = import sources.niv { };
+  system = if builtins.currentSystem == "aarch64-darwin" then "x86_64-darwin" else builtins.currentSystem;
+  nixpkgs = import sources.nixpkgs { inherit system; };
+  niv = nixpkgs.callPackage sources.niv { };
 in with nixpkgs;
 stdenv.mkDerivation {
   name = "noredink-ui";


### PR DESCRIPTION
Modify shell.nix to properly build dependencies on an M1 Mac. Prior to this, nix was failing to compile ghc due to the architecture. This change tells nix to always build for Intel-style architecture.