### PR TITLE
Tessa/media support

### DIFF
--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -1,13 +1,14 @@
 module Nri.Ui.Button.V10 exposing
     ( button, link
     , Attribute
-    , icon, custom, css, nriDescription, testId, id
     , onClick
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     , small, medium, large, modal
     , exactWidth, boundedWidth, unboundedWidth, fillContainerWidth
     , primary, secondary, danger, premium
     , enabled, unfulfilled, disabled, error, loading, success
+    , icon, custom, nriDescription, testId, id
+    , css, notMobileCss, mobileCss, quizEngineMobileCss
     , delete
     , toggleButton
     )
@@ -32,7 +33,6 @@ module Nri.Ui.Button.V10 exposing
 
 @docs button, link
 @docs Attribute
-@docs icon, custom, css, nriDescription, testId, id
 
 
 ## Behavior
@@ -57,6 +57,16 @@ module Nri.Ui.Button.V10 exposing
 @docs enabled, unfulfilled, disabled, error, loading, success
 
 
+## Customization
+
+@docs icon, custom, nriDescription, testId, id
+
+
+### CSS
+
+@docs css, notMobileCss, mobileCss, quizEngineMobileCss
+
+
 # Commonly-used buttons
 
 @docs delete
@@ -70,6 +80,7 @@ import Accessibility.Styled.Widget as Widget
 import ClickableAttributes exposing (ClickableAttributes)
 import Css exposing (Style)
 import Css.Global
+import Css.Media
 import Html.Styled as Styled
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
@@ -80,6 +91,7 @@ import Nri.Ui.Colors.Extra as ColorsExtra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1
 import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
+import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Nri.Ui.Svg.V1 as NriSvg exposing (Svg)
 import Svg
 import Svg.Attributes
@@ -180,6 +192,39 @@ css styles =
                 | customStyles = List.append config.customStyles styles
             }
         )
+
+
+{-| Equivalent to:
+
+    ClickableText.css
+        [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.notMobile ] styles ]
+
+-}
+notMobileCss : List Style -> Attribute msg
+notMobileCss styles =
+    css [ Css.Media.withMedia [ MediaQuery.notMobile ] styles ]
+
+
+{-| Equivalent to:
+
+    ClickableText.css
+        [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.mobile ] styles ]
+
+-}
+mobileCss : List Style -> Attribute msg
+mobileCss styles =
+    css [ Css.Media.withMedia [ MediaQuery.mobile ] styles ]
+
+
+{-| Equivalent to:
+
+    ClickableText.css
+        [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.quizEngineMobile ] styles ]
+
+-}
+quizEngineMobileCss : List Style -> Attribute msg
+quizEngineMobileCss styles =
+    css [ Css.Media.withMedia [ MediaQuery.quizEngineMobile ] styles ]
 
 
 

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -7,7 +7,8 @@ module Nri.Ui.ClickableSvg.V2 exposing
     , disabled
     , withBorder
     , primary, secondary, danger, dangerSecondary
-    , custom, css, nriDescription, testId, id
+    , custom, nriDescription, testId, id
+    , css, notMobileCss, mobileCss, quizEngineMobileCss
     , small, medium, large
     )
 
@@ -46,7 +47,12 @@ module Nri.Ui.ClickableSvg.V2 exposing
 @docs withBorder
 @docs primary, secondary, danger, dangerSecondary
 
-@docs custom, css, nriDescription, testId, id
+@docs custom, nriDescription, testId, id
+
+
+### CSS
+
+@docs css, notMobileCss, mobileCss, quizEngineMobileCss
 
 
 ### DEPRECATED
@@ -60,10 +66,12 @@ In practice, we don't use these sizes. Remove them!
 import Accessibility.Styled.Widget as Widget
 import ClickableAttributes exposing (ClickableAttributes)
 import Css exposing (Color, Style)
+import Css.Media
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
+import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 
 
@@ -357,6 +365,39 @@ css styles =
                 | customStyles = List.append config.customStyles styles
             }
         )
+
+
+{-| Equivalent to:
+
+    ClickableSvg.css
+        [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.notMobile ] styles ]
+
+-}
+notMobileCss : List Style -> Attribute msg
+notMobileCss styles =
+    css [ Css.Media.withMedia [ MediaQuery.notMobile ] styles ]
+
+
+{-| Equivalent to:
+
+    ClickableSvg.css
+        [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.mobile ] styles ]
+
+-}
+mobileCss : List Style -> Attribute msg
+mobileCss styles =
+    css [ Css.Media.withMedia [ MediaQuery.mobile ] styles ]
+
+
+{-| Equivalent to:
+
+    ClickableSvg.css
+        [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.quizEngineMobile ] styles ]
+
+-}
+quizEngineMobileCss : List Style -> Attribute msg
+quizEngineMobileCss styles =
+    css [ Css.Media.withMedia [ MediaQuery.quizEngineMobile ] styles ]
 
 
 

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -3,7 +3,7 @@ module Nri.Ui.ClickableSvg.V2 exposing
     , Attribute
     , onClick
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
-    , exactWidth, exactHeight
+    , exactSize, exactWidth, exactHeight
     , disabled
     , withBorder
     , primary, secondary, danger, dangerSecondary
@@ -34,7 +34,7 @@ module Nri.Ui.ClickableSvg.V2 exposing
 
 ## Sizing
 
-@docs exactWidth, exactHeight
+@docs exactSize, exactWidth, exactHeight
 
 
 ## State
@@ -187,6 +187,26 @@ medium =
 large : Attribute msg
 large =
     set (\attributes -> { attributes | size = Large })
+
+
+{-| Set the size in `px` for the element's width and height.
+
+Equivalent to:
+
+    [ exactWidth inPx
+    , exactHeight inPx
+    ]
+
+-}
+exactSize : Int -> Attribute msg
+exactSize inPx =
+    set
+        (\attributes ->
+            { attributes
+                | width = Just (toFloat inPx)
+                , height = Just (toFloat inPx)
+            }
+        )
 
 
 {-| Define a size in `px` for the element's total width.

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -3,12 +3,12 @@ module Nri.Ui.ClickableSvg.V2 exposing
     , Attribute
     , onClick
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
-    , small, medium, large
     , exactWidth, exactHeight
     , disabled
     , withBorder
     , primary, secondary, danger, dangerSecondary
     , custom, css, nriDescription, testId, id
+    , small, medium, large
     )
 
 {-|
@@ -33,7 +33,6 @@ module Nri.Ui.ClickableSvg.V2 exposing
 
 ## Sizing
 
-@docs small, medium, large
 @docs exactWidth, exactHeight
 
 
@@ -48,6 +47,13 @@ module Nri.Ui.ClickableSvg.V2 exposing
 @docs primary, secondary, danger, dangerSecondary
 
 @docs custom, css, nriDescription, testId, id
+
+
+### DEPRECATED
+
+In practice, we don't use these sizes. Remove them!
+
+@docs small, medium, large
 
 -}
 
@@ -154,20 +160,22 @@ type Size
     | Large
 
 
