### PR TITLE
Bump minor version

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "15.8.1",
+    "version": "15.9.0",
     "exposed-modules": [
         "Nri.Ui",
         "Nri.Ui.Accordion.V1",


### PR DESCRIPTION
This bumps the minor version on account of the new icons added in #892 . After this is merged, I plan to tag and publish this version so I can refer to it in `NoRedInk`.