### PR TITLE
Specific page titles

### DIFF
--- a/styleguide-app/Main.elm
+++ b/styleguide-app/Main.elm
@@ -191,10 +191,7 @@ view_ model =
                         |> Html.map (UpdateModuleStates example.name)
 
                 Nothing ->
-                    Page.notFound
-                        { link = ChangeRoute Routes.All
-                        , recoveryText = Page.ReturnTo "Component Library"
-                        }
+                    notFound
 
         Routes.Category category ->
             withSideNav model.route
@@ -222,6 +219,14 @@ viewExample model example =
             { packageDependencies = model.elliePackageDependencies }
             example
         ]
+
+
+notFound : Html Msg
+notFound =
+    Page.notFound
+        { link = ChangeRoute Routes.All
+        , recoveryText = Page.ReturnTo "Component Library"
+        }
 
 
 withSideNav : Route -> List (Html Msg) -> Html Msg

--- a/styleguide-app/Main.elm
+++ b/styleguide-app/Main.elm
@@ -187,17 +187,8 @@ view_ model =
         Routes.Doodad doodad ->
             case List.head (examples (\m -> m.name == doodad)) of
                 Just example ->
-                    Html.div
-                        [ css
-                            [ maxWidth (Css.px 1400)
-                            , margin auto
-                            ]
-                        ]
-                        [ Example.view model.previousRoute
-                            { packageDependencies = model.elliePackageDependencies }
-                            example
-                            |> Html.map (UpdateModuleStates example.name)
-                        ]
+                    viewExample model example
+                        |> Html.map (UpdateModuleStates example.name)
 
                 Nothing ->
                     Page.notFound
@@ -222,6 +213,15 @@ view_ model =
                 [ mainContentHeader "All"
                 , viewPreviews "all" (examples (\_ -> True))
                 ]
+
+
+viewExample : Model -> Example a msg -> Html msg
+viewExample model example =
+    Html.div [ css [ maxWidth (Css.px 1400), margin auto ] ]
+        [ Example.view model.previousRoute
+            { packageDependencies = model.elliePackageDependencies }
+            example
+        ]
 
 
 withSideNav : Route -> List (Html Msg) -> Html Msg

--- a/styleguide-app/Main.elm
+++ b/styleguide-app/Main.elm
@@ -4,7 +4,7 @@ import Accessibility.Styled as Html exposing (Html)
 import Browser exposing (Document, UrlRequest(..))
 import Browser.Dom
 import Browser.Navigation exposing (Key)
-import Category
+import Category exposing (Category)
 import Css exposing (..)
 import Css.Media exposing (withMedia)
 import Dict exposing (Dict)
@@ -194,16 +194,7 @@ view_ model =
                     notFound
 
         Routes.Category category ->
-            withSideNav model.route
-                [ mainContentHeader (Category.forDisplay category)
-                , examples
-                    (\doodad ->
-                        Set.memberOf
-                            (Set.fromList Category.sorter doodad.categories)
-                            category
-                    )
-                    |> viewPreviews (Category.forId category)
-                ]
+            viewCategory model category
 
         Routes.All ->
             withSideNav model.route
@@ -227,6 +218,22 @@ notFound =
         { link = ChangeRoute Routes.All
         , recoveryText = Page.ReturnTo "Component Library"
         }
+
+
+viewCategory : Model -> Category -> Html Msg
+viewCategory model category =
+    withSideNav model.route
+        [ mainContentHeader (Category.forDisplay category)
+        , model.moduleStates
+            |> Dict.values
+            |> List.filter
+                (\doodad ->
+                    Set.memberOf
+                        (Set.fromList Category.sorter doodad.categories)
+                        category
+                )
+            |> viewPreviews (Category.forId category)
+        ]
 
 
 withSideNav : Route -> List (Html Msg) -> Html Msg

--- a/styleguide-app/Main.elm
+++ b/styleguide-app/Main.elm
@@ -185,7 +185,7 @@ view model =
         Routes.Doodad doodad ->
             case findExampleByName doodad of
                 Just example ->
