### PR TITLE
Bat/button icon alignment

### DIFF
--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -640,7 +640,7 @@ buttonStyles size width colors customStyles =
 viewLabel : ButtonSize -> Maybe Svg -> String -> Html msg
 viewLabel size maybeSvg label_ =
     let
-        { imageHeight } =
+        { fontAndIconSize } =
             sizeConfig size
     in
     Nri.Ui.styled Html.span
@@ -658,10 +658,10 @@ viewLabel size maybeSvg label_ =
 
             Just svg ->
                 (svg
-                    |> NriSvg.withHeight (Css.px imageHeight)
+                    |> NriSvg.withWidth fontAndIconSize
+                    |> NriSvg.withHeight fontAndIconSize
                     |> NriSvg.withCss
-                        [ Css.width Css.auto
-                        , Css.flexShrink Css.zero
+                        [ Css.flexShrink Css.zero
                         , Css.marginRight (Css.px 5)
                         ]
                     |> NriSvg.toHtml
@@ -816,29 +816,26 @@ colorStyle colorPalette =
         ]
 
 
-sizeConfig : ButtonSize -> { fontSize : number, height : number, imageHeight : number, shadowHeight : number, minWidth : number }
+sizeConfig : ButtonSize -> { fontAndIconSize : Css.Px, height : number, shadowHeight : number, minWidth : number }
 sizeConfig size =
     case size of
         Small ->
-            { fontSize = 15
+            { fontAndIconSize = Css.px 15
             , height = 36
-            , imageHeight = 12
             , shadowHeight = 2
             , minWidth = 75
             }
 
         Medium ->
-            { fontSize = 15
+            { fontAndIconSize = Css.px 15
             , height = 45
-            , imageHeight = 14
             , shadowHeight = 3
             , minWidth = 100
             }
 
         Large ->
-            { fontSize = 20
+            { fontAndIconSize = Css.px 20
             , height = 56
-            , imageHeight = 16
             , shadowHeight = 4
             , minWidth = 200
             }
@@ -901,7 +898,7 @@ sizeStyle size width =
                     22
     in
     Css.batch
-        [ Css.fontSize (Css.px config.fontSize)
+        [ Css.fontSize config.fontAndIconSize
         , Css.borderRadius (Css.px 8)
         , Css.lineHeight (Css.px lineHeightPx)
         , Css.boxSizing Css.borderBox

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -513,7 +513,7 @@ renderButton ((ButtonOrLink config) as button_) =
             :: Attributes.type_ "button"
             :: config.customAttributes
         )
-        [ viewLabel config.icon config.label ]
+        [ viewLabel config.size config.icon config.label ]
 
 
 renderLink : ButtonOrLink msg -> Html msg
@@ -529,7 +529,7 @@ renderLink ((ButtonOrLink config) as link_) =
         (styledName linkFunctionName)
         [ buttonStyles config.size config.width colorPalette config.customStyles ]
         (attributes ++ config.customAttributes)
-        [ viewLabel config.icon config.label ]
+        [ viewLabel config.size config.icon config.label ]
 
 
 
@@ -624,7 +624,7 @@ toggleButton config =
         -- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-name
         , Attributes.type_ "button"
         ]
-        [ viewLabel Nothing config.label ]
+        [ viewLabel Medium Nothing config.label ]
 
 
 buttonStyles : ButtonSize -> ButtonWidth -> ColorPalette -> List Style -> Style
@@ -637,8 +637,12 @@ buttonStyles size width colors customStyles =
         ]
 
 
-viewLabel : Maybe Svg -> String -> Html msg
-viewLabel maybeSvg label_ =
+viewLabel : ButtonSize -> Maybe Svg -> String -> Html msg
+viewLabel size maybeSvg label_ =
+    let
+        { imageHeight } =
+            sizeConfig size
+    in
     Nri.Ui.styled Html.span
         "button-label-span"
         [ Css.overflow Css.hidden -- Keep scrollbars out of our button
@@ -653,7 +657,16 @@ viewLabel maybeSvg label_ =
                 renderMarkdown label_
 
             Just svg ->
-                NriSvg.toHtml svg :: renderMarkdown label_
+                (svg
+                    |> NriSvg.withHeight (Css.px imageHeight)
+                    |> NriSvg.withCss
+                        [ Css.width Css.auto
+                        , Css.flexShrink Css.zero
+                        , Css.marginRight (Css.px 5)
+                        ]
+                    |> NriSvg.toHtml
+                )
+                    :: renderMarkdown label_
         )
 
 
@@ -803,34 +816,39 @@ colorStyle colorPalette =
         ]
 
 
+sizeConfig : ButtonSize -> { fontSize : number, height : number, imageHeight : number, shadowHeight : number, minWidth : number }
+sizeConfig size =
+    case size of
+        Small ->
+            { fontSize = 15
+            , height = 36
+            , imageHeight = 12
+            , shadowHeight = 2
+            , minWidth = 75
+            }
+
+        Medium ->
+            { fontSize = 15
+            , height = 45
+            , imageHeight = 14
+            , shadowHeight = 3
+            , minWidth = 100
+            }
+
+        Large ->
+            { fontSize = 20
+            , height = 56
+            , imageHeight = 16
+            , shadowHeight = 4
+            , minWidth = 200
+            }
+
+
 sizeStyle : ButtonSize -> ButtonWidth -> Style
 sizeStyle size width =
     let
         config =
-            case size of
-                Small ->
-                    { fontSize = 15
-                    , height = 36
-                    , imageHeight = 12
-                    , shadowHeight = 2
-                    , minWidth = 75
-                    }
-
-                Medium ->
-                    { fontSize = 15
-                    , height = 45
-                    , imageHeight = 14
-                    , shadowHeight = 3
-                    , minWidth = 100
-                    }
-
-                Large ->
-                    { fontSize = 20
-                    , height = 56
-                    , imageHeight = 16
-                    , shadowHeight = 4
-                    , minWidth = 200
-                    }
+            sizeConfig size
 
         sizingAttributes =
             let
@@ -891,18 +909,4 @@ sizeStyle size width =
         , Css.borderBottomWidth (Css.px config.shadowHeight)
         , Css.batch sizingAttributes
         , Css.batch widthAttributes
-        , Css.Global.descendants
-            [ Css.Global.img
-                [ Css.height (Css.px config.imageHeight)
-                , Css.width Css.auto
-                , Css.marginRight (Css.px 5)
-                , Css.flexShrink Css.zero
-                ]
-            , Css.Global.svg
-                [ Css.height (Css.px config.imageHeight)
-                , Css.width Css.auto
-                , Css.marginRight (Css.px 5)
-                , Css.flexShrink Css.zero
-                ]
-            ]
         ]

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -34,6 +34,7 @@ example =
             [ Button.small
             , Button.fillContainerWidth
             , Button.custom [ Key.tabbable False ]
+            , Button.icon UiIcon.link
             ]
         , Button.link "Secondary"
             [ Button.small
@@ -41,6 +42,7 @@ example =
             , Button.secondary
             , Button.css [ Css.marginTop (Css.px 8) ]
             , Button.custom [ Key.tabbable False ]
+            , Button.icon UiIcon.link
             ]
         , Button.link "Premium"
             [ Button.small
@@ -48,6 +50,7 @@ example =
             , Button.premium
             , Button.css [ Css.marginTop (Css.px 8) ]
             , Button.custom [ Key.tabbable False ]
+            , Button.icon UiIcon.link
             ]
         ]
     , view = \state -> [ viewButtonExamples state ]
