### PR TITLE
Hide previews from screenreaders

### DIFF
--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -126,6 +126,7 @@ preview_ navigate example =
                             [ Css.displayFlex
                             , Css.flexDirection Css.column
                             ]
+                        , Widget.hidden True
                         ]
                         (List.map (Html.map never) example.preview)
                    ]


### PR DESCRIPTION
Adds `aria-hidden=true` to the mini previews on the styleguide dashboard