### PR TITLE
Fix missing table header

### DIFF
--- a/src/Nri/Ui/Table/V5.elm
+++ b/src/Nri/Ui/Table/V5.elm
@@ -18,6 +18,7 @@ module Nri.Ui.Table.V5 exposing
 
 -}
 
+import Accessibility.Styled.Style as Style
 import Css exposing (..)
 import Css.Animations
 import Html.Styled as Html exposing (..)
@@ -141,7 +142,8 @@ stylesLoadingColumn rowIndex colIndex width =
 tableWithoutHeader : List Style -> List (Column data msg) -> (a -> Html msg) -> List a -> Html msg
 tableWithoutHeader styles columns toRow data =
     table styles
-        [ tableBody toRow data
+        [ thead [] [ tr Style.invisible (List.map tableRowHeader columns) ]
+        , tableBody toRow data
         ]
 
 


### PR DESCRIPTION
Include the ths in the DOM even when they're not visually displayed so that screenreader users can navigate via the headings.