### PR TITLE
account for box-sizing: border-box in autoresize

### DIFF
--- a/lib/TextArea/V4.js
+++ b/lib/TextArea/V4.js
@@ -33,24 +33,28 @@ CustomElement.create({
     },
 
     _resize: function() {
-      var minHeight = null
+      var minHeight = null;
+      var computedStyles = window.getComputedStyle(this._textarea);
+
       if (this._textarea.style.minHeight) {
         minHeight = parseInt(this._textarea.style.minHeight, 10)
       } else {
-        minHeight = parseInt(window.getComputedStyle(this._textarea).minHeight, 10)
+        minHeight = parseInt(computedStyles.minHeight, 10)
       }
       if (minHeight === 0) {
-        minHeight = parseInt(window.getComputedStyle(this._textarea).height, 10)
+        minHeight = parseInt(computedStyles.height, 10)
       }
 
       this._textarea.style.overflowY = 'hidden'
       this._textarea.style.minHeight = minHeight + 'px'
       this._textarea.style.transition = 'none'
-      if (this._textarea.scrollHeight > minHeight) {
-        this._textarea.style.height = this._textarea.scrollHeight + 'px'
-      } else {
-        this._textarea.style.height = minHeight + 'px'
-      }
+
+      // the browser does not include border widths in `.scrollHeight`, but we
+      // use `box-sizing: borer-box` on these elements so we need to take it
+      // into account when setting the CSS `height`.
+      let borderOffset = parseInt(computedStyles.borderTopWidth, 10) + parseInt(computedStyles.borderBottomWidth, 10);
+
+      this._textarea.style.height = Math.max(minHeight, this._textarea.scrollHeight + borderOffset) + 'px'
     }
   }
 })

--- a/lib/TextArea/V4.js
+++ b/lib/TextArea/V4.js
@@ -50,9 +50,12 @@ CustomElement.create({
       this._textarea.style.transition = 'none'
 
       // the browser does not include border widths in `.scrollHeight`, but we
-      // use `box-sizing: borer-box` on these elements so we need to take it
-      // into account when setting the CSS `height`.
-      let borderOffset = parseInt(computedStyles.borderTopWidth, 10) + parseInt(computedStyles.borderBottomWidth, 10);
+      // sometimes use `box-sizing: borer-box` on these elements so we need to
+      // take it into account when setting the CSS `height`.
+      var borderOffset = 0;
+      if (computedStyles.boxSizing === 'border-box') {
+        borderOffset = parseInt(computedStyles.borderTopWidth, 10) + parseInt(computedStyles.borderBottomWidth, 10);
+      }
 
       this._textarea.style.height = Math.max(minHeight, this._textarea.scrollHeight + borderOffset) + 'px'
     }


### PR DESCRIPTION
Peer Review text inputs shrink because we are continually setting the minimum height 2px smaller because we do not currently account for the border. This fixes that by looking at the border if the computedStyles reveal that we're using `box-sizing: border-box` on the element.
