### PR TITLE
Update table example

### DIFF
--- a/styleguide-app/Debug/Control/View.elm
+++ b/styleguide-app/Debug/Control/View.elm
@@ -1,4 +1,18 @@
-module Debug.Control.View exposing (codeFromList, codeFromListWithHardcoded, codeFromListWithIndentLevel, view)
+module Debug.Control.View exposing
+    ( view
+    , codeFromListSimple
+    , codeFromList, codeFromListWithIndentLevel
+    , codeFromListWithHardcoded
+    )
+
+{-|
+
+@docs view
+@docs codeFromListSimple
+@docs codeFromList, codeFromListWithIndentLevel
+@docs codeFromListWithHardcoded
+
+-}
 
 import Css exposing (..)
 import Css.Media exposing (withMedia)
@@ -111,6 +125,16 @@ codeFromList =
 
 codeFromListWithIndentLevel : Int -> List ( String, a ) -> String
 codeFromListWithIndentLevel indent list =
+    codeFromListSimpleWithIndentLevel indent (List.map Tuple.first list)
+
+
+codeFromListSimple : List String -> String
+codeFromListSimple =
+    codeFromListSimpleWithIndentLevel 1
+
+
+codeFromListSimpleWithIndentLevel : Int -> List String -> String
+codeFromListSimpleWithIndentLevel indent list =
     let
         indents =
             String.repeat indent "\t"
@@ -118,7 +142,7 @@ codeFromListWithIndentLevel indent list =
     "\n"
         ++ indents
         ++ "[ "
-        ++ String.join ("\n" ++ indents ++ ", ") (List.map Tuple.first list)
+        ++ String.join ("\n" ++ indents ++ ", ") list
         ++ "\n"
         ++ indents
         ++ "] "

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -110,15 +110,24 @@ example =
                 , toExampleCode =
                     \settings ->
                         let
-                            toExampleCode viewName =
+                            codeWithData viewName =
+                                List.map datumToString data
+                                    |> ControlView.codeFromListSimple
+                                    |> toExampleCode viewName
+
+                            toExampleCode viewName dataStr =
                                 { sectionName = moduleName ++ "." ++ viewName
                                 , code =
                                     (moduleName ++ "." ++ viewName)
                                         ++ "[ --TODO \n ]"
-                                        ++ "[ --TODO \n ]"
+                                        ++ dataStr
                                 }
                         in
-                        List.map toExampleCode [ "view", "viewWithoutHeader", "viewLoading", "viewLoadingWithoutHeader" ]
+                        [ codeWithData "view"
+                        , codeWithData "viewWithoutHeader"
+                        , toExampleCode "viewLoading" ""
+                        , toExampleCode "viewLoadingWithoutHeader" ""
+                        ]
                 }
             , Heading.h2 [ Heading.style Heading.Subhead ] [ text "Example" ]
             , case ( showHeader, isLoading ) of
@@ -166,14 +175,27 @@ controlSettings =
         |> Control.field "is loading" (Control.bool False)
 
 
-type alias Data =
+type alias Datum =
     { firstName : String
     , lastName : String
     , submitted : Int
     }
 
 
