### PR TITLE
Add Menu opensOnHover

### DIFF
--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -531,25 +531,34 @@ viewCustom config =
 
                 CustomButton customButton ->
                     customButton buttonAttributes
-            , div
-                [ classList [ ( "Content", True ), ( "ContentVisible", contentVisible ) ]
-                , styleContent contentVisible config
-                , Role.menu
-                , Aria.labelledBy config.buttonId
-                , Attributes.id config.menuId
-                , Aria.hidden (not config.isOpen)
-                , css
-                    [ Maybe.map (\w -> Css.width (Css.px (toFloat w))) config.menuWidth
-                        |> Maybe.withDefault (Css.batch [])
+            , div [ styleOuterContent contentVisible config ]
+                [ div
+                    [ AttributesExtra.nriDescription "menu-hover-bridge"
+                    , css
+                        [ Css.height (px 10)
+                        ]
                     ]
+                    []
+                , div
+                    [ classList [ ( "Content", True ), ( "ContentVisible", contentVisible ) ]
+                    , styleContent contentVisible config
+                    , Role.menu
+                    , Aria.labelledBy config.buttonId
+                    , Attributes.id config.menuId
+                    , Aria.hidden (not config.isOpen)
+                    , css
+                        [ Maybe.map (\w -> Css.width (Css.px (toFloat w))) config.menuWidth
+                            |> Maybe.withDefault (Css.batch [])
+                        ]
+                    ]
+                    (viewEntries config
+                        { focusAndToggle = config.focusAndToggle
+                        , previousId = Maybe.withDefault "" maybeLastFocusableElementId
+                        , nextId = Maybe.withDefault "" maybeFirstFocusableElementId
+                        }
+                        config.entries
+                    )
                 ]
-                (viewEntries config
-                    { focusAndToggle = config.focusAndToggle
-                    , previousId = Maybe.withDefault "" maybeLastFocusableElementId
-                    , nextId = Maybe.withDefault "" maybeFirstFocusableElementId
-                    }
-                    config.entries
-                )
             ]
         ]
 
@@ -778,30 +787,41 @@ styleIconContainer =
     ]
 
 
