### PR TITLE
Use whitespace: pre-wrap for viewCodeDtails to preserve new lines

### DIFF
--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -333,7 +333,7 @@ viewCodeDetails errorMessageForEngineers =
         , code
             [ Attributes.css
                 [ display block
-                , whiteSpace normal
+                , whiteSpace preWrap
                 , overflowWrap breakWord
                 , color Colors.gray45
                 , backgroundColor Colors.gray96


### PR DESCRIPTION
## We've been elmifying code a lot. When dealing with decoding the white spaces in the error message helps a bunch. This PR just changes a css rule to keep them.

### Before
![image](https://user-images.githubusercontent.com/15899938/176945241-a5e9cea3-e78c-468d-a11a-1c5a418bedb0.png)

### After
![image](https://user-images.githubusercontent.com/15899938/176945155-6814b78a-ad49-4f4a-a561-7130102d9530.png)
