### PR TITLE
Add small content breakpoint

### DIFF
--- a/src/Nri/Ui/MediaQuery/V1.elm
+++ b/src/Nri/Ui/MediaQuery/V1.elm
@@ -25,6 +25,9 @@ module Nri.Ui.MediaQuery.V1 exposing
 @docs quizEngineMobile
 @docs quizEngineBreakpoint
 
+@docs narrowMobile
+@docs narrowMobileBreakPoint
+
 -}
 
 import Css exposing (px)

--- a/src/Nri/Ui/MediaQuery/V1.elm
+++ b/src/Nri/Ui/MediaQuery/V1.elm
@@ -3,6 +3,7 @@ module Nri.Ui.MediaQuery.V1 exposing
     , mobileBreakpoint
     , quizEngineMobile
     , quizEngineBreakpoint
+    , narrowMobile, narrowMobileBreakPoint
     )
 
 {-| Standard media queries for responsive pages.
@@ -73,3 +74,22 @@ quizEngineMobile =
 quizEngineBreakpoint : Css.Px
 quizEngineBreakpoint =
     px 750
+
+
+{-| Styles using the `narrowMobileBreakPoint` value as the maxWidth
+-}
+narrowMobile : MediaQuery
+narrowMobile =
+    only screen
+        [ --`minWidth (px 1)` is for a bug in IE which causes the media query to initially trigger regardless of window size
+          --See: <http://stackoverflow.com/questions/25673707/ie11-triggers-css-transition-on-page-load-when-non-applied-media-query-exists/25850649#25850649>
+          minWidth (px 1)
+        , maxWidth narrowMobileBreakPoint
+        ]
+
+
+{-| 500px
+-}
+narrowMobileBreakPoint : Css.Px
+narrowMobileBreakPoint =
+    px 500

--- a/src/Nri/Ui/MediaQuery/V1.elm
+++ b/src/Nri/Ui/MediaQuery/V1.elm
@@ -3,7 +3,8 @@ module Nri.Ui.MediaQuery.V1 exposing
     , mobileBreakpoint
     , quizEngineMobile
     , quizEngineBreakpoint
-    , narrowMobile, narrowMobileBreakPoint
+    , narrowMobile
+    , narrowMobileBreakPoint
     )
 
 {-| Standard media queries for responsive pages.


### PR DESCRIPTION
This breakpoint is a recommendation from @bendansby to small contents. One use case for this is to remove stick position for some instructions on quiz engine, for example:
https://airtable.com/app1BuwWPTsZykPWh/pagO9Ogb7flpSdkCj?Inx0b=recPCDllBWeKBrvw2