### PR TITLE
Add breadcrumbs

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,6 +11,7 @@
         "Nri.Ui.AssetPath",
         "Nri.Ui.AssignmentIcon.V2",
         "Nri.Ui.Balloon.V1",
+        "Nri.Ui.BreadCrumbs.V1",
         "Nri.Ui.Button.V10",
         "Nri.Ui.Checkbox.V5",
         "Nri.Ui.ClickableSvg.V2",

--- a/src/Nri/Ui/BreadCrumbs/V1.elm
+++ b/src/Nri/Ui/BreadCrumbs/V1.elm
@@ -1,0 +1,365 @@
+module Nri.Ui.BreadCrumbs.V1 exposing
+    ( view, IconStyle(..)
+    , BreadCrumbs, init
+    , BreadCrumb, after
+    , headerId
+    , toPageTitle
+    , toPageTitleWithSecondaryBreadCrumbs
+    )
+
+{-| Learn more about 'breadcrumbs' to help a user orient themselves within a site here: <https://www.w3.org/WAI/WCAG21/Techniques/general/G65>.
+
+Wide Viewport (with Circled IconStyle):
+
+    Home
+
+    🏠 Home > 🟠 Category 1
+
+    🏠 > 🟠 Category 1 > 🟣 Sub-Category 2
+
+Narrow Viewport (with Circled IconStyle):
+
+    Home
+
+    🏠 > 🟠 Category 1
+
+    🏠 > 🟠 > 🟣 Sub-Category 2
+
+@docs view, IconStyle
+@docs BreadCrumbs, init
+@docs BreadCrumb, after
+@docs headerId
+@docs toPageTitle
+
+-}
+
+import Accessibility.Styled exposing (..)
+import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Style as Style
+import Accessibility.Styled.Widget as Widget
+import Css exposing (..)
+import Css.Global
+import Css.Media as Media
+import Html.Styled
+import Html.Styled.Attributes as Attributes exposing (css)
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.MediaQuery.V1 as MediaQuery
+import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.UiIcon.V1 as UiIcon
+
+
+type alias BreadCrumb route =
+    { icon : Maybe Svg.Svg
+    , iconStyle : IconStyle
+    , id : String
+    , text : String
+    , route : route
+    }
+
+
+type BreadCrumbs route
+    = BreadCrumbs (List (BreadCrumb route))
+
+
+{-| -}
+init : BreadCrumb route -> BreadCrumbs route
+init breadCrumb =
+    BreadCrumbs [ breadCrumb ]
+
+
+{-| -}
+after : BreadCrumbs route -> BreadCrumb route -> BreadCrumbs route
+after (BreadCrumbs previous) new =
+    BreadCrumbs (new :: previous)
+
+
+{-| -}
+headerId : BreadCrumbs route -> String
+headerId (BreadCrumbs list) =
+    case list of
+        { id } :: _ ->
+            id
+
+        _ ->
+            -- It should be impossible to construct a BreadCrumbs without
+            -- any elements.
+            --
+            ""
+
+
+{-| -}
+type IconStyle
+    = Circled
+    | Default
+
+
+{-| Generate an HTML page title using the breadcrumbs,
+in the form "Sub-Category | Category | NoRedInk" for breadCrumbs like:
+
+    Category > Sub - Category
+
+-}
+toPageTitle : BreadCrumbs a -> String
+toPageTitle (BreadCrumbs breadcrumbs) =
+    String.join " | " (List.map .text breadcrumbs ++ [ "NoRedInk" ])
+
+
+toPageTitleWithSecondaryBreadCrumbs : BreadCrumbs a -> String
+toPageTitleWithSecondaryBreadCrumbs (BreadCrumbs breadcrumbs) =
+    (List.take 1 breadcrumbs |> List.map .text)
+        ++ [ "NoRedInk" ]
+        |> String.join " | "
+
+
+{-| -}
+view :
+    { aTagAttributes : route -> List (Attribute msg)
+    , isCurrentRoute : route -> Bool
+    }
+    -> BreadCrumbs route
+    -> Html msg
+view config (BreadCrumbs breadCrumbs) =
+    styled nav
+        [ alignItems center
+        , displayFlex
+        , Media.withMedia [ MediaQuery.mobile ] [ marginBottom (px 10) ]
+        ]
+        [ Widget.label "breadcrumbs" ]
+        (viewBreadCrumbs config (List.reverse breadCrumbs))
+
+
+viewBreadCrumbs :
+    { aTagAttributes : route -> List (Attribute msg)
+    , isCurrentRoute : route -> Bool
+    }
+    -> List (BreadCrumb route)
+    -> List (Html msg)
+viewBreadCrumbs config breadCrumbs =
+    let
+        breadCrumbCount : Int
+        breadCrumbCount =
+            List.length breadCrumbs
+    in
+    List.indexedMap
+        (\i ->
+            viewBreadCrumb config
+                { isFirst = i == 0
+                , isLast = (i + 1) == breadCrumbCount
+                , isIconOnly =
+                    -- the first breadcrumb should collapse when there
+                    -- are 3 breadcrumbs or more
+                    --
+                    -- Hypothetically, if there were 4 breadcrumbs, then the
+                    -- first 2 breadcrumbs should collapse
+                    (breadCrumbCount - i) > 2
+                }
+        )
+        breadCrumbs
+        |> List.intersperse (Svg.toHtml arrowRight)
+
+
+viewBreadCrumb :
+    { config
+        | aTagAttributes : route -> List (Attribute msg)
+        , isCurrentRoute : route -> Bool
+    }
+    -> { isFirst : Bool, isLast : Bool, isIconOnly : Bool }
+    -> BreadCrumb route
+    -> Html msg
+viewBreadCrumb config iconConfig crumb =
+    let
+        isLink =
+            not (config.isCurrentRoute crumb.route)
+
+        linkAttrs =
+            if isLink then
+                css
+                    [ hover
+                        [ Css.Global.descendants
+                            [ Css.Global.class circleIconClass
+                                [ backgroundColor Colors.glacier
+                                , borderColor Colors.azureDark
+                                , color Colors.azure
+                                ]
+                            ]
+                        ]
+                    ]
+                    :: config.aTagAttributes crumb.route
+
+            else
+                []
+
+        withIconIfPresent viewIcon =
+            case crumb.icon of
+                Just icon ->
+                    [ viewIcon iconConfig.isFirst crumb.iconStyle icon
+                    , viewHeadingWithIcon iconConfig crumb.text
+                    ]
+
+                Nothing ->
+                    [ text crumb.text ]
+    in
+    case ( iconConfig.isLast, isLink ) of
+        ( True, False ) ->
+            pageHeader crumb.id
+                (withIconIfPresent viewIconForHeading)
+
+        ( True, True ) ->
+            pageHeader crumb.id
+                [ Html.Styled.styled Html.Styled.a
+                    []
+                    (css commonCss :: linkAttrs)
+                    (withIconIfPresent viewIconForLink)
+                ]
+
+        ( False, _ ) ->
+            Html.Styled.styled Html.Styled.a
+                [ fontWeight normal ]
+                (css commonCss :: Attributes.id crumb.id :: linkAttrs)
+                (withIconIfPresent viewIconForLink)
+
+
+pageHeader : String -> List (Html msg) -> Html msg
+pageHeader id =
+    styled h1
+        [ fontWeight bold ]
+        [ Aria.currentPage
+        , Attributes.id id
+        , Attributes.tabindex -1
+        , css commonCss
+        ]
+
+
+viewIconForHeading : Bool -> IconStyle -> Svg.Svg -> Html msg
+viewIconForHeading isFirst iconStyle svg =
+    case iconStyle of
+        Circled ->
+            text ""
+
+        Default ->
+            withoutIconCircle isFirst svg
+
+
+viewIconForLink : Bool -> IconStyle -> Svg.Svg -> Html msg
+viewIconForLink isFirst iconStyle svg =
+    case iconStyle of
+        Circled ->
+            withIconCircle svg
+
+        Default ->
+            withoutIconCircle isFirst svg
+
+
+viewHeadingWithIcon : { config | isLast : Bool, isIconOnly : Bool } -> String -> Html msg
+viewHeadingWithIcon { isIconOnly, isLast } title =
+    div
+        (if isIconOnly then
+            Style.invisible
+
+         else if isLast then
+            [ css [ marginLeft horizontalSpacing ] ]
+
+         else
+            [ css
+                [ marginLeft horizontalSpacing
+                , Media.withMedia [ MediaQuery.mobile ]
+                    [ Style.invisibleStyle
+                    ]
+                ]
+            ]
+        )
+        [ text title
+        ]
+
+
+commonCss : List Style
+commonCss =
+    [ alignItems center
+    , displayFlex
+    , margin zero
+    , fontSize (px 30)
+    , Media.withMedia [ MediaQuery.mobile ] [ fontSize (px 25) ]
+    , Fonts.baseFont
+    , textDecoration none
+    , color Colors.navy
+    ]
+
+
+circleIconClass : String
+circleIconClass =
+    "Nri-BreadCrumb-base-circled-icon"
+
+
+withIconCircle : Svg.Svg -> Html msg
+withIconCircle icon =
+    styled div
+        [ borderRadius (pct 50)
+        , border3 (px 1) solid Colors.azure
+        , color Colors.azure
+        , borderBottomWidth (px 2)
+        , backgroundColor Colors.white
+        , height largeIconSize
+        , width largeIconSize
+        , fontSize (px 16)
+        , property "transition" "background-color 0.2s, color 0.2s"
+        , displayFlex
+        , alignItems center
+        , justifyContent center
+        ]
+        [ Attributes.class circleIconClass ]
+        [ icon
+            |> Svg.withWidth circledInnerIconSize
+            |> Svg.withHeight circledInnerIconSize
+            |> Svg.toHtml
+        ]
+
+
+withoutIconCircle : Bool -> Svg.Svg -> Html msg
+withoutIconCircle isFirst icon =
+    let
+        size =
+            if isFirst then
+                largeIconSize
+
+            else
+                iconSize
+    in
+    icon
+        |> Svg.withWidth size
+        |> Svg.withHeight size
+        |> Svg.withCss [ Css.flexShrink Css.zero ]
+        |> Svg.toHtml
+
+
+horizontalSpacing : Css.Px
+horizontalSpacing =
+    Css.px 10
+
+
+circledInnerIconSize : Css.Px
+circledInnerIconSize =
+    Css.px 25
+
+
+largeIconSize : Css.Px
+largeIconSize =
+    Css.px 40
+
+
+iconSize : Css.Px
+iconSize =
+    Css.px 31
+
+
+arrowRight : Svg.Svg
+arrowRight =
+    UiIcon.arrowRight
+        |> Svg.withColor Colors.gray75
+        |> Svg.withHeight (px 15)
+        |> Svg.withWidth (px 15)
+        |> Svg.withCss
+            [ marginRight horizontalSpacing
+            , marginLeft horizontalSpacing
+            , flexShrink zero
+            ]