-{-| This is the default.
+{-| This is the default. This attribute will be removed in the next version of ClickableSvg!
 -}
 small : Attribute msg
 small =
     set (\attributes -> { attributes | size = Small })
 
 
-{-| -}
+{-| This attribute will be removed in the next version of ClickableSvg!
+-}
 medium : Attribute msg
 medium =
     set (\attributes -> { attributes | size = Medium })
 
 
-{-| -}
+{-| This attribute will be removed in the next version of ClickableSvg!
+-}
 large : Attribute msg
 large =
     set (\attributes -> { attributes | size = Large })

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -6,7 +6,8 @@ module Nri.Ui.ClickableText.V3 exposing
     , onClick
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     , icon
-    , custom, css, nriDescription, testId, id
+    , custom, nriDescription, testId, id
+    , css, notMobileCss, mobileCss, quizEngineMobileCss
     )
 
 {-|
@@ -63,19 +64,29 @@ HTML `<a>` elements and are created here with `*Link` functions.
 @docs onClick
 @docs href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
 
+
+## Customization
+
 @docs icon
-@docs custom, css, nriDescription, testId, id
+@docs custom, nriDescription, testId, id
+
+
+### CSS
+
+@docs css, notMobileCss, mobileCss, quizEngineMobileCss
 
 -}
 
 import ClickableAttributes exposing (ClickableAttributes)
 import Css exposing (Style)
+import Css.Media
 import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes as Attributes
 import Nri.Ui
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1
 import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
+import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 
 
@@ -171,6 +182,39 @@ css styles =
                 | customStyles = List.append config.customStyles styles
             }
         )
+
+
+{-| Equivalent to:
+
+    ClickableText.css
+        [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.notMobile ] styles ]
+
+-}
+notMobileCss : List Style -> Attribute msg
+notMobileCss styles =
+    css [ Css.Media.withMedia [ MediaQuery.notMobile ] styles ]
+
+
+{-| Equivalent to:
+
+    ClickableText.css
+        [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.mobile ] styles ]
+
+-}
+mobileCss : List Style -> Attribute msg
+mobileCss styles =
+    css [ Css.Media.withMedia [ MediaQuery.mobile ] styles ]
+
+
+{-| Equivalent to:
+
+    ClickableText.css
+        [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.quizEngineMobile ] styles ]
+
+-}
+quizEngineMobileCss : List Style -> Attribute msg
+quizEngineMobileCss styles =
+    css [ Css.Media.withMedia [ MediaQuery.quizEngineMobile ] styles ]
 
 
 

--- a/styleguide-app/CommonControls.elm
+++ b/styleguide-app/CommonControls.elm
@@ -1,5 +1,6 @@
-module CommonControls exposing (disabledListItem, exampleHtml, httpError, premiumLevel, quickBrownFox, romeoAndJulietQuotation, uiIcon)
+module CommonControls exposing (css, disabledListItem, exampleHtml, httpError, premiumLevel, quickBrownFox, romeoAndJulietQuotation, uiIcon)
 
+import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Html.Styled as Html exposing (Html)
@@ -120,4 +121,24 @@ disabledListItem moduleName f =
             ( moduleName ++ ".disabled True"
             , f bool
             )
+        )
+
+
+css :
+    { moduleName : String
+    , helperName : String
+    , use : List Css.Style -> b
+    , default : String
+    }
+    -> Control (List ( String, b ))
+    -> Control (List ( String, b ))
+css { moduleName, helperName, use, default } =
+    ControlExtra.optionalListItem helperName
+        (Control.map
+            (\( cssString, css_ ) ->
+                ( moduleName ++ "." ++ helperName ++ " " ++ cssString
+                , use css_
+                )
+            )
+            (ControlExtra.css default)
         )

--- a/styleguide-app/CommonControls.elm
+++ b/styleguide-app/CommonControls.elm
@@ -1,6 +1,7 @@
-module CommonControls exposing (exampleHtml, httpError, premiumLevel, quickBrownFox, romeoAndJulietQuotation, uiIcon)
+module CommonControls exposing (disabledListItem, exampleHtml, httpError, premiumLevel, quickBrownFox, romeoAndJulietQuotation, uiIcon)
 
 import Debug.Control as Control exposing (Control)
+import Debug.Control.Extra as ControlExtra
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Http
@@ -110,3 +111,13 @@ uiIcon =
                 ( name, Control.value ( "UiIcon." ++ name, value ) )
             )
         |> Control.choice
+
+
+disabledListItem : String -> (Bool -> b) -> Control (List ( String, b )) -> Control (List ( String, b ))
+disabledListItem moduleName f =
+    ControlExtra.optionalBoolListItem "disabled"
+        (\bool ->
+            ( moduleName ++ ".disabled True"
+            , f bool
+            )
+        )

--- a/styleguide-app/CommonControls.elm
+++ b/styleguide-app/CommonControls.elm
@@ -1,13 +1,15 @@
 module CommonControls exposing
     ( css, mobileCss, quizEngineMobileCss, notMobileCss
     , choice
-    , disabledListItem, exampleHtml, httpError, premiumLevel, quickBrownFox, romeoAndJulietQuotation, uiIcon
+    , icon, uiIcon
+    , disabledListItem, exampleHtml, httpError, premiumLevel, quickBrownFox, romeoAndJulietQuotation
     )
 
 {-|
 
 @docs css, mobileCss, quizEngineMobileCss, notMobileCss
 @docs choice
+@docs icon, uiIcon
 
 -}
 
@@ -103,6 +105,21 @@ exampleHtml =
         [ Html.text quickBrownFox ]
     , Html.text " When I stepped out, into the bright sunlight from the darkness of the movie house, I had only two things on my mind: Paul Newman, and a ride home."
     ]
+
+
+icon :
+    String
+    -> (Svg -> value)
+    -> Control (List ( String, value ))
+    -> Control (List ( String, value ))
+icon moduleName f =
+    ControlExtra.optionalListItemDefaultChecked "icon"
+        (Control.map
+            (\( iconName, iconValue ) ->
+                ( moduleName ++ ".icon " ++ iconName, f iconValue )
+            )
+            uiIcon
+        )
 
 
 uiIcon : Control ( String, Svg )

--- a/styleguide-app/CommonControls.elm
+++ b/styleguide-app/CommonControls.elm
@@ -1,4 +1,13 @@
-module CommonControls exposing (css, disabledListItem, exampleHtml, httpError, premiumLevel, quickBrownFox, romeoAndJulietQuotation, uiIcon)
+module CommonControls exposing
+    ( css, mobileCss, quizEngineMobileCss, notMobileCss
+    , disabledListItem, exampleHtml, httpError, premiumLevel, quickBrownFox, romeoAndJulietQuotation, uiIcon
+    )
+
+{-|
+
+@docs css, mobileCss, quizEngineMobileCss, notMobileCss
+
+-}
 
 import Css
 import Debug.Control as Control exposing (Control)
@@ -125,19 +134,52 @@ disabledListItem moduleName f =
 
 
 css :
-    { moduleName : String
-    , helperName : String
-    , use : List Css.Style -> b
-    , default : String
-    }
+    { moduleName : String, use : List Css.Style -> b, default : String }
     -> Control (List ( String, b ))
     -> Control (List ( String, b ))
