### PR TITLE
Update ToolTip example table

### DIFF
--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -134,20 +134,26 @@ view ellieLinkConfig model =
     [ viewCustomizableExample ellieLinkConfig model.staticExampleSettings
     , Table.view
         [ Table.string
-            { header = "Attribute"
+            { header = "Type"
             , value = .name
             , width = Css.pct 15
-            , cellStyles = always []
+            , cellStyles = always [Css.padding2 Css.zero (Css.px 7)]
+            }
+        , Table.custom
+            { header = Html.text "Usage"
+            , view = .usage >> Markdown.toHtml Nothing >> List.map Html.fromUnstyled >> Html.span []
+            , width = Css.px 150
+            , cellStyles = always [Css.padding2 Css.zero (Css.px 7)]
             }
         , Table.custom
             { header = Html.text "About"
             , view = .description >> Markdown.toHtml Nothing >> List.map Html.fromUnstyled >> Html.span []
             , width = Css.px 200
-            , cellStyles = always []
+            , cellStyles = always [Css.padding2 Css.zero (Css.px 7)]
             }
         , Table.custom
-            { header = Html.text "view"
             , view = .view
+            { header = Html.text "Example"
             , width = Css.px 50
             , cellStyles = always [ Css.textAlign Css.center ]
             }

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -159,6 +159,13 @@ view ellieLinkConfig model =
             }
         ]
         [ { name = "Tooltip.primaryLabel"
+          , usage = """
+Use when all of the following are true:
+- the tooltip trigger does more than just reveal the tooltip content
+- the content of the tooltip is the same as the name of the tooltip trigger
+
+Think of this as the \"What.\"
+"""
           , description =
                 """
 Used when the content of the tooltip is identical to the accessible name.
@@ -172,6 +179,13 @@ This is the default.
           , tooltipId = PrimaryLabel
           }
         , { name = "Tooltip.auxiliaryDescription"
+        , usage = """
+Use when all of the following are true:
+- the tooltip trigger does more than just reveal the tooltip content
+- the content of the tooltip provides additional information about the functionality of the tooltip trigger itself.
+
+Think of this as the \"How.\"
+"""
           , description =
                 """
 Used when the content of the tooltip provides an "auxiliary description" for its content.
@@ -182,6 +196,11 @@ An auxiliary description is used when the tooltip content provides supplementary
           , tooltipId = AuxillaryDescription
           }
         , { name = "Tooltip.disclosure"
+        , usage = """
+Use when all of the following are true:
+- the tooltip trigger only opens the tooltip without doing anything else
+- the tooltip trigger ***isn't*** a \"?\" icon
+        """
           , description =
                 """
 Sometimes a "tooltip" only _looks_ like a tooltip, but is really more about hiding and showing extra information when the user asks for it.
@@ -194,6 +213,11 @@ For more information, please read [Sarah Higley's "Tooltips in the time of WCAG 
           , tooltipId = Disclosure
           }
         , { name = "Tooltip.viewToggleTip"
+        , usage = """
+Use when all of the following are true:
+- the tooltip trigger only opens the tooltip without doing anything else
+- the tooltip trigger ***is*** a \"?\" icon
+        """
           , description =
                 """
 Supplementary information triggered by a "?" icon.

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -169,12 +169,10 @@ Think of this as the \"What.\"
 """
           , description =
                 """
-Used when the content of the tooltip is identical to the accessible name.
+This is the default tooltip type.
 
-For example, when using the Tooltip component with the ClickableSvg component, the Tooltip is providing
-extra information to sighted users that screenreader users already have.
-
-This is the default.
+When using the Tooltip component with the ClickableSvg component, the Tooltip acts as a visible text indicator
+of ***what*** the tooltip trigger does. The same text is provided to assitive technology via the ClickableSvg's `name`.
 """
           , example = viewPrimaryLabelTooltip model.openTooltip
           , tooltipId = PrimaryLabel
@@ -189,9 +187,11 @@ Think of this as the \"How.\"
 """
           , description =
                 """
-Used when the content of the tooltip provides an "auxiliary description" for its content.
+In contrast to Tooltip.primaryLabel, Tooltip.auxiliaryDescription provides information about ***how*** the user should expect the tooltip target to behave when activated.
 
-An auxiliary description is used when the tooltip content provides supplementary information about its trigger content.
+Examples:
+- We might show an icon to indicate that a link opens in a new tab. This icon would have a tooltip to explain ***how*** the link will open.
+- On a Quick Write teacher preview, we use Tooltip.auxiliaryDescription on the Save button to let teachers know that the Save button will not actually save in the preview.
 """
           , example = viewAuxillaryDescriptionToolip model.openTooltip
           , tooltipId = AuxillaryDescription
@@ -204,11 +204,11 @@ Use when all of the following are true:
         """
           , description =
                 """
-Sometimes a "tooltip" only _looks_ like a tooltip, but is really more about hiding and showing extra information when the user asks for it.
+Sometimes a tooltip trigger doesn't have any functionality itself outside of revealing information.
 
 If clicking the "tooltip trigger" only ever shows you more info (and especially if this info is rich or interactable), use this attribute.
 
-For more information, please read [Sarah Higley's "Tooltips in the time of WCAG 2.1" post](https://sarahmhigley.com/writing/tooltips-in-wcag-21).
+This behavior is analogous to disclosure behavior, except that it's presented different visually. (For more information, please read [Sarah Higley's "Tooltips in the time of WCAG 2.1" post](https://sarahmhigley.com/writing/tooltips-in-wcag-21).)
 """
           , example = viewDisclosureToolip model.openTooltip
           , tooltipId = Disclosure
@@ -221,9 +221,7 @@ Use when all of the following are true:
         """
           , description =
                 """
-Supplementary information triggered by a "?" icon.
-
-This is a helper for setting up a commonly-used `disclosure` tooltip. Please see the documentation for `disclosure` to learn more.
+This is a helper for using Tooltip.disclosure with a "?" icon because it is a commonly used UI pattern. We use this helper when we want to show more information about an element but we don't want the element itself to have its own tooltip. The "?" icon typically appears visually adjacent to the element it reveals information about. Please see the documentation for `disclosure` to learn more.
 """
           , example = viewToggleTip model.openTooltip
           , tooltipId = LearnMore

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -20,6 +20,7 @@ import Html.Styled.Attributes exposing (css, href, id)
 import KeyboardSupport exposing (Key(..))
 import Markdown
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
+import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Table.V5 as Table
@@ -258,13 +259,13 @@ viewAuxillaryDescriptionToolip openTooltip =
         { id = "tooltip__auxiliaryDescription"
         , trigger =
             \eventHandlers ->
-                ClickableSvg.button "Period 1"
-                    UiIcon.class
-                    [ ClickableSvg.custom eventHandlers
-                    , ClickableSvg.onClick (Log "You totally started managing Periud 1.")
+                ClickableText.link "Tooltips & Toggletips"
+                    [ ClickableText.custom eventHandlers
+                    ,ClickableText.icon UiIcon.openInNewTab
+                    ,ClickableText.linkExternal "https://inclusive-components.design/tooltips-toggletips/"
                     ]
         }
-        [ Tooltip.plaintext "Manage class and students"
+        [ Tooltip.plaintext "Opens in a new window"
         , Tooltip.auxiliaryDescription
         , Tooltip.onToggle (ToggleTooltip AuxillaryDescription)
         , Tooltip.open (openTooltip == Just AuxillaryDescription)

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -138,19 +138,19 @@ view ellieLinkConfig model =
             { header = "Type"
             , value = .name
             , width = Css.pct 15
-            , cellStyles = always [Css.padding2 Css.zero (Css.px 7)]
+            , cellStyles = always [ Css.padding2 Css.zero (Css.px 7) ]
             }
         , Table.custom
             { header = Html.text "Usage"
             , view = .usage >> Markdown.toHtml Nothing >> List.map Html.fromUnstyled >> Html.span []
             , width = Css.px 150
-            , cellStyles = always [Css.padding2 Css.zero (Css.px 7)]
+            , cellStyles = always [ Css.padding2 Css.zero (Css.px 7) ]
             }
         , Table.custom
             { header = Html.text "About"
             , view = .description >> Markdown.toHtml Nothing >> List.map Html.fromUnstyled >> Html.span []
             , width = Css.px 200
-            , cellStyles = always [Css.padding2 Css.zero (Css.px 7)]
+            , cellStyles = always [ Css.padding2 Css.zero (Css.px 7) ]
             }
         , Table.custom
             { header = Html.text "Example"
@@ -165,7 +165,7 @@ Use when all of the following are true:
 - the tooltip trigger does more than just reveal the tooltip content
 - the content of the tooltip is the same as the name of the tooltip trigger
 
-Think of this as the \"What.\"
+Think of this as the "What."
 """
           , description =
                 """
@@ -178,12 +178,12 @@ of ***what*** the tooltip trigger does. The same text is provided to assitive te
           , tooltipId = PrimaryLabel
           }
         , { name = "Tooltip.auxiliaryDescription"
-        , usage = """
+          , usage = """
 Use when all of the following are true:
 - the tooltip trigger does more than just reveal the tooltip content
 - the content of the tooltip provides additional information about the functionality of the tooltip trigger itself.
 
-Think of this as the \"How.\"
+Think of this as the "How."
 """
           , description =
                 """
@@ -197,10 +197,10 @@ Examples:
           , tooltipId = AuxillaryDescription
           }
         , { name = "Tooltip.disclosure"
-        , usage = """
+          , usage = """
 Use when all of the following are true:
 - the tooltip trigger only opens the tooltip without doing anything else
-- the tooltip trigger ***isn't*** a \"?\" icon
+- the tooltip trigger ***isn't*** a "?" icon
         """
           , description =
                 """
@@ -214,10 +214,10 @@ This behavior is analogous to disclosure behavior, except that it's presented di
           , tooltipId = Disclosure
           }
         , { name = "Tooltip.viewToggleTip"
-        , usage = """
+          , usage = """
 Use when all of the following are true:
 - the tooltip trigger only opens the tooltip without doing anything else
-- the tooltip trigger ***is*** a \"?\" icon
+- the tooltip trigger ***is*** a "?" icon
         """
           , description =
                 """
@@ -259,8 +259,8 @@ viewAuxillaryDescriptionToolip openTooltip =
             \eventHandlers ->
                 ClickableText.link "Tooltips & Toggletips"
                     [ ClickableText.custom eventHandlers
-                    ,ClickableText.icon UiIcon.openInNewTab
-                    ,ClickableText.linkExternal "https://inclusive-components.design/tooltips-toggletips/"
+                    , ClickableText.icon UiIcon.openInNewTab
+                    , ClickableText.linkExternal "https://inclusive-components.design/tooltips-toggletips/"
                     ]
         }
         [ Tooltip.plaintext "Opens in a new window"

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -152,8 +152,8 @@ view ellieLinkConfig model =
             , cellStyles = always [Css.padding2 Css.zero (Css.px 7)]
             }
         , Table.custom
-            , view = .view
             { header = Html.text "Example"
+            , view = .example
             , width = Css.px 50
             , cellStyles = always [ Css.textAlign Css.center ]
             }
@@ -168,7 +168,7 @@ extra information to sighted users that screenreader users already have.
 
 This is the default.
 """
-          , view = viewPrimaryLabelTooltip model.openTooltip
+          , example = viewPrimaryLabelTooltip model.openTooltip
           , tooltipId = PrimaryLabel
           }
         , { name = "Tooltip.auxiliaryDescription"
@@ -178,7 +178,7 @@ Used when the content of the tooltip provides an "auxiliary description" for its
 
 An auxiliary description is used when the tooltip content provides supplementary information about its trigger content.
 """
-          , view = viewAuxillaryDescriptionToolip model.openTooltip
+          , example = viewAuxillaryDescriptionToolip model.openTooltip
           , tooltipId = AuxillaryDescription
           }
         , { name = "Tooltip.disclosure"
@@ -190,7 +190,7 @@ If clicking the "tooltip trigger" only ever shows you more info (and especially 
 
 For more information, please read [Sarah Higley's "Tooltips in the time of WCAG 2.1" post](https://sarahmhigley.com/writing/tooltips-in-wcag-21).
 """
-          , view = viewDisclosureToolip model.openTooltip
+          , example = viewDisclosureToolip model.openTooltip
           , tooltipId = Disclosure
           }
         , { name = "Tooltip.viewToggleTip"
@@ -200,7 +200,7 @@ Supplementary information triggered by a "?" icon.
 
 This is a helper for setting up a commonly-used `disclosure` tooltip. Please see the documentation for `disclosure` to learn more.
 """
-          , view = viewToggleTip model.openTooltip
+          , example = viewToggleTip model.openTooltip
           , tooltipId = LearnMore
           }
         ]


### PR DESCRIPTION
## What's this?
Updates the ToolTip example table:
- Clearer headings
- Separate out usage info from further details
   - Usage for each type follows a consistent format for clearer distinction between types
- Updates auxiliaryDescription  example

## Outfoxes
Partially fixes A11-824
Kristine doing some noredink-ui stuff, messing with baby Elm, and getting to work with Tessa 🎉 

## TODOs
[TODOs are in Linear](https://linear.app/noredink/issue/A11-824/clarify-tooltip-types-table-in-noredink-ui).

## Reviewer, please...
- check for accuracy of information.
- let me know if TODOs are okay in Linear or if they should go in an issue in this repo instead.
- feel free to remove "Please see the documentation for disclosure to learn more." in the new wording if you think it makes sense to do so. I wasn't sure if I should.
- flag any text you don't like.
- provide any other feedback!