--- a/src/Nri/Ui/BreadCrumbs/V1.elm
+++ b/src/Nri/Ui/BreadCrumbs/V1.elm
@@ -3,8 +3,7 @@ module Nri.Ui.BreadCrumbs.V1 exposing
     , BreadCrumbs, init
     , BreadCrumb, after
     , headerId
-    , toPageTitle
-    , toPageTitleWithSecondaryBreadCrumbs
+    , toPageTitle, toPageTitleWithSecondaryBreadCrumbs
     )
 
 {-| Learn more about 'breadcrumbs' to help a user orient themselves within a site here: <https://www.w3.org/WAI/WCAG21/Techniques/general/G65>.
@@ -29,7 +28,7 @@ Narrow Viewport (with Circled IconStyle):
 @docs BreadCrumbs, init
 @docs BreadCrumb, after
 @docs headerId
-@docs toPageTitle
+@docs toPageTitle, toPageTitleWithSecondaryBreadCrumbs
 
 -}
 
@@ -49,6 +48,7 @@ import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.UiIcon.V1 as UiIcon
 
 
+{-| -}
 type alias BreadCrumb route =
     { icon : Maybe Svg.Svg
     , iconStyle : IconStyle
@@ -58,6 +58,7 @@ type alias BreadCrumb route =
     }
 
 