-data : List Data
+datumToString : Datum -> String
+datumToString { firstName, lastName, submitted } =
+    ("{ firstName = " ++ str firstName)
+        ++ (", lastName = " ++ str lastName)
+        ++ (", submitted =" ++ String.fromInt 10)
+        ++ "}"
+
+
+str : String -> String
+str s =
+    "\"" ++ s ++ "\""
+
+
+data : List Datum
 data =
     [ { firstName = "Monique", lastName = "Garcia", submitted = 10 }
     , { firstName = "Gabriel", lastName = "Smith", submitted = 0 }

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -8,7 +8,7 @@ module Examples.Table exposing (Msg, State, example)
 
 import Accessibility.Styled exposing (..)
 import Category exposing (Category(..))
-import Css exposing (..)
+import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.View as ControlView
 import Example exposing (Example)
@@ -48,13 +48,13 @@ example =
             [ Table.string
                 { header = "A"
                 , value = .a
-                , width = px 50
+                , width = Css.px 50
                 , cellStyles = always []
                 }
             , Table.string
                 { header = "B"
                 , value = .b
-                , width = px 50
+                , width = Css.px 50
                 , cellStyles = always []
                 }
             ]
@@ -69,35 +69,11 @@ example =
     , view =
         \ellieLinkConfig state ->
             let
-                columns =
-                    [ Table.string
-                        { header = "First Name"
-                        , value = .firstName
-                        , width = calc (pct 50) minus (px 250)
-                        , cellStyles = always []
-                        }
-                    , Table.string
-                        { header = "Last Name"
-                        , value = .lastName
-                        , width = calc (pct 50) minus (px 250)
-                        , cellStyles = always []
-                        }
-                    , Table.string
-                        { header = "Submitted"
-                        , value = .submitted >> String.fromInt
-                        , width = px 125
-                        , cellStyles = \value -> [ textAlign center ]
-                        }
-                    , Table.custom
-                        { header = text "Actions"
-                        , width = px 250
-                        , view = \_ -> Button.button "Action" [ Button.small, Button.onClick (ConsoleLog "Clicked button!") ]
-                        , cellStyles = always []
-                        }
-                    ]
-
                 { showHeader, isLoading } =
                     Control.currentValue state
+
+                ( columnsCode, columns ) =
+                    List.unzip columnsWithCode
             in
             [ ControlView.view
                 { ellieLinkConfig = ellieLinkConfig
@@ -106,7 +82,7 @@ example =
                 , update = UpdateControl
                 , settings = state
                 , mainType = "RootHtml.Html msg"
-                , extraImports = []
+                , extraImports = [ "import Nri.Ui.Button.V10 as Button" ]
                 , toExampleCode =
                     \settings ->
                         let
@@ -119,7 +95,7 @@ example =
                                 { sectionName = moduleName ++ "." ++ viewName
                                 , code =
                                     (moduleName ++ "." ++ viewName)
-                                        ++ "[ --TODO \n ]"
+                                        ++ ControlView.codeFromListSimple columnsCode
                                         ++ dataStr
                                 }
                         in
@@ -186,7 +162,7 @@ datumToString : Datum -> String
 datumToString { firstName, lastName, submitted } =
     ("{ firstName = " ++ str firstName)
         ++ (", lastName = " ++ str lastName)
-        ++ (", submitted =" ++ String.fromInt 10)
+        ++ (", submitted = " ++ String.fromInt 10)
         ++ "}"
 
 
@@ -202,4 +178,69 @@ data =
     , { firstName = "Mariah", lastName = "Lopez", submitted = 3 }
     , { firstName = "Amber", lastName = "Brown", submitted = 15 }
     , { firstName = "Carlos", lastName = "Martinez", submitted = 8 }
+    ]
+
+
+columnsWithCode : List ( String, Column Datum Msg )
+columnsWithCode =
+    [ ( [ "Table.string"
+        , "  { header = \"First Name\""
+        , "  , value = .firstName"
+        , "  , width = Css.calc (Css.pct 50) Css.minus (Css.px 250)"
+        , "  , cellStyles = always []"
+        , "  }"
+        ]
+            |> String.join "\n\t  "
+      , Table.string
+            { header = "First Name"
+            , value = .firstName
+            , width = Css.calc (Css.pct 50) Css.minus (Css.px 250)
+            , cellStyles = always []
+            }
+      )
+    , ( [ "Table.string"
+        , "  { header = \"Last Name\""
+        , "  , value = .lastName"
+        , "  , width = Css.calc (Css.pct 50) Css.minus (Css.px 250)"
+        , "  , cellStyles = always []"
+        , "  }"
+        ]
+            |> String.join "\n\t  "
+      , Table.string
+            { header = "Last Name"
+            , value = .lastName
+            , width = Css.calc (Css.pct 50) Css.minus (Css.px 250)
+            , cellStyles = always []
+            }
+      )
+    , ( [ "Table.string"
+        , "  { header = \"Submitted\""
+        , "  , value = .submitted >> String.fromInt"
+        , "  , width = Css.px 125"
+        , "  , cellStyles = always [ Css.textAlign Css.center ]"
+        , "  }"
+        ]
+            |> String.join "\n\t  "
+      , Table.string
+            { header = "Submitted"
+            , value = .submitted >> String.fromInt
+            , width = Css.px 125
+            , cellStyles = \value -> [ Css.textAlign Css.center ]
+            }
+      )
+    , ( [ "Table.custom"
+        , "  { header = text \"Actions\""
+        , "  , width = Css.px 250"
+        , "  , view = \\_ -> Button.button \"Action\" [ Button.small ]"
+        , "  , cellStyles = always []"
+        , "  }"
+        ]
+            |> String.join "\n\t  "
+      , Table.custom
+            { header = text "Actions"
+            , width = Css.px 250
+            , view = \_ -> Button.button "Action" [ Button.small, Button.onClick (ConsoleLog "Clicked button!") ]
+            , cellStyles = always []
+            }
+      )
     ]

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -103,6 +103,9 @@ example =
                         , cellStyles = always []
                         }
                     ]
