### PR TITLE
Fix premium checkbox locked clicks

### DIFF
--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -188,7 +188,7 @@ viewPremiumCheckboxes state =
             , onChange = ToggleCheck "premium-1"
             }
             [ PremiumCheckbox.premium PremiumDisplay.PremiumUnlocked
-            , PremiumCheckbox.showPennant NoOp
+            , PremiumCheckbox.onLockedClick NoOp
             , PremiumCheckbox.selected (Set.member "premium-1" state.isChecked)
             ]
         , PremiumCheckbox.view
@@ -196,7 +196,7 @@ viewPremiumCheckboxes state =
             , onChange = ToggleCheck "premium-2"
             }
             [ PremiumCheckbox.premium PremiumDisplay.Free
-            , PremiumCheckbox.showPennant NoOp
+            , PremiumCheckbox.onLockedClick NoOp
             , PremiumCheckbox.selected (Set.member "premium-2" state.isChecked)
             ]
         , PremiumCheckbox.view
@@ -204,7 +204,7 @@ viewPremiumCheckboxes state =
             , onChange = ToggleCheck "premium-3"
             }
             [ PremiumCheckbox.premium PremiumDisplay.PremiumLocked
-            , PremiumCheckbox.showPennant NoOp
+            , PremiumCheckbox.onLockedClick NoOp
             , PremiumCheckbox.selected (Set.member "premium-3" state.isChecked)
             ]
         ]

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -184,7 +184,7 @@ viewPremiumCheckboxes : State -> Html Msg
 viewPremiumCheckboxes state =
     Html.div []
         [ PremiumCheckbox.view
-            { label = "Identify Adjectives 1 (Premium)"
+            { label = "Identify Adjectives 1 (Premium, Unlocked)"
             , onChange = ToggleCheck "premium-1"
             }
             [ PremiumCheckbox.premium PremiumDisplay.PremiumUnlocked
@@ -200,12 +200,21 @@ viewPremiumCheckboxes state =
             , PremiumCheckbox.selected (Set.member "premium-2" state.isChecked)
             ]
         , PremiumCheckbox.view
-            { label = "Revising Wordy Phrases 3 (Premium, Disabled)"
+            { label = "Revising Wordy Phrases 3 (Premium, Locked)"
             , onChange = ToggleCheck "premium-3"
             }
             [ PremiumCheckbox.premium PremiumDisplay.PremiumLocked
             , PremiumCheckbox.onLockedClick NoOp
             , PremiumCheckbox.selected (Set.member "premium-3" state.isChecked)
+            ]
+        , PremiumCheckbox.view
+            { label = "Revising Wordy Phrases 4 (Premium, Disabled)"
+            , onChange = ToggleCheck "premium-4"
+            }
+            [ PremiumCheckbox.premium PremiumDisplay.PremiumLocked
+
+            -- disabled because there is no PremiumCheckbox.onLockedClick
+            , PremiumCheckbox.selected (Set.member "premium-4" state.isChecked)
             ]
         ]
 


### PR DESCRIPTION
Relevant changes:
  - Rename showPennant to onLockedClick
  - Fix clicking on locked checkbox to send a onLockedClick
 
We want locked checkbox to trigger the msg specified by onLockedClick, but if the checkbox is locked and there is no onLockedClick specified we need to disable the checkbox because we don't want to receive any message from the underlying checkbox in that case. Unfortunately that has some differences due to the disable style.

The following recording shows in which contexts a msg is triggered.

![kQ5JH8IR9n](https://user-images.githubusercontent.com/459923/157922125-dc7c38b1-0d74-4466-98a3-e3bece1c8319.gif)