-css { moduleName, helperName, use, default } =
+css =
+    css_ "css"
+
+
+mobileCss :
+    { moduleName : String, use : List Css.Style -> b, default : String }
+    -> Control (List ( String, b ))
+    -> Control (List ( String, b ))
+mobileCss =
+    css_ "mobileCss"
+
+
+quizEngineMobileCss :
+    { moduleName : String, use : List Css.Style -> b, default : String }
+    -> Control (List ( String, b ))
+    -> Control (List ( String, b ))
+quizEngineMobileCss =
+    css_ "quizEngineMobileCss"
+
+
+notMobileCss :
+    { moduleName : String, use : List Css.Style -> b, default : String }
+    -> Control (List ( String, b ))
+    -> Control (List ( String, b ))
+notMobileCss =
+    css_ "notMobileCss"
+
+
+css_ :
+    String
+    ->
+        { moduleName : String
+        , use : List Css.Style -> b
+        , default : String
+        }
+    -> Control (List ( String, b ))
+    -> Control (List ( String, b ))
+css_ helperName { moduleName, use, default } =
     ControlExtra.optionalListItem helperName
         (Control.map
-            (\( cssString, css_ ) ->
+            (\( cssString, cssValue ) ->
                 ( moduleName ++ "." ++ helperName ++ " " ++ cssString
-                , use css_
+                , use cssValue
                 )
             )
             (ControlExtra.css default)

--- a/styleguide-app/CommonControls.elm
+++ b/styleguide-app/CommonControls.elm
@@ -1,11 +1,13 @@
 module CommonControls exposing
     ( css, mobileCss, quizEngineMobileCss, notMobileCss
+    , choice
     , disabledListItem, exampleHtml, httpError, premiumLevel, quickBrownFox, romeoAndJulietQuotation, uiIcon
     )
 
 {-|
 
 @docs css, mobileCss, quizEngineMobileCss, notMobileCss
+@docs choice
 
 -}
 
@@ -22,9 +24,9 @@ import Nri.Ui.UiIcon.V1 as UiIcon
 
 premiumLevel : Control ( String, PremiumLevel )
 premiumLevel =
-    Control.choice
-        [ ( "Free", Control.value ( "Free", Free ) )
-        , ( "PremiumWithWriting", Control.value ( "PremiumWithWriting", PremiumWithWriting ) )
+    choice "PremiumLevel"
+        [ ( "Free", Free )
+        , ( "PremiumWithWriting", PremiumWithWriting )
         ]
 
 
@@ -116,9 +118,15 @@ uiIcon =
     , ( "library", UiIcon.library )
     , ( "searchInCicle", UiIcon.searchInCicle )
     ]
+        |> choice "UiIcon"
+
+
+choice : String -> List ( String, value ) -> Control ( String, value )
+choice moduleName options =
+    options
         |> List.map
             (\( name, value ) ->
-                ( name, Control.value ( "UiIcon." ++ name, value ) )
+                ( name, Control.value ( moduleName ++ "." ++ name, value ) )
             )
         |> Control.choice
 

--- a/styleguide-app/CommonControls.elm
+++ b/styleguide-app/CommonControls.elm
@@ -1,10 +1,12 @@
-module CommonControls exposing (exampleHtml, httpError, premiumLevel, quickBrownFox, romeoAndJulietQuotation)
+module CommonControls exposing (exampleHtml, httpError, premiumLevel, quickBrownFox, romeoAndJulietQuotation, uiIcon)
 
 import Debug.Control as Control exposing (Control)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Http
 import Nri.Ui.Data.PremiumLevel exposing (PremiumLevel(..))
+import Nri.Ui.Svg.V1 exposing (Svg)
+import Nri.Ui.UiIcon.V1 as UiIcon
 
 
 premiumLevel : Control ( String, PremiumLevel )
@@ -88,3 +90,23 @@ exampleHtml =
         [ Html.text quickBrownFox ]
     , Html.text " When I stepped out, into the bright sunlight from the darkness of the movie house, I had only two things on my mind: Paul Newman, and a ride home."
     ]
+
+
+uiIcon : Control ( String, Svg )
+uiIcon =
+    [ ( "arrowLeft", UiIcon.arrowLeft )
+    , ( "unarchive", UiIcon.unarchive )
+    , ( "share", UiIcon.share )
+    , ( "preview", UiIcon.preview )
+    , ( "skip", UiIcon.skip )
+    , ( "copyToClipboard", UiIcon.copyToClipboard )
+    , ( "gift", UiIcon.gift )
+    , ( "home", UiIcon.home )
+    , ( "library", UiIcon.library )
+    , ( "searchInCicle", UiIcon.searchInCicle )
+    ]
+        |> List.map
+            (\( name, value ) ->
+                ( name, Control.value ( "UiIcon." ++ name, value ) )
+            )
+        |> Control.choice

--- a/styleguide-app/Debug/Control/Extra.elm
+++ b/styleguide-app/Debug/Control/Extra.elm
@@ -1,11 +1,11 @@
 module Debug.Control.Extra exposing
-    ( float
+    ( float, int
     , list, listItem, optionalListItem
     )
 
 {-|
 
-@docs float
+@docs float, int
 @docs list, listItem, optionalListItem
 
 -}
@@ -18,6 +18,13 @@ float : Float -> Control Float
 float default =
     Control.map (String.toFloat >> Maybe.withDefault default)
         (Control.string (String.fromFloat default))
+
+
+{-| -}
+int : Int -> Control Int
+int default =
+    Control.map (String.toInt >> Maybe.withDefault default)
+        (Control.string (String.fromInt default))
 
 
 {-| Use with `listItem` and `optionalListItem`

--- a/styleguide-app/Debug/Control/Extra.elm
+++ b/styleguide-app/Debug/Control/Extra.elm
@@ -1,13 +1,13 @@
 module Debug.Control.Extra exposing
     ( float, int
-    , list, listItem, optionalListItem
+    , list, listItem, optionalListItem, optionalBoolListItem
     , css
     )
 
 {-|
 
 @docs float, int
-@docs list, listItem, optionalListItem
+@docs list, listItem, optionalListItem, optionalBoolListItem
 @docs css
 
 -}
@@ -55,6 +55,23 @@ optionalListItem : String -> Control a -> Control (List a) -> Control (List a)
 optionalListItem name accessor accumulator =
     Control.field name
         (Control.map (List.singleton >> List.filterMap identity) (Control.maybe False accessor))
+        (Control.map (++) accumulator)
+
+
+{-| -}
+optionalBoolListItem : String -> (Bool -> a) -> Control (List a) -> Control (List a)
+optionalBoolListItem name f accumulator =
+    Control.field name
+        (Control.map
+            (\value ->
+                if value then
+                    [ f value ]
+
+                else
+                    []
+            )
+            (Control.bool False)
+        )
         (Control.map (++) accumulator)
 
 

--- a/styleguide-app/Debug/Control/Extra.elm
+++ b/styleguide-app/Debug/Control/Extra.elm
@@ -28,6 +28,11 @@ int default =
 
 
 {-| Use with `listItem` and `optionalListItem`
+
+    list
+        |> listItem "first name" string
+        |> listItem "last name" string
+
 -}
 list : Control (List a)
 list =

--- a/styleguide-app/Debug/Control/Extra.elm
+++ b/styleguide-app/Debug/Control/Extra.elm
@@ -1,15 +1,18 @@
 module Debug.Control.Extra exposing
     ( float, int
     , list, listItem, optionalListItem
+    , css
     )
 
 {-|
 
 @docs float, int
 @docs list, listItem, optionalListItem
+@docs css
 
 -}
 
+import Css
 import Debug.Control as Control exposing (Control)
 
 
@@ -53,3 +56,24 @@ optionalListItem name accessor accumulator =
     Control.field name
         (Control.map (List.singleton >> List.filterMap identity) (Control.maybe False accessor))
         (Control.map (++) accumulator)
+
+
+{-| -}
+css : String -> Control (List Css.Style)
+css exampleCss =
+    Control.map
+        (\rawStr ->
+            rawStr
+                |> String.split ";"
+                |> List.map
+                    (\segment ->
+                        case String.split ":" segment of
+                            name :: value :: [] ->
+                                Css.property name value
+
+                            _ ->
+                                -- Unable to parse css
+                                Css.property "" ""
+                    )
+        )
+        (Control.stringTextarea exampleCss)

--- a/styleguide-app/Debug/Control/Extra.elm
+++ b/styleguide-app/Debug/Control/Extra.elm
@@ -107,14 +107,14 @@ css exampleCss =
 selectorAndStyles : Regex.Regex
 selectorAndStyles =
     Maybe.withDefault Regex.never
-        (Regex.fromString "([\\s\\S]+)\\s*{\\s*([\\s\\S]*)\\s*}\\s*")
+        (Regex.fromString "([^{]+){([^}]*)}")
 
 
 toCss : List Regex.Match -> ( String, List Css.Style )
 toCss matches =
     List.concatMap
         (\match ->
-            case Debug.log "Matches" <| List.filterMap identity match.submatches of
+            case List.filterMap identity match.submatches of
                 selector :: styles :: [] ->
                     let
                         ( stylesStr, stylesVal ) =
@@ -130,7 +130,7 @@ toCss matches =
         )
         matches
         |> List.unzip
-        |> Tuple.mapFirst (\props -> "[ Css.Global.descendants [ " ++ String.join "," props ++ " ] ]")
+        |> Tuple.mapFirst (\props -> "\n\t\t[ Css.Global.descendants \n\t\t\t[ " ++ String.join "\n\t\t," props ++ " \n\t\t\t]\n\t\t]")
         |> Tuple.mapSecond (\props -> [ Css.Global.descendants props ])
 
 

--- a/styleguide-app/Debug/Control/Extra.elm
+++ b/styleguide-app/Debug/Control/Extra.elm
@@ -1,13 +1,13 @@
 module Debug.Control.Extra exposing
     ( float, int
-    , list, listItem, optionalListItem, optionalBoolListItem
+    , list, listItem, optionalListItem, optionalListItemDefaultChecked, optionalBoolListItem
     , css
     )
 
 {-|
 
 @docs float, int
-@docs list, listItem, optionalListItem, optionalBoolListItem
+@docs list, listItem, optionalListItem, optionalListItemDefaultChecked, optionalBoolListItem
 @docs css
 
 -}
@@ -52,9 +52,21 @@ listItem name accessor accumulator =
 
 {-| -}
 optionalListItem : String -> Control a -> Control (List a) -> Control (List a)
-optionalListItem name accessor accumulator =
+optionalListItem =
+    optionalListItem_ False
+
+
+{-| -}
+optionalListItemDefaultChecked : String -> Control a -> Control (List a) -> Control (List a)
+optionalListItemDefaultChecked =
+    optionalListItem_ True
+
+
+{-| -}
+optionalListItem_ : Bool -> String -> Control a -> Control (List a) -> Control (List a)
+optionalListItem_ default name accessor accumulator =
     Control.field name
-        (Control.map (List.singleton >> List.filterMap identity) (Control.maybe False accessor))
+        (Control.map (List.singleton >> List.filterMap identity) (Control.maybe default accessor))
         (Control.map (++) accumulator)
 
 

--- a/styleguide-app/Debug/Control/Extra.elm
+++ b/styleguide-app/Debug/Control/Extra.elm
@@ -76,21 +76,26 @@ optionalBoolListItem name f accumulator =
 
 
 {-| -}
-css : String -> Control (List Css.Style)
+css : String -> Control ( String, List Css.Style )
 css exampleCss =
     Control.map
         (\rawStr ->
             rawStr
                 |> String.split ";"
-                |> List.map
+                |> List.filterMap
                     (\segment ->
                         case String.split ":" segment of
                             name :: value :: [] ->
-                                Css.property name value
+                                Just
+                                    ( "Css.property \"" ++ String.trim name ++ "\" \"" ++ String.trim value ++ "\""
+                                    , Css.property name value
+                                    )
 
                             _ ->
                                 -- Unable to parse css
-                                Css.property "" ""
+                                Nothing
                     )
+                |> List.unzip
+                |> Tuple.mapFirst (\props -> "[ " ++ String.join "," props ++ " ]")
         )
         (Control.stringTextarea exampleCss)

--- a/styleguide-app/Debug/Control/View.elm
+++ b/styleguide-app/Debug/Control/View.elm
@@ -1,0 +1,46 @@
+module Debug.Control.View exposing (codeFromList, view)
+
+import Css exposing (..)
+import Debug.Control as Control exposing (Control)
+import Html.Styled exposing (..)
+import Html.Styled.Attributes exposing (css)
+import Nri.Ui.Heading.V2 as Heading
+
+
+{-| -}
+view :
+    { update : Control a -> msg
+    , settings : Control a
+    , toExampleCode : a -> List { sectionName : String, code : String }
+    }
+    -> Html msg
+view config =
+    let
+        value =
+            Control.currentValue config.settings
+    in
+    div [ css [ displayFlex ] ]
+        [ fromUnstyled (Control.view config.update config.settings)
+        , viewExampleCode (config.toExampleCode value)
+        ]
+
+
+viewExampleCode : List { sectionName : String, code : String } -> Html msg
+viewExampleCode values =
+    section []
+        (Heading.h3 [] [ text "Generated Code" ]
+            :: List.concatMap
+                (\{ sectionName, code } ->
+                    [ Heading.h4 [] [ text sectionName ]
+                    , Html.Styled.code [] [ text code ]
+                    ]
+                )
+                values
+        )
+
+
+codeFromList : List ( String, a ) -> String
+codeFromList list =
+    "\n\t[ "
+        ++ String.join "\n\t, " (List.map Tuple.first list)
+        ++ "\n\t] "

--- a/styleguide-app/Debug/Control/View.elm
+++ b/styleguide-app/Debug/Control/View.elm
@@ -1,10 +1,12 @@
 module Debug.Control.View exposing (codeFromList, view)
 
 import Css exposing (..)
+import Css.Media exposing (withMedia)
 import Debug.Control as Control exposing (Control)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Heading.V2 as Heading
+import Nri.Ui.MediaQuery.V1 exposing (mobile)
 
 
 {-| -}
@@ -19,26 +21,40 @@ view config =
         value =
             Control.currentValue config.settings
     in
-    div [ css [ displayFlex ] ]
-        [ fromUnstyled (Control.view config.update config.settings)
+    div
+        [ css
+            [ displayFlex
+            , Css.flexWrap Css.wrap
+            , Css.property "gap" "10px"
+            , withMedia [ mobile ] [ flexDirection column, alignItems stretch ]
+            ]
+        ]
+        [ viewSection "Settings" <|
+            [ fromUnstyled (Control.view config.update config.settings) ]
         , viewExampleCode (config.toExampleCode value)
         ]
 
 
 viewExampleCode : List { sectionName : String, code : String } -> Html msg
 viewExampleCode values =
-    section []
-        (Heading.h3 [] [ text "Generated Code" ]
-            :: List.concatMap
-                (\{ sectionName, code } ->
-                    [ Heading.h4 [] [ text sectionName ]
-                    , Html.Styled.code
-                        [ css [ whiteSpace preWrap ]
-                        ]
-                        [ text code ]
+    viewSection "Generated Code" <|
+        List.concatMap
+            (\{ sectionName, code } ->
+                [ Heading.h4 [] [ text sectionName ]
+                , Html.Styled.code
+                    [ css [ whiteSpace preWrap ]
                     ]
-                )
-                values
+                    [ text code ]
+                ]
+            )
+            values
+
+
+viewSection : String -> List (Html msg) -> Html msg
+viewSection name children =
+    section [ css [ flex (int 1) ] ]
+        (Heading.h3 [] [ text name ]
+            :: children
         )
 
 

--- a/styleguide-app/Debug/Control/View.elm
+++ b/styleguide-app/Debug/Control/View.elm
@@ -32,7 +32,10 @@ viewExampleCode values =
             :: List.concatMap
                 (\{ sectionName, code } ->
                     [ Heading.h4 [] [ text sectionName ]
-                    , Html.Styled.code [] [ text code ]
+                    , Html.Styled.code
+                        [ css [ whiteSpace preWrap ]
+                        ]
+                        [ text code ]
                     ]
                 )
                 values

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -166,6 +166,26 @@ initDebugControls =
                         , ( "success", Button.success )
                         ]
                     )
+                |> CommonControls.css
+                    { moduleName = "Button"
+                    , use = Button.css
+                    , default = "border: 2px solid red;"
+                    }
+                |> CommonControls.mobileCss
+                    { moduleName = "Button"
+                    , use = Button.mobileCss
+                    , default = "[role=img] { display: none !important; }"
+                    }
+                |> CommonControls.quizEngineMobileCss
+                    { moduleName = "Button"
+                    , use = Button.quizEngineMobileCss
+                    , default = "[role=img] { display: none !important; }"
+                    }
+                |> CommonControls.notMobileCss
+                    { moduleName = "Button"
+                    , use = Button.notMobileCss
+                    , default = ""
+                    }
             )
 
 

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -8,8 +8,10 @@ module Examples.Button exposing (Msg, State, example)
 
 import Accessibility.Styled.Key as Key
 import Category exposing (Category(..))
+import CommonControls
 import Css exposing (middle, verticalAlign)
 import Debug.Control as Control exposing (Control)
+import Debug.Control.Extra as ControlExtra
 import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css, id)
@@ -126,10 +128,8 @@ update msg state =
 
 type alias Model =
     { label : String
-    , icon : Maybe Svg
     , buttonType : ButtonType
-    , width : Button.Attribute Msg
-    , state : Button.Attribute Msg
+    , attributes : List ( String, Button.Attribute Msg )
     }
 
 
@@ -138,43 +138,35 @@ initDebugControls : Control Model
 initDebugControls =
     Control.record Model
         |> Control.field "label" (Control.string "Label")
-        |> Control.field "icon" (Control.maybe True iconChoice)
         |> Control.field "button type"
             (Control.choice
                 [ ( "button", Control.value Button )
                 , ( "link", Control.value Link )
                 ]
             )
-        |> Control.field "width"
-            (Control.choice
-                [ ( "exactWidth 120", Control.value (Button.exactWidth 120) )
-                , ( "exactWidth 70", Control.value (Button.exactWidth 70) )
-                , ( "boundedWidth 100 180", Control.value (Button.boundedWidth { min = 100, max = 180 }) )
-                , ( "unboundedWidth", Control.value Button.unboundedWidth )
-                , ( "fillContainerWidth", Control.value Button.fillContainerWidth )
-                ]
+        |> Control.field "attributes"
+            (ControlExtra.list
+                |> CommonControls.icon "Button" Button.icon
+                |> ControlExtra.optionalListItem "width"
+                    (CommonControls.choice "Button"
+                        [ ( "exactWidth 120", Button.exactWidth 120 )
+                        , ( "exactWidth 70", Button.exactWidth 70 )
+                        , ( "boundedWidth 100 180", Button.boundedWidth { min = 100, max = 180 } )
+                        , ( "unboundedWidth", Button.unboundedWidth )
+                        , ( "fillContainerWidth", Button.fillContainerWidth )
+                        ]
+                    )
+                |> ControlExtra.optionalListItem "state (button only)"
+                    (CommonControls.choice "Button"
+                        [ ( "enabled", Button.enabled )
+                        , ( "disabled", Button.disabled )
+                        , ( "error", Button.error )
+                        , ( "unfulfilled", Button.unfulfilled )
+                        , ( "loading", Button.loading )
+                        , ( "success", Button.success )
+                        ]
+                    )
             )
-        |> Control.field "state (button only)"
-            (Control.choice
-                [ ( "enabled", Control.value Button.enabled )
-                , ( "disabled", Control.value Button.disabled )
-                , ( "error", Control.value Button.error )
-                , ( "unfulfilled", Control.value Button.unfulfilled )
-                , ( "loading", Control.value Button.loading )
-                , ( "success", Control.value Button.success )
-                ]
-            )
-
-
-iconChoice : Control.Control Svg
-iconChoice =
-    Control.choice
-        [ ( "preview", Control.value UiIcon.preview )
-        , ( "arrowLeft", Control.value UiIcon.arrowLeft )
-        , ( "performance", Control.value UiIcon.performance )
-        , ( "share", Control.value UiIcon.share )
-        , ( "download", Control.value UiIcon.download )
-        ]
 
 
 viewButtonExamples : State -> Html Msg
@@ -238,19 +230,13 @@ buttons model =
 
         exampleCell setStyle setSize =
             buttonOrLink model.label
-                [ setSize
-                , setStyle
-                , model.width
-                , model.state
-                , Button.custom [ Html.Styled.Attributes.class "styleguide-button" ]
-                , Button.onClick (ShowItWorked "ButtonExample" "Button clicked!")
-                , case model.icon of
-                    Just icon ->
-                        Button.icon icon
-
-                    Nothing ->
-                        Button.custom []
-                ]
+                ([ setSize
+                 , setStyle
+                 , Button.custom [ Html.Styled.Attributes.class "styleguide-button" ]
+                 , Button.onClick (ShowItWorked "ButtonExample" "Button clicked!")
+                 ]
+                    ++ List.map Tuple.second model.attributes
+                )
                 |> List.singleton
                 |> td
                     [ css

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -127,8 +127,8 @@ update msg state =
 
 
 type alias Model =
-    { label : String
-    , buttonType : ButtonType
+    { buttonType : ButtonType
+    , label : String
     , attributes : List ( String, Button.Attribute Msg )
     }
 
@@ -137,13 +137,13 @@ type alias Model =
 initDebugControls : Control Model
 initDebugControls =
     Control.record Model
-        |> Control.field "label" (Control.string "Label")
-        |> Control.field "button type"
+        |> Control.field "type"
             (Control.choice
                 [ ( "button", Control.value Button )
                 , ( "link", Control.value Link )
                 ]
             )
+        |> Control.field "label" (Control.string "Label")
         |> Control.field "attributes"
             (ControlExtra.list
                 |> CommonControls.icon "Button" Button.icon

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -12,6 +12,7 @@ import CommonControls
 import Css exposing (middle, verticalAlign)
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
+import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css, id)
@@ -195,8 +196,28 @@ viewButtonExamples state =
         model =
             Control.currentValue state.debugControlsState
     in
-    [ Control.view SetDebugControlsState state.debugControlsState
-        |> fromUnstyled
+    [ ControlView.view
+        { update = SetDebugControlsState
+        , settings = state.debugControlsState
+        , toExampleCode =
+            \{ label, attributes } ->
+                let
+                    toCode fName =
+                        "Button."
+                            ++ fName
+                            ++ " \""
+                            ++ label
+                            ++ "\"\n\t"
+                            ++ ControlView.codeFromList attributes
+                in
+                [ { sectionName = "Button"
+                  , code = toCode "button"
+                  }
+                , { sectionName = "Link"
+                  , code = toCode "link"
+                  }
+                ]
+        }
     , buttons model
     , toggleButtons state.pressedToggleButtons
     , Button.link "linkExternalWithTracking"

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -278,25 +278,21 @@ initSettings =
                     )
                 |> CommonControls.css
                     { moduleName = "ClickableSvg"
-                    , helperName = "css"
                     , use = ClickableSvg.css
                     , default = "border: 2px solid red;"
                     }
-                |> CommonControls.css
+                |> CommonControls.mobileCss
                     { moduleName = "ClickableSvg"
-                    , helperName = "mobileCss"
                     , use = ClickableSvg.mobileCss
                     , default = "padding: 10px;"
                     }
-                |> CommonControls.css
+                |> CommonControls.quizEngineMobileCss
                     { moduleName = "ClickableSvg"
-                    , helperName = "quizEngineMobileCss"
                     , use = ClickableSvg.quizEngineMobileCss
                     , default = ""
                     }
-                |> CommonControls.css
+                |> CommonControls.notMobileCss
                     { moduleName = "ClickableSvg"
-                    , helperName = "notMobileCss"
                     , use = ClickableSvg.notMobileCss
                     , default = ""
                     }

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -10,6 +10,7 @@ import Accessibility.Styled.Key as Key
 import Category exposing (Category(..))
 import Css
 import Debug.Control as Control exposing (Control)
+import Debug.Control.Extra as ControlExtra
 import EventExtras
 import Example exposing (Example)
 import Examples.IconExamples as IconExamples
@@ -234,20 +235,17 @@ update msg state =
 
 type alias Settings msg =
     { icon : Svg
-    , disabled : ClickableSvg.Attribute msg
-    , size : ClickableSvg.Attribute msg
-    , width : Maybe (ClickableSvg.Attribute msg)
-    , height : Maybe (ClickableSvg.Attribute msg)
+    , attributes : List (ClickableSvg.Attribute msg)
     }
 
 
 applySettings : Control (Settings msg) -> ( Svg, List (ClickableSvg.Attribute msg) )
 applySettings settings =
     let
-        { icon, disabled, size, width, height } =
+        { icon, attributes } =
             Control.currentValue settings
     in
-    ( icon, List.filterMap identity [ Just disabled, Just size, width, height ] )
+    ( icon, attributes )
 
 
 initSettings : Control (Settings msg)
@@ -267,19 +265,22 @@ initSettings =
                 , ( "searchInCicle", Control.value UiIcon.searchInCicle )
                 ]
             )
-        |> Control.field "disabled"
-            (Control.map ClickableSvg.disabled (Control.bool False))
-        |> Control.field "size"
-            (Control.choice
-                [ ( "small", Control.value ClickableSvg.small )
-                , ( "medium", Control.value ClickableSvg.medium )
-                , ( "large", Control.value ClickableSvg.large )
-                ]
+        |> Control.field "attributes"
+            (ControlExtra.list
+                |> ControlExtra.listItem "disabled"
+                    (Control.map ClickableSvg.disabled (Control.bool False))
+                |> ControlExtra.listItem "size"
+                    (Control.choice
+                        [ ( "small", Control.value ClickableSvg.small )
+                        , ( "medium", Control.value ClickableSvg.medium )
+                        , ( "large", Control.value ClickableSvg.large )
+                        ]
+                    )
+                |> ControlExtra.optionalListItem "exactWidth"
+                    (Control.map ClickableSvg.exactWidth (controlInt 40))
+                |> ControlExtra.optionalListItem "exactHeight"
+                    (Control.map ClickableSvg.exactHeight (controlInt 20))
             )
-        |> Control.field "exactWidth"
-            (Control.maybe False (Control.map ClickableSvg.exactWidth (controlInt 40)))
-        |> Control.field "exactHeight"
-            (Control.maybe False (Control.map ClickableSvg.exactHeight (controlInt 20)))
 
 
 controlInt : Int -> Control Int

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -8,6 +8,7 @@ module Examples.ClickableSvg exposing (Msg, State, example)
 
 import Accessibility.Styled.Key as Key
 import Category exposing (Category(..))
+import CommonControls
 import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
@@ -68,7 +69,8 @@ example =
                                     ++ fName
                                     ++ " \""
                                     ++ label
-                                    ++ "\""
+                                    ++ "\"\n\t"
+                                    ++ Tuple.first icon
                                     ++ ControlView.codeFromList attributes
                         in
                         [ { sectionName = "Button"
@@ -151,14 +153,14 @@ viewExampleTable { label, icon, attributes } =
 
         buttonExample attributes_ =
             ClickableSvg.button label
-                icon
+                (Tuple.second icon)
                 (ClickableSvg.onClick (ShowItWorked "You clicked the back button!")
                     :: attributes_
                 )
 
         linkExample attributes_ =
             ClickableSvg.link label
-                icon
+                (Tuple.second icon)
                 (ClickableSvg.linkSpa "some_link" :: attributes_)
     in
     Html.table []
@@ -256,7 +258,7 @@ update msg state =
 
 type alias Settings msg =
     { label : String
-    , icon : Svg
+    , icon : ( String, Svg )
     , attributes : List ( String, ClickableSvg.Attribute msg )
     }
 
@@ -265,20 +267,7 @@ initSettings : Control (Settings msg)
 initSettings =
     Control.record Settings
         |> Control.field "label" (Control.string "Back")
-        |> Control.field "icon"
-            (Control.choice
-                [ ( "arrowLeft", Control.value UiIcon.arrowLeft )
-                , ( "unarchive", Control.value UiIcon.unarchive )
-                , ( "share", Control.value UiIcon.share )
-                , ( "preview", Control.value UiIcon.preview )
-                , ( "skip", Control.value UiIcon.skip )
-                , ( "copyToClipboard", Control.value UiIcon.copyToClipboard )
-                , ( "gift", Control.value UiIcon.gift )
-                , ( "home", Control.value UiIcon.home )
-                , ( "library", Control.value UiIcon.library )
-                , ( "searchInCicle", Control.value UiIcon.searchInCicle )
-                ]
-            )
+        |> Control.field "icon" CommonControls.uiIcon
         |> Control.field "attributes"
             (ControlExtra.list
                 |> ControlExtra.listItem "disabled"

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -270,17 +270,15 @@ initSettings =
         |> Control.field "icon" CommonControls.uiIcon
         |> Control.field "attributes"
             (ControlExtra.list
-                |> ControlExtra.listItem "disabled"
-                    (Control.map ClickableSvg.disabled (Control.bool False))
-                |> ControlExtra.optionalListItem "exactSize"
-                    (Control.map ClickableSvg.exactSize (ControlExtra.int 36))
-                |> ControlExtra.optionalListItem "css"
-                    (Control.map ClickableSvg.css (ControlExtra.css "border: 2px solid red;"))
-                |> ControlExtra.optionalListItem "mobileCss"
-                    (Control.map ClickableSvg.mobileCss (ControlExtra.css "padding: 10px;"))
-                |> ControlExtra.optionalListItem "quizEngineMobileCss"
-                    (Control.map ClickableSvg.quizEngineMobileCss (ControlExtra.css ""))
-                |> ControlExtra.optionalListItem "notMobileCss"
-                    (Control.map ClickableSvg.notMobileCss (ControlExtra.css ""))
-                |> Control.map (List.map (\v -> ( Debug.toString v, v )))
+                |> CommonControls.disabledListItem "ClickableSvg" ClickableSvg.disabled
+             --|> ControlExtra.optionalListItem "exactSize"
+             --    (Control.map ClickableSvg.exactSize (ControlExtra.int 36))
+             --|> ControlExtra.optionalListItem "css"
+             --    (Control.map ClickableSvg.css (ControlExtra.css "border: 2px solid red;"))
+             --|> ControlExtra.optionalListItem "mobileCss"
+             --    (Control.map ClickableSvg.mobileCss (ControlExtra.css "padding: 10px;"))
+             --|> ControlExtra.optionalListItem "quizEngineMobileCss"
+             --    (Control.map ClickableSvg.quizEngineMobileCss (ControlExtra.css ""))
+             --|> ControlExtra.optionalListItem "notMobileCss"
+             --    (Control.map ClickableSvg.notMobileCss (ControlExtra.css ""))
             )

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -271,14 +271,33 @@ initSettings =
         |> Control.field "attributes"
             (ControlExtra.list
                 |> CommonControls.disabledListItem "ClickableSvg" ClickableSvg.disabled
-             --|> ControlExtra.optionalListItem "exactSize"
-             --    (Control.map ClickableSvg.exactSize (ControlExtra.int 36))
-             --|> ControlExtra.optionalListItem "css"
-             --    (Control.map ClickableSvg.css (ControlExtra.css "border: 2px solid red;"))
-             --|> ControlExtra.optionalListItem "mobileCss"
-             --    (Control.map ClickableSvg.mobileCss (ControlExtra.css "padding: 10px;"))
-             --|> ControlExtra.optionalListItem "quizEngineMobileCss"
-             --    (Control.map ClickableSvg.quizEngineMobileCss (ControlExtra.css ""))
-             --|> ControlExtra.optionalListItem "notMobileCss"
-             --    (Control.map ClickableSvg.notMobileCss (ControlExtra.css ""))
+                |> ControlExtra.optionalListItem "exactSize"
+                    (Control.map
+                        (\v -> ( "ClickableSvg.exactSize " ++ String.fromInt v, ClickableSvg.exactSize v ))
+                        (ControlExtra.int 36)
+                    )
+                |> CommonControls.css
+                    { moduleName = "ClickableSvg"
+                    , helperName = "css"
+                    , use = ClickableSvg.css
+                    , default = "border: 2px solid red;"
+                    }
+                |> CommonControls.css
+                    { moduleName = "ClickableSvg"
+                    , helperName = "mobileCss"
+                    , use = ClickableSvg.mobileCss
+                    , default = "padding: 10px;"
+                    }
+                |> CommonControls.css
+                    { moduleName = "ClickableSvg"
+                    , helperName = "quizEngineMobileCss"
+                    , use = ClickableSvg.quizEngineMobileCss
+                    , default = ""
+                    }
+                |> CommonControls.css
+                    { moduleName = "ClickableSvg"
+                    , helperName = "notMobileCss"
+                    , use = ClickableSvg.notMobileCss
+                    , default = ""
+                    }
             )

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -269,8 +269,6 @@ initSettings =
             (ControlExtra.list
                 |> ControlExtra.listItem "disabled"
                     (Control.map ClickableSvg.disabled (Control.bool False))
-                |> ControlExtra.optionalListItem "exactWidth"
-                    (Control.map ClickableSvg.exactWidth (ControlExtra.int 40))
-                |> ControlExtra.optionalListItem "exactHeight"
-                    (Control.map ClickableSvg.exactHeight (ControlExtra.int 20))
+                |> ControlExtra.optionalListItem "exactSize"
+                    (Control.map ClickableSvg.exactSize (ControlExtra.int 36))
             )

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -269,13 +269,6 @@ initSettings =
             (ControlExtra.list
                 |> ControlExtra.listItem "disabled"
                     (Control.map ClickableSvg.disabled (Control.bool False))
-                |> ControlExtra.listItem "size"
-                    (Control.choice
-                        [ ( "small", Control.value ClickableSvg.small )
-                        , ( "medium", Control.value ClickableSvg.medium )
-                        , ( "large", Control.value ClickableSvg.large )
-                        ]
-                    )
                 |> ControlExtra.optionalListItem "exactWidth"
                     (Control.map ClickableSvg.exactWidth (controlInt 40))
                 |> ControlExtra.optionalListItem "exactHeight"

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -57,11 +57,11 @@ example =
     , view =
         \state ->
             let
-                ( icon, attributes ) =
-                    applySettings state.settings
+                { label, icon, attributes } =
+                    Control.currentValue state.settings
             in
             [ Html.fromUnstyled (Control.view SetControls state.settings)
-            , viewExampleTable icon attributes
+            , viewExampleTable label icon attributes
             , viewExample
                 """
 Tooltip.view
@@ -104,8 +104,8 @@ Tooltip.view
     }
 
 
-viewExampleTable : Svg -> List (ClickableSvg.Attribute Msg) -> Html Msg
-viewExampleTable icon attributes =
+viewExampleTable : String -> Svg -> List (ClickableSvg.Attribute Msg) -> Html Msg
+viewExampleTable label icon attributes =
     let
         viewExampleRow index ( themeName, theme ) =
             Html.tr []
@@ -129,14 +129,14 @@ viewExampleTable icon attributes =
                 ]
 
         buttonExample attributes_ =
-            ClickableSvg.button "Button example"
+            ClickableSvg.button label
                 icon
                 (ClickableSvg.onClick (ShowItWorked "You clicked the back button!")
                     :: attributes_
                 )
 
         linkExample attributes_ =
-            ClickableSvg.link "Link example"
+            ClickableSvg.link label
                 icon
                 (ClickableSvg.linkSpa "some_link" :: attributes_)
     in
@@ -234,23 +234,16 @@ update msg state =
 
 
 type alias Settings msg =
-    { icon : Svg
+    { label : String
+    , icon : Svg
     , attributes : List (ClickableSvg.Attribute msg)
     }
-
-
-applySettings : Control (Settings msg) -> ( Svg, List (ClickableSvg.Attribute msg) )
-applySettings settings =
-    let
-        { icon, attributes } =
-            Control.currentValue settings
-    in
-    ( icon, attributes )
 
 
 initSettings : Control (Settings msg)
 initSettings =
     Control.record Settings
+        |> Control.field "label" (Control.string "Back")
         |> Control.field "icon"
             (Control.choice
                 [ ( "arrowLeft", Control.value UiIcon.arrowLeft )

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -273,4 +273,6 @@ initSettings =
                     (Control.map ClickableSvg.exactSize (ControlExtra.int 36))
                 |> ControlExtra.optionalListItem "css"
                     (Control.map ClickableSvg.css (ControlExtra.css "border: 2px solid red;"))
+                |> ControlExtra.optionalListItem "mobileCss"
+                    (Control.map ClickableSvg.mobileCss (ControlExtra.css "padding: 10px;"))
             )

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -268,4 +268,8 @@ initSettings =
                     (Control.map ClickableSvg.css (ControlExtra.css "border: 2px solid red;"))
                 |> ControlExtra.optionalListItem "mobileCss"
                     (Control.map ClickableSvg.mobileCss (ControlExtra.css "padding: 10px;"))
+                |> ControlExtra.optionalListItem "quizEngineMobileCss"
+                    (Control.map ClickableSvg.quizEngineMobileCss (ControlExtra.css ""))
+                |> ControlExtra.optionalListItem "notMobileCss"
+                    (Control.map ClickableSvg.notMobileCss (ControlExtra.css ""))
             )

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -270,13 +270,7 @@ initSettings =
                 |> ControlExtra.listItem "disabled"
                     (Control.map ClickableSvg.disabled (Control.bool False))
                 |> ControlExtra.optionalListItem "exactWidth"
-                    (Control.map ClickableSvg.exactWidth (controlInt 40))
+                    (Control.map ClickableSvg.exactWidth (ControlExtra.int 40))
                 |> ControlExtra.optionalListItem "exactHeight"
-                    (Control.map ClickableSvg.exactHeight (controlInt 20))
+                    (Control.map ClickableSvg.exactHeight (ControlExtra.int 20))
             )
-
-
-controlInt : Int -> Control Int
-controlInt default =
-    Control.map (String.toInt >> Maybe.withDefault default)
-        (Control.string (String.fromInt default))

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -271,4 +271,6 @@ initSettings =
                     (Control.map ClickableSvg.disabled (Control.bool False))
                 |> ControlExtra.optionalListItem "exactSize"
                     (Control.map ClickableSvg.exactSize (ControlExtra.int 36))
+                |> ControlExtra.optionalListItem "css"
+                    (Control.map ClickableSvg.css (ControlExtra.css "border: 2px solid red;"))
             )

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -66,13 +66,7 @@ init =
         |> Control.field "label" (Control.string "Clickable Text")
         |> Control.field "attributes"
             (ControlExtra.list
-                |> ControlExtra.optionalListItemDefaultChecked "icon"
-                    (Control.map
-                        (\( iconName, icon ) ->
-                            ( "ClickableText.icon " ++ iconName, ClickableText.icon icon )
-                        )
-                        CommonControls.uiIcon
-                    )
+                |> CommonControls.icon "ClickableText" ClickableText.icon
                 |> CommonControls.css
                     { moduleName = "ClickableText"
                     , use = ClickableText.css

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -73,6 +73,26 @@ init =
                         )
                         CommonControls.uiIcon
                     )
+                |> CommonControls.css
+                    { moduleName = "ClickableText"
+                    , use = ClickableText.css
+                    , default = "border: 2px solid red;"
+                    }
+                |> CommonControls.mobileCss
+                    { moduleName = "ClickableText"
+                    , use = ClickableText.mobileCss
+                    , default = "padding: 10px;"
+                    }
+                |> CommonControls.quizEngineMobileCss
+                    { moduleName = "ClickableText"
+                    , use = ClickableText.quizEngineMobileCss
+                    , default = ""
+                    }
+                |> CommonControls.notMobileCss
+                    { moduleName = "ClickableText"
+                    , use = ClickableText.notMobileCss
+                    , default = ""
+                    }
             )
         |> State
 

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -81,12 +81,12 @@ init =
                 |> CommonControls.mobileCss
                     { moduleName = "ClickableText"
                     , use = ClickableText.mobileCss
-                    , default = "padding: 10px;"
+                    , default = "[role=img] { display: none !important; }"
                     }
                 |> CommonControls.quizEngineMobileCss
                     { moduleName = "ClickableText"
                     , use = ClickableText.quizEngineMobileCss
-                    , default = ""
+                    , default = "[role=img] { display: none !important; }"
                     }
                 |> CommonControls.notMobileCss
                     { moduleName = "ClickableText"


### PR DESCRIPTION
Hack day project!

First step towards making clickable components easier to make mobile-friendly. Also sets up some additional styleguide helpers for displaying custom code examples. When custom code examples include css, some manual intervention will be required.

<img width="1268" alt="image" src="https://user-images.githubusercontent.com/8811312/156862033-7be86326-732c-4d76-a806-1562fe644e3f.png">


Relevant elm diff results:
```
---- Nri.Ui.Button.V10 - MINOR ----

    Added:
        mobileCss : List.List Css.Style -> Nri.Ui.Button.V10.Attribute msg
        notMobileCss : List.List Css.Style -> Nri.Ui.Button.V10.Attribute msg
        quizEngineMobileCss :
            List.List Css.Style -> Nri.Ui.Button.V10.Attribute msg


---- Nri.Ui.ClickableSvg.V2 - MINOR ----

    Added:
        exactSize : Basics.Int -> Nri.Ui.ClickableSvg.V2.Attribute msg
        mobileCss : List.List Css.Style -> Nri.Ui.ClickableSvg.V2.Attribute msg
        notMobileCss :
            List.List Css.Style -> Nri.Ui.ClickableSvg.V2.Attribute msg
        quizEngineMobileCss :
            List.List Css.Style -> Nri.Ui.ClickableSvg.V2.Attribute msg


---- Nri.Ui.ClickableText.V3 - MINOR ----

    Added:
        mobileCss : List.List Css.Style -> Nri.Ui.ClickableText.V3.Attribute msg
        notMobileCss :
            List.List Css.Style -> Nri.Ui.ClickableText.V3.Attribute msg
        quizEngineMobileCss :
            List.List Css.Style -> Nri.Ui.ClickableText.V3.Attribute msg


---- Nri.Ui.Menu.V3 - MINOR ----

    Added:
        type alias Config msg =
            { button : Nri.Ui.Menu.V3.Button msg
            , entries : List.List (Nri.Ui.Menu.V3.Entry msg)
            , isOpen : Basics.Bool
            , focusAndToggle :
                  { isOpen : Basics.Bool, focus : Maybe.Maybe String.String }
                  -> msg
            }
```