+
+                { showHeader, isLoading } =
+                    Control.currentValue state
             in
             [ ControlView.view
                 { ellieLinkConfig = ellieLinkConfig
@@ -112,16 +115,32 @@ example =
                 , settings = state
                 , mainType = "RootHtml.Html msg"
                 , extraImports = []
-                , toExampleCode = \settings -> [ { sectionName = moduleName ++ ".view", code = "TODO" } ]
+                , toExampleCode =
+                    \settings ->
+                        let
+                            toExampleCode viewName =
+                                { sectionName = moduleName ++ "." ++ viewName
+                                , code =
+                                    (moduleName ++ "." ++ viewName)
+                                        ++ "[ --TODO \n ]"
+                                        ++ "[ --TODO \n ]"
+                                }
+                        in
+                        List.map toExampleCode [ "view", "viewWithoutHeader", "viewLoading", "viewLoadingWithoutHeader" ]
                 }
-            , Heading.h2 [ Heading.style Heading.Subhead ] [ text "With header" ]
-            , Table.view columns data
-            , Heading.h2 [ Heading.style Heading.Subhead ] [ text "Without header" ]
-            , Table.viewWithoutHeader columns data
-            , Heading.h2 [ Heading.style Heading.Subhead ] [ text "Loading" ]
-            , Table.viewLoading columns
-            , Heading.h2 [ Heading.style Heading.Subhead ] [ text "Loading without header" ]
-            , Table.viewLoadingWithoutHeader columns
+            , Heading.h2 [ Heading.style Heading.Subhead ] [ text "Example" ]
+            , case ( showHeader, isLoading ) of
+                ( True, False ) ->
+                    Table.view columns data
+
+                ( False, False ) ->
+                    Table.viewWithoutHeader columns data
+
+                ( True, True ) ->
+                    Table.viewLoading columns
+
+                ( False, True ) ->
+                    Table.viewLoadingWithoutHeader columns
             ]
     }
 
@@ -143,12 +162,16 @@ update msg state =
 
 
 type alias Settings =
-    {}
+    { showHeader : Bool
+    , isLoading : Bool
+    }
 
 
 controlSettings : Control Settings
 controlSettings =
     Control.record Settings
+        |> Control.field "visible header" (Control.bool True)
+        |> Control.field "is loading" (Control.bool False)
 
 
 type alias Data =

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -83,18 +83,10 @@ example =
                         , cellStyles = always []
                         }
                     , Table.string
