### PR TITLE
Adds a customizable Carousel

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -13,6 +13,7 @@
         "Nri.Ui.Balloon.V1",
         "Nri.Ui.BreadCrumbs.V1",
         "Nri.Ui.Button.V10",
+        "Nri.Ui.Carousel.V1",
         "Nri.Ui.Checkbox.V5",
         "Nri.Ui.ClickableSvg.V2",
         "Nri.Ui.ClickableText.V3",

--- a/src/Nri/Ui/Carousel/V1.elm
+++ b/src/Nri/Ui/Carousel/V1.elm
@@ -1,15 +1,34 @@
-module Nri.Ui.Carousel.V1 exposing (Item, buildItem, view)
+module Nri.Ui.Carousel.V1 exposing
+    ( view
+    , Item
+    , buildItem
+    )
+
+{-|
+
+@docs view
+@docs Item
+@docs buildItem
+
+-}
 
 import Css exposing (..)
 import Html.Styled as Html exposing (Html)
 import TabsInternal.V2 as TabsInternal
 
 
+{-| -}
 type Item id msg
     = Item (TabsInternal.Tab id msg)
 
 
-{-| -}
+{-| Builds an selectable item in the Caroursel
+
+`controlHtml` represents the element that will appear in the list of options.
+
+`slideHtml` represents the element that will be shown in your carousel when this item is selected.
+
+-}
 buildItem : { id : id, idString : String, slideHtml : Html msg, controlHtml : Html Never } -> Item id msg
 buildItem config =
     Item
@@ -20,12 +39,13 @@ buildItem config =
         )
 
 
+{-| -}
 view :
     { focusAndSelect : { select : id, focus : Maybe String } -> msg
     , selected : id
-    , items : List (Item id msg)
     , controlStyles : Bool -> List Style
     , controlListStyles : List Style
+    , items : List (Item id msg)
     }
     -> { controls : Html msg, slides : Html msg }
 view config =

--- a/src/Nri/Ui/Carousel/V1.elm
+++ b/src/Nri/Ui/Carousel/V1.elm
@@ -1,0 +1,94 @@
+module Nri.Ui.Carousel.V1 exposing (..)
+
+import Css exposing (..)
+import Html.Styled as Html exposing (Html)
+import Nri.Ui
+import Nri.Ui.Tooltip.V3 as Tooltip
+import TabsInternal.V2 as TabsInternal
+
+
+type Tab id msg
+    = Tab (TabsInternal.Tab id msg)
+
+
+type Attribute id msg
+    = Attribute (TabsInternal.Tab id msg -> TabsInternal.Tab id msg)
+
+
+type TabPosition
+    = Before
+    | After
+
+
+{-| Tooltip defaults: `[Tooltip.smallPadding, Tooltip.onBottom, Tooltip.fitToContent]`
+-}
+withTooltip : List (Tooltip.Attribute msg) -> Attribute id msg
+withTooltip attributes =
+    Attribute (\tab -> { tab | tabTooltip = attributes })
+
+
+{-| Makes it so that the tab can't be clicked or focused via keyboard navigation
+-}
+disabled : Bool -> Attribute id msg
+disabled isDisabled =
+    Attribute (\tab -> { tab | disabled = isDisabled })
+
+
+{-| -}
+slideHtml : Html msg -> Attribute id msg
+slideHtml content =
+    Attribute (\tab -> { tab | panelView = content })
+
+
+labelledBy : String -> Attribute id msg
+labelledBy labelledById =
+    Attribute (\tab -> { tab | labelledBy = Just labelledById })
+
+
+tabHtml : Html Never -> Attribute id msg
+tabHtml content =
+    Attribute (\tab -> { tab | tabView = [ Html.map never content ] })
+
+
+{-| -}
+buildTab : { id : id, idString : String } -> List (Attribute id msg) -> Tab id msg
+buildTab config attributes =
+    Tab (TabsInternal.fromList config (List.map (\(Attribute f) -> f) attributes))
+
+
+view :
+    { focusAndSelect : { select : id, focus : Maybe String } -> msg
+    , selected : id
+    , tabs : List (Tab id msg)
+    , tabStyles : Int -> Bool -> List Style
+    , tabListStyles : List Style
+    , containerStyles : List Style
+    , tabListPosition : TabPosition
+    }
+    -> Html msg
+view config =
+    let
+        { tabList, tabPanels } =
+            TabsInternal.views
+                { focusAndSelect = config.focusAndSelect
+                , selected = config.selected
+                , tabs = List.map (\(Tab t) -> t) config.tabs
+                , tabStyles = config.tabStyles
+                , tabListStyles = config.tabListStyles
+                }
+    in
+    Nri.Ui.styled Html.div
+        "Nri-Ui-Carousel__container"
+        config.containerStyles
+        []
+        (case config.tabListPosition of
+            Before ->
+                [ tabList
+                , tabPanels
+                ]
+
+            After ->
+                [ tabPanels
+                , tabList
+                ]
+        )

