### PR TITLE
Prevent scroll on arrow down

### DIFF
--- a/src/EventExtras.elm
+++ b/src/EventExtras.elm
@@ -1,8 +1,8 @@
-module EventExtras exposing (onClickForLinkWithHref, onClickPreventDefaultForLinkWithHref, onClickStopPropagation)
+module EventExtras exposing (onClickForLinkWithHref, onClickPreventDefaultForLinkWithHref, onClickStopPropagation, onKeyDownPreventDefault)
 
 import Html.Styled as Html
 import Html.Styled.Events as Events
-import Json.Decode
+import Json.Decode exposing (Decoder)
 
 
 {-| This is necessary to use in single-page apps (SPA) when intercepting the
@@ -83,3 +83,19 @@ onWithStopPropagation : String -> msg -> Html.Attribute msg
 onWithStopPropagation name msg =
     Events.stopPropagationOn name
         (Json.Decode.succeed ( msg, True ))
+
+
+{-| Use with a list of key decoders.
+
+    import EventExtras exposing (onKeyDownPreventDefault)
+    import Accessibility.Styled.Key as Key
+
+    button
+        [ onKeyDownPreventDefault [ Key.down DoSomething ] ]
+        [ text "Try arrow down" ]
+
+-}
+onKeyDownPreventDefault : List (Decoder msg) -> Html.Attribute msg
+onKeyDownPreventDefault decoders =
+    Events.preventDefaultOn "keydown"
+        (Json.Decode.map (\d -> ( d, True )) (Json.Decode.oneOf decoders))

--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -48,6 +48,7 @@ import Accessibility.Styled.Role as Role
 import Accessibility.Styled.Widget as Widget
 import Css exposing (..)
 import Css.Global exposing (descendants)
+import EventExtras exposing (onKeyDownPreventDefault)
 import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes as Attributes exposing (class, classList, css)
 import Html.Styled.Events as Events
@@ -446,7 +447,7 @@ viewCustom config =
                       -- first menu item if the "down" arrow is pressed
                       case ( maybeFirstFocusableElementId, maybeLastFocusableElementId ) of
                         ( Just firstFocusableElementId, Just lastFocusableElementId ) ->
-                            Key.onKeyDown
+                            onKeyDownPreventDefault
                                 [ Key.down
                                     (config.focusAndToggle
                                         { isOpen = True
@@ -593,7 +594,7 @@ viewEntry config focusAndToggle { upId, downId, entry_ } =
                     [ Role.menuItem
                     , Attributes.id id
                     , Key.tabbable False
-                    , Key.onKeyDown
+                    , onKeyDownPreventDefault
                         [ Key.up
                             (focusAndToggle
                                 { isOpen = True


### PR DESCRIPTION
Fixes https://github.com/NoRedInk/noredink-ui/issues/832

The Menu component should not scroll the page when the up or down arrows are used to navigate within the options.


https://user-images.githubusercontent.com/8811312/155007201-32a39043-0a6f-49b5-af39-f8df5c3f0c50.mov
