### PR TITLE
Add PremiumPromo PremiumLevel

### DIFF
--- a/src/Nri/Ui/Data/PremiumLevel.elm
+++ b/src/Nri/Ui/Data/PremiumLevel.elm
@@ -11,6 +11,7 @@ module Nri.Ui.Data.PremiumLevel exposing (PremiumLevel(..), allowedFor, highest,
 type PremiumLevel
     = Free
     | Premium
+    | PremiumPromo
     | PremiumWithWriting
 
 
@@ -44,9 +45,12 @@ order : PremiumLevel -> Int
 order privileges =
     case privileges of
         PremiumWithWriting ->
-            2
+            3
 
         Premium ->
+            2
+
+        PremiumPromo ->
             1
 
         Free ->

--- a/src/Nri/Ui/RadioButton/V2.elm
+++ b/src/Nri/Ui/RadioButton/V2.elm
@@ -107,6 +107,9 @@ premium config =
                 PremiumLevel.Premium ->
                     config.showPennant
 
+                PremiumLevel.PremiumPromo ->
+                    config.showPennant
+
                 PremiumLevel.PremiumWithWriting ->
                     config.showPennant
 


### PR DESCRIPTION
Adds `PremiumPromo` PremiumLevel for upcoming marketing initiative.

There are no visible changes introduced here, and fwiw as far as I can tell RadioButton.V2 isn't being used anywhere.