### PR TITLE
adds role img and hide decorative svgs

### DIFF
--- a/src/Nri/Ui/Svg/V1.elm
+++ b/src/Nri/Ui/Svg/V1.elm
@@ -12,6 +12,7 @@ module Nri.Ui.Svg.V1 exposing
 
 -}
 
+import Accessibility.Styled.Role as Role
 import Accessibility.Styled.Widget as Widget
 import Css exposing (Color)
 import Html.Styled as Html exposing (Html)
@@ -55,6 +56,8 @@ withColor color (Svg record) =
 
 See [Using the aria-label attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) for
 guidelines of when and how to use this attribute.
+
+Note that when the label is _not_ present, `aria-hidden` will be added. See <https://css-tricks.com/accessible-svg-icons/> for a quick summary on why.
 
 -}
 withLabel : String -> Svg -> Svg
@@ -102,11 +105,9 @@ toHtml (Svg record) =
                   else
                     Just (Attributes.css (Css.display Css.inlineBlock :: css))
                 , Maybe.map Widget.label record.label
+                    |> Maybe.withDefault (Widget.hidden True)
+                    |> Just
+                , Just Role.img
                 ]
     in
-    case attributes of
-        [] ->
-            Html.map never record.icon
-
-        _ ->
-            Html.div attributes [ Html.map never record.icon ]
+    Html.div attributes [ Html.map never record.icon ]

--- a/styleguide-app/Examples/Svg.elm
+++ b/styleguide-app/Examples/Svg.elm
@@ -104,21 +104,24 @@ viewResults state =
                 , Css.marginRight (Css.px 20)
                 ]
             ]
-            [ [ "color : Css.Color"
-              , "color ="
+            [ [ "color : Css.Color\n"
+              , "color =\n"
               , "    Css.rgb " ++ String.fromFloat red ++ " " ++ String.fromFloat green ++ " " ++ String.fromFloat blue
-              , ""
-              , ""
-              , "renderedSvg : Svg "
-              , "renderedSvg = "
-              , "   UiIcon.newspaper"
-              , "       |> Svg.withColor color"
-              , "       |> Svg.withWidth (Css.px " ++ String.fromFloat state.width ++ ")"
-              , "       |> Svg.withHeight (Css.px " ++ String.fromFloat state.height ++ ")"
-              , "       |> Svg.withLabel \"" ++ state.label ++ "\""
-              , "       |> Svg.toHtml"
+              , "\n\n\n"
+              , "renderedSvg : Svg\n"
+              , "renderedSvg =\n"
+              , "   UiIcon.newspaper\n"
+              , "       |> Svg.withColor color\n"
+              , "       |> Svg.withWidth (Css.px " ++ String.fromFloat state.width ++ ")\n"
+              , "       |> Svg.withHeight (Css.px " ++ String.fromFloat state.height ++ ")\n"
+              , if String.isEmpty state.label then
+                    ""
+
+                else
+                    "       |> Svg.withLabel \"" ++ state.label ++ "\"\n"
+              , "       |> Svg.toHtml\n"
               ]
-                |> String.join "\n"
+                |> String.join ""
                 |> Html.text
             ]
         , Html.div
@@ -131,7 +134,13 @@ viewResults state =
                 |> Svg.withColor (toCssColor state.color)
                 |> Svg.withWidth (Css.px state.width)
                 |> Svg.withHeight (Css.px state.height)
-                |> Svg.withLabel state.label
+                |> (\svg ->
+                        if String.isEmpty state.label then
+                            svg
+
+                        else
+                            Svg.withLabel state.label svg
+                   )
                 |> Svg.toHtml
             ]
         ]


### PR DESCRIPTION
Per audit (line one, https://docs.google.com/spreadsheets/d/1bRr62TZB0I3JZzLm-UDBIoAPFB3Dzl-B/edit#gid=14356013) -- our SVGs were missing role img and were being displayed even when they didn't have a title.

This PR updates the Svg behavior such that if there's a label, it's read out, and if there's _not_ a label, the SVG is assumed to be decorative.

This is a pretty safe default behavior, in my opinion, since our SVGs are generally used directly with other components (like ClickableSvg, ClickableText, and Button).

Prior to this PR, you could get to a state like this with VO:
<img width="1396" alt="Screen Shot 2022-01-05 at 4 10 11 PM" src="https://user-images.githubusercontent.com/8811312/148307681-2fadf2d2-f298-4b6f-b0fb-2821907af1b0.png">

Now, you won't be able to use VO-arrow to navigate to the search icon (as an example).

cc @krinhorn 