+{-| -}
 type BreadCrumbs route
     = BreadCrumbs (List (BreadCrumb route))
 
@@ -105,6 +106,7 @@ toPageTitle (BreadCrumbs breadcrumbs) =
     String.join " | " (List.map .text breadcrumbs ++ [ "NoRedInk" ])
 
 
+{-| -}
 toPageTitleWithSecondaryBreadCrumbs : BreadCrumbs a -> String
 toPageTitleWithSecondaryBreadCrumbs (BreadCrumbs breadcrumbs) =
     (List.take 1 breadcrumbs |> List.map .text)

--- a/styleguide-app/App.elm
+++ b/styleguide-app/App.elm
@@ -209,7 +209,6 @@ view model =
                     { title = example.name ++ " in the NoRedInk Style Guide"
                     , body =
                         viewExample model example
-                            |> Html.map (UpdateModuleStates example.name)
                             |> toBody
                     }
 
@@ -229,13 +228,13 @@ view model =
             }
 
 
-viewExample : Model key -> Example a msg -> Html msg
+viewExample : Model key -> Example a Examples.Msg -> Html Msg
 viewExample model example =
-    Html.div [ css [ maxWidth (Css.px 1400), margin auto ] ]
-        [ Example.view model.previousRoute
-            { packageDependencies = model.elliePackageDependencies }
-            example
-        ]
+    Example.view model.previousRoute
+        { packageDependencies = model.elliePackageDependencies }
+        example
+        |> Html.map (UpdateModuleStates example.name)
+        |> withSideNav model.route
 
 
 notFound : Html Msg

