### PR TITLE
Revert "Add PremiumPromo PremiumLevel"

### DIFF
--- a/src/Nri/Ui/Data/PremiumLevel.elm
+++ b/src/Nri/Ui/Data/PremiumLevel.elm
@@ -11,7 +11,6 @@ module Nri.Ui.Data.PremiumLevel exposing (PremiumLevel(..), allowedFor, highest,
 type PremiumLevel
     = Free
     | Premium
-    | PremiumPromo
     | PremiumWithWriting
 
 
@@ -45,12 +44,9 @@ order : PremiumLevel -> Int
 order privileges =
     case privileges of
         PremiumWithWriting ->
-            3
-
-        Premium ->
             2
 
-        PremiumPromo ->
+        Premium ->
             1
 
         Free ->

--- a/src/Nri/Ui/RadioButton/V2.elm
+++ b/src/Nri/Ui/RadioButton/V2.elm
@@ -107,9 +107,6 @@ premium config =
                 PremiumLevel.Premium ->
                     config.showPennant
 
-                PremiumLevel.PremiumPromo ->
-                    config.showPennant
-
                 PremiumLevel.PremiumWithWriting ->
                     config.showPennant
 


### PR DESCRIPTION
This PR reverts "NoRedInk/noredink-ui#846".

Due to the ongoing discussions on #847, it makes sense to revert the changes #846, since it would:

1. Be moved to the monolith; or
2. Be moved to a `Nri.Ui.Data.PremiumLevel.V2` module.