### PR TITLE
Tooltip table take two

### DIFF
--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -184,7 +184,7 @@ of ***what*** the tooltip trigger does. The same text is provided to assitive te
           , usage = """
 Use when all of the following are true:
 - the tooltip trigger does more than just reveal the tooltip content
-- the content of the tooltip provides additional information about the functionality of the tooltip trigger itself.
+- the content of the tooltip provides additional information about the functionality of the tooltip trigger itself
 - the content of the tooltip doesn't contain interactive elements such as links
 
 Think of this as the "How."

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -166,6 +166,7 @@ view ellieLinkConfig model =
 Use when all of the following are true:
 - the tooltip trigger does more than just reveal the tooltip content
 - the content of the tooltip is the same as the name of the tooltip trigger
+- the content of the tooltip doesn't contain interactive elements such as links
 
 Think of this as the "What."
 """
@@ -184,6 +185,7 @@ of ***what*** the tooltip trigger does. The same text is provided to assitive te
 Use when all of the following are true:
 - the tooltip trigger does more than just reveal the tooltip content
 - the content of the tooltip provides additional information about the functionality of the tooltip trigger itself.
+- the content of the tooltip doesn't contain interactive elements such as links
 
 Think of this as the "How."
 """
@@ -203,6 +205,8 @@ Examples:
 Use when all of the following are true:
 - the tooltip trigger only opens the tooltip without doing anything else
 - the tooltip trigger ***isn't*** a "?" icon
+
+This type can (but is not required to) contain interactive elements such as links.
         """
           , description =
                 """
@@ -220,6 +224,9 @@ This behavior is analogous to disclosure behavior, except that it's presented di
 Use when all of the following are true:
 - the tooltip trigger only opens the tooltip without doing anything else
 - the tooltip trigger ***is*** a "?" icon
+
+This type can (but is not required to) contain interactive elements such as links.
+
         """
           , description =
                 """

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -22,6 +22,7 @@ import Markdown
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Heading.V2 as Heading
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Table.V5 as Table
 import Nri.Ui.Tooltip.V3 as Tooltip
@@ -133,6 +134,7 @@ update msg model =
 view : EllieLink.Config -> State -> List (Html Msg)
 view ellieLinkConfig model =
     [ viewCustomizableExample ellieLinkConfig model.staticExampleSettings
+    , Heading.h2 [ Heading.style Heading.Subhead ] [ Html.text "What type of tooltip should I use?" ]
     , Table.view
         [ Table.string
             { header = "Type"

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -223,7 +223,7 @@ Use when all of the following are true:
 - the tooltip trigger only opens the tooltip without doing anything else
 - the tooltip trigger ***is*** a "?" icon
 
-This type can (but is not required to) contain interactive elements such as links.
+This type may contain interactive elements such as links.
 
         """
           , description =

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -212,8 +212,6 @@ This type can (but is not required to) contain interactive elements such as link
                 """
 Sometimes a tooltip trigger doesn't have any functionality itself outside of revealing information.
 
-If clicking the "tooltip trigger" only ever shows you more info (and especially if this info is rich or interactable), use this attribute.
-
 This behavior is analogous to disclosure behavior, except that it's presented different visually. (For more information, please read [Sarah Higley's "Tooltips in the time of WCAG 2.1" post](https://sarahmhigley.com/writing/tooltips-in-wcag-21).)
 """
           , example = viewDisclosureToolip model.openTooltip

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -312,12 +312,15 @@ viewDisclosureToolip openTooltip =
 
 viewToggleTip : Maybe TooltipId -> Html Msg
 viewToggleTip openTooltip =
-    Tooltip.viewToggleTip { label = "What is mastery?", lastId = Nothing }
+   Html.span [ css [Css.displayFlex, Css.alignItems Css.center, Css.justifyContent Css.center] ] [
+    Html.text "Mastery"
+    ,Tooltip.viewToggleTip { label = "What is mastery?", lastId = Nothing }
         [ Tooltip.plaintext "Students master topics by correctly answering a series of questions of varying difficulty and scope."
         , Tooltip.onToggle (ToggleTooltip LearnMore)
         , Tooltip.open (openTooltip == Just LearnMore)
         , Tooltip.alignEndForMobile (Css.px 144)
         ]
+   ]
 
 
 initStaticExampleSettings : Control (List ( String, Tooltip.Attribute Never ))

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -261,6 +261,7 @@ viewAuxillaryDescriptionToolip openTooltip =
             \eventHandlers ->
                 ClickableText.link "Tooltips & Toggletips"
                     [ ClickableText.custom eventHandlers
+                    , ClickableText.small
                     , ClickableText.icon UiIcon.openInNewTab
                     , ClickableText.linkExternal "https://inclusive-components.design/tooltips-toggletips/"
                     ]

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -206,7 +206,7 @@ Use when all of the following are true:
 - the tooltip trigger only opens the tooltip without doing anything else
 - the tooltip trigger ***isn't*** a "?" icon
 