--- a/styleguide-app/Debug/Control/View.elm
+++ b/styleguide-app/Debug/Control/View.elm
@@ -1,6 +1,6 @@
 module Debug.Control.View exposing
     ( view
-    , codeFromListSimple
+    , codeFromListSimple, codeFromListSimpleWithIndentLevel
     , codeFromList, codeFromListWithIndentLevel
     , codeFromListWithHardcoded
     , withIndentLevel
@@ -9,9 +9,10 @@ module Debug.Control.View exposing
 {-|
 
 @docs view
-@docs codeFromListSimple
+@docs codeFromListSimple, codeFromListSimpleWithIndentLevel
 @docs codeFromList, codeFromListWithIndentLevel
 @docs codeFromListWithHardcoded
+
 @docs withIndentLevel
 
 -}

--- a/styleguide-app/Examples.elm
+++ b/styleguide-app/Examples.elm
@@ -6,6 +6,7 @@ import Examples.AssignmentIcon as AssignmentIcon
 import Examples.Balloon as Balloon
 import Examples.BreadCrumbs as BreadCrumbs
 import Examples.Button as Button
+import Examples.Carousel as Carousel
 import Examples.Checkbox as Checkbox
 import Examples.ClickableSvg as ClickableSvg
 import Examples.ClickableText as ClickableText
@@ -134,6 +135,25 @@ all =
             (\msg ->
                 case msg of
                     ButtonState childState ->
+                        Just childState
+
+                    _ ->
+                        Nothing
+            )
+    , Carousel.example
+        |> Example.wrapMsg CarouselMsg
+            (\msg ->
+                case msg of
+                    CarouselMsg childMsg ->
+                        Just childMsg
+
+                    _ ->
+                        Nothing
+            )
+        |> Example.wrapState CarouselState
+            (\msg ->
+                case msg of
+                    CarouselState childState ->
                         Just childState
 
                     _ ->
@@ -794,6 +814,7 @@ type State
     | BalloonState Balloon.State
     | BreadCrumbsState BreadCrumbs.State
     | ButtonState Button.State
+    | CarouselState Carousel.State
     | CheckboxState Checkbox.State
     | ClickableSvgState ClickableSvg.State
     | ClickableTextState ClickableText.State
@@ -836,6 +857,7 @@ type Msg
     | BalloonMsg Balloon.Msg
     | BreadCrumbsMsg BreadCrumbs.Msg
     | ButtonMsg Button.Msg
+    | CarouselMsg Carousel.Msg
     | CheckboxMsg Checkbox.Msg
     | ClickableSvgMsg ClickableSvg.Msg
     | ClickableTextMsg ClickableText.Msg

--- a/styleguide-app/Examples/Carousel.elm
+++ b/styleguide-app/Examples/Carousel.elm
@@ -15,6 +15,7 @@ import Browser.Dom as Dom
 import Category exposing (Category(..))
 import Css exposing (Style)
 import Debug.Control as Control exposing (Control)
+import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled as Html exposing (fromUnstyled)
 import Html.Styled.Attributes as Attributes
@@ -82,15 +83,20 @@ update msg model =
             ( { model | settings = settings }, Cmd.none )
 
 
-exampleName : String
-exampleName =
+moduleName : String
+moduleName =
     "Carousel"
+
+
+version : Int
+version =
+    1
 
 
 example : Example State Msg
 example =
-    { name = exampleName
-    , version = 1
+    { name = moduleName
+    , version = version
     , categories = [ Layout ]
     , keyboardSupport =
         [ { keys = [ KeyboardSupport.Tab ]
@@ -114,7 +120,24 @@ example =
                 settings =
                     Control.currentValue model.settings
             in
-            [ Control.view SetSettings model.settings |> fromUnstyled
+            [ ControlView.view
+                { ellieLinkConfig = ellieLinkConfig
+                , name = moduleName
+                , version = version
+                , update = SetSettings
+                , settings = model.settings
+                , mainType = "RootHtml.Html String"
+                , extraImports = []
+                , toExampleCode =
+                    \_ ->
+                        [ { sectionName = "Tab-list Before example"
+                          , code = "TODO"
+                          }
+                        , { sectionName = "Tab-list After example"
+                          , code = "TODO"
+                          }
+                        ]
+                }
             , Carousel.view
                 { focusAndSelect = FocusAndSelectTab
                 , selected = model.selected

--- a/styleguide-app/Examples/Carousel.elm
+++ b/styleguide-app/Examples/Carousel.elm
@@ -18,6 +18,7 @@ import Debug.Control.Extra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled as Html
+import Html.Styled.Attributes as Attributes
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Carousel.V1 as Carousel
 import Nri.Ui.Colors.V1 as Colors
@@ -62,29 +63,32 @@ controlControlListStyles =
         |> Control.map (Maybe.withDefault ( "[]", [] ))
 
 
+controlStyles : Bool -> List Css.Style
+controlStyles isSelected =
+    let
+        ( backgroundColor, textColor ) =
+            if isSelected then
+                ( Colors.azure, Colors.white )
+
+            else
+                ( Colors.gray92, Colors.gray20 )
+    in
+    [ Css.padding2 (Css.px 10) (Css.px 20)
+    , Css.backgroundColor backgroundColor
+    , Css.borderRadius (Css.px 8)
+    , Css.border Css.zero
+    , Css.color textColor
+    , Css.cursor Css.pointer
+    ]
+
+
 controlControlStyles : Control ( String, Bool -> List Css.Style )
 controlControlStyles =
     let
         simplifiedCodeVersion =
             "\\isSelected -> [ -- styles that depend on selection status\n    ]"
     in
-    (\isSelected ->
-        let
-            ( backgroundColor, textColor ) =
-                if isSelected then
-                    ( Colors.azure, Colors.white )
-
-                else
-                    ( Colors.gray92, Colors.gray20 )
-        in
-        [ Css.padding2 (Css.px 10) (Css.px 20)
-        , Css.backgroundColor backgroundColor
-        , Css.borderRadius (Css.px 8)
-        , Css.border Css.zero
-        , Css.color textColor
-        , Css.cursor Css.pointer
-        ]
-    )
+    controlStyles
         |> Control.value
         |> Control.maybe False
         |> Control.map (Maybe.withDefault (\_ -> []))
@@ -144,7 +148,17 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , preview =
-        []
+        [ -- faking a mini version of the Carousel component to give styleguide users a sense of what the
+          -- component might look like
+          Html.div []
+            [ Html.text "1 slide"
+            , Html.div [ Attributes.css [ Css.displayFlex, Css.property "gap" "5px" ] ]
+                [ Html.div [ Attributes.css (controlStyles True) ] [ Html.text "1" ]
+                , Html.div [ Attributes.css (controlStyles False) ] [ Html.text "2" ]
+                , Html.div [ Attributes.css (controlStyles False) ] [ Html.text "2" ]
+                ]
+            ]
+        ]
     , view =
         \ellieLinkConfig model ->
             let

--- a/styleguide-app/Examples/Carousel.elm
+++ b/styleguide-app/Examples/Carousel.elm
@@ -46,7 +46,11 @@ init =
 
 
 type alias Settings =
-    { tabListPosition : Carousel.TabPosition }
+    { tabListPosition : Carousel.TabPosition
+    , tabListStyles : List Style
+    , tabStyles : Int -> Bool -> List Style
+    , containerStyles : List Style
+    }
 
 
 initSettings : Control Settings
@@ -58,6 +62,51 @@ initSettings =
                 , ( "After", Control.value After )
                 ]
             )
+        |> Control.field "tabListStyles" controlTabListStyles
+        |> Control.field "tabStyles" controlTabStyles
+        |> Control.field "containerStyles" controlContainerStyles
+
+
+controlTabListStyles : Control (List Style)
+controlTabListStyles =
+    [ Css.displayFlex
+    , Css.property "gap" "20px"
+    ]
+        |> Control.value
+        |> Control.maybe False
+        |> Control.map (Maybe.withDefault [])
+
+
+controlTabStyles : Control (Int -> Bool -> List Css.Style)
+controlTabStyles =
+    (\_ isSelected ->
+        let
+            ( backgroundColor, textColor ) =
+                if isSelected then
+                    ( Colors.azure, Colors.white )
+
+                else
+                    ( Colors.gray92, Colors.gray20 )
+        in
+        [ Css.padding2 (Css.px 10) (Css.px 20)
+        , Css.backgroundColor backgroundColor
+        , Css.borderRadius (Css.px 8)
+        , Css.border Css.zero
+        , Css.color textColor
+        , Css.cursor Css.pointer
+        ]
+    )
+        |> Control.value
+        |> Control.maybe False
+        |> Control.map (Maybe.withDefault (\_ _ -> []))
+
+
+controlContainerStyles : Control (List Style)
+controlContainerStyles =
+    [ Css.margin (Css.px 20) ]
+        |> Control.value
+        |> Control.maybe False
+        |> Control.map (Maybe.withDefault [])
 
 
 type Msg
@@ -141,45 +190,14 @@ example =
             , Carousel.view
                 { focusAndSelect = FocusAndSelectTab
                 , selected = model.selected
-                , tabListStyles = tabListStyles
-                , tabStyles = tabStyles
-                , containerStyles = containerStyles
+                , tabListStyles = settings.tabListStyles
+                , tabStyles = settings.tabStyles
+                , containerStyles = settings.containerStyles
                 , tabListPosition = settings.tabListPosition
                 , tabs = allTabs
                 }
             ]
     }
-
-
-containerStyles : List Style
-containerStyles =
-    [ Css.margin (Css.px 20) ]
-
-
-tabListStyles : List Style
-tabListStyles =
-    [ Css.displayFlex
-    , Css.property "gap" "20px"
-    ]
-
-
-tabStyles : Int -> Bool -> List Css.Style
-tabStyles _ isSelected =
-    let
-        ( backgroundColor, textColor ) =
-            if isSelected then
-                ( Colors.azure, Colors.white )
-
-            else
-                ( Colors.gray92, Colors.gray20 )
-    in
-    [ Css.padding2 (Css.px 10) (Css.px 20)
-    , Css.backgroundColor backgroundColor
-    , Css.borderRadius (Css.px 8)
-    , Css.border Css.zero
-    , Css.color textColor
-    , Css.cursor Css.pointer
-    ]
 
 
 slideStyles : List Style

--- a/styleguide-app/Examples/Carousel.elm
+++ b/styleguide-app/Examples/Carousel.elm
@@ -1,13 +1,12 @@
 module Examples.Carousel exposing
     ( example
-    , State
-    , Msg
+    , State, Msg
     )
 
 {-|
 
 @docs example
-@docs State, msg
+@docs State, Msg
 
 -}
 

--- a/styleguide-app/Examples/Carousel.elm
+++ b/styleguide-app/Examples/Carousel.elm
@@ -200,14 +200,6 @@ example =
     }
 
 
-slideStyles : List Style
-slideStyles =
-    [ Css.marginTop (Css.px 20)
-    , Css.padding2 (Css.px 10) (Css.px 30)
-    , Css.borderRadius (Css.px 4)
-    ]
-
-
 allTabs : List (Tab Id Msg)
 allTabs =
     [ ( First, "first", "1" )
@@ -219,6 +211,6 @@ allTabs =
             (\( id, idString, buttonText ) ->
                 Carousel.buildTab { id = id, idString = idString ++ "-slide" }
                     [ Carousel.tabHtml (Html.text buttonText)
-                    , Carousel.slideHtml (Html.div [ Attributes.css slideStyles ] [ Html.text <| idString ++ " slide" ])
+                    , Carousel.slideHtml (Html.text <| idString ++ " slide")
                     ]
             )

--- a/styleguide-app/Examples/Carousel.elm
+++ b/styleguide-app/Examples/Carousel.elm
@@ -197,6 +197,7 @@ example =
                                 , "    , controlStyles = " ++ Tuple.first settings.controlStyles
                                 , "    , items =" ++ ControlView.codeFromListSimpleWithIndentLevel 2 (List.map Tuple.first allItems)
                                 , "    }"
+                                , "    |> (\\{ controls, slides } -> section [] [ slides, controls ] )"
                                 ]
                                     |> String.join "\n"
                         in
@@ -219,8 +220,8 @@ toCarouselItem id _ =
     ( [ "Carousel.buildItem"
       , "        { id = " ++ idString
       , "        , idString = \"" ++ idString ++ "-slide\""
-      , "        , controlHtml (Html.text \"" ++ String.fromInt (id + 1) ++ "\")"
-      , "        , slideHtml (Html.text \"" ++ String.fromInt (id + 1) ++ " slide\")"
+      , "        , controlHtml = Html.text \"" ++ String.fromInt (id + 1) ++ "\""
+      , "        , slideHtml = Html.text \"" ++ String.fromInt (id + 1) ++ " slide\""
       , "        }"
       ]
         |> String.join "\n    "

--- a/styleguide-app/Examples/Carousel.elm
+++ b/styleguide-app/Examples/Carousel.elm
@@ -171,13 +171,14 @@ tabStyles _ isSelected =
                 ( Colors.azure, Colors.white )
 
             else
-                ( Colors.gray92, Colors.gray45 )
+                ( Colors.gray92, Colors.gray20 )
     in
     [ Css.padding2 (Css.px 10) (Css.px 20)
     , Css.backgroundColor backgroundColor
     , Css.borderRadius (Css.px 8)
     , Css.border Css.zero
     , Css.color textColor
+    , Css.cursor Css.pointer
     ]
 
 

--- a/styleguide-app/Examples/Carousel.elm
+++ b/styleguide-app/Examples/Carousel.elm
@@ -13,7 +13,7 @@ module Examples.Carousel exposing
 
 import Browser.Dom as Dom
 import Category exposing (Category(..))
-import Css
+import Css exposing (Style)
 import Debug.Control as Control exposing (Control)
 import Example exposing (Example)
 import Html.Styled as Html exposing (fromUnstyled)
@@ -128,10 +128,12 @@ example =
     }
 
 
+containerStyles : List Style
 containerStyles =
     [ Css.margin (Css.px 20) ]
 
 
+tabListStyles : List Style
 tabListStyles =
     [ Css.displayFlex
     , Css.property "gap" "20px"
@@ -156,6 +158,7 @@ tabStyles _ isSelected =
     ]
 
 
+slideStyles : List Style
 slideStyles =
     [ Css.marginTop (Css.px 20)
     , Css.padding2 (Css.px 10) (Css.px 30)

--- a/styleguide-app/Examples/Carousel.elm
+++ b/styleguide-app/Examples/Carousel.elm
@@ -1,0 +1,179 @@
+module Examples.Carousel exposing
+    ( example
+    , State
+    , Msg
+    )
+
+{-|
+
+@docs example
+@docs State, msg
+
+-}
+
+import Browser.Dom as Dom
+import Category exposing (Category(..))
+import Css
+import Debug.Control as Control exposing (Control)
+import Example exposing (Example)
+import Html.Styled as Html exposing (fromUnstyled)
+import Html.Styled.Attributes as Attributes
+import KeyboardSupport exposing (Key(..))
+import Nri.Ui.Carousel.V1 as Carousel exposing (Tab, TabPosition(..))
+import Nri.Ui.Colors.V1 as Colors
+import Task
+
+
+type Id
+    = First
+    | Second
+    | Third
+    | Fourth
+
+
+type alias State =
+    { selected : Id
+    , settings : Control Settings
+    }
+
+
+init : State
+init =
+    { selected = First
+    , settings = initSettings
+    }
+
+
+type alias Settings =
+    { tabListPosition : Carousel.TabPosition }
+
+
+initSettings : Control Settings
+initSettings =
+    Control.record Settings
+        |> Control.field "tabListPosition"
+            (Control.choice
+                [ ( "Before", Control.value Before )
+                , ( "After", Control.value After )
+                ]
+            )
+
+
+type Msg
+    = FocusAndSelectTab { select : Id, focus : Maybe String }
+    | Focused (Result Dom.Error ())
+    | SetSettings (Control Settings)
+
+
+update : Msg -> State -> ( State, Cmd Msg )
+update msg model =
+    case msg of
+        FocusAndSelectTab { select, focus } ->
+            ( { model | selected = select }
+            , focus
+                |> Maybe.map (Dom.focus >> Task.attempt Focused)
+                |> Maybe.withDefault Cmd.none
+            )
+
+        Focused error ->
+            ( model, Cmd.none )
+
+        SetSettings settings ->
+            ( { model | settings = settings }, Cmd.none )
+
+
+exampleName : String
+exampleName =
+    "Carousel"
+
+
+example : Example State Msg
+example =
+    { name = exampleName
+    , version = 1
+    , categories = [ Layout ]
+    , keyboardSupport =
+        [ { keys = [ KeyboardSupport.Tab ]
+          , result = "Move focus to the currently-selected Tab's tab panel"
+          }
+        , { keys = [ Arrow KeyboardSupport.Left ]
+          , result = "Select the tab to the left of the currently-selected Tab"
+          }
+        , { keys = [ Arrow KeyboardSupport.Right ]
+          , result = "Select the tab to the right of the currently-selected Tab"
+          }
+        ]
+    , state = init
+    , update = update
+    , subscriptions = \_ -> Sub.none
+    , preview =
+        []
+    , view =
+        \ellieLinkConfig model ->
+            let
+                settings =
+                    Control.currentValue model.settings
+            in
+            [ Control.view SetSettings model.settings |> fromUnstyled
+            , Carousel.view
+                { focusAndSelect = FocusAndSelectTab
+                , selected = model.selected
+                , tabListStyles = tabListStyles
+                , tabStyles = tabStyles
+                , containerStyles = containerStyles
+                , tabListPosition = settings.tabListPosition
+                , tabs = allTabs
+                }
+            ]
+    }
+
+
+containerStyles =
+    [ Css.margin (Css.px 20) ]
+
+
+tabListStyles =
+    [ Css.displayFlex
+    , Css.property "gap" "20px"
+    ]
+
+
+tabStyles : Int -> Bool -> List Css.Style
+tabStyles _ isSelected =
+    let
+        ( backgroundColor, textColor ) =
+            if isSelected then
+                ( Colors.azure, Colors.white )
+
+            else
+                ( Colors.gray92, Colors.gray45 )
+    in
+    [ Css.padding2 (Css.px 10) (Css.px 20)
+    , Css.backgroundColor backgroundColor
+    , Css.borderRadius (Css.px 8)
+    , Css.border Css.zero
+    , Css.color textColor
+    ]
+
+
+slideStyles =
+    [ Css.marginTop (Css.px 20)
+    , Css.padding2 (Css.px 10) (Css.px 30)
+    , Css.borderRadius (Css.px 4)
+    ]
+
+
+allTabs : List (Tab Id Msg)
+allTabs =
+    [ ( First, "first", "1" )
+    , ( Second, "second", "2" )
+    , ( Third, "third", "3" )
+    , ( Fourth, "fourth", "4" )
+    ]
+        |> List.map
+            (\( id, idString, buttonText ) ->
+                Carousel.buildTab { id = id, idString = idString ++ "-slide" }
+                    [ Carousel.tabHtml (Html.text buttonText)
+                    , Carousel.slideHtml (Html.div [ Attributes.css slideStyles ] [ Html.text <| idString ++ " slide" ])
+                    ]
+            )

--- a/styleguide-app/Examples/Carousel.elm
+++ b/styleguide-app/Examples/Carousel.elm
@@ -16,6 +16,7 @@ import Category exposing (Category(..))
 import CommonControls
 import Css exposing (Style)
 import Debug.Control as Control exposing (Control)
+import Debug.Control.Extra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled as Html exposing (fromUnstyled)
@@ -26,28 +27,22 @@ import Nri.Ui.Colors.V1 as Colors
 import Task
 
 
-type Id
-    = First
-    | Second
-    | Third
-    | Fourth
-
-
 type alias State =
-    { selected : Id
+    { selected : Int
     , settings : Control Settings
     }
 
 
 init : State
 init =
-    { selected = First
+    { selected = 0
     , settings = initSettings
     }
 
 
 type alias Settings =
-    { tabListPosition : ( String, Carousel.TabPosition )
+    { tabs : Int
+    , tabListPosition : ( String, Carousel.TabPosition )
     , tabListStyles : ( String, List Style )
     , tabStyles : ( String, Int -> Bool -> List Style )
     , containerStyles : ( String, List Style )
@@ -57,6 +52,7 @@ type alias Settings =
 initSettings : Control Settings
 initSettings =
     Control.record Settings
+        |> Control.field "tabs" (Debug.Control.Extra.int 4)
         |> Control.field "tabListPosition"
             (CommonControls.choice moduleName
                 [ ( "Before", Before )
@@ -116,7 +112,7 @@ controlContainerStyles =
 
 
 type Msg
-    = FocusAndSelectTab { select : Id, focus : Maybe String }
+    = FocusAndSelectTab { select : Int, focus : Maybe String }
     | Focused (Result Dom.Error ())
     | SetSettings (Control Settings)
 
@@ -211,23 +207,17 @@ example =
                 , tabStyles = Tuple.second settings.tabStyles
                 , containerStyles = Tuple.second settings.containerStyles
                 , tabListPosition = Tuple.second settings.tabListPosition
-                , tabs = allTabs
+                , tabs =
+                    List.repeat settings.tabs ()
+                        |> List.indexedMap toTab
                 }
             ]
     }
 
 
-allTabs : List (Tab Id Msg)
-allTabs =
-    [ ( First, "first", "1" )
-    , ( Second, "second", "2" )
-    , ( Third, "third", "3" )
-    , ( Fourth, "fourth", "4" )
-    ]
-        |> List.map
-            (\( id, idString, buttonText ) ->
-                Carousel.buildTab { id = id, idString = idString ++ "-slide" }
-                    [ Carousel.tabHtml (Html.text buttonText)
-                    , Carousel.slideHtml (Html.text <| idString ++ " slide")
-                    ]
-            )
+toTab : Int -> a -> Tab Int msg
+toTab id _ =
+    Carousel.buildTab { id = id, idString = String.fromInt id ++ "-slide" }
+        [ Carousel.tabHtml (Html.text (String.fromInt (id + 1)))
+        , Carousel.slideHtml (Html.text (String.fromInt (id + 1) ++ " slide"))
+        ]


### PR DESCRIPTION
This PR adds a `Nri.Ui.Carousel.V1` module.
This is a simple Carousel that takes advantage of the `TabsInternal.V2` module and exposes it in a simple yet configurable way. 
Unlike other elements like `Tabs` and `SegmentedControl`, this module does not implement any styles, leaving it to the user.
A simple example of its functionality, copied from the our styleguide app example, can be seen below:

![out](https://user-images.githubusercontent.com/12688694/174140363-286fdb77-ff1f-4433-901c-aef916172574.gif)


