### PR TITLE
Tessa/accessibility invisible style

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -81,8 +81,8 @@
         "elm-community/random-extra": "3.2.0 <= v < 4.0.0",
         "elm-community/string-extra": "4.0.1 <= v < 5.0.0",
         "pablohirafuji/elm-markdown": "2.0.5 <= v < 3.0.0",
-        "rtfeldman/elm-css": "17.0.1 <= v < 18.0.0",
-        "tesk9/accessible-html-with-css": "2.2.1 <= v < 3.0.0",
+        "rtfeldman/elm-css": "17.0.4 <= v < 18.0.0",
+        "tesk9/accessible-html-with-css": "2.3.1 <= v < 3.0.0",
         "tesk9/palette": "3.0.1 <= v < 4.0.0"
     },
     "test-dependencies": {

--- a/src/Nri/Ui/SideNav/V1.elm
+++ b/src/Nri/Ui/SideNav/V1.elm
@@ -33,6 +33,7 @@ module Nri.Ui.SideNav.V1 exposing
 -}
 
 import Accessibility.Styled exposing (..)
+import Accessibility.Styled.Style as Style
 import ClickableAttributes exposing (ClickableAttributes)
 import Css exposing (..)
 import Css.Media as Media
@@ -116,17 +117,7 @@ viewSkipLink onSkip =
         , ClickableText.small
         , ClickableText.css
             [ Css.pseudoClass "not(:focus)"
-                -- TODO: use Accessibility.Styled.Style.invisibleStyle
-                -- when we're on a higher version of tesk9/accessible-html-with-css
-                -- than 2.2.1
-                [ Css.property "clip" "rect(1px, 1px, 1px, 1px)"
-                , Css.position Css.absolute
-                , Css.height (Css.px 1)
-                , Css.width (Css.px 1)
-                , Css.overflow Css.hidden
-                , Css.margin (Css.px -1)
-                , Css.padding Css.zero
-                , Css.border Css.zero
+                [ Style.invisibleStyle
                 ]
             ]
         , ClickableText.onClick onSkip

--- a/styleguide-app/elm.json
+++ b/styleguide-app/elm.json
@@ -9,7 +9,7 @@
         "direct": {
             "BrianHicks/elm-particle": "1.5.0",
             "Gizra/elm-keyboard-event": "1.0.1",
-            "avh4/elm-debug-controls": "2.2.1",
+            "avh4/elm-debug-controls": "2.2.2",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
@@ -23,14 +23,14 @@
             "elm-community/random-extra": "3.2.0",
             "elm-community/string-extra": "4.0.1",
             "pablohirafuji/elm-markdown": "2.0.5",
-            "rtfeldman/elm-css": "16.1.1",
+            "rtfeldman/elm-css": "17.0.4",
             "rtfeldman/elm-sorter-experiment": "2.1.1",
-            "tesk9/accessible-html-with-css": "2.2.0",
+            "tesk9/accessible-html-with-css": "2.3.1",
             "tesk9/palette": "3.0.1",
             "wernerdegroot/listzipper": "4.0.0"
         },
         "indirect": {
-            "NoRedInk/datetimepicker-legacy": "1.0.4",
+            "NoRedInk/datetimepicker-legacy": "1.0.5",
             "SwiftsNamesake/proper-keyboard": "4.0.0",
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
@@ -38,6 +38,7 @@
             "elm/virtual-dom": "1.0.2",
             "justinmimbs/date": "3.2.1",
             "justinmimbs/time-extra": "1.1.0",
+            "robinheghan/murmur3": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0"
         }
     },


### PR DESCRIPTION
Use https://package.elm-lang.org/packages/tesk9/accessible-html-with-css/latest/Accessibility-Styled-Style#invisibleStyle to hide navbar skiplink.

Also updates to elm-css 17.0.4, per https://noredink.slack.com/archives/C0VVDLEES/p1641739931013700


