### PR TITLE
Bat/one doodad at a time

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Run tests with
 - `shake test`
 - `elm-test`
 
+You can run the Puppeteer tests for only one component by passing the name of the component to the test script, for example: `./script/puppeteer-tests-no-percy.sh Button`
+
 ### CI (Travis)
 
 Travis will run `shake ci` to verify everything looks good.

--- a/script/puppeteer-tests-no-percy.sh
+++ b/script/puppeteer-tests-no-percy.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-npx mocha script/puppeteer-tests.js --timeout 15000 --exit
+env ONLYDOODAD=${1-default} npx mocha script/puppeteer-tests.js --timeout 15000 --exit

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -49,7 +49,6 @@ describe('UI tests', function () {
     await page.goto(location)
     await page.waitFor(`#${name.replace(".", "-")}`)
     await percySnapshot(page, name)
-    console.log(`Snapshot complete for ${name}`)
 
     const results = await new AxePuppeteer(page).disableRules(skippedRules[name] || []).analyze();
     handleAxeResults(name, results);
@@ -65,7 +64,6 @@ describe('UI tests', function () {
     await page.waitForSelector(".checkbox-V5__Checked")
     await percySnapshot(page, `${name} - display icon names`)
 
-    console.log(`Snapshots complete for ${name}`)
 
     const results = await new AxePuppeteer(page).disableRules(skippedRules[name] || []).analyze();
     handleAxeResults(name, results);
@@ -156,10 +154,12 @@ describe('UI tests', function () {
 
     await links.reduce((acc, [name, location]) => {
       return acc.then(() => {
-          let handler = specialProcessing[name] || defaultProcessing
-          return handler(name, location)
+        if (process.env.ONLYDOODAD == "default" || process.env.ONLYDOODAD == name) {
+          console.log(`Testing ${name}`)
+          let handler = specialProcessing[name] || defaultProcessing;
+          return handler(name, location);
         }
-      )
+      })
     }, Promise.resolve())
 
     page.close();


### PR DESCRIPTION
Support running the axe checks on one doodad at a time, by passing its name to the test runner script.

For example:
```
./script/puppeteer-tests-no-percy.sh Page
```