### PR TITLE
Kraken/radio styling

### DIFF
--- a/src/Nri/Ui/RadioButton/V3.elm
+++ b/src/Nri/Ui/RadioButton/V3.elm
@@ -327,6 +327,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
         , css
             [ position relative
             , marginLeft (px -4)
+            , Css.paddingLeft (Css.px 40)
             , display inlineBlock
             , Css.height (px 34)
             , pseudoClass "focus-within"
@@ -380,8 +381,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
                 , ( "Nri-RadioButton-RadioButtonChecked", isChecked )
                 ]
             , css
-                [ position relative
-                , outline Css.none
+                [ outline Css.none
                 , margin zero
                 , Fonts.baseFont
                 , Css.batch
@@ -400,7 +400,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
                         , cursor pointer
                         ]
                     )
-                , padding4 (px 6) zero (px 4) (px 40)
+                , padding4 (px 6) zero (px 4) zero
                 , fontSize (px 15)
                 , Css.property "font-weight" "600"
                 , display inlineBlock

--- a/src/Nri/Ui/RadioButton/V3.elm
+++ b/src/Nri/Ui/RadioButton/V3.elm
@@ -301,20 +301,17 @@ view { label, name, value, valueToString, selectedValue } attributes =
                 |> Maybe.withDefault True
                 |> not
 
-        ( disclosureIds, disclosureElements ) =
-            case ( config.disclosedContent, isChecked ) of
-                ( [], _ ) ->
-                    ( [], [] )
-
-                ( _, False ) ->
-                    ( [], [] )
-
-                ( _, True ) ->
-                    ( List.indexedMap
-                        (\index _ -> (idValue ++ "-disclosure-content-") ++ String.fromInt index)
-                        config.disclosedContent
-                    , config.disclosedContent
+        ( disclosureIds, disclosedElements ) =
+            config.disclosedContent
+                |> List.indexedMap
+                    (\index element ->
+                        let
+                            id_ =
+                                (idValue ++ "-disclosure-content-") ++ String.fromInt index
+                        in
+                        ( id_, span [ Attributes.id id_ ] [ element ] )
                     )
+                |> List.unzip
 
         isInError =
             InputErrorAndGuidanceInternal.getIsInError config.error
@@ -354,7 +351,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
                 _ ->
                     Extra.none
              , class "Nri-RadioButton-HiddenRadioInput"
-             , Attributes.attribute "aria-controls" (String.join " " disclosureIds)
+             , Aria.describedBy disclosureIds
              , css
                 [ position absolute
                 , top (pct 50)
@@ -452,7 +449,12 @@ view { label, name, value, valueToString, selectedValue } attributes =
             ]
          , InputErrorAndGuidanceInternal.view idValue config
          ]
-            ++ disclosureElements
+            ++ (if isChecked then
+                    disclosedElements
+
+                else
+                    []
+               )
         )
 
 

