### PR TITLE
Standardize the Tabs example a bit

### DIFF
--- a/styleguide-app/Code.elm
+++ b/styleguide-app/Code.elm
@@ -2,7 +2,6 @@ module Code exposing
     ( string, maybeString
     , maybeFloat
     , bool
-    , maybe
     )
 
 {-|
@@ -10,7 +9,6 @@ module Code exposing
 @docs string, maybeString
 @docs maybeFloat
 @docs bool
-@docs maybe
 
 -}
 

--- a/styleguide-app/Code.elm
+++ b/styleguide-app/Code.elm
@@ -1,0 +1,29 @@
+module Code exposing
+    ( string, maybeString
+    , maybe
+    )
+
+{-|
+
+@docs string, maybeString
+@docs maybe
+
+-}
+
+
+{-| -}
+string : String -> String
+string s =
+    "\"" ++ s ++ "\""
+
+
+{-| -}
+maybe : Maybe String -> String
+maybe =
+    Maybe.map (\s -> "Just " ++ s) >> Maybe.withDefault "Nothing"
+
+
+{-| -}
+maybeString : Maybe String -> String
+maybeString =
+    maybe << Maybe.map string

--- a/styleguide-app/Code.elm
+++ b/styleguide-app/Code.elm
@@ -1,11 +1,13 @@
 module Code exposing
     ( string, maybeString
+    , maybeFloat
     , maybe
     )
 
 {-|
 
 @docs string, maybeString
+@docs maybeFloat
 @docs maybe
 
 -}
@@ -27,3 +29,9 @@ maybe =
 maybeString : Maybe String -> String
 maybeString =
     maybe << Maybe.map string
+
+
+{-| -}
+maybeFloat : Maybe Float -> String
+maybeFloat =
+    maybe << Maybe.map String.fromFloat

--- a/styleguide-app/Code.elm
+++ b/styleguide-app/Code.elm
@@ -1,6 +1,7 @@
 module Code exposing
     ( string, maybeString
     , maybeFloat
+    , bool
     , maybe
     )
 
@@ -8,6 +9,7 @@ module Code exposing
 
 @docs string, maybeString
 @docs maybeFloat
+@docs bool
 @docs maybe
 
 -}
@@ -35,3 +37,9 @@ maybeString =
 maybeFloat : Maybe Float -> String
 maybeFloat =
     maybe << Maybe.map String.fromFloat
+
+
+{-| -}
+bool : Bool -> String
+bool =
+    Debug.toString

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -14,6 +14,7 @@ import Browser.Dom as Dom
 import Category exposing (Category(..))
 import Css
 import Debug.Control as Control exposing (Control)
+import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled as Html exposing (fromUnstyled)
 import Html.Styled.Attributes exposing (css)
@@ -25,6 +26,176 @@ import Nri.Ui.Text.V6 as Text
 import Nri.Ui.Tooltip.V3 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Task