--- a/styleguide-app/App.elm
+++ b/styleguide-app/App.elm
@@ -248,17 +248,14 @@ notFound =
 
 viewAll : Model key -> Html Msg
 viewAll model =
-    withSideNav model.route
-        [ mainContentHeader "All"
-        , viewPreviews "all" (Dict.values model.moduleStates)
-        ]
+    withSideNav model.route <|
+        viewPreviews "all" (Dict.values model.moduleStates)
 
 
 viewCategory : Model key -> Category -> Html Msg
 viewCategory model category =
     withSideNav model.route
-        [ mainContentHeader (Category.forDisplay category)
-        , model.moduleStates
+        (model.moduleStates
             |> Dict.values
             |> List.filter
                 (\doodad ->
@@ -267,10 +264,10 @@ viewCategory model category =
                         category
                 )
             |> viewPreviews (Category.forId category)
-        ]
+        )
 
 
-withSideNav : Route -> List (Html Msg) -> Html Msg
+withSideNav : Route -> Html Msg -> Html Msg
 withSideNav currentRoute content =
     Html.div
         [ css
@@ -291,16 +288,12 @@ withSideNav currentRoute content =
             , id "maincontent"
             , Key.tabbable False
             ]
-            content
+            [ Html.div [ css [ Css.marginBottom (Css.px 30) ] ]
+                [ Routes.viewBreadCrumbs currentRoute
+                ]
+            , content
+            ]
         ]
-
-
-mainContentHeader : String -> Html msg
-mainContentHeader heading =
-    Heading.h1
-        [ Heading.css [ marginBottom (px 30) ]
-        ]
-        [ Html.text heading ]
 
 
 viewPreviews : String -> List (Example state msg) -> Html Msg

--- a/styleguide-app/App.elm
+++ b/styleguide-app/App.elm
@@ -1,6 +1,7 @@
 module App exposing (Effect(..), Model, Msg(..), init, perform, subscriptions, update, view)
 
 import Accessibility.Styled as Html exposing (Html)
+import Accessibility.Styled.Key as Key
 import Browser exposing (Document, UrlRequest(..))
 import Browser.Dom
 import Browser.Navigation exposing (Key)
@@ -287,6 +288,8 @@ withSideNav currentRoute content =
                 , margin2 (px 40) zero
                 , Css.minHeight (Css.vh 100)
                 ]
+            , id "maincontent"
+            , Key.tabbable False
             ]
             content
         ]
@@ -295,9 +298,7 @@ withSideNav currentRoute content =
 mainContentHeader : String -> Html msg
 mainContentHeader heading =
     Heading.h1
-        [ Heading.customAttr (id "maincontent")
-        , Heading.customAttr (tabindex -1)
-        , Heading.css [ marginBottom (px 30) ]
+        [ Heading.css [ marginBottom (px 30) ]
         ]
         [ Html.text heading ]
 

--- a/styleguide-app/App.elm
+++ b/styleguide-app/App.elm
@@ -210,6 +210,11 @@ view model =
             , body = viewExample model example |> toBody
             }
 
+        Routes.CategoryDoodad _ example ->
+            { title = example.name ++ " in the NoRedInk Style Guide"
+            , body = viewExample model example |> toBody
+            }
+
         Routes.NotFound name ->
             { title = name ++ " was not found in the NoRedInk Style Guide"
             , body = toBody notFound
@@ -244,7 +249,11 @@ notFound =
 viewAll : Model key -> Html Msg
 viewAll model =
     withSideNav model.route <|
-        viewPreviews "all" (Dict.values model.moduleStates)
+        viewPreviews "all"
+            { navigate = Routes.Doodad >> ChangeRoute
+            , exampleHref = Routes.Doodad >> Routes.toString
+            }
+            (Dict.values model.moduleStates)
 
 
 viewCategory : Model key -> Category -> Html Msg
@@ -259,6 +268,9 @@ viewCategory model category =
                         category
                 )
             |> viewPreviews (Category.forId category)
+                { navigate = Routes.CategoryDoodad category >> ChangeRoute
+                , exampleHref = Routes.CategoryDoodad category >> Routes.toString
+                }
         )
 
 
@@ -291,16 +303,17 @@ withSideNav currentRoute content =
         ]
 
 
-viewPreviews : String -> List (Example Examples.State Examples.Msg) -> Html Msg
-viewPreviews containerId examples =
+viewPreviews :
+    String
+    ->
+        { navigate : Example Examples.State Examples.Msg -> Msg
+        , exampleHref : Example Examples.State Examples.Msg -> String
+        }
+    -> List (Example Examples.State Examples.Msg)
+    -> Html Msg
+viewPreviews containerId navConfig examples =
     examples
