### PR TITLE
Bressa/media support 2

### DIFF
--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -8,7 +8,7 @@ module Nri.Ui.Button.V10 exposing
     , primary, secondary, danger, premium
     , enabled, unfulfilled, disabled, error, loading, success
     , icon, custom, nriDescription, testId, id
-    , hideIconForMobile
+    , hideIconForMobile, hideIconFor
     , css, notMobileCss, mobileCss, quizEngineMobileCss
     , delete
     , toggleButton
@@ -27,7 +27,7 @@ adding a span around the text could potentially lead to regressions.
   - adds `nriDescription`, `testId`, and `id` helpers
   - adds `modal` helper, an alias for `large` size
   - adds `notMobileCss`, `mobileCss`, `quizEngineMobileCss`
-  - adds `hideIconForMobile` and `hideIconAt`
+  - adds `hideIconForMobile` and `hideIconFor`
 
 
 # Changes from V9:
@@ -71,7 +71,7 @@ adding a span around the text could potentially lead to regressions.
 
 ### CSS
 
-@docs hideIconForMobile, hideIconAt
+@docs hideIconForMobile, hideIconFor
 @docs css, notMobileCss, mobileCss, quizEngineMobileCss
 
 
@@ -195,14 +195,14 @@ id id_ =
 {-| -}
 hideIconForMobile : Attribute msg
 hideIconForMobile =
-    hideIconAt MediaQuery.mobile
+    hideIconFor MediaQuery.mobile
 
 
 {-| -}
-hideIconAt : MediaQuery -> Attribute msg
-hideIconAt =
+hideIconFor : MediaQuery -> Attribute msg
+hideIconFor mediaQuery =
     css
-        [ Css.Media.withMedia [ MediaQuery.mobile ]
+        [ Css.Media.withMedia [ mediaQuery ]
             [ Css.Global.descendants
                 [ Css.Global.selector "[role=img]"
                     [ Css.display Css.none

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -8,12 +8,17 @@ module Nri.Ui.Button.V10 exposing
     , primary, secondary, danger, premium
     , enabled, unfulfilled, disabled, error, loading, success
     , icon, custom, nriDescription, testId, id
+    , hideIconForMobile
     , css, notMobileCss, mobileCss, quizEngineMobileCss
     , delete
     , toggleButton
     )
 
-{-|
+{-| Notes for V11:
+
+The next version of `Button` should add a `hideTextForMobile` helper.
+This will require adding a selector for the text. We are not making this change in V10, as
+adding a span around the text could potentially lead to regressions.
 
 
 # Patch changes:
@@ -21,6 +26,8 @@ module Nri.Ui.Button.V10 exposing
   - uses ClickableAttributes
   - adds `nriDescription`, `testId`, and `id` helpers
   - adds `modal` helper, an alias for `large` size
+  - adds `notMobileCss`, `mobileCss`, `quizEngineMobileCss`
+  - adds `hideIconForMobile` and `hideIconAt`
 
 
 # Changes from V9:
@@ -64,6 +71,7 @@ module Nri.Ui.Button.V10 exposing
 
 ### CSS
 
+@docs hideIconForMobile, hideIconAt
 @docs css, notMobileCss, mobileCss, quizEngineMobileCss
 
 
@@ -76,11 +84,12 @@ module Nri.Ui.Button.V10 exposing
 
 import Accessibility.Styled as Html exposing (Html)
 import Accessibility.Styled.Role as Role
+import Accessibility.Styled.Style exposing (invisibleStyle)
 import Accessibility.Styled.Widget as Widget
 import ClickableAttributes exposing (ClickableAttributes)
 import Css exposing (Style)
 import Css.Global
-import Css.Media
+import Css.Media exposing (MediaQuery)
 import Html.Styled as Styled
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
@@ -181,6 +190,26 @@ testId id_ =
 id : String -> Attribute msg
 id id_ =
     custom [ Attributes.id id_ ]
+
+
+{-| -}
+hideIconForMobile : Attribute msg
+hideIconForMobile =
+    hideIconAt MediaQuery.mobile
+
+
+{-| -}
+hideIconAt : MediaQuery -> Attribute msg
+hideIconAt =
+    css
+        [ Css.Media.withMedia [ MediaQuery.mobile ]
+            [ Css.Global.descendants
+                [ Css.Global.selector "[role=img]"
+                    [ Css.display Css.none
+                    ]
+                ]
+            ]
+        ]
 
 
 {-| -}

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -8,6 +8,7 @@ module Nri.Ui.ClickableText.V3 exposing
     , icon
     , custom, nriDescription, testId, id
     , hideIconForMobile, hideIconFor
+    , hideTextForMobile, hideTextFor
     , css, notMobileCss, mobileCss, quizEngineMobileCss
     )
 
@@ -24,6 +25,7 @@ module Nri.Ui.ClickableText.V3 exposing
   - adds `modal` helper, for use in modal footers, same as applying large and Css.marginTop (Css.px 15)
   - adds `notMobileCss`, `mobileCss`, `quizEngineMobileCss`
   - adds `hideIconForMobile` and `hideIconAt`
+  - adds `hideTextForMobile` and `hideTextAt`
 
 
 # Changes from V2
@@ -77,10 +79,12 @@ HTML `<a>` elements and are created here with `*Link` functions.
 ### CSS
 
 @docs hideIconForMobile, hideIconFor
+@docs hideTextForMobile, hideTextFor
 @docs css, notMobileCss, mobileCss, quizEngineMobileCss
 
 -}
 
+import Accessibility.Styled.Style exposing (invisibleStyle)
 import ClickableAttributes exposing (ClickableAttributes)
 import Css exposing (Style)
 import Css.Global
@@ -192,6 +196,26 @@ hideIconFor mediaQuery =
             [ Css.Global.descendants
                 [ Css.Global.selector "[role=img]"
                     [ Css.display Css.none
+                    ]
+                ]
+            ]
+        ]
+
+
+{-| -}
+hideTextForMobile : Attribute msg
+hideTextForMobile =
+    hideTextFor MediaQuery.mobile
+
+
+{-| -}
+hideTextFor : MediaQuery -> Attribute msg
+hideTextFor mediaQuery =
+    css
+        [ Css.Media.withMedia [ mediaQuery ]
+            [ Css.Global.descendants
+                [ ExtraAttributes.nriDescriptionSelector "clickable-text-label"
+                    [ invisibleStyle
                     ]
                 ]
             ]
@@ -378,7 +402,7 @@ viewContent config =
                                     Css.marginRight (Css.px 4)
                             ]
                         |> Svg.toHtml
-                    , span [] [ text config.label ]
+                    , span [ ExtraAttributes.nriDescription "clickable-text-label" ] [ text config.label ]
                     ]
                 ]
 

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -12,7 +12,10 @@ module Nri.Ui.ClickableText.V3 exposing
     , css, notMobileCss, mobileCss, quizEngineMobileCss
     )
 
