### PR TITLE
Support "disabled" links

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -98,6 +98,6 @@
         "avh4/elm-program-test": "3.3.0 <= v < 4.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
         "elm-explorations/test": "1.2.2 <= v < 2.0.0",
-        "tesk9/accessible-html": "4.1.0 <= v < 5.0.0"
+        "tesk9/accessible-html": "5.0.0 <= v < 6.0.0"
     }
 }

--- a/src/ClickableAttributes.elm
+++ b/src/ClickableAttributes.elm
@@ -112,8 +112,8 @@ toButtonAttributes clickableAttributes =
 
 
 {-| -}
-toLinkAttributes : (route -> String) -> ClickableAttributes route msg -> ( String, List (Attribute msg) )
-toLinkAttributes routeToString clickableAttributes =
+toLinkAttributes : { routeToString : route -> String, isDisabled : Bool } -> ClickableAttributes route msg -> ( String, List (Attribute msg) )
+toLinkAttributes { routeToString } clickableAttributes =
     let
         stringUrl =
             case ( clickableAttributes.urlString, clickableAttributes.url ) of

--- a/src/ClickableAttributes.elm
+++ b/src/ClickableAttributes.elm
@@ -1,18 +1,32 @@
 module ClickableAttributes exposing
-    ( ClickableAttributes
-    , href
-    , init
-    , linkExternal
-    , linkExternalWithTracking
-    , linkSpa
-    , linkWithMethod
-    , linkWithTracking
+    ( ClickableAttributes, init
     , onClick
     , toButtonAttributes
+    , href, linkWithMethod, linkWithTracking
+    , linkSpa
+    , linkExternal, linkExternalWithTracking
     , toLinkAttributes
     )
 
-{-| -}
+{-|
+
+@docs ClickableAttributes, init
+
+
+# For buttons
+
+@docs onClick
+@docs toButtonAttributes
+
+
+# For links
+
+@docs href, linkWithMethod, linkWithTracking
+@docs linkSpa
+@docs linkExternal, linkExternalWithTracking
+@docs toLinkAttributes
+
+-}
 
 import EventExtras
 import Html.Styled exposing (Attribute)

--- a/src/ClickableAttributes.elm
+++ b/src/ClickableAttributes.elm
@@ -28,6 +28,8 @@ module ClickableAttributes exposing
 
 -}
 
+import Accessibility.Styled.Role as Role
+import Accessibility.Styled.Widget as Widget
 import EventExtras
 import Html.Styled exposing (Attribute)
 import Html.Styled.Attributes as Attributes
@@ -127,7 +129,24 @@ toButtonAttributes clickableAttributes =
 
 {-| -}
 toLinkAttributes : { routeToString : route -> String, isDisabled : Bool } -> ClickableAttributes route msg -> ( String, List (Attribute msg) )
-toLinkAttributes { routeToString } clickableAttributes =
+toLinkAttributes { routeToString, isDisabled } clickableAttributes =
+    let
+        ( linkTypeName, attributes ) =
+            toEnabledLinkAttributes routeToString clickableAttributes
+    in
+    ( linkTypeName
+    , if isDisabled then
+        [ Role.link
+        , Widget.disabled True
+        ]
+
+      else
+        attributes
+    )
+
+
+toEnabledLinkAttributes : (route -> String) -> ClickableAttributes route msg -> ( String, List (Attribute msg) )
+toEnabledLinkAttributes routeToString clickableAttributes =
     let
         stringUrl =
             case ( clickableAttributes.urlString, clickableAttributes.url ) of

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -499,7 +499,13 @@ unfulfilled =
     set (\attributes -> { attributes | state = Unfulfilled })
 
 