-        |> List.map
-            (\example ->
-                Example.preview
-                    (Routes.Doodad >> ChangeRoute)
-                    (Routes.Doodad >> Routes.toString)
-                    example
-            )
+        |> List.map (Example.preview navConfig)
         |> Html.div
             [ id containerId
             , css

--- a/styleguide-app/App.elm
+++ b/styleguide-app/App.elm
@@ -81,11 +81,15 @@ update action model =
                     example.update exampleMsg example.state
                         |> Tuple.mapFirst
                             (\newState ->
+                                let
+                                    newExample =
+                                        { example | state = newState }
+                                in
                                 { model
-                                    | moduleStates =
-                                        Dict.insert key
-                                            { example | state = newState }
-                                            model.moduleStates
+                                    | moduleStates = Dict.insert key newExample model.moduleStates
+                                    , route =
+                                        Maybe.withDefault model.route
+                                            (Routes.updateExample newExample model.route)
                                 }
                             )
                         |> Tuple.mapSecond (Cmd.map (UpdateModuleStates key) >> Command)

--- a/styleguide-app/Category.elm
+++ b/styleguide-app/Category.elm
@@ -1,7 +1,7 @@
 module Category exposing
     ( Category(..)
     , fromString
-    , forDisplay, forId
+    , forDisplay, forId, forRoute
     , all
     , sorter
     )
@@ -10,7 +10,7 @@ module Category exposing
 
 @docs Category
 @docs fromString
-@docs forDisplay, forId
+@docs forDisplay, forId, forRoute
 @docs all
 @docs sorter
 
@@ -105,6 +105,12 @@ forDisplay category =
 
         Animations ->
             "Animations"
+
+
+{-| -}
+forRoute : Category -> String
+forRoute =
+    Debug.toString
 
 
 {-| -}

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -16,7 +16,6 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.UiIcon.V1 as UiIcon
-import Routes exposing (Route)
 
 
 type alias Example state msg =
@@ -98,13 +97,13 @@ wrapState wrapState_ unwrapState example =
     }
 
 
-preview : (Route -> msg2) -> Example state msg -> Html msg2
-preview navigate =
-    Lazy.lazy (preview_ navigate)
+preview : (Example state msg -> msg2) -> (Example state msg -> String) -> Example state msg -> Html msg2
+preview navigate exampleHref =
+    Lazy.lazy (preview_ navigate exampleHref)
 
 
-preview_ : (Route -> msg2) -> Example state msg -> Html msg2
-preview_ navigate example =
+preview_ : (Example state msg -> msg2) -> (Example state msg -> String) -> Example state msg -> Html msg2
+preview_ navigate exampleHref example =
     Container.view
         [ Container.gray
         , Container.css
@@ -114,7 +113,7 @@ preview_ navigate example =
                 , Css.cursor Css.pointer
                 ]
             ]