+
+
+moduleName : String
+moduleName =
+    "Tabs"
+
+
+version : Int
+version =
+    7
+
+
+example : Example State Msg
+example =
+    { name = moduleName
+    , version = version
+    , categories = [ Layout ]
+    , keyboardSupport =
+        [ { keys = [ KeyboardSupport.Tab ]
+          , result = "Move focus to the currently-selected Tab's tab panel"
+          }
+        , { keys = [ Arrow KeyboardSupport.Left ]
+          , result = "Select the tab to the left of the currently-selected Tab"
+          }
+        , { keys = [ Arrow KeyboardSupport.Right ]
+          , result = "Select the tab to the right of the currently-selected Tab"
+          }
+        ]
+    , state = init
+    , update = update
+    , subscriptions = \_ -> Sub.none
+    , preview =
+        [ -- faking a mini version of the Tabs component to give styleguide users a sense of what the
+          -- component might look like
+          Html.div [ css [ Css.displayFlex, Css.flexWrap Css.wrap ] ]
+            [ Html.div
+                [ css
+                    [ Css.backgroundColor Colors.white
+                    , Css.padding (Css.px 4)
+                    , Css.borderRadius4 (Css.px 4) (Css.px 4) Css.zero Css.zero
+                    , Css.border3 (Css.px 1) Css.solid Colors.navy
+                    , Css.borderBottomWidth Css.zero
+                    ]
+                ]
+                [ Text.smallBody [ Text.plaintext "Tab 1" ] ]
+            , Html.div
+                [ css [ Css.width (Css.px 4), Css.borderBottom3 (Css.px 1) Css.solid Colors.navy ]
+                ]
+                []
+            , Html.div
+                [ css
+                    [ Css.backgroundColor Colors.frost
+                    , Css.padding (Css.px 4)
+                    , Css.borderRadius4 (Css.px 4) (Css.px 4) Css.zero Css.zero
+                    , Css.border3 (Css.px 1) Css.solid Colors.navy
+                    ]
+                ]
+                [ Text.smallBody [ Text.plaintext "Tab 1" ] ]
+            , Html.div
+                [ css
+                    [ Css.width (Css.px 30)
+                    , Css.borderBottom3 (Css.px 1) Css.solid Colors.navy
+                    ]
+                ]
+                []
+            , Html.div
+                [ css
+                    [ Css.paddingTop (Css.px 4)
+                    , Css.minWidth (Css.px 100)
+                    ]
+                ]
+                [ Text.caption [ Text.plaintext "Tab 1 content" ] ]
+            ]
+        ]
+    , view =
+        \ellieLinkConfig model ->
+            let
+                settings =
+                    Control.currentValue model.settings
+            in
+            [ ControlView.view
+                { ellieLinkConfig = ellieLinkConfig
+                , name = moduleName
+                , version = version
+                , update = SetSettings
+                , settings = model.settings
+                , mainType = "RootHtml.Html { select : Int, focus : Maybe String }"
+                , extraImports = []
+                , toExampleCode =
+                    \_ ->
+                        let
+                            code =
+                                [ moduleName ++ ".view"
+                                , "    { title = " ++ " TODO"
+                                , "    , alignment = " ++ " TODO"
+                                , "    , customSpacing = " ++ " TODO"
+                                , "    , focusAndSelect = " ++ " TODO"
+                                , "    , selected = " ++ " TODO"
+                                , "    , tabs = " ++ " TODO"
+                                , "    }"
+                                ]
+                                    |> String.join "\n"
+                        in
+                        [ { sectionName = "Example"
+                          , code = code
+                          }
+                        ]
+                }
+            , Tabs.view
+                { title = settings.title
+                , alignment = settings.alignment
+                , customSpacing = settings.customSpacing
+                , focusAndSelect = FocusAndSelectTab
+                , selected = model.selected
+                , tabs = allTabs model.openTooltip settings.labelledBy
+                }
+            ]
+    }
+
+
+allTabs : Maybe Id -> Maybe String -> List (Tab Id Msg)
+allTabs openTooltipId labelledBy =
+    let
+        bulbIcon =
+            UiIcon.bulb
+                |> Svg.withWidth (Css.px 40)
+                |> Svg.withHeight (Css.px 45)
+                |> Svg.withLabel "Bulb"
+                |> Svg.withCss [ Css.padding2 Css.zero (Css.px 6) ]
+                |> Svg.toHtml
+    in
+    [ Tabs.build { id = First, idString = "tab-0" }
+        ([ Tabs.tabString "1"
+         , Tabs.withTooltip
+            [ Tooltip.plaintext "Link Example"
+            , Tooltip.onToggle (ToggleTooltip First)
+            , Tooltip.alignStart (Css.px 75)
+            , Tooltip.primaryLabel
+            , Tooltip.open (openTooltipId == Just First)
+            ]
+         , Tabs.panelHtml (Html.text "First Panel")
+         ]
+            ++ (case labelledBy of
+                    Nothing ->
+                        []
+
+                    Just labelledById ->
+                        [ Tabs.labelledBy labelledById ]
+               )
+        )
+    , Tabs.build { id = Second, idString = "tab-1" }
+        [ Tabs.tabString "Second Tab (disabled)"
+        , Tabs.disabled True
+        , Tabs.panelHtml (Html.text "Second Panel")
+        ]
+    , Tabs.build { id = Third, idString = "tab-2" }
+        [ Tabs.tabHtml bulbIcon
+        , Tabs.withTooltip
+            [ Tooltip.plaintext "The Electrifying Third Tab"
+            , Tooltip.onToggle (ToggleTooltip Third)
+            , Tooltip.primaryLabel
+            , Tooltip.open (openTooltipId == Just Third)
+            ]
+        , Tabs.panelHtml (Html.text "Third Panel")
+        ]
+    , Tabs.build { id = Fourth, idString = "tab-3" }
+        [ Tabs.tabString "Fourth Tab"
+        , Tabs.panelHtml (Html.text "Fourth Panel")
+        ]
+    ]
 
 
 type alias State =