-{-|
+{-| Notes for V4:
+
+  - Remove the -v2- from dataDescriptor to avoid version specific
+  - Use dataDescriptor for clickable-text-label
 
 
 # Post-release patches

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -7,6 +7,7 @@ module Nri.Ui.ClickableText.V3 exposing
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     , icon
     , custom, nriDescription, testId, id
+    , hideIconForMobile, hideIconFor
     , css, notMobileCss, mobileCss, quizEngineMobileCss
     )
 
@@ -21,6 +22,8 @@ module Nri.Ui.ClickableText.V3 exposing
   - removes bottom border
   - adds `nriDescription`, `testId`, and `id` helpers
   - adds `modal` helper, for use in modal footers, same as applying large and Css.marginTop (Css.px 15)
+  - adds `notMobileCss`, `mobileCss`, `quizEngineMobileCss`
+  - adds `hideIconForMobile` and `hideIconAt`
 
 
 # Changes from V2
@@ -73,13 +76,15 @@ HTML `<a>` elements and are created here with `*Link` functions.
 
 ### CSS
 
+@docs hideIconForMobile, hideIconFor
 @docs css, notMobileCss, mobileCss, quizEngineMobileCss
 
 -}
 
 import ClickableAttributes exposing (ClickableAttributes)
 import Css exposing (Style)
-import Css.Media
+import Css.Global
+import Css.Media exposing (MediaQuery)
 import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes as Attributes
 import Nri.Ui
@@ -171,6 +176,26 @@ testId id_ =
 id : String -> Attribute msg
 id id_ =
     custom [ Attributes.id id_ ]