-        , Container.custom [ Events.onClick (navigate (Routes.Doodad example.name)) ]
+        , Container.custom [ Events.onClick (navigate example) ]
         , Container.html
             (ClickableText.link example.name
                 [ ClickableText.href (exampleHref example)
@@ -134,26 +133,17 @@ preview_ navigate example =
         ]
 
 
-view : Maybe Route -> EllieLink.Config -> Example state msg -> Html msg
-view previousRoute ellieLinkConfig example =
-    Container.view
-        [ Container.pillow
-        , Container.css
-            [ Css.position Css.relative
-            , Css.margin (Css.px 10)
-            , Css.minHeight (Css.calc (Css.vh 100) Css.minus (Css.px 20))
-            , Css.boxSizing Css.borderBox
-            ]
-        , Container.html (view_ previousRoute ellieLinkConfig example)
-        , Container.custom [ Attributes.id (String.replace "." "-" example.name) ]
-        ]
+view : EllieLink.Config -> Example state msg -> Html msg
+view ellieLinkConfig example =
+    Html.div [ Attributes.id (String.replace "." "-" example.name) ]
+        (view_ ellieLinkConfig example)
 
 
-view_ : Maybe Route -> EllieLink.Config -> Example state msg -> List (Html msg)
-view_ previousRoute ellieLinkConfig example =
+view_ : EllieLink.Config -> Example state msg -> List (Html msg)
+view_ ellieLinkConfig example =
     let
         navMenu items =
-            Html.nav [ Widget.label "Example" ]
+            Html.nav [ Widget.label (fullName example) ]
                 [ Html.ul
                     [ Attributes.css
                         [ margin zero
@@ -183,41 +173,11 @@ view_ previousRoute ellieLinkConfig example =
             , Css.borderBottom3 (Css.px 1) Css.solid Colors.gray92
             ]
         ]
-        [ navMenu
-            [ Heading.h1
-                [ Heading.custom [ Aria.currentPage ] ]
-                [ Html.text (fullName example)
-                ]
-            , docsLink example
-            , srcLink example
-            , closeExample previousRoute example
-            ]
+        [ navMenu [ docsLink example, srcLink example ]
         ]
     , KeyboardSupport.view example.keyboardSupport
     , Html.main_ [] (example.view ellieLinkConfig example.state)
     ]
-
-
-closeExample : Maybe Route -> Example state msg -> Html msg
-closeExample previousRoute example =
-    ClickableSvg.link ("Close " ++ example.name ++ " example")
-        UiIcon.x
-        [ ClickableSvg.href
-            (Maybe.withDefault Routes.All previousRoute
-                |> Routes.toString
-            )
-        , ClickableSvg.exactSize 20
-        , ClickableSvg.css
-            [ Css.position Css.absolute
-            , Css.top (Css.px 15)
-            , Css.right (Css.px 15)
-            ]
-        ]
-
-
-exampleHref : Example state msg -> String
-exampleHref example =
-    Routes.toString (Routes.Doodad example.name)
 
 
 docsLink : Example state msg -> Html msg
@@ -229,7 +189,6 @@ docsLink example =
     in
     ClickableText.link "Docs"
         [ ClickableText.linkExternal link
-        , ClickableText.css [ Css.marginLeft (Css.px 20) ]
         ]
 
 

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -1,6 +1,5 @@
 module Example exposing (Example, fullName, preview, view, wrapMsg, wrapState)
 
-import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Widget as Widget
 import Category exposing (Category)
 import Css exposing (..)
@@ -10,12 +9,9 @@ import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Html.Styled.Lazy as Lazy
 import KeyboardSupport exposing (KeyboardSupport)
-import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
-import Nri.Ui.Heading.V2 as Heading
-import Nri.Ui.UiIcon.V1 as UiIcon
 
 
 type alias Example state msg =
@@ -176,7 +172,7 @@ view_ ellieLinkConfig example =
                     )
                 ]
     in
