### PR TITLE
Kraken/input positioning

### DIFF
--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -1,6 +1,7 @@
 Nri.Ui.Accordion.V1,upgrade to V3
 Nri.Ui.Menu.V1,upgrade to V3
 Nri.Ui.Menu.V2,upgrade to V3
+Nri.Ui.PremiumCheckbox.V6,upgrade to V7
 Nri.Ui.RadioButton.V2,upgrade to V3
 Nri.Ui.Table.V4,upgrade to V5
 Nri.Ui.Tabs.V6,upgrade to V7

--- a/elm.json
+++ b/elm.json
@@ -43,6 +43,7 @@
         "Nri.Ui.Palette.V1",
         "Nri.Ui.Pennant.V2",
         "Nri.Ui.PremiumCheckbox.V6",
+        "Nri.Ui.PremiumCheckbox.V7",
         "Nri.Ui.RadioButton.V2",
         "Nri.Ui.RadioButton.V3",
         "Nri.Ui.SegmentedControl.V14",

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -78,6 +78,9 @@ usages = ['styleguide-app/Examples/RadioButton.elm']
 [forbidden."Nri.Ui.Modal.V3"]
 hint = 'upgrade to V11'
 
+[forbidden."Nri.Ui.PremiumCheckbox.V6"]
+hint = 'upgrade to V7'
+
 [forbidden."Nri.Ui.RadioButton.V1"]
 hint = 'upgrade to V2'
 

--- a/src/Nri/Ui/PremiumCheckbox/V7.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V7.elm
@@ -2,6 +2,7 @@ module Nri.Ui.PremiumCheckbox.V7 exposing
     ( view
     , selected, partiallySelected
     , premium, showPennant
+    , disabled, enabled
     )
 
 {-|
@@ -20,6 +21,12 @@ module Nri.Ui.PremiumCheckbox.V7 exposing
 
 @docs premium, showPennant
 
+
+### Attributes
+
+@docs Attribute
+@docs disabled, enabled
+
 -}
 
 import Accessibility.Styled as Html exposing (Html)
@@ -32,6 +39,20 @@ import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Util exposing (removePunctuation)
 import String exposing (toLower)
 import String.Extra exposing (dasherize)