-                        { header = "# Submitted"
+                        { header = "Submitted"
                         , value = .submitted >> String.fromInt
                         , width = px 125
-                        , cellStyles =
-                            \value ->
-                                if value.submitted < 5 then
-                                    [ backgroundColor Colors.redLight
-                                    , textAlign center
-                                    ]
-
-                                else
-                                    [ textAlign center ]
+                        , cellStyles = \value -> [ textAlign center ]
                         }
                     , Table.custom
                         { header = text "Actions"

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -13,7 +13,6 @@ import Debug.Control as Control exposing (Control)
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Nri.Ui.Button.V10 as Button
-import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Table.V5 as Table exposing (Column)
 

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -8,6 +8,8 @@ module Examples.Table exposing (Msg, State, example)
 
 import Category exposing (Category(..))
 import Css exposing (..)
+import Debug.Control as Control exposing (Control)
+import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled as Html
 import Nri.Ui.Button.V10 as Button
@@ -18,21 +20,26 @@ import Nri.Ui.Table.V5 as Table
 
 {-| -}
 type alias State =
-    ()
+    Control Settings
 
 
-{-| -}
-type alias Msg =
-    ()
+moduleName : String
+moduleName =
+    "Table"
+
+
+version : Int
+version =
+    5
 
 
 {-| -}
 example : Example State Msg
 example =
-    { name = "Table"
-    , version = 5
-    , state = ()
-    , update = \_ state -> ( state, Cmd.none )
+    { name = moduleName
+    , version = version
+    , state = controlSettings
+    , update = update
     , subscriptions = \_ -> Sub.none
     , categories = [ Layout ]
     , keyboardSupport = []
@@ -60,7 +67,7 @@ example =
             ]
         ]
     , view =
-        \ellieLinkConfig () ->
+        \ellieLinkConfig state ->
             let
                 columns =
                     [ Table.string
@@ -93,7 +100,7 @@ example =
                         { header =
                             Html.text "Actions"
                         , width = px 250
-                        , view = \_ -> Button.button "Action" [ Button.small, Button.onClick () ]
+                        , view = \_ -> Button.button "Action" [ Button.small, Button.onClick (ConsoleLog "Clicked button!") ]
                         , cellStyles = always []
                         }
                     ]
@@ -106,7 +113,17 @@ example =
                     , { firstName = "First5", lastName = "Last5", submitted = 8 }
                     ]
             in
-            [ Heading.h2 [ Heading.style Heading.Subhead ] [ Html.text "With header" ]
+            [ ControlView.view
+                { ellieLinkConfig = ellieLinkConfig
+                , name = moduleName
+                , version = version
+                , update = UpdateControl
+                , settings = state
+                , mainType = "RootHtml.Html msg"
+                , extraImports = []
+                , toExampleCode = \settings -> [ { sectionName = moduleName ++ ".view", code = "TODO" } ]
+                }
+            , Heading.h2 [ Heading.style Heading.Subhead ] [ Html.text "With header" ]
             , Table.view columns data
             , Heading.h2 [ Heading.style Heading.Subhead ] [ Html.text "Without header" ]
             , Table.viewWithoutHeader columns data
@@ -116,3 +133,28 @@ example =
             , Table.viewLoadingWithoutHeader columns
             ]
     }
+
+
+{-| -}
+type Msg
+    = UpdateControl (Control Settings)
+    | ConsoleLog String
+
+
+update : Msg -> State -> ( State, Cmd msg )
+update msg state =
+    case msg of
+        UpdateControl control ->
+            ( control, Cmd.none )
+
+        ConsoleLog message ->
+            ( Debug.log "Menu Example" message |> always state, Cmd.none )
+
+
+type alias Settings =
+    {}
+
+
+controlSettings : Control Settings
+controlSettings =
+    Control.record Settings

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -6,16 +6,16 @@ module Examples.Table exposing (Msg, State, example)
 
 -}
 
+import Accessibility.Styled exposing (..)
 import Category exposing (Category(..))
 import Css exposing (..)
 import Debug.Control as Control exposing (Control)
 import Debug.Control.View as ControlView
 import Example exposing (Example)
-import Html.Styled as Html
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V2 as Heading
-import Nri.Ui.Table.V5 as Table
+import Nri.Ui.Table.V5 as Table exposing (Column)
 
 
 {-| -}
@@ -97,20 +97,11 @@ example =
                                     [ textAlign center ]
                         }
                     , Table.custom
