### PR TITLE
Message styles

### DIFF
--- a/script/puppeteer-tests-percy.sh
+++ b/script/puppeteer-tests-percy.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-env ONLYDOODAD=${1-default} npx percy exec -- mocha script/puppeteer-tests.js --timeout 50000 --exit
+env ONLYDOODAD=${1-default} npx percy exec -- mocha script/puppeteer-tests.js --timeout 100000 --exit

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -78,11 +78,11 @@ describe("UI tests", function () {
       const option = await page.evaluate((el) => el.innerText, optionEl);
       select.select(option);
 
-      await percySnapshot(page, `name - ${option}`);
+      await percySnapshot(page, `${name} - ${option}`);
       axe = await new AxePuppeteer(page)
         .withRules(["color-contrast"])
         .analyze();
-      handleAxeResults(`name - ${option}`, axe);
+      handleAxeResults(`${name} - ${option}`, axe);
     }
   };
 

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -712,7 +712,7 @@ getColor size theme =
                     Colors.redDark
 
                 _ ->
-                    Colors.navy
+                    Colors.redDark
 
         Tip ->
             Colors.navy
@@ -731,7 +731,7 @@ getBackgroundColor size theme =
             Css.backgroundColor Colors.sunshine
 
         ( Banner, Tip ) ->
-            Css.backgroundColor Colors.frost
+            Css.backgroundColor Colors.sunshine
 
         ( _, Error ) ->
             Css.backgroundColor Colors.purpleLight
@@ -779,7 +779,7 @@ getIcon customIcon size theme =
                             Colors.red
 
                         _ ->
-                            Colors.ochre
+                            Colors.red
             in
             UiIcon.exclamation
                 |> NriSvg.withColor color
@@ -793,31 +793,55 @@ getIcon customIcon size theme =
         ( Nothing, Tip ) ->
             case size of
                 Tiny ->
-                    UiIcon.baldBulb
-                        |> NriSvg.withColor Colors.yellow
-                        |> NriSvg.withWidth iconSize
-                        |> NriSvg.withHeight iconSize
-                        |> NriSvg.withCss [ marginRight, Css.flexShrink Css.zero ]
-                        |> NriSvg.withLabel "Tip"
-                        |> NriSvg.withNriDescription messageIconDescription
-                        |> NriSvg.toHtml
+                    div
+                        [ Attributes.css
+                            [ borderRadius (pct 50)
+                            , height (px 20)
+                            , width (px 20)
+                            , Css.marginRight (Css.px 5)
+                            , backgroundColor Colors.navy
+                            , displayFlex
+                            , Css.flexShrink Css.zero
+                            , alignItems center
+                            , justifyContent center
+                            ]
+                        , ExtraAttributes.nriDescription messageIconDescription
+                        ]
+                        [ UiIcon.baldBulb
+                            |> NriSvg.withColor Colors.mustard
+                            |> NriSvg.withWidth (Css.px 13)
+                            |> NriSvg.withHeight (Css.px 13)
+                            |> NriSvg.toHtml
+                        ]
 
                 Large ->
-                    UiIcon.sparkleBulb
-                        |> NriSvg.withColor Colors.navy
-                        |> NriSvg.withWidth iconSize
-                        |> NriSvg.withHeight iconSize
-                        |> NriSvg.withCss [ marginRight, Css.flexShrink Css.zero ]
-                        |> NriSvg.withLabel "Tip"
-                        |> NriSvg.withNriDescription messageIconDescription
-                        |> NriSvg.toHtml
+                    div
+                        [ Attributes.css
+                            [ borderRadius (pct 50)
+                            , height (px 35)
+                            , width (px 35)
+                            , Css.marginRight (Css.px 10)
+                            , backgroundColor Colors.navy
+                            , displayFlex
+                            , Css.flexShrink Css.zero
+                            , alignItems center
+                            , justifyContent center
+                            ]
+                        , ExtraAttributes.nriDescription messageIconDescription
+                        ]
+                        [ UiIcon.sparkleBulb
+                            |> NriSvg.withColor Colors.mustard
+                            |> NriSvg.withWidth (Css.px 22)
+                            |> NriSvg.withHeight (Css.px 22)
+                            |> NriSvg.toHtml
+                        ]
 
                 Banner ->
                     div
                         [ Attributes.css
                             [ borderRadius (pct 50)
-                            , height (px 50)
-                            , width (px 50)
+                            , height (px 35)
+                            , width (px 35)
                             , Css.marginRight (Css.px 10)
                             , backgroundColor Colors.navy
                             , displayFlex
@@ -834,14 +858,8 @@ getIcon customIcon size theme =
                         ]
                         [ UiIcon.sparkleBulb
                             |> NriSvg.withColor Colors.mustard
-                            |> NriSvg.withWidth (Css.px 32)
-                            |> NriSvg.withHeight (Css.px 32)
-                            |> NriSvg.withCss
-                                [ Css.Media.withMedia
-                                    [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
-                                    [ height (px 20)
-                                    ]
-                                ]
+                            |> NriSvg.withWidth (Css.px 22)
+                            |> NriSvg.withHeight (Css.px 22)
                             |> NriSvg.toHtml
                         ]
 

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -91,12 +91,12 @@ controlCustomTheme =
         )
         |> Control.field "color"
             (CommonControls.choice "Colors"
-                [ ( "aquaDark", Colors.aquaDark )
+                [ ( "purpleDark", Colors.purpleDark )
                 ]
             )
         |> Control.field "backgroundColor"
             (CommonControls.choice "Colors"
-                [ ( "gray92", Colors.gray92 )
+                [ ( "gray96", Colors.gray96 )
                 ]
             )
 


### PR DESCRIPTION
This improves contrast and removes some of the inconsistencies between and within message styles.

<img width="560" alt="Screen Shot 2022-06-17 at 12 27 08 PM" src="https://user-images.githubusercontent.com/13528834/174390205-1bde6004-9ffe-48aa-9db8-10bb1d36201e.png">
<img width="579" alt="Screen Shot 2022-06-17 at 12 26 48 PM" src="https://user-images.githubusercontent.com/13528834/174390207-11cc5e5f-8242-49f0-8f9c-292d28bdf980.png">

## Outfoxes
https://airtable.com/app1BuwWPTsZykPWh/pagGSfGFRwuY9jWfZ?FGZNE=b%3AeyIwT0Y2aiI6W1s2LFsic2VsaUozdlprMWNqY1dqaHQiLCJzZWxKeUlISVBZQmdNU01yVCJdXV19&Inx0b=recaTbTyB3PxKra7T