-    [ Html.header
+    [ Html.div
         [ Attributes.css
             [ Css.paddingBottom (Css.px 10)
             , Css.marginBottom (Css.px 20)
@@ -186,7 +182,7 @@ view_ ellieLinkConfig example =
         [ navMenu [ docsLink example, srcLink example ]
         ]
     , KeyboardSupport.view example.keyboardSupport
-    , Html.main_ [] (example.view ellieLinkConfig example.state)
+    , Html.div [] (example.view ellieLinkConfig example.state)
     ]
 
 

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -97,13 +97,23 @@ wrapState wrapState_ unwrapState example =
     }
 
 
-preview : (Example state msg -> msg2) -> (Example state msg -> String) -> Example state msg -> Html msg2
-preview navigate exampleHref =
-    Lazy.lazy (preview_ navigate exampleHref)
+preview :
+    { navigate : Example state msg -> msg2
+    , exampleHref : Example state msg -> String
+    }
+    -> Example state msg
+    -> Html msg2
+preview navConfig =
+    Lazy.lazy (preview_ navConfig)
 
 
-preview_ : (Example state msg -> msg2) -> (Example state msg -> String) -> Example state msg -> Html msg2
-preview_ navigate exampleHref example =
+preview_ :
+    { navigate : Example state msg -> msg2
+    , exampleHref : Example state msg -> String
+    }
+    -> Example state msg
+    -> Html msg2
+preview_ { navigate, exampleHref } example =
     Container.view
         [ Container.gray
         , Container.css

--- a/styleguide-app/Examples.elm
+++ b/styleguide-app/Examples.elm
@@ -4,6 +4,7 @@ import Example exposing (Example)
 import Examples.Accordion as Accordion
 import Examples.AssignmentIcon as AssignmentIcon
 import Examples.Balloon as Balloon
+import Examples.BreadCrumbs as BreadCrumbs
 import Examples.Button as Button
 import Examples.Checkbox as Checkbox
 import Examples.ClickableSvg as ClickableSvg
@@ -95,6 +96,25 @@ all =
             (\msg ->
                 case msg of
                     BalloonState childState ->
+                        Just childState
+
+                    _ ->
+                        Nothing
+            )
+    , BreadCrumbs.example
+        |> Example.wrapMsg BreadCrumbsMsg
+            (\msg ->
+                case msg of
+                    BreadCrumbsMsg childMsg ->
+                        Just childMsg
+
+                    _ ->
+                        Nothing
+            )
+        |> Example.wrapState BreadCrumbsState
+            (\msg ->
+                case msg of
+                    BreadCrumbsState childState ->
                         Just childState
 
                     _ ->
@@ -772,6 +792,7 @@ type State
     = AccordionState Accordion.State
     | AssignmentIconState AssignmentIcon.State
     | BalloonState Balloon.State
+    | BreadCrumbsState BreadCrumbs.State
     | ButtonState Button.State
     | CheckboxState Checkbox.State
     | ClickableSvgState ClickableSvg.State
@@ -813,6 +834,7 @@ type Msg
     = AccordionMsg Accordion.Msg
     | AssignmentIconMsg AssignmentIcon.Msg
     | BalloonMsg Balloon.Msg
+    | BreadCrumbsMsg BreadCrumbs.Msg
     | ButtonMsg Button.Msg
     | CheckboxMsg Checkbox.Msg
     | ClickableSvgMsg ClickableSvg.Msg

--- a/styleguide-app/Examples/BreadCrumbs.elm
+++ b/styleguide-app/Examples/BreadCrumbs.elm
@@ -8,6 +8,7 @@ module Examples.BreadCrumbs exposing (example, State, Msg)
 
 import Category exposing (Category(..))
 import Example exposing (Example)
+import Nri.Ui.Text.V6 as Text
 
 
 {-| -}
@@ -33,5 +34,6 @@ example =
     , preview = []
     , view =
         \ellieLinkConfig settings ->
-            []
+            [ Text.mediumBody [ Text.plaintext "🚧 Example coming soon! 🚧" ]
+            ]
     }

--- a/styleguide-app/Examples/BreadCrumbs.elm
+++ b/styleguide-app/Examples/BreadCrumbs.elm
@@ -1,0 +1,41 @@
+module Examples.BreadCrumbs exposing (example, State, Msg)
+
+{-|
+
+@docs example, State, Msg
+
+-}
+
+import Accessibility.Styled exposing (..)
+import Category exposing (Category(..))
+import Css
+import Example exposing (Example)
+import Examples.IconExamples as IconExamples
+import Nri.Ui.BreadCrumbs.V1 as BreadCrumbs
+
+
+{-| -}
+type alias State =
+    {}
+
+
+{-| -}
+type alias Msg =
+    ()
+
+
+{-| -}
+example : Example State Msg
+example =
+    { name = "BreadCrumbs"
+    , version = 1
+    , categories = [ Layout ]
+    , keyboardSupport = []
+    , state = {}
+    , update = \_ m -> ( m, Cmd.none )
+    , subscriptions = \_ -> Sub.none
+    , preview = []
+    , view =
+        \ellieLinkConfig settings ->
+            []
+    }

--- a/styleguide-app/Examples/BreadCrumbs.elm
+++ b/styleguide-app/Examples/BreadCrumbs.elm
@@ -6,12 +6,8 @@ module Examples.BreadCrumbs exposing (example, State, Msg)
 
 -}
 
-import Accessibility.Styled exposing (..)
 import Category exposing (Category(..))
-import Css
 import Example exposing (Example)
-import Examples.IconExamples as IconExamples
-import Nri.Ui.BreadCrumbs.V1 as BreadCrumbs
 
 
 {-| -}

--- a/styleguide-app/Examples/SideNav.elm
+++ b/styleguide-app/Examples/SideNav.elm
@@ -143,14 +143,14 @@ init =
 controlNavAttributes : Control (List ( String, SideNav.NavAttribute ))
 controlNavAttributes =
     ControlExtra.list
-        |> ControlExtra.optionalListItem "navLabel"
+        |> ControlExtra.optionalListItemDefaultChecked "navLabel"
             (Control.map
                 (\val ->
                     ( "SideNav.navLabel \"" ++ val ++ "\""
                     , SideNav.navLabel val
                     )
                 )
-                (Control.string "Entries")
+                (Control.string "Example")
             )
         |> ControlExtra.optionalListItem "navNotMobileCss"
             (Control.choice

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -24,7 +24,6 @@ import Nri.Ui.Tabs.V7 as Tabs exposing (Alignment(..), Tab)
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.Tooltip.V3 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon
-import Routes
 import Task
 
 

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -217,8 +217,7 @@ allTabs openTooltipId labelledBy =
                 |> Svg.toHtml
     in
     [ Tabs.build { id = First, idString = "tab-0" }
-        ([ Tabs.spaHref <| Routes.toString (Routes.Doodad exampleName)
-         , Tabs.tabString "1"
+        ([ Tabs.tabString "1"
          , Tabs.withTooltip
             [ Tooltip.plaintext "Link Example"
             , Tooltip.onToggle (ToggleTooltip First)

--- a/styleguide-app/Routes.elm
+++ b/styleguide-app/Routes.elm
@@ -1,4 +1,4 @@
-module Routes exposing (Route(..), fromLocation, toString, viewBreadCrumbs)
+module Routes exposing (Route(..), fromLocation, toString, updateExample, viewBreadCrumbs)
 
 import Accessibility.Styled as Html exposing (Html)
 import Category
@@ -78,6 +78,19 @@ category string =
 
         Err e ->
             Parser.problem e
+
+
+updateExample : Example state msg -> Route state msg -> Maybe (Route state msg)
+updateExample example route_ =
+    case route_ of
+        Doodad _ ->
+            Just (Doodad example)
+
+        CategoryDoodad cat _ ->
+            Just (CategoryDoodad cat example)
+
+        _ ->
+            Nothing
 
 
 fromLocation : Dict String (Example state msg) -> Url -> Route state msg

--- a/styleguide-app/Routes.elm
+++ b/styleguide-app/Routes.elm
@@ -1,6 +1,9 @@
-module Routes exposing (Route(..), fromLocation, toString)
+module Routes exposing (Route(..), fromLocation, toString, viewBreadCrumbs)
 
+import Accessibility.Styled as Html exposing (Html)
 import Category
+import Html.Styled.Attributes as Attributes
+import Nri.Ui.BreadCrumbs.V1 as BreadCrumbs exposing (BreadCrumbs)
 import Parser exposing ((|.), (|=), Parser)
 import Url exposing (Url)
 
@@ -58,3 +61,50 @@ fromLocation location =
         |> Maybe.withDefault ""
         |> Parser.run route
         |> Result.withDefault All
+
+
+viewBreadCrumbs : Route -> Html msg
+viewBreadCrumbs currentRoute =
+    breadCrumbs currentRoute
+        |> Maybe.map
+            (BreadCrumbs.view
+                { aTagAttributes = \r -> [ Attributes.href ("/" ++ toString r) ]
+                , isCurrentRoute = (==) currentRoute
+                }
+            )
+        |> Maybe.withDefault (Html.text "")
+
+
+breadCrumbs : Route -> Maybe (BreadCrumbs Route)
+breadCrumbs route_ =
+    case route_ of
+        All ->
+            Just allBreadCrumb
+
+        Category category_ ->
+            Just (categoryCrumb category_)
+
+        Doodad _ ->
+            Nothing
+
+
+allBreadCrumb : BreadCrumbs Route
+allBreadCrumb =
+    BreadCrumbs.init
+        { icon = Nothing
+        , iconStyle = BreadCrumbs.Default
+        , id = "breadcrumbs__all"
+        , text = "All"
+        , route = All
+        }
+
+
+categoryCrumb : Category.Category -> BreadCrumbs Route
+categoryCrumb category_ =
+    BreadCrumbs.after allBreadCrumb
+        { icon = Nothing
+        , iconStyle = BreadCrumbs.Default
+        , id = "breadcrumbs__" ++ Category.forId category_
+        , text = Category.forDisplay category_
+        , route = Category category_
+        }

--- a/styleguide/tests/SwitchExampleSpec.elm
+++ b/styleguide/tests/SwitchExampleSpec.elm
@@ -1,5 +1,6 @@
 module SwitchExampleSpec exposing (suite)
 
+import Examples.Switch exposing (Msg, State, example)
 import ProgramTest exposing (..)
 import Routes exposing (Route)
 import Test exposing (..)
@@ -7,9 +8,9 @@ import Test.Html.Selector exposing (..)
 import TestApp exposing (app)
 
 
-route : Route
+route : Route State Msg
 route =
-    Routes.Doodad "Switch"
+    Routes.Doodad example
 
 
 suite : Test

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -7,6 +7,7 @@
         "Nri.Ui.AssetPath",
         "Nri.Ui.AssignmentIcon.V2",
         "Nri.Ui.Balloon.V1",
+        "Nri.Ui.BreadCrumbs.V1",
         "Nri.Ui.Button.V10",
         "Nri.Ui.Checkbox.V5",
         "Nri.Ui.ClickableSvg.V2",


### PR DESCRIPTION
Fixes https://github.com/NoRedInk/noredink-ui/issues/921 partway -- moves breadcrumbs into noredink-ui, and switches to an app design that uses the breadcrumbs, but does not implement a preview or an example.

<img width="1492" alt="" src="https://user-images.githubusercontent.com/8811312/169674660-5e0bd8d2-13f3-4f5e-9a34-e22d445473ca.png">

Note that in this view, we are focused on a single component, but we're also still able to access the sidenav.

cc @NoRedInk/design trying out some puppychow -- what do you think?