+
+
+{-| This disables the input
+-}
+disabled : Attribute msg
+disabled =
+    Attribute <| \config -> { config | isDisabled = True }
+
+
+{-| This enables the input, this is the default behavior
+-}
+enabled : Attribute msg
+enabled =
+    Attribute <| \config -> { config | isDisabled = False }
 
 
 {-| Lock Premium content if the user does not have Premium.

--- a/src/Nri/Ui/PremiumCheckbox/V7.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V7.elm
@@ -1,0 +1,78 @@
+module Nri.Ui.PremiumCheckbox.V7 exposing (view)
+
+{-|
+
+@docs view
+
+This module is used when there may or may not be Premium
+content to be "checked"!
+
+
+# Changes from V6
+
+  - Move the Premium pennant to the left of the checkbox
+
+-}
+
+import Accessibility.Styled as Html exposing (Html)
+import Css
+import Html.Styled.Attributes as Attributes exposing (css)
+import Nri.Ui.Checkbox.V5 as Checkbox
+import Nri.Ui.Pennant.V2 exposing (premiumFlag)
+import Nri.Ui.Svg.V1 as Svg
+
+
+{-| A checkbox that should be used for premium content
+
+  - `onChange`: A message for when the user toggles the checkbox
+  - `onLockedClick`: A message for when the user clicks a checkbox they don't have PremiumLevel for.
+    If you get this message, you should show an `Nri.Ui.Premium.Model.view`
+
+-}
+view :
+    { label : String
+    , id : String
+    , selected : Checkbox.IsSelected
+    , disabled : Bool
+    , isLocked : Bool
+    , isPremium : Bool
+    , onChange : Bool -> msg
+    , onLockedClick : msg
+    }
+    -> Html msg
+view config =
+    Html.div
+        [ css
+            [ Css.displayFlex
+            , Css.alignItems Css.center
+            ]
+        ]
+        [ if config.isPremium then
+            premiumFlag
+                |> Svg.withLabel "Premium"
+                |> Svg.withWidth (Css.px 25)
+                |> Svg.withHeight (Css.px 30)
+                |> Svg.withCss [ Css.marginRight (Css.px 8) ]
+                |> Svg.toHtml
+
+          else
+            Html.text ""
+        , Checkbox.viewWithLabel
+            { identifier = config.id
+            , label = config.label
+            , setterMsg =
+                if config.isLocked then
+                    \_ -> config.onLockedClick
+
+                else
+                    config.onChange
+            , selected = config.selected
+            , disabled = config.disabled
+            , theme =
+                if config.isLocked then
+                    Checkbox.Locked
+
+                else
+                    Checkbox.Square
+            }
+        ]

--- a/src/Nri/Ui/PremiumCheckbox/V7.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V7.elm
@@ -50,13 +50,14 @@ view config =
         [ if config.isPremium then
             premiumFlag
                 |> Svg.withLabel "Premium"
-                |> Svg.withWidth (Css.px 25)
+                |> Svg.withWidth (Css.px iconWidth)
                 |> Svg.withHeight (Css.px 30)
-                |> Svg.withCss [ Css.marginRight (Css.px 8) ]
+                |> Svg.withCss [ Css.marginRight (Css.px iconRightMargin) ]
                 |> Svg.toHtml
 
           else
-            Html.text ""
+            -- left-align the checkbox with checkboxes that _do_ have the premium pennant
+            Html.div [ css [ Css.width (Css.px (iconWidth + iconRightMargin)) ] ] []
         , Checkbox.viewWithLabel
             { identifier = config.id
             , label = config.label
@@ -76,3 +77,13 @@ view config =
                     Checkbox.Square
             }
         ]
+
+
+iconWidth : Float
+iconWidth =
+    25
+
+
+iconRightMargin : Float
+iconRightMargin =
+    8

--- a/src/Nri/Ui/PremiumCheckbox/V7.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V7.elm
@@ -2,6 +2,7 @@ module Nri.Ui.PremiumCheckbox.V7 exposing
     ( view
     , selected, partiallySelected
     , premium, showPennant
+    , Attribute
     , disabled, enabled
     )
 

--- a/src/Nri/Ui/PremiumCheckbox/V7.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V7.elm
@@ -1,5 +1,6 @@
 module Nri.Ui.PremiumCheckbox.V7 exposing
     ( view
+    , selected, partiallySelected
     , premium, showPennant
     )
 
@@ -12,6 +13,7 @@ module Nri.Ui.PremiumCheckbox.V7 exposing
   - list based API instead of record based
 
 @docs view
+@docs selected, partiallySelected
 
 
 ### Content
@@ -56,6 +58,28 @@ When a locked premium checkbox is clicked, the msg that's passed in will fire.
 showPennant : msg -> Attribute msg
 showPennant premiumMsg =
     Attribute <| \config -> { config | premiumMsg = Just premiumMsg }
+
+
+setSelectionStatus : Checkbox.IsSelected -> Attribute msg
+setSelectionStatus status =
+    Attribute (\config -> { config | selected = status })
+
+
+{-| -}
+selected : Bool -> Attribute msg
+selected isSelected =
+    setSelectionStatus <|
+        if isSelected then
+            Checkbox.Selected
+
+        else
+            Checkbox.NotSelected
+
+
+{-| -}
+partiallySelected : Attribute msg
+partiallySelected =
+    setSelectionStatus Checkbox.PartiallySelected
 
 
 {-| Customizations for the RadioButton.

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -186,11 +186,6 @@ viewPremiumCheckboxes state =
         [ PremiumCheckbox.view
             { label = "Identify Adjectives 1 (Premium)"
 
-            --, selected =
-            --    if Set.member "premium-1" state.isChecked then
-            --        Checkbox.Selected
-            --    else
-            --        Checkbox.NotSelected
             --, disabled = False
             --, isLocked = False
             --, isPremium = True
@@ -201,15 +196,11 @@ viewPremiumCheckboxes state =
                 , contentPremiumLevel = PremiumLevel.PremiumWithWriting
                 }
             , PremiumCheckbox.showPennant NoOp
+            , PremiumCheckbox.selected (Set.member "premium-1" state.isChecked)
             ]
         , PremiumCheckbox.view
             { label = "Identify Adjectives 2 (Free)"
 
-            --, selected =
-            --    if Set.member "premium-2" state.isChecked then
-            --        Checkbox.Selected
-            --    else
-            --        Checkbox.NotSelected
             --, disabled = False
             --, isLocked = False
             --, isPremium = False
@@ -220,15 +211,11 @@ viewPremiumCheckboxes state =
                 , contentPremiumLevel = PremiumLevel.Free
                 }
             , PremiumCheckbox.showPennant NoOp
+            , PremiumCheckbox.selected (Set.member "premium-2" state.isChecked)
             ]
         , PremiumCheckbox.view
             { label = "Revising Wordy Phrases 3 (Premium, Disabled)"
 
-            --, selected =
-            --    if Set.member "premium-3" state.isChecked then
-            --        Checkbox.Selected
-            --    else
-            --        Checkbox.NotSelected
             --, disabled = True
             --, isLocked = True
             --, isPremium = True
@@ -239,6 +226,7 @@ viewPremiumCheckboxes state =
                 , contentPremiumLevel = PremiumLevel.PremiumWithWriting
                 }
             , PremiumCheckbox.showPennant NoOp
+            , PremiumCheckbox.selected (Set.member "premium-3" state.isChecked)
             ]
         ]
 

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -185,49 +185,61 @@ viewPremiumCheckboxes state =
     Html.div []
         [ PremiumCheckbox.view
             { label = "Identify Adjectives 1 (Premium)"
-            , id = "premium-checkbox-identify-adjectives-premium"
-            , selected =
-                if Set.member "premium-1" state.isChecked then
-                    Checkbox.Selected
 
-                else
-                    Checkbox.NotSelected
-            , disabled = False
-            , isLocked = False
-            , isPremium = True
+            --, selected =
+            --    if Set.member "premium-1" state.isChecked then
+            --        Checkbox.Selected
+            --    else
+            --        Checkbox.NotSelected
+            --, disabled = False
+            --, isLocked = False
+            --, isPremium = True
             , onChange = ToggleCheck "premium-1"
-            , onLockedClick = NoOp
             }
+            [ PremiumCheckbox.premium
+                { teacherPremiumLevel = PremiumLevel.PremiumWithWriting
+                , contentPremiumLevel = PremiumLevel.PremiumWithWriting
+                }
+            , PremiumCheckbox.showPennant NoOp
+            ]
         , PremiumCheckbox.view
             { label = "Identify Adjectives 2 (Free)"
-            , id = "premium-checkbox-identify-adjectives-free"
-            , selected =
-                if Set.member "premium-2" state.isChecked then
-                    Checkbox.Selected
 
-                else
-                    Checkbox.NotSelected
-            , disabled = False
-            , isLocked = False
-            , isPremium = False
+            --, selected =
+            --    if Set.member "premium-2" state.isChecked then
+            --        Checkbox.Selected
+            --    else
+            --        Checkbox.NotSelected
+            --, disabled = False
+            --, isLocked = False
+            --, isPremium = False
             , onChange = ToggleCheck "premium-2"
-            , onLockedClick = NoOp
             }
+            [ PremiumCheckbox.premium
+                { teacherPremiumLevel = PremiumLevel.PremiumWithWriting
+                , contentPremiumLevel = PremiumLevel.Free
+                }
+            , PremiumCheckbox.showPennant NoOp
+            ]
         , PremiumCheckbox.view
             { label = "Revising Wordy Phrases 3 (Premium, Disabled)"
-            , id = "premium-checkbox-premium-disabled"
-            , selected =
-                if Set.member "premium-3" state.isChecked then
-                    Checkbox.Selected
 
-                else
-                    Checkbox.NotSelected
-            , disabled = True
-            , isLocked = True
-            , isPremium = True
+            --, selected =
+            --    if Set.member "premium-3" state.isChecked then
+            --        Checkbox.Selected
+            --    else
+            --        Checkbox.NotSelected
+            --, disabled = True
+            --, isLocked = True
+            --, isPremium = True
             , onChange = ToggleCheck "premium-3"
-            , onLockedClick = NoOp
             }
+            [ PremiumCheckbox.premium
+                { teacherPremiumLevel = PremiumLevel.Free
+                , contentPremiumLevel = PremiumLevel.PremiumWithWriting
+                }
+            , PremiumCheckbox.showPennant NoOp
+            ]
         ]
 
 

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -185,10 +185,6 @@ viewPremiumCheckboxes state =
     Html.div []
         [ PremiumCheckbox.view
             { label = "Identify Adjectives 1 (Premium)"
-
-            --, disabled = False
-            --, isLocked = False
-            --, isPremium = True
             , onChange = ToggleCheck "premium-1"
             }
             [ PremiumCheckbox.premium
@@ -200,10 +196,6 @@ viewPremiumCheckboxes state =
             ]
         , PremiumCheckbox.view
             { label = "Identify Adjectives 2 (Free)"
-
-            --, disabled = False
-            --, isLocked = False
-            --, isPremium = False
             , onChange = ToggleCheck "premium-2"
             }
             [ PremiumCheckbox.premium
@@ -215,10 +207,6 @@ viewPremiumCheckboxes state =
             ]
         , PremiumCheckbox.view
             { label = "Revising Wordy Phrases 3 (Premium, Disabled)"
-
-            --, disabled = True
-            --, isLocked = True
-            --, isPremium = True
             , onChange = ToggleCheck "premium-3"
             }
             [ PremiumCheckbox.premium

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -14,7 +14,7 @@ import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Checkbox.V5 as Checkbox
 import Nri.Ui.Data.PremiumLevel as PremiumLevel exposing (PremiumLevel(..))
-import Nri.Ui.PremiumCheckbox.V6 as PremiumCheckbox
+import Nri.Ui.PremiumCheckbox.V7 as PremiumCheckbox
 import Set exposing (Set)
 
 

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -39,6 +39,7 @@
         "Nri.Ui.Palette.V1",
         "Nri.Ui.Pennant.V2",
         "Nri.Ui.PremiumCheckbox.V6",
+        "Nri.Ui.PremiumCheckbox.V7",
         "Nri.Ui.RadioButton.V2",
         "Nri.Ui.RadioButton.V3",
         "Nri.Ui.SegmentedControl.V14",


### PR DESCRIPTION
Fixes https://github.com/NoRedInk/noredink-ui/issues/795

![image](https://user-images.githubusercontent.com/8811312/145093642-d9086f5e-ac6c-4225-8b3d-dfbf52b3bd7a.png)

Pennants showing to the left of the checkbox.

---

@NoRedInk/design I have a couple of questions/concerns that don't necessarily block this PR, but that I thought I'd best mention:
- Should the Pennant flip to look like `>=|` instead of like `|=<`? It doesn't look like a sticky that's attached to the checkbox anymore
- Should the Pennant do anything on click? The RadioButton component launches the Premium modal when you click the Premium Pennant, not if you click the label or input.
- Should the RadioButton pennant also go on the other side?

I also want to flag (ha) that there are accessibility issues with the way the Premium icon is currently shown -- it's not attached to the input in a screenreader-friendly way. I think fixing this relationship will require a new Checkbox version to do properly, so I'm not going to do it yet.