@@ -116,141 +287,3 @@ update msg model =
               }
             , Cmd.none
             )
-
-
-exampleName : String
-exampleName =
-    "Tabs"
-
-
-example : Example State Msg
-example =
-    { name = exampleName
-    , version = 7
-    , categories = [ Layout ]
-    , keyboardSupport =
-        [ { keys = [ KeyboardSupport.Tab ]
-          , result = "Move focus to the currently-selected Tab's tab panel"
-          }
-        , { keys = [ Arrow KeyboardSupport.Left ]
-          , result = "Select the tab to the left of the currently-selected Tab"
-          }
-        , { keys = [ Arrow KeyboardSupport.Right ]
-          , result = "Select the tab to the right of the currently-selected Tab"
-          }
-        ]
-    , state = init
-    , update = update
-    , subscriptions = \_ -> Sub.none
-    , preview =
-        [ -- faking a mini version of the Tabs component to give styleguide users a sense of what the
-          -- component might look like
-          Html.div [ css [ Css.displayFlex, Css.flexWrap Css.wrap ] ]
-            [ Html.div
-                [ css
-                    [ Css.backgroundColor Colors.white
-                    , Css.padding (Css.px 4)
-                    , Css.borderRadius4 (Css.px 4) (Css.px 4) Css.zero Css.zero
-                    , Css.border3 (Css.px 1) Css.solid Colors.navy
-                    , Css.borderBottomWidth Css.zero
-                    ]
-                ]
-                [ Text.smallBody [ Text.plaintext "Tab 1" ] ]
-            , Html.div
-                [ css [ Css.width (Css.px 4), Css.borderBottom3 (Css.px 1) Css.solid Colors.navy ]
-                ]
-                []
-            , Html.div
-                [ css
-                    [ Css.backgroundColor Colors.frost
-                    , Css.padding (Css.px 4)
-                    , Css.borderRadius4 (Css.px 4) (Css.px 4) Css.zero Css.zero
-                    , Css.border3 (Css.px 1) Css.solid Colors.navy
-                    ]
-                ]
-                [ Text.smallBody [ Text.plaintext "Tab 1" ] ]
-            , Html.div
-                [ css
-                    [ Css.width (Css.px 30)
-                    , Css.borderBottom3 (Css.px 1) Css.solid Colors.navy
-                    ]
-                ]
-                []
-            , Html.div
-                [ css
-                    [ Css.paddingTop (Css.px 4)
-                    , Css.minWidth (Css.px 100)
-                    ]
-                ]
-                [ Text.caption [ Text.plaintext "Tab 1 content" ] ]
-            ]
-        ]
-    , view =
-        \ellieLinkConfig model ->
-            let
-                settings =
-                    Control.currentValue model.settings
-            in
-            [ Control.view SetSettings model.settings |> fromUnstyled
-            , Tabs.view
-                { title = settings.title
-                , alignment = settings.alignment
-                , customSpacing = settings.customSpacing
-                , focusAndSelect = FocusAndSelectTab
-                , selected = model.selected
-                , tabs = allTabs model.openTooltip settings.labelledBy
-                }
-            ]
-    }
-
-
-allTabs : Maybe Id -> Maybe String -> List (Tab Id Msg)
-allTabs openTooltipId labelledBy =
-    let
-        bulbIcon =
-            UiIcon.bulb
-                |> Svg.withWidth (Css.px 40)
-                |> Svg.withHeight (Css.px 45)
-                |> Svg.withLabel "Bulb"
-                |> Svg.withCss [ Css.padding2 Css.zero (Css.px 6) ]
-                |> Svg.toHtml
-    in
-    [ Tabs.build { id = First, idString = "tab-0" }
-        ([ Tabs.tabString "1"
-         , Tabs.withTooltip
-            [ Tooltip.plaintext "Link Example"
-            , Tooltip.onToggle (ToggleTooltip First)
-            , Tooltip.alignStart (Css.px 75)
-            , Tooltip.primaryLabel
-            , Tooltip.open (openTooltipId == Just First)
-            ]
-         , Tabs.panelHtml (Html.text "First Panel")
-         ]
-            ++ (case labelledBy of
-                    Nothing ->
-                        []
-
-                    Just labelledById ->
-                        [ Tabs.labelledBy labelledById ]
-               )
-        )
-    , Tabs.build { id = Second, idString = "tab-1" }
-        [ Tabs.tabString "Second Tab (disabled)"
-        , Tabs.disabled True
-        , Tabs.panelHtml (Html.text "Second Panel")
-        ]
-    , Tabs.build { id = Third, idString = "tab-2" }
-        [ Tabs.tabHtml bulbIcon
-        , Tabs.withTooltip
-            [ Tooltip.plaintext "The Electrifying Third Tab"
-            , Tooltip.onToggle (ToggleTooltip Third)
-            , Tooltip.primaryLabel
-            , Tooltip.open (openTooltipId == Just Third)
-            ]
-        , Tabs.panelHtml (Html.text "Third Panel")
-        ]
-    , Tabs.build { id = Fourth, idString = "tab-3" }
-        [ Tabs.tabString "Fourth Tab"
-        , Tabs.panelHtml (Html.text "Fourth Panel")
-        ]
-    ]

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -12,6 +12,7 @@ module Examples.Tabs exposing
 
 import Browser.Dom as Dom
 import Category exposing (Category(..))
