### PR TITLE
Bat/improve page nav

### DIFF
--- a/styleguide-app/App.elm
+++ b/styleguide-app/App.elm
@@ -105,12 +105,14 @@ update action model =
                 External loc ->
                     ( model, Load loc )
 
-        OnUrlChange route ->
-            ( { model
-                | route = Routes.fromLocation model.moduleStates route
-                , previousRoute = Just model.route
-              }
-            , None
+        OnUrlChange location ->
+            let
+                route =
+                    Routes.fromLocation model.moduleStates location
+            in
+            ( { model | route = route, previousRoute = Just model.route }
+            , Maybe.map FocusOn (Routes.headerId route)
+                |> Maybe.withDefault None
             )
 
         ChangeRoute route ->

--- a/styleguide-app/Routes.elm
+++ b/styleguide-app/Routes.elm
@@ -1,4 +1,4 @@
-module Routes exposing (Route(..), fromLocation, toString, updateExample, viewBreadCrumbs)
+module Routes exposing (Route(..), fromLocation, headerId, toString, updateExample, viewBreadCrumbs)
 
 import Accessibility.Styled as Html exposing (Html)
 import Category
@@ -111,6 +111,11 @@ viewBreadCrumbs currentRoute =
                 }
             )
         |> Maybe.withDefault (Html.text "")
+
+
+headerId : Route state msg -> Maybe String
+headerId route_ =
+    Maybe.map BreadCrumbs.headerId (breadCrumbs route_)
 
 
 breadCrumbs : Route state msg -> Maybe (BreadCrumbs (Route state msg))


### PR DESCRIPTION
When the route changes, focus the heading.

Fixes A11-789, and also improves the experience for screenreader users, since they'll be notified of the page heading.