### PR TITLE
Allow setting custom ID attribute on PremiumCheckbox

### DIFF
--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -1,5 +1,6 @@
 module Nri.Ui.PremiumCheckbox.V8 exposing
     ( view
+    , id
     , selected, partiallySelected
     , premium, showPennant
     , Attribute
@@ -38,6 +39,15 @@ import Nri.Ui.Util exposing (removePunctuation)
 import String exposing (toLower)
 import String.Extra exposing (dasherize)
 
+
+{-| Set a custom ID for this checkbox and label. If you don't set this,
+we'll automatically generate one from the label you pass in, but this can
+cause problems if you have more than one checkbox with the same label on
+the page. Use this to be more specific and avoid issues with duplicate IDs!
+-}
+id : String -> Attribute msg
+id id_ =
+    Attribute (\config -> { config | id = Just id_ })
 
 {-| This disables the input
 -}

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -27,7 +27,6 @@ module Nri.Ui.PremiumCheckbox.V8 exposing
 @docs disabled, enabled
 @docs id
 
-
 -}
 
 import Accessibility.Styled as Html exposing (Html)

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -1,10 +1,10 @@
 module Nri.Ui.PremiumCheckbox.V8 exposing
     ( view
-    , id
     , selected, partiallySelected
     , premium, showPennant
     , Attribute
     , disabled, enabled
+    , id
     )
 
 {-| Changes from V7:
@@ -48,6 +48,7 @@ the page. Use this to be more specific and avoid issues with duplicate IDs!
 id : String -> Attribute msg
 id id_ =
     Attribute (\config -> { config | id = Just id_ })
+
 
 {-| This disables the input
 -}

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -25,6 +25,8 @@ module Nri.Ui.PremiumCheckbox.V8 exposing
 
 @docs Attribute
 @docs disabled, enabled
+@docs id
+
 
 -}
 


### PR DESCRIPTION
`id` was configurable via the `config` record in V6, but omitted in the swap to list-based configuration in V7