### PR TITLE
Expose spriteIdToString

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "15.5.0",
+    "version": "15.6.0",
     "exposed-modules": [
         "Nri.Ui",
         "Nri.Ui.Accordion.V1",

--- a/src/Nri/Ui/Sprite/V1.elm
+++ b/src/Nri/Ui/Sprite/V1.elm
@@ -1,13 +1,13 @@
 module Nri.Ui.Sprite.V1 exposing
     ( Sprite, attach
-    , SpriteId, use
+    , SpriteId, use, spriteIdToString
     , bold, italic, underline, list, link, undo, redo
     )
 
 {-|
 
 @docs Sprite, attach
-@docs SpriteId, use
+@docs SpriteId, use, spriteIdToString
 @docs bold, italic, underline, list, link, undo, redo
 
 -}
@@ -33,6 +33,7 @@ type SpriteId
     = SpriteId String
 
 
+{-| -}
 spriteIdToString : SpriteId -> String
 spriteIdToString (SpriteId id_) =
     id_


### PR DESCRIPTION
Necessary for Quill.ToolbarSprite replacements.