--- a/src/Nri/Ui/RadioButton/V3.elm
+++ b/src/Nri/Ui/RadioButton/V3.elm
@@ -328,6 +328,8 @@ view { label, name, value, valueToString, selectedValue } attributes =
             [ position relative
             , marginLeft (px -4)
             , Css.paddingLeft (Css.px 40)
+            , Css.paddingTop (px 6)
+            , Css.paddingBottom (px 4)
             , display inlineBlock
             , pseudoClass "focus-within"
                 [ Css.Global.descendants
@@ -381,7 +383,6 @@ view { label, name, value, valueToString, selectedValue } attributes =
                 ]
             , css
                 [ outline Css.none
-                , margin zero
                 , Fonts.baseFont
                 , Css.batch
                     (if config.isDisabled then
@@ -399,7 +400,8 @@ view { label, name, value, valueToString, selectedValue } attributes =
                         , cursor pointer
                         ]
                     )
-                , padding4 (px 6) zero (px 4) zero
+                , margin zero
+                , padding zero
                 , fontSize (px 15)
                 , Css.property "font-weight" "600"
                 , display inlineBlock

--- a/src/Nri/Ui/RadioButton/V3.elm
+++ b/src/Nri/Ui/RadioButton/V3.elm
@@ -329,7 +329,6 @@ view { label, name, value, valueToString, selectedValue } attributes =
             , marginLeft (px -4)
             , Css.paddingLeft (Css.px 40)
             , display inlineBlock
-            , Css.height (px 34)
             , pseudoClass "focus-within"
                 [ Css.Global.descendants
                     [ Css.Global.class "Nri-RadioButton-RadioButtonIcon"
@@ -356,7 +355,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
              , Attributes.attribute "aria-controls" (String.join " " disclosureIds)
              , css
                 [ position absolute
-                , top (px 4)
+                , top (pct 50)
                 , left (px 4)
                 , opacity zero
                 , pseudoClass "focus"
@@ -490,6 +489,15 @@ radioInputIcon config =
 
                 ( _, False, False ) ->
                     unselectedSvg
+
+        iconHeight =
+            26
+
+        borderWidth =
+            2
+
+        iconPadding =
+            2
     in
     div
         [ classList
@@ -505,18 +513,18 @@ radioInputIcon config =
                     []
             , position absolute
             , left zero
-            , top zero
+            , top (calc (pct 50) Css.minus (Css.px ((iconHeight + borderWidth + iconPadding) / 2)))
             , Css.property "transition" ".3s all"
-            , border3 (px 2) solid transparent
+            , border3 (px borderWidth) solid transparent
             , borderRadius (px 50)
-            , padding (px 2)
+            , padding (px iconPadding)
             , displayFlex
             , justifyContent center
             , alignItems center
             ]
         ]
         [ image
-            |> Nri.Ui.Svg.V1.withHeight (Css.px 26)
+            |> Nri.Ui.Svg.V1.withHeight (Css.px iconHeight)
             |> Nri.Ui.Svg.V1.withWidth (Css.px 26)
             |> Nri.Ui.Svg.V1.toHtml
         ]

--- a/src/Nri/Ui/RadioButton/V3.elm
+++ b/src/Nri/Ui/RadioButton/V3.elm
@@ -301,18 +301,19 @@ view { label, name, value, valueToString, selectedValue } attributes =
                 |> Maybe.withDefault True
                 |> not
 
-        ( disclosureId, disclosureElement ) =
+        ( disclosureIds, disclosureElements ) =
             case ( config.disclosedContent, isChecked ) of
                 ( [], _ ) ->
-                    ( Nothing, text "" )
+                    ( [], [] )
 
                 ( _, False ) ->
-                    ( Nothing, text "" )
+                    ( [], [] )
 
-                ( (_ :: _) as childNodes, True ) ->
-                    ( Just (idValue ++ "-disclosure-content")
-                    , span [ Attributes.id (idValue ++ "-disclosure-content") ]
-                        childNodes
+                ( _, True ) ->
+                    ( List.indexedMap
+                        (\index _ -> (idValue ++ "-disclosure-content-") ++ String.fromInt index)
+                        config.disclosedContent
+                    , config.disclosedContent
                     )
 
         isInError =
@@ -338,7 +339,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
             , Css.batch config.containerCss
             ]
         ]
-        [ radio name
+        ([ radio name
             stringValue
             isChecked
             ([ Attributes.id idValue
@@ -351,7 +352,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
                 _ ->
                     Extra.none
              , class "Nri-RadioButton-HiddenRadioInput"
-             , maybeAttr Aria.controls disclosureId
+             , Attributes.attribute "aria-controls" (String.join " " disclosureIds)
              , css
                 [ position absolute
                 , top (px 4)
@@ -372,7 +373,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
              ]
                 ++ List.map (Attributes.map never) config.custom
             )
-        , Html.label
+         , Html.label
             [ for idValue
             , classList
                 [ ( "Nri-RadioButton-RadioButton", True )
@@ -448,9 +449,10 @@ view { label, name, value, valueToString, selectedValue } attributes =
                         text ""
                 ]
             ]
-        , disclosureElement
-        , InputErrorAndGuidanceInternal.view idValue config
-        ]
+         , InputErrorAndGuidanceInternal.view idValue config
+         ]
+            ++ disclosureElements
+        )
 
 
 premiumPennant : msg -> Html msg

--- a/styleguide-app/Examples/RadioButton.elm
+++ b/styleguide-app/Examples/RadioButton.elm
@@ -155,9 +155,11 @@ viewExamplesCode selectionSettings selectedValue =
         [ css
             [ Css.display Css.block
             , Css.marginLeft (Css.px 20)
+            , Css.flexBasis (Css.px 300)
+            , Css.flexGrow Css.zero
             ]
         ]
-        [ Html.pre []
+        [ Html.pre [ css [ Css.whiteSpace Css.preWrap ] ]
             [ text
                 ("  " ++ String.join "\n, " (List.map toExampleCode (examples selectionSettings)))
             ]


### PR DESCRIPTION
Change the radio icon SVG to align vertically at the center of the label & disclosure content, rather than at the top. 

See https://github.com/NoRedInk/NoRedInk/pull/36500 for the context in which this will be useful.

![image](https://user-images.githubusercontent.com/8811312/145479217-1809d476-1623-42e0-8d9a-3340cabfee10.png)


<img width="291" alt="Screen Shot 2021-12-09 at 1 32 21 PM" src="https://user-images.githubusercontent.com/8811312/145479152-4e99e8f3-c7e2-4f6d-bb9f-1ebdb45e1707.png">

This should also improve the screenreader experience described in https://github.com/NoRedInk/NoRedInk/pull/36492#issuecomment-990259528 

cc @NoRedInk/design 