### PR TITLE
Use 'Html.button' element for PremiumLocked checkboxes

### DIFF
--- a/src/Nri/Ui/Checkbox/V5.elm
+++ b/src/Nri/Ui/Checkbox/V5.elm
@@ -2,8 +2,9 @@ module Nri.Ui.Checkbox.V5 exposing
     ( Model, Theme(..), IsSelected(..)
     , view, viewWithLabel
     , selectedFromBool
+    , checkboxLockOnInside
+    , viewIcon
     )
-
 {-|
 
 
@@ -200,7 +201,6 @@ viewCheckbox model =
 viewEnabledLabel :
     { a
         | identifier : String
-        , setterMsg : Bool -> msg
         , selected : IsSelected
         , label : String
     }

--- a/src/Nri/Ui/Checkbox/V5.elm
+++ b/src/Nri/Ui/Checkbox/V5.elm
@@ -2,9 +2,9 @@ module Nri.Ui.Checkbox.V5 exposing
     ( Model, Theme(..), IsSelected(..)
     , view, viewWithLabel
     , selectedFromBool
-    , checkboxLockOnInside
-    , viewIcon
+    , viewIcon, checkboxLockOnInside
     )
+
 {-|
 
 
@@ -25,6 +25,8 @@ module Nri.Ui.Checkbox.V5 exposing
 @docs view, viewWithLabel
 
 @docs selectedFromBool
+
+@docs viewIcon, checkboxLockOnInside
 
 -}
 
@@ -289,6 +291,7 @@ textStyle =
         ]
 
 
+{-| -}
 viewIcon : List Style -> Svg -> Html.Html msg
 viewIcon styles icon =
     Html.div
@@ -556,6 +559,7 @@ checkboxBackground attrs =
         []
 
 
+{-| -}
 checkboxLockOnInside : String -> Svg
 checkboxLockOnInside idSuffix =
     let

--- a/src/Nri/Ui/Checkbox/V5.elm
+++ b/src/Nri/Ui/Checkbox/V5.elm
@@ -201,6 +201,7 @@ viewCheckbox model =
 viewEnabledLabel :
     { a
         | identifier : String
+        , setterMsg : Bool -> msg
         , selected : IsSelected
         , label : String
     }

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -204,17 +204,8 @@ viewPremiumCheckboxes state =
             , onChange = ToggleCheck "premium-3"
             }
             [ PremiumCheckbox.premium PremiumDisplay.PremiumLocked
-            , PremiumCheckbox.onLockedClick NoOp
+            , PremiumCheckbox.onLockedClick (Debug.log "Locked" NoOp)
             , PremiumCheckbox.selected (Set.member "premium-3" state.isChecked)
-            ]
-        , PremiumCheckbox.view
-            { label = "Revising Wordy Phrases 4 (Premium, Disabled)"
-            , onChange = ToggleCheck "premium-4"
-            }
-            [ PremiumCheckbox.premium PremiumDisplay.PremiumLocked
-
-            -- disabled because there is no PremiumCheckbox.onLockedClick
-            , PremiumCheckbox.selected (Set.member "premium-4" state.isChecked)
             ]
         ]
 


### PR DESCRIPTION
This change fixes the problem introduced in #855, where locked/disabled checkboxes were acting as enabled underneath.

The solution, as discussed in a meeting, was changing these checkboxes into buttons.

I also have a question: do you think it make sense to actually have PremiumLocked Disabled checkboxes? I didn't take those in account, but they can be easily implemented.