+import Code
 import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.View as ControlView
@@ -119,7 +120,7 @@ example =
                         let
                             code =
                                 [ moduleName ++ ".view"
-                                , "    { title = " ++ " TODO"
+                                , "    { title = " ++ Code.maybeString settings.title
                                 , "    , alignment = " ++ " TODO"
                                 , "    , customSpacing = " ++ " TODO"
                                 , "    , focusAndSelect = " ++ " TODO"

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -121,7 +121,7 @@ example =
                             code =
                                 [ moduleName ++ ".view"
                                 , "    { title = " ++ Code.maybeString settings.title
-                                , "    , alignment = " ++ " TODO"
+                                , "    , alignment = " ++ moduleName ++ "." ++ Debug.toString settings.alignment
                                 , "    , customSpacing = " ++ " TODO"
                                 , "    , focusAndSelect = " ++ " TODO"
                                 , "    , selected = " ++ " TODO"

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -123,9 +123,9 @@ example =
                                 , "    { title = " ++ Code.maybeString settings.title
                                 , "    , alignment = " ++ moduleName ++ "." ++ Debug.toString settings.alignment
                                 , "    , customSpacing = " ++ Code.maybeFloat settings.customSpacing
-                                , "    , focusAndSelect = " ++ " TODO"
-                                , "    , selected = " ++ " TODO"
-                                , "    , tabs = " ++ " TODO"
+                                , "    , focusAndSelect = identity"
+                                , "    , selected = " ++ String.fromInt model.selected
+                                , "    , tabs = " ++ "[]"
                                 , "    }"
                                 ]
                                     |> String.join "\n"
@@ -147,7 +147,7 @@ example =
     }
 
 
-allTabs : Maybe Id -> Maybe String -> List (Tab Id Msg)
+allTabs : Maybe Int -> Maybe String -> List (Tab Int Msg)
 allTabs openTooltipId labelledBy =
     let
         bulbIcon =
@@ -158,14 +158,14 @@ allTabs openTooltipId labelledBy =
                 |> Svg.withCss [ Css.padding2 Css.zero (Css.px 6) ]
                 |> Svg.toHtml
     in
