### PR TITLE
Fix accordion styles

### DIFF
--- a/src/Nri/Ui/DisclosureIndicator/V2.elm
+++ b/src/Nri/Ui/DisclosureIndicator/V2.elm
@@ -59,8 +59,8 @@ view { styles, size, isOpen } =
                 ++ styles
             )
         ]
-        [ div
-            [ css
+        [ arrowLeft
+            |> NriSvg.withCss
                 [ Css.displayFlex
                 , Css.justifyContent Css.center
                 , Css.alignItems Css.center
@@ -72,7 +72,5 @@ view { styles, size, isOpen } =
                   else
                     transform (rotate (deg -180))
                 ]
-            ]
-            [ NriSvg.toHtml arrowLeft
-            ]
+            |> NriSvg.toHtml
         ]


### PR DESCRIPTION
https://github.com/NoRedInk/noredink-ui/pull/801 caused a regression in the DisclosureIcon alignment. This fixes.

# Before

<img width="412" alt="Screen Shot 2022-01-18 at 11 22 39 AM" src="https://user-images.githubusercontent.com/8811312/150004586-ed3efb3b-d53a-43d1-bcd7-22cf4c46949b.png">


# After

<img width="422" alt="Screen Shot 2022-01-18 at 11 22 31 AM" src="https://user-images.githubusercontent.com/8811312/150004590-5c568eb3-9fe0-4c7e-9239-f6ccfaf5521a.png">