@@ -135,7 +138,7 @@ initDebugControls : Control Model
 initDebugControls =
     Control.record Model
         |> Control.field "label" (Control.string "Label")
-        |> Control.field "icon" iconChoice
+        |> Control.field "icon" (Control.maybe True iconChoice)
         |> Control.field "button type"
             (Control.choice
                 [ ( "button", Control.value Button )
@@ -163,15 +166,14 @@ initDebugControls =
             )
 
 
-iconChoice : Control.Control (Maybe Svg)
+iconChoice : Control.Control Svg
 iconChoice =
     Control.choice
-        [ ( "none", Control.value Nothing )
-        , ( "preview", Control.value (Just UiIcon.preview) )
-        , ( "arrowLeft", Control.value (Just UiIcon.arrowLeft) )
-        , ( "performance", Control.value (Just UiIcon.performance) )
-        , ( "share", Control.value (Just UiIcon.share) )
-        , ( "download", Control.value (Just UiIcon.download) )
+        [ ( "preview", Control.value UiIcon.preview )
+        , ( "arrowLeft", Control.value UiIcon.arrowLeft )
+        , ( "performance", Control.value UiIcon.performance )
+        , ( "share", Control.value UiIcon.share )
+        , ( "download", Control.value UiIcon.download )
         ]
 
 


### PR DESCRIPTION
Changes to SVG rendered caused about 2px of icon shift on Button (which I didn't notice because we didn't have percy snapshots on noredink-ui including buttons with icons -- this PR changes the default view so that the snapshots should include some icons). This PR changes how styles are applied to the button icon so that the icons render in (what I hope is) the right spot.

We _did_ [have percy snapshots on monolith buttons with icons](https://percy.io/NoRedInk/NRI-Cypress/builds/15873368/changed/895582665), which is how we found this minor misalignment issue:
<img width="1527" alt="image" src="https://user-images.githubusercontent.com/8811312/154752857-355eda0a-11b9-4111-8846-e31830be3b8c.png">


### Before - Preview

<img width="752" alt="image" src="https://user-images.githubusercontent.com/8811312/154752497-24f4a930-0229-4cfb-93df-7e4ae9d9a1f8.png">


### After - Preview

<img width="665" alt="Screen Shot 2022-02-18 at 11 50 36 AM" src="https://user-images.githubusercontent.com/8811312/154752078-917ab87e-9840-4ed4-93e4-cbbb3f0e847e.png">

### Before - Left Arrow

<img width="691" alt="image" src="https://user-images.githubusercontent.com/8811312/154752530-f6f719fe-8fd9-4d77-8fe6-53891fb0261c.png">

### After - Left Arrow

<img width="686" alt="Screen Shot 2022-02-18 at 11 50 54 AM" src="https://user-images.githubusercontent.com/8811312/154752080-1237cb21-8dbf-457b-823c-87963ed8e5fa.png">

### Before - Download

<img width="722" alt="image" src="https://user-images.githubusercontent.com/8811312/154752563-663f3be9-c29a-44a1-b8d0-cc4e85dfbfbe.png">


### After - Download

<img width="712" alt="Screen Shot 2022-02-18 at 11 50 41 AM" src="https://user-images.githubusercontent.com/8811312/154752083-19980775-1904-4321-aa37-13e13a1bdfd4.png">

---

@NoRedInk/design 
