### PR TITLE
Fix ClickableText minor visual regression

### DIFF
--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -76,7 +76,7 @@ import Nri.Ui
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1
 import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
-import Nri.Ui.Svg.V1 as NriSvg exposing (Svg)
+import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 
 
 label : String -> Attribute msg
@@ -294,12 +294,11 @@ viewContent config =
                         , Css.property "line-height" "normal"
                         ]
                     ]
-                    [ div
-                        [ Attributes.css
-                            [ Css.height fontSize
-                            , Css.maxWidth fontSize
-                            , Css.minWidth fontSize -- so it doesn't shrink when the label is long
-                            , case config.size of
+                    [ icon_
+                        |> Svg.withWidth fontSize
+                        |> Svg.withHeight fontSize
+                        |> Svg.withCss
+                            [ case config.size of
                                 Small ->
                                     Css.marginRight (Css.px 3)
 
@@ -309,8 +308,7 @@ viewContent config =
                                 Large ->
                                     Css.marginRight (Css.px 4)
                             ]
-                        ]
-                        [ NriSvg.toHtml icon_ ]
+                        |> Svg.toHtml
                     , span [] [ text config.label ]
                     ]
                 ]

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -64,9 +64,10 @@ init =
         |> Control.field "icon"
             (Control.maybe True <|
                 Control.choice
-                    [ ( "Preview", Control.value UiIcon.preview )
-                    , ( "Performance", Control.value UiIcon.performance )
-                    , ( "Edit", Control.value UiIcon.edit )
+                    [ ( "premiumLock", Control.value UiIcon.premiumLock )
+                    , ( "preview", Control.value UiIcon.preview )
+                    , ( "performance", Control.value UiIcon.performance )
+                    , ( "edit", Control.value UiIcon.edit )
                     ]
             )
         |> State


### PR DESCRIPTION
# Before

<img width="680" alt="Screen Shot 2022-01-28 at 9 25 24 AM" src="https://user-images.githubusercontent.com/8811312/151593390-3c93e7c3-d5af-4340-8e99-6112a88b94d2.png">


# After

<img width="668" alt="Screen Shot 2022-01-28 at 9 25 35 AM" src="https://user-images.githubusercontent.com/8811312/151593395-8b804c3c-4ca0-44ac-a472-488cae8c8845.png">


--

Also adds the premiumLock to the dropdown options.