### PR TITLE
Adds breakpoint css helpers to Container

### DIFF
--- a/src/Nri/Ui/Container/V2.elm
+++ b/src/Nri/Ui/Container/V2.elm
@@ -1,6 +1,8 @@
 module Nri.Ui.Container.V2 exposing
     ( view, Attribute
-    , paddingPx, custom, css, testId, id
+    , custom, testId, id
+    , css, notMobileCss, mobileCss, quizEngineMobileCss
+    , paddingPx
     , plaintext, markdown, html
     , gray, default, disabled, invalid, pillow, buttony
     )
@@ -14,6 +16,7 @@ module Nri.Ui.Container.V2 exposing
 ## Patch changes
 
   - use `Shadows`
+  - add notMobileCss, mobileCss, quizEngineMobileCss
 
 
 ## Changes from V1
@@ -36,7 +39,10 @@ module Nri.Ui.Container.V2 exposing
 ## View
 
 @docs view, Attribute
-@docs paddingPx, custom, css, testId, id
+@docs custom, testId, id
+
+@docs css, notMobileCss, mobileCss, quizEngineMobileCss
+@docs paddingPx
 
 
 ## Content
@@ -58,7 +64,7 @@ import Markdown
 import Nri.Ui
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
-import Nri.Ui.MediaQuery.V1 exposing (mobile)
+import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Nri.Ui.Shadows.V1 as Shadows
 
 
@@ -118,6 +124,39 @@ id id_ =
 css : List Css.Style -> Attribute msg
 css css_ =
     Attribute <| \config -> { config | css = config.css ++ css_ }
+
+
+{-| Equivalent to:
+
+    Container.css
+        [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.notMobile ] styles ]
+
+-}
+notMobileCss : List Style -> Attribute msg
+notMobileCss styles =
+    css [ Css.Media.withMedia [ MediaQuery.notMobile ] styles ]
+
+
+{-| Equivalent to:
+
+    Container.css
+        [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.mobile ] styles ]
+
+-}
+mobileCss : List Style -> Attribute msg
+mobileCss styles =
+    css [ Css.Media.withMedia [ MediaQuery.mobile ] styles ]
+
+
+{-| Equivalent to:
+
+    Container.css
+        [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.quizEngineMobile ] styles ]
+
+-}
+quizEngineMobileCss : List Style -> Attribute msg
+quizEngineMobileCss styles =
+    css [ Css.Media.withMedia [ MediaQuery.quizEngineMobile ] styles ]
 
 
 {-| -}
@@ -244,7 +283,7 @@ pillowStyles =
     , border3 (px 1) solid Colors.gray92
     , Shadows.medium
     , backgroundColor Colors.white
-    , withMedia [ mobile ]
+    , withMedia [ MediaQuery.mobile ]
         [ borderRadius (px 8)
         , padding (px 20)
         ]
@@ -269,7 +308,7 @@ buttonyStyles =
     , border3 (px 1) solid Colors.gray85
     , borderBottom3 (px 4) solid Colors.gray85
     , backgroundColor Colors.white
-    , withMedia [ mobile ]
+    , withMedia [ MediaQuery.mobile ]
         [ borderRadius (px 8)
         ]
     ]

--- a/src/Nri/Ui/Container/V2.elm
+++ b/src/Nri/Ui/Container/V2.elm
@@ -126,7 +126,9 @@ css css_ =
     Attribute <| \config -> { config | css = config.css ++ css_ }
 
 
-{-| Equivalent to:
+{-| Set styles that will only apply if the viewport is wider than NRI's mobile breakpoint.
+
+Equivalent to:
 
     Container.css
         [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.notMobile ] styles ]
@@ -137,7 +139,9 @@ notMobileCss styles =
     css [ Css.Media.withMedia [ MediaQuery.notMobile ] styles ]
 
 
-{-| Equivalent to:
+{-| Set styles that will only apply if the viewport is narrower than NRI's mobile breakpoint.
+
+Equivalent to:
 
     Container.css
         [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.mobile ] styles ]
@@ -148,7 +152,9 @@ mobileCss styles =
     css [ Css.Media.withMedia [ MediaQuery.mobile ] styles ]
 
 
-{-| Equivalent to:
+{-| Set styles that will only apply if the viewport is narrower than NRI's quiz-engine-specific mobile breakpoint.
+
+Equivalent to:
 
     Container.css
         [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.quizEngineMobile ] styles ]

--- a/styleguide-app/Examples/Container.elm
+++ b/styleguide-app/Examples/Container.elm
@@ -157,7 +157,10 @@ init =
     { control =
         ControlExtra.list
             |> ControlExtra.optionalListItem "paddingPx" controlPaddingPx
-            |> CommonControls.css { moduleName = "Container", use = Container.css }
+            |> CommonControls.css { moduleName = moduleName, use = Container.css }
+            |> CommonControls.mobileCss { moduleName = moduleName, use = Container.mobileCss }
+            |> CommonControls.quizEngineMobileCss { moduleName = moduleName, use = Container.quizEngineMobileCss }
+            |> CommonControls.notMobileCss { moduleName = moduleName, use = Container.notMobileCss }
             |> ControlExtra.listItem "content" controlContent
     }
 


### PR DESCRIPTION
Fixes https://github.com/NoRedInk/noredink-ui/issues/877
Fixes A11-542

```
This is a MINOR change.

---- Nri.Ui.Container.V2 - MINOR ----

    Added:
        mobileCss : List.List Css.Style -> Nri.Ui.Container.V2.Attribute msg
        notMobileCss : List.List Css.Style -> Nri.Ui.Container.V2.Attribute msg
        quizEngineMobileCss :
            List.List Css.Style -> Nri.Ui.Container.V2.Attribute msg
```