### PR TITLE
Bat/fix a11y failures

### DIFF
--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -72,7 +72,6 @@ describe('UI tests', function () {
   const skippedRules = {
     'Accordion': ['heading-order'],
     'RadioButton': ['duplicate-id'],
-    'Select': ['label'],
     'Switch': ['aria-allowed-attr'],
   }
 

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -70,18 +70,12 @@ describe('UI tests', function () {
   }
 
   const skippedRules = {
-    'Accordion': ['heading-order', 'region'],
-    'Checkbox': ['region'],
+    'Accordion': ['heading-order'],
     'Loading': ['color-contrast'],
-    'Menu': ['region'],
-    'Modal': ['region'],
-    'Message': ['region'],
     'Page': ['color-contrast', 'select-name'],
-    'RadioButton': ['duplicate-id', 'region'],
-    'SegmentedControl': ['region'],
+    'RadioButton': ['duplicate-id'],
     'Select': ['label'],
     'Switch': ['aria-allowed-attr'],
-    'Tabs': ['region'],
   }
 
   const specialProcessing = {

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -71,7 +71,7 @@ describe('UI tests', function () {
 
   const skippedRules = {
     'Accordion': ['heading-order'],
-    'Page': ['color-contrast', 'select-name'],
+    'Page': ['select-name'],
     'RadioButton': ['duplicate-id'],
     'Select': ['label'],
     'Switch': ['aria-allowed-attr'],

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -71,7 +71,6 @@ describe('UI tests', function () {
 
   const skippedRules = {
     'Accordion': ['heading-order'],
-    'Page': ['select-name'],
     'RadioButton': ['duplicate-id'],
     'Select': ['label'],
     'Switch': ['aria-allowed-attr'],

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -71,7 +71,6 @@ describe('UI tests', function () {
 
   const skippedRules = {
     'Accordion': ['heading-order', 'region'],
-    'Balloon': ['color-contrast'],
     'Checkbox': ['region'],
     'Loading': ['color-contrast'],
     'Menu': ['region'],

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -71,7 +71,6 @@ describe('UI tests', function () {
 
   const skippedRules = {
     'Accordion': ['heading-order'],
-    'Loading': ['color-contrast'],
     'Page': ['color-contrast', 'select-name'],
     'RadioButton': ['duplicate-id'],
     'Select': ['label'],

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -71,7 +71,7 @@ describe('UI tests', function () {
 
   const skippedRules = {
     'Accordion': ['heading-order', 'region'],
-    'Balloon': ['color-contrast', 'label'],
+    'Balloon': ['color-contrast'],
     'Checkbox': ['region'],
     'Loading': ['color-contrast'],
     'Menu': ['region'],

--- a/src/Nri/Ui/Balloon/V1.elm
+++ b/src/Nri/Ui/Balloon/V1.elm
@@ -326,8 +326,8 @@ balloonTheme theme =
 
         Green ->
             batch
-                [ backgroundColor Colors.greenDark
-                , border3 (px 1) solid Colors.greenDark
+                [ backgroundColor Colors.greenDarkest
+                , border3 (px 1) solid Colors.greenDarkest
                 , Fonts.baseFont
                 , fontSize (px 15)
                 , color Colors.white
@@ -439,8 +439,8 @@ arrowTheme theme =
 
         Green ->
             batch
-                [ backgroundColor Colors.greenDark
-                , border3 (px 1) solid Colors.greenDark
+                [ backgroundColor Colors.greenDarkest
+                , border3 (px 1) solid Colors.greenDarkest
                 , Fonts.baseFont
                 , fontSize (px 15)
                 , color Colors.white

--- a/src/Nri/Ui/Page/V3.elm
+++ b/src/Nri/Ui/Page/V3.elm
@@ -17,6 +17,7 @@ import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Http
 import Nri.Ui.Button.V10 as Button
+import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Html.V3 exposing (viewIf)
 
@@ -263,7 +264,7 @@ viewDetails detailsForEngineers =
             ]
             []
             [ Html.styled Html.summary
-                [ color (hex "8F8F8F") ]
+                [ color Colors.gray45 ]
                 []
                 [ Html.text "Details for NoRedInk engineers" ]
             , Html.styled Html.code

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -54,7 +54,14 @@ example =
     , version = 3
     , categories = [ Messaging ]
     , keyboardSupport = []
-    , state = { httpError = CommonControls.httpError, recoveryText = initRecoveryText }
+    , state =
+        { httpError =
+            Control.record identity
+                |> Control.field "httpError" CommonControls.httpError
+        , recoveryText =
+            Control.record identity
+                |> Control.field "recoveryText" initRecoveryText
+        }
     , update = update
     , subscriptions = \_ -> Sub.none
     , preview =

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -85,7 +85,7 @@ type alias State =
 {-| -}
 init : State
 init =
-    { label = Control.string "Tortilla Selector"
+    { label = Control.record identity |> Control.field "label" (Control.string "Tortilla Selector")
     , attributes = initControls
     }
 

--- a/styleguide-app/KeyboardSupport.elm
+++ b/styleguide-app/KeyboardSupport.elm
@@ -39,6 +39,8 @@ view keyboardSupport =
                     ]
                     (List.map viewKeyboardActions keyboardSupport)
                 ]
+                |> List.singleton
+                |> aside []
 
 
 viewKeyboardActions : KeyboardSupport -> Html msg


### PR DESCRIPTION
Fix most of the axe errors found on the styleguide app, with a couple of exceptions.

1. Accordion header order -- I don't want to fix the errors here until https://github.com/NoRedInk/noredink-ui/pull/902 goes in
2. RadioButton duplicate-id -- this one is an error in the svg, where the id is included accidentally. gonna be irritating to fix and I'm not feeling it right this second
3. Switch aria-allowed-attr -- looks like a potentially a real a11y issue in the Switch component!

I adjusted a couple of colors in order to fix insufficient color contrast. @NoRedInk/design please feel free to tell me to cool my jets, as always 😄 

# Balloon

## Before

<img width="149" alt="" src="https://user-images.githubusercontent.com/8811312/163480330-de6fecfb-70a2-42f0-9d3b-546da08e26af.png">

## After

<img width="159" alt="" src="https://user-images.githubusercontent.com/8811312/163480293-c868fd11-70d5-4dc9-96d1-587d19c53918.png">


# Page error

(Look at the details color)

## Before

<img width="466" alt="" src="https://user-images.githubusercontent.com/8811312/163480371-b02aec7a-48ce-43f5-b67b-ba0e6e5c27fa.png">


## After

<img width="476" alt="" src="https://user-images.githubusercontent.com/8811312/163480236-e4c1c4d9-b8d0-4270-8881-dd7e0e0d83d2.png">