-This type can (but is not required to) contain interactive elements such as links.
+This type may contain interactive elements such as links.
         """
           , description =
                 """

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -140,19 +140,19 @@ view ellieLinkConfig model =
             { header = "Type"
             , value = .name
             , width = Css.pct 15
-            , cellStyles = always [ Css.padding2 Css.zero (Css.px 7) ]
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.top, Css.fontWeight Css.bold ]
             }
         , Table.custom
             { header = Html.text "Usage"
             , view = .usage >> Markdown.toHtml Nothing >> List.map Html.fromUnstyled >> Html.span []
             , width = Css.px 150
-            , cellStyles = always [ Css.padding2 Css.zero (Css.px 7) ]
+            , cellStyles = always [ Css.padding2 Css.zero (Css.px 7), Css.verticalAlign Css.top ]
             }
         , Table.custom
             { header = Html.text "About"
             , view = .description >> Markdown.toHtml Nothing >> List.map Html.fromUnstyled >> Html.span []
             , width = Css.px 200
-            , cellStyles = always [ Css.padding2 Css.zero (Css.px 7) ]
+            , cellStyles = always [ Css.padding2 Css.zero (Css.px 7), Css.verticalAlign Css.top ]
             }
         , Table.custom
             { header = Html.text "Example"
@@ -320,15 +320,15 @@ viewDisclosureToolip openTooltip =
 
 viewToggleTip : Maybe TooltipId -> Html Msg
 viewToggleTip openTooltip =
-   Html.span [ css [Css.displayFlex, Css.alignItems Css.center, Css.justifyContent Css.center] ] [
-    Html.text "Mastery"
-    ,Tooltip.viewToggleTip { label = "What is mastery?", lastId = Nothing }
-        [ Tooltip.plaintext "Students master topics by correctly answering a series of questions of varying difficulty and scope."
-        , Tooltip.onToggle (ToggleTooltip LearnMore)
-        , Tooltip.open (openTooltip == Just LearnMore)
-        , Tooltip.alignEndForMobile (Css.px 144)
+    Html.span [ css [ Css.displayFlex, Css.alignItems Css.center, Css.justifyContent Css.center ] ]
+        [ Html.text "Mastery"
+        , Tooltip.viewToggleTip { label = "What is mastery?", lastId = Nothing }
+            [ Tooltip.plaintext "Students master topics by correctly answering a series of questions of varying difficulty and scope."
+            , Tooltip.onToggle (ToggleTooltip LearnMore)
+            , Tooltip.open (openTooltip == Just LearnMore)
+            , Tooltip.alignEndForMobile (Css.px 144)
+            ]
         ]
-   ]
 
 
 initStaticExampleSettings : Control (List ( String, Tooltip.Attribute Never ))

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -223,7 +223,7 @@ Use when all of the following are true:
         """
           , description =
                 """
-This is a helper for using Tooltip.disclosure with a "?" icon because it is a commonly used UI pattern. We use this helper when we want to show more information about an element but we don't want the element itself to have its own tooltip. The "?" icon typically appears visually adjacent to the element it reveals information about. Please see the documentation for `disclosure` to learn more.
+This is a helper for using Tooltip.disclosure with a "?" icon because it is a commonly used UI pattern. We use this helper when we want to show more information about an element but we don't want the element itself to have its own tooltip. The "?" icon typically appears visually adjacent to the element it reveals information about.
 """
           , example = viewToggleTip model.openTooltip
           , tooltipId = LearnMore


### PR DESCRIPTION
- Add a hopefully usable heading to the table
- Make toggletip example more authentic so it makes more sense to folks looking at it
- Make clickable text small so it fits in the table better
- Remove redundant and possibly unclear reference to disclosure documentation
- Clarify conditions for using each component wrt interactive elements
    - And drop references to rich text
- Top align text in text-only cells
- Emphasize the primary column w bold styling

## For the reviewer
- Should be reviewable by commit
- [x] Can you please check that I did the vertical alignment for text-only cells properly? I had to add more padding to the leftmost column. I assume this is bc it's using `Table.string`, but the css in the console had me baffled bc I could not find the extra 7px of padding on the other columns. 🤷 
- [x] Make sure the interactive element conditions are correct.
- [ ] Can you check the unapproved percy snapshot? I don't think it has anything to do with what I did but it is weird.

## Outfoxes
Fixes A11-824