### PR TITLE
Fix missing snapshots

### DIFF
--- a/script/puppeteer-tests-percy.sh
+++ b/script/puppeteer-tests-percy.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-npx percy exec -- mocha script/puppeteer-tests.js --timeout 50000 --exit
+env ONLYDOODAD=${1-default} npx percy exec -- mocha script/puppeteer-tests.js --timeout 50000 --exit

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -70,6 +70,8 @@ describe('UI tests', function () {
   }
 
   const skippedRules = {
+    // Loading's color contrast check seems to change behavior depending on whether Percy snapshots are taken or not
+    'Loading': ['color-contrast'],
     'RadioButton': ['duplicate-id'],
     'Switch': ['aria-allowed-attr'],
   }


### PR DESCRIPTION
Missing env variable meant just the index page was getting snapshotted. Oops.