+styleOuterContent : Bool -> MenuConfig msg -> Html.Attribute msg
+styleOuterContent contentVisible config =
+    css
+        [ position absolute
+        , zIndex (int <| config.zIndex + 1)
+        , case config.alignment of
+            Left ->
+                left zero
+
+            Right ->
+                right zero
+        ]
+
+
 styleContent : Bool -> MenuConfig msg -> Html.Attribute msg
 styleContent contentVisible config =
     css
         [ padding (px 25)
         , border3 (px 1) solid Colors.gray85
         , minWidth (px 202)
-        , position absolute
         , borderRadius (px 8)
-        , marginTop (px 10)
-        , zIndex (int <| config.zIndex + 1)
         , backgroundColor Colors.white
         , listStyle Css.none
         , Shadows.high
         , before
             [ property "content" "\"\""
             , position absolute
-            , top (px -12)
+            , top (px -2)
             , border3 (px 6) solid transparent
             , borderBottomColor Colors.gray85
             ]
         , after
             [ property "content" "\"\""
             , position absolute
-            , top (px -10)
+            , top (px 1)
             , zIndex (int 2)
             , border3 (px 5) solid transparent
             , borderBottomColor Colors.white
@@ -809,15 +829,13 @@ styleContent contentVisible config =
         , case config.alignment of
             Left ->
                 Css.batch
-                    [ left zero
-                    , before [ left (px 19) ]
+                    [ before [ left (px 19) ]
                     , after [ left (px 20) ]
                     ]
 
             Right ->
                 Css.batch
-                    [ right zero
-                    , before [ right (px 19) ]
+                    [ before [ right (px 19) ]
                     , after [ right (px 20) ]
                     ]
         , if contentVisible then

--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -849,6 +849,7 @@ styleContent contentVisible config =
 styleContainer : List (Html.Attribute msg)
 styleContainer =
     [ class "Container"
+    , AttributesExtra.nriDescription "Nri-Ui-Menu-V3"
     , css
         [ position relative
         , display inlineBlock

--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -1,7 +1,7 @@
 module Nri.Ui.Menu.V3 exposing
     ( view, button, custom, Config
     , Attribute, Button, ButtonAttribute
-    , alignment, isDisabled, menuWidth, buttonId, menuId, menuZIndex
+    , alignment, isDisabled, menuWidth, buttonId, menuId, menuZIndex, opensOnHover
     , Alignment(..)
     , icon, wrapping, hasBorder, buttonWidth
     , TitleWrapping(..)
@@ -30,7 +30,7 @@ A togglable menu view and related buttons.
 
 ## Menu attributes
 
-@docs alignment, isDisabled, menuWidth, buttonId, menuId, menuZIndex
+@docs alignment, isDisabled, menuWidth, buttonId, menuId, menuZIndex, opensOnHover
 @docs Alignment
 
 
@@ -104,6 +104,7 @@ type alias MenuConfig msg =
     , buttonId : String
     , menuId : String
     , zIndex : Int
+    , opensOnHover : Bool
     }
 
 
@@ -193,6 +194,11 @@ menuZIndex value =
     Attribute <| \config -> { config | zIndex = value }
 
 
+opensOnHover : Bool -> Attribute msg
+opensOnHover value =
+    Attribute <| \config -> { config | opensOnHover = value }
+
+
 {-| Menu/pulldown configuration:
 
   - `attributes`: List of (attributes)[#menu-attributes] to apply to the menu.
@@ -217,6 +223,7 @@ view attributes config =
             , buttonId = ""
             , menuId = ""
             , zIndex = 1
+            , opensOnHover = False
             }
 
         menuConfig =
@@ -486,6 +493,16 @@ viewCustom config =
                                         }
                                 }
                             )
+                    , if not config.isDisabled && config.opensOnHover then
+                        Events.onMouseEnter
+                            (config.focusAndToggle
+                                { isOpen = True
+                                , focus = Nothing
+                                }
+                            )
+
+                      else
+                        AttributesExtra.none
                     ]
               in
               case config.button of

--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -449,7 +449,27 @@ viewCustom config =
 
           else
             Html.text ""
-        , div styleInnerContainer
+        , div
+            [ class "InnerContainer"
+            , css
+                [ position relative
+                , if config.isOpen then
+                    zIndex (int <| config.zIndex + 1)
+
+                  else
+                    Css.batch []
+                ]
+            , if not config.isDisabled && config.opensOnHover && config.isOpen then
+                Events.onMouseLeave
+                    (config.focusAndToggle
+                        { isOpen = False
+                        , focus = Nothing
+                        }
+                    )
+
+              else
+                AttributesExtra.none
+            ]
             [ let
                 buttonAttributes =
                     [ Aria.disabled config.isDisabled
@@ -652,14 +672,6 @@ viewEntry config focusAndToggle { upId, downId, entry_ } =
 
 
 -- STYLES
-
-
-{-| -}
-styleInnerContainer : List (Html.Attribute msg)
-styleInnerContainer =
-    [ class "InnerContainer"
-    , css [ position relative ]
-    ]
 
 
 styleOverlay : MenuConfig msg -> List (Html.Attribute msg)

--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -194,6 +194,8 @@ menuZIndex value =
     Attribute <| \config -> { config | zIndex = value }
 
 
+{-| Whether the menu will be opened/closed by mouseEnter and mouseLeave interaction. Defaults to `False`.
+-}
 opensOnHover : Bool -> Attribute msg
 opensOnHover value =
     Attribute <| \config -> { config | opensOnHover = value }

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -290,6 +290,7 @@ controlMenuAttributes =
         |> ControlExtra.optionalListItem "alignment" controlAlignment
         |> ControlExtra.optionalBoolListItem "isDisabled" ( "Menu.isDisabled True", Menu.isDisabled True )
         |> ControlExtra.optionalListItem "menuWidth" controlMenuWidth
+        |> ControlExtra.optionalBoolListItem "opensOnHover" ( "Menu.opensOnHover True", Menu.opensOnHover True )
 
 
 controlAlignment : Control ( String, Menu.Attribute msg )

--- a/tests/Spec/Nri/Ui/Menu.elm
+++ b/tests/Spec/Nri/Ui/Menu.elm
@@ -1,0 +1,99 @@
+module Spec.Nri.Ui.Menu exposing (spec)
+
+import Html.Attributes as Attributes
+import Html.Styled as HtmlStyled
+import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.Menu.V3 as Menu
+import ProgramTest exposing (ProgramTest, ensureViewHas, ensureViewHasNot)
+import Test exposing (..)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector exposing (text)
+
+
+spec : Test
+spec =
+    describe "Nri.Ui.Menu.V3"
+        [ test "Menu.view" <|
+            \() ->
+                let
+                    menuContent =
+                        "Hello"
+                in
+                program [ Menu.opensOnHover True ]
+                    -- Menu opens on mouse enter
+                    |> mouseEnter menuButtonSelector
+                    |> ensureViewHas (menuContentSelector menuContent)
+                    |> mouseLeave menuInteractiveAreaSelector
+                    |> ensureViewHasNot (menuContentSelector menuContent)
+                    |> ProgramTest.done
+        ]
+
+
+type alias Model =
+    { isOpen : Bool }
+
+
+type alias Msg =
+    Bool
+
+
+program : List (Menu.Attribute Msg) -> ProgramTest Model Msg ()
+program attributes =
+    ProgramTest.createSandbox
+        { init = { isOpen = False }
+        , update = \msg _ -> { isOpen = msg }
+        , view =
+            \model ->
+                HtmlStyled.div []
+                    [ Menu.view attributes
+                        { button = Menu.button [] "Menu"
+                        , isOpen = model.isOpen
+                        , entries =
+                            [ Menu.entry "hello-button" <|
+                                \attrs ->
+                                    ClickableText.button "Hello" [ ClickableText.custom attrs ]
+                            ]
+                        , focusAndToggle = \{ isOpen } -> isOpen
+                        }
+                    ]
+                    |> HtmlStyled.toUnstyled
+        }
+        |> ProgramTest.start ()
+
+
+menuButtonSelector : List Selector.Selector
+menuButtonSelector =
+    [ nriDescription "Nri-Ui-Menu-V3"
+    , Selector.class "ToggleButton"
+    ]
+
+
+menuInteractiveAreaSelector : List Selector.Selector
+menuInteractiveAreaSelector =
+    [ nriDescription "Nri-Ui-Menu-V3"
+    , Selector.class "InnerContainer"
+    ]
+
+
+menuContentSelector : String -> List Selector.Selector
+menuContentSelector menuContent =
+    [ Selector.class "InnerContainer"
+    , Selector.attribute (Attributes.attribute "aria-expanded" "true")
+    , Selector.containing [ text menuContent ]
+    ]
+
+
+nriDescription : String -> Selector.Selector
+nriDescription desc =
+    Selector.attribute (Attributes.attribute "data-nri-description" desc)
+
+
+mouseEnter : List Selector.Selector -> ProgramTest model msg effect -> ProgramTest model msg effect
+mouseEnter selectors =
+    ProgramTest.simulateDomEvent (Query.find selectors) Event.mouseEnter
+
+
+mouseLeave : List Selector.Selector -> ProgramTest model msg effect -> ProgramTest model msg effect
+mouseLeave selectors =
+    ProgramTest.simulateDomEvent (Query.find selectors) Event.mouseLeave


### PR DESCRIPTION
When a `Menu` uses `opensOnHover True` the menu can be opened by mouse enter and closed by mouse leave.

This required some changes in the dom structure to include a menu-hover-bridge to avoid closing the menu when the user is transitioning from the menu trigger to it's content. I also tweaked the zIndex so the overlay is below the trigger button, this was not the case before.

Some tests were added, they introduce a bit of duplication with `tests/Spec/Nri/Ui/Tooltip.elm`.

I notice the Menu does not introduce aria-label components as in the case of the tooltip which would have lead to some slightly nicer test code.

I would have wanted to test that if `opensOnHover False` is passed, the menu will not open on mouse enter, but alas that test will fail since there is no event listener of the event wanted to be simulated.