-    [ Tabs.build { id = First, idString = "tab-0" }
+    [ Tabs.build { id = 0, idString = "tab-0" }
         ([ Tabs.tabString "1"
          , Tabs.withTooltip
             [ Tooltip.plaintext "Link Example"
-            , Tooltip.onToggle (ToggleTooltip First)
+            , Tooltip.onToggle (ToggleTooltip 0)
             , Tooltip.alignStart (Css.px 75)
             , Tooltip.primaryLabel
-            , Tooltip.open (openTooltipId == Just First)
+            , Tooltip.open (openTooltipId == Just 0)
             ]
          , Tabs.panelHtml (Html.text "First Panel")
          ]
@@ -177,22 +177,22 @@ allTabs openTooltipId labelledBy =
                         [ Tabs.labelledBy labelledById ]
                )
         )
-    , Tabs.build { id = Second, idString = "tab-1" }
+    , Tabs.build { id = 1, idString = "tab-1" }
         [ Tabs.tabString "Second Tab (disabled)"
         , Tabs.disabled True
         , Tabs.panelHtml (Html.text "Second Panel")
         ]
-    , Tabs.build { id = Third, idString = "tab-2" }
+    , Tabs.build { id = 2, idString = "tab-2" }
         [ Tabs.tabHtml bulbIcon
         , Tabs.withTooltip
             [ Tooltip.plaintext "The Electrifying Third Tab"
-            , Tooltip.onToggle (ToggleTooltip Third)
+            , Tooltip.onToggle (ToggleTooltip 2)
             , Tooltip.primaryLabel
-            , Tooltip.open (openTooltipId == Just Third)
+            , Tooltip.open (openTooltipId == Just 2)
             ]
         , Tabs.panelHtml (Html.text "Third Panel")
         ]
-    , Tabs.build { id = Fourth, idString = "tab-3" }
+    , Tabs.build { id = 3, idString = "tab-3" }
         [ Tabs.tabString "Fourth Tab"
         , Tabs.panelHtml (Html.text "Fourth Panel")
         ]
@@ -200,15 +200,15 @@ allTabs openTooltipId labelledBy =
 
 
 type alias State =
-    { selected : Id
+    { selected : Int
     , settings : Control Settings
-    , openTooltip : Maybe Id
+    , openTooltip : Maybe Int
     }
 
 
 init : State
 init =
-    { selected = First
+    { selected = 0
     , settings = initSettings
     , openTooltip = Nothing
     }
@@ -247,18 +247,11 @@ initSettings =
         |> Control.field "labelledBy" (Control.maybe False (Control.string "someId"))
 
 
-type Id
-    = First
-    | Second
-    | Third
-    | Fourth
-
-
 type Msg
-    = FocusAndSelectTab { select : Id, focus : Maybe String }
+    = FocusAndSelectTab { select : Int, focus : Maybe String }
     | Focused (Result Dom.Error ())
     | SetSettings (Control Settings)
-    | ToggleTooltip Id Bool
+    | ToggleTooltip Int Bool
 
 
 update : Msg -> State -> ( State, Cmd Msg )

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -17,15 +17,13 @@ import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.View as ControlView
 import Example exposing (Example)
-import Html.Styled as Html exposing (fromUnstyled)
+import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Tabs.V7 as Tabs exposing (Alignment(..), Tab)
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.Tooltip.V3 as Tooltip
-import Nri.Ui.UiIcon.V1 as UiIcon
 import Task
 
 

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -122,7 +122,7 @@ example =
                                 [ moduleName ++ ".view"
                                 , "    { title = " ++ Code.maybeString settings.title
                                 , "    , alignment = " ++ moduleName ++ "." ++ Debug.toString settings.alignment
-                                , "    , customSpacing = " ++ " TODO"
+                                , "    , customSpacing = " ++ Code.maybeFloat settings.customSpacing
                                 , "    , focusAndSelect = " ++ " TODO"
                                 , "    , selected = " ++ " TODO"
                                 , "    , tabs = " ++ " TODO"

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -9,6 +9,7 @@
         "Nri.Ui.Balloon.V1",
         "Nri.Ui.BreadCrumbs.V1",
         "Nri.Ui.Button.V10",
+        "Nri.Ui.Carousel.V1",
         "Nri.Ui.Checkbox.V5",
         "Nri.Ui.ClickableSvg.V2",
         "Nri.Ui.ClickableText.V3",


### PR DESCRIPTION
- no longer includes a disabled tab (I would prefer that we avoid disabling tabs, since the styles are not clear)
- generates example code & valid Ellie link