### PR TITLE
Adds class name to premium checkbox flag

### DIFF
--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -45,7 +45,6 @@ import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Util exposing (removePunctuation)
 import String exposing (toLower)
 import String.Extra exposing (dasherize)
-import Svg.Attributes
 
 
 {-| Set a custom ID for this checkbox and label. If you don't set this,

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -265,24 +265,25 @@ viewLockedButton { idValue, label, containerCss, onLockedMsg } =
 
 viewPremiumFlag : { hidden : Bool } -> Html msg
 viewPremiumFlag { hidden } =
+    let
+        flagSvg =
+            premiumFlag
+                |> Svg.withWidth (Css.px iconWidth)
+                |> Svg.withHeight (Css.px 30)
+                |> Svg.withClass "premium-checkbox-flag-V8"
+    in
     if hidden then
-        premiumFlag
-            |> Svg.withWidth (Css.px iconWidth)
-            |> Svg.withHeight (Css.px 30)
+        flagSvg
             |> Svg.withCss
                 [ Css.marginRight (Css.px iconRightMargin)
                 , Css.visibility Css.hidden
                 ]
-            |> Svg.withClass "premium-checkbox-flag-V8"
             |> Svg.toHtml
 
     else
-        premiumFlag
-            |> Svg.withWidth (Css.px iconWidth)
-            |> Svg.withHeight (Css.px 30)
+        flagSvg
             |> Svg.withCss [ Css.marginRight (Css.px iconRightMargin) ]
             |> Svg.withLabel "Premium"
-            |> Svg.withClass "premium-checkbox-flag-V8"
             |> Svg.toHtml
 
 

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -41,7 +41,7 @@ import Nri.Ui.Data.PremiumDisplay as PremiumDisplay exposing (PremiumDisplay)
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.Pennant.V2 exposing (premiumFlag)
-import Nri.Ui.Svg.V1 as Svg exposing (Svg)
+import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Util exposing (removePunctuation)
 import String exposing (toLower)
 import String.Extra exposing (dasherize)

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -41,10 +41,11 @@ import Nri.Ui.Data.PremiumDisplay as PremiumDisplay exposing (PremiumDisplay)
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.Pennant.V2 exposing (premiumFlag)
-import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Util exposing (removePunctuation)
 import String exposing (toLower)
 import String.Extra exposing (dasherize)
+import Svg.Attributes
 
 
 {-| Set a custom ID for this checkbox and label. If you don't set this,
@@ -186,11 +187,10 @@ view { label, onChange } attributes =
     else
         Html.div [ css config.containerCss ]
             [ if isPremium then
-                viewPremiumFlag
+                viewPremiumFlag { hidden = False }
 
               else
-                -- left-align the checkbox with checkboxes that _do_ have the premium pennant
-                Html.div [ css [ Css.width (Css.px (iconWidth + iconRightMargin)) ] ] []
+                viewPremiumFlag { hidden = True }
             , Checkbox.viewWithLabel
                 { identifier = idValue
                 , label = label
@@ -228,7 +228,7 @@ viewLockedButton { idValue, label, containerCss, onLockedMsg } =
             Nothing ->
                 Extra.none
         ]
-        [ viewPremiumFlag
+        [ viewPremiumFlag { hidden = False }
         , Html.span
             [ css
                 [ outline Css.none
@@ -264,14 +264,27 @@ viewLockedButton { idValue, label, containerCss, onLockedMsg } =
         ]
 
 
-viewPremiumFlag : Html msg
-viewPremiumFlag =
-    premiumFlag
-        |> Svg.withLabel "Premium"
-        |> Svg.withWidth (Css.px iconWidth)
-        |> Svg.withHeight (Css.px 30)
-        |> Svg.withCss [ Css.marginRight (Css.px iconRightMargin) ]
-        |> Svg.toHtml
+viewPremiumFlag : { hidden : Bool } -> Html msg
+viewPremiumFlag { hidden } =
+    if hidden then
+        premiumFlag
+            |> Svg.withWidth (Css.px iconWidth)
+            |> Svg.withHeight (Css.px 30)
+            |> Svg.withCss
+                [ Css.marginRight (Css.px iconRightMargin)
+                , Css.visibility Css.hidden
+                ]
+            |> Svg.withClass "premium-checkbox-flag-V8"
+            |> Svg.toHtml
+
+    else
+        premiumFlag
+            |> Svg.withWidth (Css.px iconWidth)
+            |> Svg.withHeight (Css.px 30)
+            |> Svg.withCss [ Css.marginRight (Css.px iconRightMargin) ]
+            |> Svg.withLabel "Premium"
+            |> Svg.withClass "premium-checkbox-flag-V8"
+            |> Svg.toHtml
 
 
 iconWidth : Float

--- a/src/Nri/Ui/Svg/V1.elm
+++ b/src/Nri/Ui/Svg/V1.elm
@@ -1,6 +1,6 @@
 module Nri.Ui.Svg.V1 exposing
     ( Svg
-    , withColor, withLabel, withWidth, withHeight, withCss, withNriDescription
+    , withColor, withLabel, withWidth, withHeight, withCss, withNriDescription, withClass
     , fromHtml, toHtml
     , toRawSvg
     )
@@ -8,7 +8,7 @@ module Nri.Ui.Svg.V1 exposing
 {-|
 
 @docs Svg
-@docs withColor, withLabel, withWidth, withHeight, withCss, withNriDescription
+@docs withColor, withLabel, withWidth, withHeight, withCss, withNriDescription, withClass
 @docs fromHtml, toHtml
 @docs toRawSvg
 
@@ -100,6 +100,12 @@ withCustom attributes (Svg record) =
 withNriDescription : String -> Svg -> Svg
 withNriDescription description =
     withCustom [ AttributesExtra.nriDescription description ]
+
+
+{-| -}
+withClass : String -> Svg -> Svg
+withClass class =
+    withCustom [ Attributes.class class ]
 
 
 {-| Render an svg.


### PR DESCRIPTION
This change is part of a fix for [an alignment issue in curriculum](https://linear.app/noredink/issue/GRO-231/fix-alignment).

The Curriculum Pathway view was using a selector based on the `aria-label` for the Premium flag, which caused problems when it either didn't exist or had no `label` (used for `aria-hidden=true`). 

The solution was to add a hidden flag for the Free PremiumCheckboxes, and a class to be used on the page's selector.