-{-| Shows inactive styling. If a button, this attribute will disable it.
+{-| Shows inactive styling.
+
+If a button, this attribute will disable it as you'd expect.
+
+If a link, this attribute will follow the pattern laid out in [Scott O'Hara's disabled links](https://www.scottohara.me/blog/2021/05/28/disabled-links.html) article,
+and essentially make the anchor a disabled placeholder.
+
 -}
 disabled : Attribute msg
 disabled =

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -28,6 +28,7 @@ adding a span around the text could potentially lead to regressions.
   - adds `modal` helper, an alias for `large` size
   - adds `notMobileCss`, `mobileCss`, `quizEngineMobileCss`
   - adds `hideIconForMobile` and `hideIconFor`
+  - support 'disabled' links according to [Scott O'Hara's disabled links](https://www.scottohara.me/blog/2021/05/28/disabled-links.html) article
 
 
 # Changes from V9:
@@ -463,6 +464,28 @@ type ButtonState
     | Success
 
 
+isDisabled : ButtonState -> Bool
+isDisabled state =
+    case state of
+        Enabled ->
+            False
+
+        Disabled ->
+            True
+
+        Error ->
+            True
+
+        Unfulfilled ->
+            False
+
+        Loading ->
+            True
+
+        Success ->
+            True
+
+
 {-| -}
 enabled : Attribute msg
 enabled =
@@ -557,32 +580,12 @@ renderButton ((ButtonOrLink config) as button_) =
     let
         buttonStyle_ =
             getColorPalette button_
-
-        isDisabled =
-            case config.state of
-                Enabled ->
-                    False
-
-                Disabled ->
-                    True
-
-                Error ->
-                    True
-
-                Unfulfilled ->
-                    False
-
-                Loading ->
-                    True
-
-                Success ->
-                    True
     in
     Nri.Ui.styled Html.button
         (styledName "customButton")
         [ buttonStyles config.size config.width buttonStyle_ config.customStyles ]
         (ClickableAttributes.toButtonAttributes config.clickableAttributes
-            ++ Attributes.disabled isDisabled
+            ++ Attributes.disabled (isDisabled config.state)
             :: Attributes.type_ "button"
             :: config.customAttributes
         )
@@ -596,7 +599,11 @@ renderLink ((ButtonOrLink config) as link_) =
             getColorPalette link_
 
         ( linkFunctionName, attributes ) =
-            ClickableAttributes.toLinkAttributes identity config.clickableAttributes
+            ClickableAttributes.toLinkAttributes
+                { routeToString = identity
+                , isDisabled = isDisabled config.state
+                }
+                config.clickableAttributes
     in
     Nri.Ui.styled Styled.a
         (styledName linkFunctionName)

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -495,7 +495,11 @@ renderLink : ButtonOrLink msg -> Html msg
 renderLink ((ButtonOrLink config) as link_) =
     let
         ( linkFunctionName, extraAttrs ) =
-            ClickableAttributes.toLinkAttributes identity config.clickableAttributes
+            ClickableAttributes.toLinkAttributes
+                { routeToString = identity
+                , isDisabled = config.disabled
+                }
+                config.clickableAttributes
 
         theme =
             if config.disabled then

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -365,7 +365,11 @@ link label_ attributes =
                 |> List.foldl (\(Attribute attribute) l -> attribute l) defaults
 
         ( name, clickableAttributes ) =
-            ClickableAttributes.toLinkAttributes identity config.clickableAttributes
+            ClickableAttributes.toLinkAttributes
+                { routeToString = identity
+                , isDisabled = False
+                }
+                config.clickableAttributes
     in
     Nri.Ui.styled Html.a
         (dataDescriptor name)

--- a/src/Nri/Ui/SideNav/V1.elm
+++ b/src/Nri/Ui/SideNav/V1.elm
@@ -180,7 +180,10 @@ viewSidebarLeaf :
 viewSidebarLeaf config extraStyles entryConfig =
     let
         ( linkFunctionName, attributes ) =
-            ClickableAttributes.toLinkAttributes config.routeToString
+            ClickableAttributes.toLinkAttributes
+                { routeToString = config.routeToString
+                , isDisabled = False
+                }
                 entryConfig.clickableAttributes
     in
     Nri.Ui.styled Html.Styled.a

--- a/src/Nri/Ui/SideNav/V2.elm
+++ b/src/Nri/Ui/SideNav/V2.elm
@@ -181,7 +181,10 @@ viewSidebarLeaf :
 viewSidebarLeaf config extraStyles entryConfig =
     let
         ( linkFunctionName, attributes ) =
-            ClickableAttributes.toLinkAttributes config.routeToString
+            ClickableAttributes.toLinkAttributes
+                { routeToString = config.routeToString
+                , isDisabled = False
+                }
                 entryConfig.clickableAttributes
     in
     Nri.Ui.styled Html.Styled.a

--- a/src/Nri/Ui/SideNav/V3.elm
+++ b/src/Nri/Ui/SideNav/V3.elm
@@ -259,7 +259,10 @@ viewSidebarLeaf :
 viewSidebarLeaf config extraStyles entryConfig =
     let
         ( linkFunctionName, attributes ) =
-            ClickableAttributes.toLinkAttributes config.routeToString
+            ClickableAttributes.toLinkAttributes
+                { routeToString = config.routeToString
+                , isDisabled = False
+                }
                 entryConfig.clickableAttributes
     in
     Nri.Ui.styled Html.Styled.a

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -158,11 +158,10 @@ initDebugControls =
                         , ( "fillContainerWidth", Button.fillContainerWidth )
                         ]
                     )
+                |> ControlExtra.optionalBoolListItem "disabled" ( "disabled", Button.disabled )
                 |> ControlExtra.optionalListItem "state (button only)"
                     (CommonControls.choice moduleName
-                        [ ( "enabled", Button.enabled )
-                        , ( "disabled", Button.disabled )
-                        , ( "error", Button.error )
+                        [ ( "error", Button.error )
                         , ( "unfulfilled", Button.unfulfilled )
                         , ( "loading", Button.loading )
                         , ( "success", Button.success )

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -275,13 +275,7 @@ buttons model =
 
         exampleCell setStyle setSize =
             buttonOrLink model.label
-                ([ setSize
-                 , setStyle
-                 , Button.custom [ Html.Styled.Attributes.class "styleguide-button" ]
-                 , Button.onClick (ShowItWorked "ButtonExample" "Button clicked!")
-                 ]
-                    ++ List.map Tuple.second model.attributes
-                )
+                (setSize :: setStyle :: List.map Tuple.second model.attributes)
                 |> List.singleton
                 |> td
                     [ css

--- a/tests/Spec/ClickableAttributes.elm
+++ b/tests/Spec/ClickableAttributes.elm
@@ -1,0 +1,89 @@
+module Spec.ClickableAttributes exposing (suite)
+
+import ClickableAttributes
+import Expect
+import Html.Attributes exposing (href)
+import Html.Styled exposing (a, text, toUnstyled)
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+
+
+suite : Test
+suite =
+    describe "ClickableAttributes"
+        [ validLinkAttributes ]
+
+
+validLinkAttributes : Test
+validLinkAttributes =
+    let
+        renderTestAnchorTag ( _, attributes ) =
+            a attributes [ text "Test link" ]
+                |> toUnstyled
+                |> Query.fromHtml
+    in
+    describe "link attributes"
+        [ test "with an href" <|
+            \() ->
+                ClickableAttributes.init
+                    |> ClickableAttributes.href "some-route"
+                    |> ClickableAttributes.toLinkAttributes
+                        { routeToString = identity, isDisabled = False }
+                    |> renderTestAnchorTag
+                    |> Expect.all
+                        [ Query.has [ Selector.attribute (href "some-route") ]
+                        ]
+        , test "with an external href" <|
+            \() ->
+                ClickableAttributes.init
+                    |> ClickableAttributes.linkExternal "some-route"
+                    |> ClickableAttributes.toLinkAttributes
+                        { routeToString = identity, isDisabled = False }
+                    |> renderTestAnchorTag
+                    |> Expect.all
+                        [ Query.has [ Selector.attribute (href "some-route") ]
+                        ]
+        , test "with an external href that also supports tracking" <|
+            \() ->
+                ClickableAttributes.init
+                    |> ClickableAttributes.linkExternalWithTracking
+                        { track = "track it!", url = "some-route" }
+                    |> ClickableAttributes.toLinkAttributes
+                        { routeToString = identity, isDisabled = False }
+                    |> renderTestAnchorTag
+                    |> Expect.all
+                        [ Query.has [ Selector.attribute (href "some-route") ]
+                        ]
+        , test "with a SPA link" <|
+            \() ->
+                ClickableAttributes.init
+                    |> ClickableAttributes.linkSpa "some-route"
+                    |> ClickableAttributes.toLinkAttributes
+                        { routeToString = identity, isDisabled = False }
+                    |> renderTestAnchorTag
+                    |> Expect.all
+                        [ Query.has [ Selector.attribute (href "some-route") ]
+                        ]
+        , test "with a link with a method" <|
+            \() ->
+                ClickableAttributes.init
+                    |> ClickableAttributes.linkWithMethod { method = "the right way", url = "some-route" }
+                    |> ClickableAttributes.toLinkAttributes
+                        { routeToString = identity, isDisabled = False }
+                    |> renderTestAnchorTag
+                    |> Expect.all
+                        [ Query.has [ Selector.attribute (href "some-route") ]
+                        ]
+        , test "with a link with tracking" <|
+            \() ->
+                ClickableAttributes.init
+                    |> ClickableAttributes.linkWithTracking
+                        { track = "track it!", url = "some-route" }
+                    |> ClickableAttributes.toLinkAttributes
+                        { routeToString = identity, isDisabled = False }
+                    |> renderTestAnchorTag
+                    |> Expect.all
+                        [ Query.has [ Selector.attribute (href "some-route") ]
+                        ]
+        ]

--- a/tests/Spec/ClickableAttributes.elm
+++ b/tests/Spec/ClickableAttributes.elm
@@ -1,5 +1,6 @@
 module Spec.ClickableAttributes exposing (suite)
 
+import Accessibility.Role as Role
 import ClickableAttributes exposing (ClickableAttributes)
 import Expect
 import Html.Attributes exposing (href)
@@ -24,6 +25,8 @@ linkAttributes =
                     |> setupLinkTest
                     |> Expect.all
                         [ Query.has [ Selector.attribute (href "some-route") ]
+                        , -- should not include redundant roles
+                          Query.hasNot [ Selector.attribute Role.link ]
                         ]
         , test "with an external href" <|
             \() ->
@@ -31,6 +34,8 @@ linkAttributes =
                     |> setupLinkTest
                     |> Expect.all
                         [ Query.has [ Selector.attribute (href "some-route") ]
+                        , -- should not include redundant roles
+                          Query.hasNot [ Selector.attribute Role.link ]
                         ]
         , test "with an external href that also supports tracking" <|
             \() ->
@@ -38,6 +43,8 @@ linkAttributes =
                     |> setupLinkTest
                     |> Expect.all
                         [ Query.has [ Selector.attribute (href "some-route") ]
+                        , -- should not include redundant roles
+                          Query.hasNot [ Selector.attribute Role.link ]
                         ]
         , test "with a SPA link" <|
             \() ->
@@ -45,6 +52,8 @@ linkAttributes =
                     |> setupLinkTest
                     |> Expect.all
                         [ Query.has [ Selector.attribute (href "some-route") ]
+                        , -- should not include redundant roles
+                          Query.hasNot [ Selector.attribute Role.link ]
                         ]
         , test "with a link with a method" <|
             \() ->
@@ -52,6 +61,8 @@ linkAttributes =
                     |> setupLinkTest
                     |> Expect.all
                         [ Query.has [ Selector.attribute (href "some-route") ]
+                        , -- should not include redundant roles
+                          Query.hasNot [ Selector.attribute Role.link ]
                         ]
         , test "with a link with tracking" <|
             \() ->
@@ -59,6 +70,8 @@ linkAttributes =
                     |> setupLinkTest
                     |> Expect.all
                         [ Query.has [ Selector.attribute (href "some-route") ]
+                        , -- should not include redundant roles
+                          Query.hasNot [ Selector.attribute Role.link ]
                         ]
         ]
 
@@ -72,6 +85,8 @@ disabledLinkAttributes =
                     |> setupDisabledLinkTest
                     |> Expect.all
                         [ Query.hasNot [ Selector.attribute (href "some-route") ]
+                        , -- should explicitly be tagged as having the link role
+                          Query.has [ Selector.attribute Role.link ]
                         ]
         , test "with an external href" <|
             \() ->
@@ -79,6 +94,8 @@ disabledLinkAttributes =
                     |> setupDisabledLinkTest
                     |> Expect.all
                         [ Query.hasNot [ Selector.attribute (href "some-route") ]
+                        , -- should explicitly be tagged as having the link role
+                          Query.has [ Selector.attribute Role.link ]
                         ]
         , test "with an external href that also supports tracking" <|
             \() ->
@@ -86,6 +103,8 @@ disabledLinkAttributes =
                     |> setupDisabledLinkTest
                     |> Expect.all
                         [ Query.hasNot [ Selector.attribute (href "some-route") ]
+                        , -- should explicitly be tagged as having the link role
+                          Query.has [ Selector.attribute Role.link ]
                         ]
         , test "with a SPA link" <|
             \() ->
@@ -93,6 +112,8 @@ disabledLinkAttributes =
                     |> setupDisabledLinkTest
                     |> Expect.all
                         [ Query.hasNot [ Selector.attribute (href "some-route") ]
+                        , -- should explicitly be tagged as having the link role
+                          Query.has [ Selector.attribute Role.link ]
                         ]
         , test "with a link with a method" <|
             \() ->
@@ -100,6 +121,8 @@ disabledLinkAttributes =
                     |> setupDisabledLinkTest
                     |> Expect.all
                         [ Query.hasNot [ Selector.attribute (href "some-route") ]
+                        , -- should explicitly be tagged as having the link role
+                          Query.has [ Selector.attribute Role.link ]
                         ]
         , test "with a link with tracking" <|
             \() ->
@@ -107,6 +130,8 @@ disabledLinkAttributes =
                     |> setupDisabledLinkTest
                     |> Expect.all
                         [ Query.hasNot [ Selector.attribute (href "some-route") ]
+                        , -- should explicitly be tagged as having the link role
+                          Query.has [ Selector.attribute Role.link ]
                         ]
         ]
 

--- a/tests/Spec/ClickableAttributes.elm
+++ b/tests/Spec/ClickableAttributes.elm
@@ -12,11 +12,11 @@ import Test.Html.Selector as Selector
 suite : Test
 suite =
     describe "ClickableAttributes"
-        [ validLinkAttributes ]
+        [ linkAttributes, disabledLinkAttributes ]
 
 
-validLinkAttributes : Test
-validLinkAttributes =
+linkAttributes : Test
+linkAttributes =
     describe "link attributes"
         [ test "with an href" <|
             \() ->
@@ -63,16 +63,74 @@ validLinkAttributes =
         ]
 
 
+disabledLinkAttributes : Test
+disabledLinkAttributes =
+    describe "disabled link attributes"
+        [ test "with an href" <|
+            \() ->
+                ClickableAttributes.href "some-route"
+                    |> setupDisabledLinkTest
+                    |> Expect.all
+                        [ Query.hasNot [ Selector.attribute (href "some-route") ]
+                        ]
+        , test "with an external href" <|
+            \() ->
+                ClickableAttributes.linkExternal "some-route"
+                    |> setupDisabledLinkTest
+                    |> Expect.all
+                        [ Query.hasNot [ Selector.attribute (href "some-route") ]
+                        ]
+        , test "with an external href that also supports tracking" <|
+            \() ->
+                ClickableAttributes.linkExternalWithTracking { track = "track it!", url = "some-route" }
+                    |> setupDisabledLinkTest
+                    |> Expect.all
+                        [ Query.hasNot [ Selector.attribute (href "some-route") ]
+                        ]
+        , test "with a SPA link" <|
+            \() ->
+                ClickableAttributes.linkSpa "some-route"
+                    |> setupDisabledLinkTest
+                    |> Expect.all
+                        [ Query.hasNot [ Selector.attribute (href "some-route") ]
+                        ]
+        , test "with a link with a method" <|
+            \() ->
+                ClickableAttributes.linkWithMethod { method = "the right way", url = "some-route" }
+                    |> setupDisabledLinkTest
+                    |> Expect.all
+                        [ Query.hasNot [ Selector.attribute (href "some-route") ]
+                        ]
+        , test "with a link with tracking" <|
+            \() ->
+                ClickableAttributes.linkWithTracking { track = "track it!", url = "some-route" }
+                    |> setupDisabledLinkTest
+                    |> Expect.all
+                        [ Query.hasNot [ Selector.attribute (href "some-route") ]
+                        ]
+        ]
+
+
 setupLinkTest : (ClickableAttributes String msg -> ClickableAttributes String msg) -> Query.Single msg
 setupLinkTest withLink =
-    let
-        renderTestAnchorTag ( _, attributes ) =
-            a attributes [ text "Test link" ]
-                |> toUnstyled
-                |> Query.fromHtml
-    in
     ClickableAttributes.init
         |> withLink
         |> ClickableAttributes.toLinkAttributes
             { routeToString = identity, isDisabled = False }
         |> renderTestAnchorTag
+
+
+setupDisabledLinkTest : (ClickableAttributes String msg -> ClickableAttributes String msg) -> Query.Single msg
+setupDisabledLinkTest withLink =
+    ClickableAttributes.init
+        |> withLink
+        |> ClickableAttributes.toLinkAttributes
+            { routeToString = identity, isDisabled = True }
+        |> renderTestAnchorTag
+
+
+renderTestAnchorTag : ( a, List (Html.Styled.Attribute msg) ) -> Query.Single msg
+renderTestAnchorTag ( _, attributes ) =
+    a attributes [ text "Test link" ]
+        |> toUnstyled
+        |> Query.fromHtml

--- a/tests/Spec/ClickableAttributes.elm
+++ b/tests/Spec/ClickableAttributes.elm
@@ -1,5 +1,6 @@
 module Spec.ClickableAttributes exposing (suite)
 
+import Accessibility.Aria as Aria
 import Accessibility.Role as Role
 import ClickableAttributes exposing (ClickableAttributes)
 import Expect
@@ -25,8 +26,9 @@ linkAttributes =
                     |> setupLinkTest
                     |> Expect.all
                         [ Query.has [ Selector.attribute (href "some-route") ]
-                        , -- should not include redundant roles
+                        , -- should not include a redundant role
                           Query.hasNot [ Selector.attribute Role.link ]
+                        , Query.hasNot [ Selector.attribute (Aria.disabled True) ]
                         ]
         , test "with an external href" <|
             \() ->
@@ -34,8 +36,9 @@ linkAttributes =
                     |> setupLinkTest
                     |> Expect.all
                         [ Query.has [ Selector.attribute (href "some-route") ]
-                        , -- should not include redundant roles
+                        , -- should not include a redundant role
                           Query.hasNot [ Selector.attribute Role.link ]
+                        , Query.hasNot [ Selector.attribute (Aria.disabled True) ]
                         ]
         , test "with an external href that also supports tracking" <|
             \() ->
@@ -43,8 +46,9 @@ linkAttributes =
                     |> setupLinkTest
                     |> Expect.all
                         [ Query.has [ Selector.attribute (href "some-route") ]
-                        , -- should not include redundant roles
+                        , -- should not include a redundant role
                           Query.hasNot [ Selector.attribute Role.link ]
+                        , Query.hasNot [ Selector.attribute (Aria.disabled True) ]
                         ]
         , test "with a SPA link" <|
             \() ->
@@ -52,8 +56,9 @@ linkAttributes =
                     |> setupLinkTest
                     |> Expect.all
                         [ Query.has [ Selector.attribute (href "some-route") ]
-                        , -- should not include redundant roles
+                        , -- should not include a redundant role
                           Query.hasNot [ Selector.attribute Role.link ]
+                        , Query.hasNot [ Selector.attribute (Aria.disabled True) ]
                         ]
         , test "with a link with a method" <|
             \() ->
@@ -61,8 +66,9 @@ linkAttributes =
                     |> setupLinkTest
                     |> Expect.all
                         [ Query.has [ Selector.attribute (href "some-route") ]
-                        , -- should not include redundant roles
+                        , -- should not include a redundant role
                           Query.hasNot [ Selector.attribute Role.link ]
+                        , Query.hasNot [ Selector.attribute (Aria.disabled True) ]
                         ]
         , test "with a link with tracking" <|
             \() ->
@@ -70,8 +76,9 @@ linkAttributes =
                     |> setupLinkTest
                     |> Expect.all
                         [ Query.has [ Selector.attribute (href "some-route") ]
-                        , -- should not include redundant roles
+                        , -- should not include a redundant role
                           Query.hasNot [ Selector.attribute Role.link ]
+                        , Query.hasNot [ Selector.attribute (Aria.disabled True) ]
                         ]
         ]
 
@@ -87,6 +94,8 @@ disabledLinkAttributes =
                         [ Query.hasNot [ Selector.attribute (href "some-route") ]
                         , -- should explicitly be tagged as having the link role
                           Query.has [ Selector.attribute Role.link ]
+                        , -- should be marked as disabled for screenreader users
+                          Query.has [ Selector.attribute (Aria.disabled True) ]
                         ]
         , test "with an external href" <|
             \() ->
@@ -96,6 +105,8 @@ disabledLinkAttributes =
                         [ Query.hasNot [ Selector.attribute (href "some-route") ]
                         , -- should explicitly be tagged as having the link role
                           Query.has [ Selector.attribute Role.link ]
+                        , -- should be marked as disabled for screenreader users
+                          Query.has [ Selector.attribute (Aria.disabled True) ]
                         ]
         , test "with an external href that also supports tracking" <|
             \() ->
@@ -105,6 +116,8 @@ disabledLinkAttributes =
                         [ Query.hasNot [ Selector.attribute (href "some-route") ]
                         , -- should explicitly be tagged as having the link role
                           Query.has [ Selector.attribute Role.link ]
+                        , -- should be marked as disabled for screenreader users
+                          Query.has [ Selector.attribute (Aria.disabled True) ]
                         ]
         , test "with a SPA link" <|
             \() ->
@@ -114,6 +127,8 @@ disabledLinkAttributes =
                         [ Query.hasNot [ Selector.attribute (href "some-route") ]
                         , -- should explicitly be tagged as having the link role
                           Query.has [ Selector.attribute Role.link ]
+                        , -- should be marked as disabled for screenreader users
+                          Query.has [ Selector.attribute (Aria.disabled True) ]
                         ]
         , test "with a link with a method" <|
             \() ->
@@ -123,6 +138,8 @@ disabledLinkAttributes =
                         [ Query.hasNot [ Selector.attribute (href "some-route") ]
                         , -- should explicitly be tagged as having the link role
                           Query.has [ Selector.attribute Role.link ]
+                        , -- should be marked as disabled for screenreader users
+                          Query.has [ Selector.attribute (Aria.disabled True) ]
                         ]
         , test "with a link with tracking" <|
             \() ->
@@ -132,6 +149,8 @@ disabledLinkAttributes =
                         [ Query.hasNot [ Selector.attribute (href "some-route") ]
                         , -- should explicitly be tagged as having the link role
                           Query.has [ Selector.attribute Role.link ]
+                        , -- should be marked as disabled for screenreader users
+                          Query.has [ Selector.attribute (Aria.disabled True) ]
                         ]
         ]
 

--- a/tests/Spec/ClickableAttributes.elm
+++ b/tests/Spec/ClickableAttributes.elm
@@ -1,6 +1,6 @@
 module Spec.ClickableAttributes exposing (suite)
 
-import ClickableAttributes
+import ClickableAttributes exposing (ClickableAttributes)
 import Expect
 import Html.Attributes exposing (href)
 import Html.Styled exposing (a, text, toUnstyled)
@@ -17,73 +17,62 @@ suite =
 
 validLinkAttributes : Test
 validLinkAttributes =
+    describe "link attributes"
+        [ test "with an href" <|
+            \() ->
+                ClickableAttributes.href "some-route"
+                    |> setupLinkTest
+                    |> Expect.all
+                        [ Query.has [ Selector.attribute (href "some-route") ]
+                        ]
+        , test "with an external href" <|
+            \() ->
+                ClickableAttributes.linkExternal "some-route"
+                    |> setupLinkTest
+                    |> Expect.all
+                        [ Query.has [ Selector.attribute (href "some-route") ]
+                        ]
+        , test "with an external href that also supports tracking" <|
+            \() ->
+                ClickableAttributes.linkExternalWithTracking { track = "track it!", url = "some-route" }
+                    |> setupLinkTest
+                    |> Expect.all
+                        [ Query.has [ Selector.attribute (href "some-route") ]
+                        ]
+        , test "with a SPA link" <|
+            \() ->
+                ClickableAttributes.linkSpa "some-route"
+                    |> setupLinkTest
+                    |> Expect.all
+                        [ Query.has [ Selector.attribute (href "some-route") ]
+                        ]
+        , test "with a link with a method" <|
+            \() ->
+                ClickableAttributes.linkWithMethod { method = "the right way", url = "some-route" }
+                    |> setupLinkTest
+                    |> Expect.all
+                        [ Query.has [ Selector.attribute (href "some-route") ]
+                        ]
+        , test "with a link with tracking" <|
+            \() ->
+                ClickableAttributes.linkWithTracking { track = "track it!", url = "some-route" }
+                    |> setupLinkTest
+                    |> Expect.all
+                        [ Query.has [ Selector.attribute (href "some-route") ]
+                        ]
+        ]
+
+
+setupLinkTest : (ClickableAttributes String msg -> ClickableAttributes String msg) -> Query.Single msg
+setupLinkTest withLink =
     let
         renderTestAnchorTag ( _, attributes ) =
             a attributes [ text "Test link" ]
                 |> toUnstyled
                 |> Query.fromHtml
     in
-    describe "link attributes"
-        [ test "with an href" <|
-            \() ->
-                ClickableAttributes.init
-                    |> ClickableAttributes.href "some-route"
-                    |> ClickableAttributes.toLinkAttributes
-                        { routeToString = identity, isDisabled = False }
-                    |> renderTestAnchorTag
-                    |> Expect.all
-                        [ Query.has [ Selector.attribute (href "some-route") ]
-                        ]
-        , test "with an external href" <|
-            \() ->
-                ClickableAttributes.init
-                    |> ClickableAttributes.linkExternal "some-route"
-                    |> ClickableAttributes.toLinkAttributes
-                        { routeToString = identity, isDisabled = False }
-                    |> renderTestAnchorTag
-                    |> Expect.all
-                        [ Query.has [ Selector.attribute (href "some-route") ]
-                        ]
-        , test "with an external href that also supports tracking" <|
-            \() ->
-                ClickableAttributes.init
-                    |> ClickableAttributes.linkExternalWithTracking
-                        { track = "track it!", url = "some-route" }
-                    |> ClickableAttributes.toLinkAttributes
-                        { routeToString = identity, isDisabled = False }
-                    |> renderTestAnchorTag
-                    |> Expect.all
-                        [ Query.has [ Selector.attribute (href "some-route") ]
-                        ]
-        , test "with a SPA link" <|
-            \() ->
-                ClickableAttributes.init
-                    |> ClickableAttributes.linkSpa "some-route"
-                    |> ClickableAttributes.toLinkAttributes
-                        { routeToString = identity, isDisabled = False }
-                    |> renderTestAnchorTag
-                    |> Expect.all
-                        [ Query.has [ Selector.attribute (href "some-route") ]
-                        ]
-        , test "with a link with a method" <|
-            \() ->
-                ClickableAttributes.init
-                    |> ClickableAttributes.linkWithMethod { method = "the right way", url = "some-route" }
-                    |> ClickableAttributes.toLinkAttributes
-                        { routeToString = identity, isDisabled = False }
-                    |> renderTestAnchorTag
-                    |> Expect.all
-                        [ Query.has [ Selector.attribute (href "some-route") ]
-                        ]
-        , test "with a link with tracking" <|
-            \() ->
-                ClickableAttributes.init
-                    |> ClickableAttributes.linkWithTracking
-                        { track = "track it!", url = "some-route" }
-                    |> ClickableAttributes.toLinkAttributes
-                        { routeToString = identity, isDisabled = False }
-                    |> renderTestAnchorTag
-                    |> Expect.all
-                        [ Query.has [ Selector.attribute (href "some-route") ]
-                        ]
-        ]
+    ClickableAttributes.init
+        |> withLink
+        |> ClickableAttributes.toLinkAttributes
+            { routeToString = identity, isDisabled = False }
+        |> renderTestAnchorTag

--- a/tests/Spec/Nri/Ui/Tooltip.elm
+++ b/tests/Spec/Nri/Ui/Tooltip.elm
@@ -1,6 +1,6 @@
 module Spec.Nri.Ui.Tooltip exposing (spec)
 
-import Accessibility.Widget as Widget
+import Accessibility.Aria as Aria
 import Html.Attributes as Attributes
 import Html.Styled as HtmlStyled
 import Nri.Ui.Tooltip.V3 as Tooltip
@@ -136,7 +136,7 @@ clickButtonByLabel label =
     ProgramTest.simulateDomEvent
         (Query.find
             [ Selector.tag "button"
-            , Selector.attribute (Widget.label label)
+            , Selector.attribute (Aria.label label)
             ]
         )
         Event.click


### PR DESCRIPTION
Adds "disabled" link support by following the recommendations in [Scott O'Hara's "Disabling a link" post](https://www.scottohara.me/blog/2021/05/28/disabled-links.html).

Essentially, when the link is disabled:
- removes the href
- adds role link
- adds aria-disabled true

# Caveats

The styleguide example will NOT work correctly because of https://github.com/elm/browser/issues/34, which describes a problem where "a tags without href generate a navigation event".

However, I still expect this to work in the NoRedInk context in most cases, including the case that's the reason that we're adding "disabled" link support at all.
