### PR TITLE
Tessa/sidebar wrap

### DIFF
--- a/src/Nri/Ui/SideNav/V2.elm
+++ b/src/Nri/Ui/SideNav/V2.elm
@@ -241,7 +241,8 @@ viewLockedEntry extraStyles entryConfig =
 sharedEntryStyles : List Style
 sharedEntryStyles =
     [ padding2 (px 13) (px 20)
-    , Css.property "word-break" "break-word"
+    , Css.property "word-break" "normal"
+    , Css.property "overflow-wrap" "anywhere"
     , displayFlex
     , borderRadius (px 8)
     , alignItems center

--- a/src/Nri/Ui/SideNav/V2.elm
+++ b/src/Nri/Ui/SideNav/V2.elm
@@ -241,6 +241,7 @@ viewLockedEntry extraStyles entryConfig =
 sharedEntryStyles : List Style
 sharedEntryStyles =
     [ padding2 (px 13) (px 20)
+    , Css.property "word-break" "break-word"
     , displayFlex
     , borderRadius (px 8)
     , alignItems center

--- a/src/Nri/Ui/SideNav/V2.elm
+++ b/src/Nri/Ui/SideNav/V2.elm
@@ -240,9 +240,7 @@ viewLockedEntry extraStyles entryConfig =
 
 sharedEntryStyles : List Style
 sharedEntryStyles =
-    [ paddingLeft (px 20)
-    , paddingRight (px 20)
-    , height (px 45)
+    [ padding2 (px 13) (px 20)
     , displayFlex
     , borderRadius (px 8)
     , alignItems center


### PR DESCRIPTION
Fixes https://github.com/NoRedInk/noredink-ui/issues/817 (At least partially. The sidebar nav is set up to expand to the full width of its parent container by default. If the /curriculum library is using flexbox and permitting flex grow on the sidebar, then the sidebar may keep growing!)

## Before
the height of each sidebar element was hardcoded to 45px, meaning tons of ugly overflowing content for long text.

<img width="590" alt="" src="https://user-images.githubusercontent.com/8811312/157985892-cff846c4-33cc-4f14-91ce-1de746026121.png">

## After
the height of each sidebar element is 45px if the content isn't multline, but padding is used to achieve this rather than a hardcoded height value.

<img width="574" alt="" src="https://user-images.githubusercontent.com/8811312/157985896-8f337b96-e95e-4b8f-b103-69087db952c0.png">

cc @NoRedInk/design 