### PR TITLE
Add back link to Ui Style Guide

### DIFF
--- a/styleguide-app/App.elm
+++ b/styleguide-app/App.elm
@@ -19,6 +19,7 @@ import Nri.Ui.MediaQuery.V1 exposing (mobile)
 import Nri.Ui.Page.V3 as Page
 import Nri.Ui.SideNav.V3 as SideNav
 import Nri.Ui.Sprite.V1 as Sprite
+import Nri.Ui.UiIcon.V1 as UiIcon
 import Routes exposing (Route)
 import Sort.Set as Set
 import Task
@@ -337,7 +338,11 @@ navigation currentRoute =
             , top (px 55)
             ]
         ]
-        (SideNav.entry "All" [ SideNav.href Routes.All ]
+        (SideNav.entry "UI Style Guide"
+            [ SideNav.linkExternal "https://paper.dropbox.com/doc/UI-Style-Guide-and-Caveats--BhJHYronm1RGM1hRfnkvhrZMAg-PvOLxeX3oyujYEzdJx5pu"
+            , SideNav.icon UiIcon.openInNewTab
+            ]
+            :: SideNav.entry "All" [ SideNav.href Routes.All ]
             :: categoryNavLinks
         )
 

--- a/styleguide-app/App.elm
+++ b/styleguide-app/App.elm
@@ -338,7 +338,7 @@ navigation currentRoute =
             , top (px 55)
             ]
         ]
-        (SideNav.entry "UI Style Guide"
+        (SideNav.entry "Usage Guidelines"
             [ SideNav.linkExternal "https://paper.dropbox.com/doc/UI-Style-Guide-and-Caveats--BhJHYronm1RGM1hRfnkvhrZMAg-PvOLxeX3oyujYEzdJx5pu"
             , SideNav.icon UiIcon.openInNewTab
             ]


### PR DESCRIPTION
For https://paper.dropbox.com/doc/UI-Style-Guide-and-Caveats--BhJHYronm1RGM1hRfnkvhrZMAg-PvOLxeX3oyujYEzdJx5pu?t=592119438022453822421502#:t=592119438022453822421502

Adds a link to the internal ui styleguide to the sidenav.

<img width="422" alt="" src="https://user-images.githubusercontent.com/8811312/167509917-49e4de38-36c8-4cbe-9d26-37185da38448.png">


@NoRedInk/design what do you think about this placement?