+
+
+{-| -}
+hideIconForMobile : Attribute msg
+hideIconForMobile =
+    hideIconFor MediaQuery.mobile
+
+
+{-| -}
+hideIconFor : MediaQuery -> Attribute msg
+hideIconFor mediaQuery =
+    css
+        [ Css.Media.withMedia [ mediaQuery ]
+            [ Css.Global.descendants
+                [ Css.Global.selector "[role=img]"
+                    [ Css.display Css.none
+                    ]
+                ]
+            ]
+        ]
 
 
 {-| -}

--- a/src/Nri/Ui/Html/Attributes/V2.elm
+++ b/src/Nri/Ui/Html/Attributes/V2.elm
@@ -1,4 +1,4 @@
-module Nri.Ui.Html.Attributes.V2 exposing (none, includeIf, targetBlank, nriDescription, testId)
+module Nri.Ui.Html.Attributes.V2 exposing (none, includeIf, targetBlank, nriDescription, nriDescriptionSelector, testId)
 
 {-|
 
@@ -11,10 +11,12 @@ Extras for working with Html.Attributes.
 
 This is the new version of Nri.Ui.Html.Attributes.Extra.
 
-@docs none, includeIf, targetBlank, nriDescription, testId
+@docs none, includeIf, targetBlank, nriDescription, nriDescriptionSelector, testId
 
 -}
 
+import Css
+import Css.Global
 import Html.Styled exposing (Attribute)
 import Html.Styled.Attributes as Attributes
 import Json.Encode as Encode
@@ -75,3 +77,13 @@ testId id =
 nriDescription : String -> Attribute msg
 nriDescription description =
     Attributes.attribute "data-nri-description" description
+
+
+{-|
+
+    Note: this does not handle html escaping the description before building the query
+
+-}
+nriDescriptionSelector : String -> List Css.Style -> Css.Global.Snippet
+nriDescriptionSelector description =
+    Css.Global.selector (String.join "" [ "[data-nri-description=\"", description, "\"]" ])

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -167,6 +167,10 @@ initDebugControls =
                         , ( "success", Button.success )
                         ]
                     )
+                |> ControlExtra.optionalBoolListItem "hideIconForMobile"
+                    (\_ ->
+                        ( "Button.hideIconForMobile", Button.hideIconForMobile )
+                    )
                 |> CommonControls.css
                     { moduleName = "Button"
                     , use = Button.css

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -67,6 +67,10 @@ init =
         |> Control.field "attributes"
             (ControlExtra.list
                 |> CommonControls.icon "ClickableText" ClickableText.icon
+                |> ControlExtra.optionalBoolListItem "hideIconForMobile"
+                    (\_ ->
+                        ( "ClickableText.hideIconForMobile", ClickableText.hideIconForMobile )
+                    )
                 |> CommonControls.css
                     { moduleName = "ClickableText"
                     , use = ClickableText.css

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -71,6 +71,10 @@ init =
                     (\_ ->
                         ( "ClickableText.hideIconForMobile", ClickableText.hideIconForMobile )
                     )
+                |> ControlExtra.optionalBoolListItem "hideTextForMobile"
+                    (\_ ->
+                        ( "ClickableText.hideTextForMobile", ClickableText.hideTextForMobile )
+                    )
                 |> CommonControls.css
                     { moduleName = "ClickableText"
                     , use = ClickableText.css


### PR DESCRIPTION
Adds helpers for conveniently hiding the icons used to augment buttons and clickable text elements on mobile.
Also adds a way to hide (without removing from the dom) the clickabletext text on mobile.

### Relevant changes

```
---- Nri.Ui.Button.V10 - MINOR ----

    Added:
        hideIconFor : Css.Media.MediaQuery -> Nri.Ui.Button.V10.Attribute msg
        hideIconForMobile : Nri.Ui.Button.V10.Attribute msg

---- Nri.Ui.ClickableText.V3 - MINOR ----

    Added:
        hideIconFor :
            Css.Media.MediaQuery -> Nri.Ui.ClickableText.V3.Attribute msg
        hideIconForMobile : Nri.Ui.ClickableText.V3.Attribute msg
        hideTextFor :
            Css.Media.MediaQuery -> Nri.Ui.ClickableText.V3.Attribute msg
        hideTextForMobile : Nri.Ui.ClickableText.V3.Attribute msg

---- Nri.Ui.Html.Attributes.V2 - MINOR ----

    Added:
        nriDescriptionSelector :
            String.String -> List.List Css.Style -> Css.Global.Snippet
```