-                        { header =
-                            Html.text "Actions"
+                        { header = text "Actions"
                         , width = px 250
                         , view = \_ -> Button.button "Action" [ Button.small, Button.onClick (ConsoleLog "Clicked button!") ]
                         , cellStyles = always []
                         }
-                    ]
-
-                data =
-                    [ { firstName = "First1", lastName = "Last1", submitted = 10 }
-                    , { firstName = "First2", lastName = "Last2", submitted = 0 }
-                    , { firstName = "First3", lastName = "Last3", submitted = 3 }
-                    , { firstName = "First4", lastName = "Last4", submitted = 15 }
-                    , { firstName = "First5", lastName = "Last5", submitted = 8 }
                     ]
             in
             [ ControlView.view
@@ -123,13 +114,13 @@ example =
                 , extraImports = []
                 , toExampleCode = \settings -> [ { sectionName = moduleName ++ ".view", code = "TODO" } ]
                 }
-            , Heading.h2 [ Heading.style Heading.Subhead ] [ Html.text "With header" ]
+            , Heading.h2 [ Heading.style Heading.Subhead ] [ text "With header" ]
             , Table.view columns data
-            , Heading.h2 [ Heading.style Heading.Subhead ] [ Html.text "Without header" ]
+            , Heading.h2 [ Heading.style Heading.Subhead ] [ text "Without header" ]
             , Table.viewWithoutHeader columns data
-            , Heading.h2 [ Heading.style Heading.Subhead ] [ Html.text "Loading" ]
+            , Heading.h2 [ Heading.style Heading.Subhead ] [ text "Loading" ]
             , Table.viewLoading columns
-            , Heading.h2 [ Heading.style Heading.Subhead ] [ Html.text "Loading without header" ]
+            , Heading.h2 [ Heading.style Heading.Subhead ] [ text "Loading without header" ]
             , Table.viewLoadingWithoutHeader columns
             ]
     }
@@ -158,3 +149,20 @@ type alias Settings =
 controlSettings : Control Settings
 controlSettings =
     Control.record Settings
+
+
+type alias Data =
+    { firstName : String
+    , lastName : String
+    , submitted : Int
+    }
+
+
+data : List Data
+data =
+    [ { firstName = "First1", lastName = "Last1", submitted = 10 }
+    , { firstName = "First2", lastName = "Last2", submitted = 0 }
+    , { firstName = "First3", lastName = "Last3", submitted = 3 }
+    , { firstName = "First4", lastName = "Last4", submitted = 15 }
+    , { firstName = "First5", lastName = "Last5", submitted = 8 }
+    ]

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -110,8 +110,6 @@ example =
             , Table.view columns data
             , Heading.h2 [ Heading.style Heading.Subhead ] [ Html.text "Without header" ]
             , Table.viewWithoutHeader columns data
-            , Heading.h2 [ Heading.style Heading.Subhead ] [ Html.text "With additional cell styles" ]
-            , Table.view columns data
             , Heading.h2 [ Heading.style Heading.Subhead ] [ Html.text "Loading" ]
             , Table.viewLoading columns
             , Heading.h2 [ Heading.style Heading.Subhead ] [ Html.text "Loading without header" ]

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -175,9 +175,9 @@ type alias Data =
 
 data : List Data
 data =
-    [ { firstName = "First1", lastName = "Last1", submitted = 10 }
-    , { firstName = "First2", lastName = "Last2", submitted = 0 }
-    , { firstName = "First3", lastName = "Last3", submitted = 3 }
-    , { firstName = "First4", lastName = "Last4", submitted = 15 }
-    , { firstName = "First5", lastName = "Last5", submitted = 8 }
+    [ { firstName = "Monique", lastName = "Garcia", submitted = 10 }
+    , { firstName = "Gabriel", lastName = "Smith", submitted = 0 }
+    , { firstName = "Mariah", lastName = "Lopez", submitted = 3 }
+    , { firstName = "Amber", lastName = "Brown", submitted = 15 }
+    , { firstName = "Carlos", lastName = "Martinez", submitted = 8 }
     ]


### PR DESCRIPTION
The table example now includes Ellie links, and highlights one example at a time. This is also much nicer if you find the loading animation irritating or distracting, since now you can see the static example without seeing the animation running!

<img width="1122" alt="" src="https://user-images.githubusercontent.com/8811312/170152653-5e1efc8d-ca3e-405d-87bd-f8d68d892ee5.png">