-                    { title = "Style Guide"
+                    { title = example.name ++ " in the NoRedInk Style Guide"
                     , body =
                         viewExample model example
                             |> Html.map (UpdateModuleStates example.name)
@@ -193,17 +193,17 @@ view model =
                     }
 
                 Nothing ->
-                    { title = "Style Guide"
+                    { title = "Not found in the NoRedInk Style Guide"
                     , body = toBody notFound
                     }
 
         Routes.Category category ->
-            { title = "Style Guide"
+            { title = Category.forDisplay category ++ " Category in the NoRedInk Style Guide"
             , body = toBody (viewCategory model category)
             }
 
         Routes.All ->
-            { title = "Style Guide"
+            { title = "NoRedInk Style Guide"
             , body = toBody (viewAll model)
             }
 

--- a/styleguide-app/Main.elm
+++ b/styleguide-app/Main.elm
@@ -180,12 +180,14 @@ view model =
 view_ : Model -> Html Msg
 view_ model =
     let
-        examples filterBy =
-            List.filter (\m -> filterBy m) (Dict.values model.moduleStates)
+        findExampleByName name =
+            Dict.values model.moduleStates
+                |> List.filter (\m -> m.name == name)
+                |> List.head
     in
     case model.route of
         Routes.Doodad doodad ->
-            case List.head (examples (\m -> m.name == doodad)) of
+            case findExampleByName doodad of
                 Just example ->
                     viewExample model example
                         |> Html.map (UpdateModuleStates example.name)

--- a/styleguide-app/Main.elm
+++ b/styleguide-app/Main.elm
@@ -197,10 +197,7 @@ view_ model =
             viewCategory model category
 
         Routes.All ->
-            withSideNav model.route
-                [ mainContentHeader "All"
-                , viewPreviews "all" (examples (\_ -> True))
-                ]
+            viewAll model
 
 
 viewExample : Model -> Example a msg -> Html msg
@@ -218,6 +215,14 @@ notFound =
         { link = ChangeRoute Routes.All
         , recoveryText = Page.ReturnTo "Component Library"
         }
+
+
+viewAll : Model -> Html Msg
+viewAll model =
+    withSideNav model.route
+        [ mainContentHeader "All"
+        , viewPreviews "all" (Dict.values model.moduleStates)
+        ]
 
 
 viewCategory : Model -> Category -> Html Msg

--- a/styleguide-app/Main.elm
+++ b/styleguide-app/Main.elm
@@ -169,37 +169,43 @@ subscriptions model =
 
 view : Model -> Document Msg
 view model =
-    { title = "Style Guide"
-    , body =
-        [ view_ model |> Html.toUnstyled
-        , Sprite.attach |> Html.map never |> Html.toUnstyled
-        ]
-    }
-
-
-view_ : Model -> Html Msg
-view_ model =
     let
         findExampleByName name =
             Dict.values model.moduleStates
                 |> List.filter (\m -> m.name == name)
                 |> List.head
+
+        toBody view_ =
+            List.map Html.toUnstyled
+                [ view_
+                , Html.map never Sprite.attach
+                ]
     in
     case model.route of
         Routes.Doodad doodad ->
             case findExampleByName doodad of
                 Just example ->
-                    viewExample model example
-                        |> Html.map (UpdateModuleStates example.name)
+                    { title = "Style Guide"
+                    , body =
+                        viewExample model example
+                            |> Html.map (UpdateModuleStates example.name)
+                            |> toBody
+                    }
 
                 Nothing ->
-                    notFound
+                    { title = "Style Guide"
+                    , body = toBody notFound
+                    }
 
         Routes.Category category ->
-            viewCategory model category
+            { title = "Style Guide"
+            , body = toBody (viewCategory model category)
+            }
 
         Routes.All ->
-            viewAll model
+            { title = "Style Guide"
+            , body = toBody (viewAll model)
+            }
 
 
 viewExample : Model -> Example a msg -> Html msg


### PR DESCRIPTION
Provide specific page titles for every route in the styleguide, implementing [Technique H25](https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/H25) for [Success Criterion 2.4.2](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-title.html).
