### PR TITLE
Add Menu.containsForm

### DIFF
--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -217,7 +217,6 @@ You will need to pass in the last focusable element in the disclosed content in 
   - any focusable elements in the disclosed content to be keyboard accessible
   - the disclosure to close appropriately when the user tabs past all of the disclosed content
 
-You may pass a lastId of Nothing if there is NO focusable content within the disclosure.
 
 -}
 disclosure : { lastId : String } -> Attribute msg

--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -460,30 +460,24 @@ viewCustom config =
                                     )
                                 ]
 
-                            Disclosure _ ->
-                                []
+                            Disclosure { lastId } ->
+                                [ WhenFocusLeaves.toDecoder
+                                    { firstId = config.buttonId
+                                    , lastId = lastId
+                                    , tabBackAction =
+                                        config.focusAndToggle
+                                            { isOpen = False
+                                            , focus = Nothing
+                                            }
+                                    , tabForwardAction =
+                                        config.focusAndToggle
+                                            { isOpen = False
+                                            , focus = Nothing
+                                            }
+                                    }
+                                ]
                        )
                 )
-            :: (case config.purpose of
-                    NavMenu ->
-                        AttributesExtra.none
-
-                    Disclosure { lastId } ->
-                        WhenFocusLeaves.toAttribute
-                            { firstId = config.buttonId
-                            , lastId = lastId
-                            , tabBackAction =
-                                config.focusAndToggle
-                                    { isOpen = False
-                                    , focus = Nothing
-                                    }
-                            , tabForwardAction =
-                                config.focusAndToggle
-                                    { isOpen = False
-                                    , focus = Nothing
-                                    }
-                            }
-               )
             :: styleContainer
         )
         [ if config.isOpen then

--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -1,7 +1,7 @@
 module Nri.Ui.Menu.V3 exposing
     ( view, button, custom, Config
     , Attribute, Button, ButtonAttribute
-    , alignment, isDisabled, menuWidth, buttonId, menuId, menuZIndex, opensOnHover
+    , alignment, isDisabled, menuWidth, buttonId, menuId, menuZIndex, opensOnHover, containsForm
     , Alignment(..)
     , icon, wrapping, hasBorder, buttonWidth
     , TitleWrapping(..)
@@ -30,7 +30,7 @@ A togglable menu view and related buttons.
 
 ## Menu attributes
 
-@docs alignment, isDisabled, menuWidth, buttonId, menuId, menuZIndex, opensOnHover
+@docs alignment, isDisabled, menuWidth, buttonId, menuId, menuZIndex, opensOnHover, containsForm
 @docs Alignment
 
 
@@ -105,6 +105,7 @@ type alias MenuConfig msg =
     , menuId : String
     , zIndex : Int
     , opensOnHover : Bool
+    , containsForm : Bool
     }
 
 
@@ -201,6 +202,13 @@ opensOnHover value =
     Attribute <| \config -> { config | opensOnHover = value }
 
 
+{-| Whether the menu contains a form when opened. This affects how Tab key behaves Defaults to `False`.
+-}
+containsForm : Bool -> Attribute msg
+containsForm value =
+    Attribute <| \config -> { config | containsForm = value }
+
+
 {-| Menu/pulldown configuration:
 
   - `attributes`: List of (attributes)[#menu-attributes] to apply to the menu.
@@ -226,6 +234,7 @@ view attributes config =
             , menuId = ""
             , zIndex = 1
             , opensOnHover = False
+            , containsForm = False
             }
 
         menuConfig =
@@ -415,25 +424,31 @@ viewCustom config =
     div
         (Attributes.id (config.buttonId ++ "__container")
             :: Key.onKeyDown
-                [ Key.escape
+                (Key.escape
                     (config.focusAndToggle
                         { isOpen = False
                         , focus = Just config.buttonId
                         }
                     )
-                , Key.tab
-                    (config.focusAndToggle
-                        { isOpen = False
-                        , focus = Nothing
-                        }
-                    )
-                , Key.tabBack
-                    (config.focusAndToggle
-                        { isOpen = False
-                        , focus = Nothing
-                        }
-                    )
-                ]
+                    :: (if config.containsForm then
+                            []
+
+                        else
+                            [ Key.tab
+                                (config.focusAndToggle
+                                    { isOpen = False
+                                    , focus = Nothing
+                                    }
+                                )
+                            , Key.tabBack
+                                (config.focusAndToggle
+                                    { isOpen = False
+                                    , focus = Nothing
+                                    }
+                                )
+                            ]
+                       )
+                )
             :: styleContainer
         )
         [ if config.isOpen then

--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -445,19 +445,25 @@ viewCustom config =
                         , focus = Just config.buttonId
                         }
                     )
-                    :: [ Key.tab
-                            (config.focusAndToggle
-                                { isOpen = False
-                                , focus = Nothing
-                                }
-                            )
-                       , Key.tabBack
-                            (config.focusAndToggle
-                                { isOpen = False
-                                , focus = Nothing
-                                }
-                            )
-                       ]
+                    :: (case config.purpose of
+                            NavMenu ->
+                                [ Key.tab
+                                    (config.focusAndToggle
+                                        { isOpen = False
+                                        , focus = Nothing
+                                        }
+                                    )
+                                , Key.tabBack
+                                    (config.focusAndToggle
+                                        { isOpen = False
+                                        , focus = Nothing
+                                        }
+                                    )
+                                ]
+
+                            Disclosure _ ->
+                                []
+                       )
                 )
             :: styleContainer
         )
@@ -509,8 +515,9 @@ viewCustom config =
                     , Aria.expanded config.isOpen
                     , -- Whether the menu is open or closed, move to the
                       -- first menu item if the "down" arrow is pressed
-                      case ( maybeFirstFocusableElementId, maybeLastFocusableElementId ) of
-                        ( Just firstFocusableElementId, Just lastFocusableElementId ) ->
+                      -- as long as it's not a Disclosed
+                      case ( config.purpose, maybeFirstFocusableElementId, maybeLastFocusableElementId ) of
+                        ( NavMenu, Just firstFocusableElementId, Just lastFocusableElementId ) ->
                             onKeyDownPreventDefault
                                 [ Key.down
                                     (config.focusAndToggle

--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -63,6 +63,7 @@ import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.Shadows.V1 as Shadows
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.UiIcon.V1 as UiIcon
+import Nri.Ui.WhenFocusLeaves.V1 as WhenFocusLeaves
 
 
 {-| -}
@@ -465,6 +466,26 @@ viewCustom config =
                                 []
                        )
                 )
+            :: (case config.purpose of
+                    NavMenu ->
+                        AttributesExtra.none
+
+                    Disclosure { lastId } ->
+                        WhenFocusLeaves.toAttribute
+                            { firstId = config.buttonId
+                            , lastId = Maybe.withDefault config.buttonId lastId
+                            , tabBackAction =
+                                config.focusAndToggle
+                                    { isOpen = False
+                                    , focus = Nothing
+                                    }
+                            , tabForwardAction =
+                                config.focusAndToggle
+                                    { isOpen = False
+                                    , focus = Nothing
+                                    }
+                            }
+               )
             :: styleContainer
         )
         [ if config.isOpen then

--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -1,7 +1,7 @@
 module Nri.Ui.Menu.V3 exposing
     ( view, button, custom, Config
     , Attribute, Button, ButtonAttribute
-    , alignment, isDisabled, menuWidth, buttonId, menuId, menuZIndex, opensOnHover, containsForm
+    , alignment, isDisabled, menuWidth, buttonId, menuId, menuZIndex, opensOnHover, disclosure
     , Alignment(..)
     , icon, wrapping, hasBorder, buttonWidth
     , TitleWrapping(..)
@@ -30,7 +30,7 @@ A togglable menu view and related buttons.
 
 ## Menu attributes
 
-@docs alignment, isDisabled, menuWidth, buttonId, menuId, menuZIndex, opensOnHover, containsForm
+@docs alignment, isDisabled, menuWidth, buttonId, menuId, menuZIndex, opensOnHover, disclosure
 @docs Alignment
 
 
@@ -105,7 +105,7 @@ type alias MenuConfig msg =
     , menuId : String
     , zIndex : Int
     , opensOnHover : Bool
-    , containsForm : Bool
+    , disclosure : Bool
     }
 
 
@@ -204,9 +204,9 @@ opensOnHover value =
 
 {-| Whether the menu contains a form when opened. This affects how Tab key behaves Defaults to `False`.
 -}
-containsForm : Bool -> Attribute msg
-containsForm value =
-    Attribute <| \config -> { config | containsForm = value }
+disclosure : Bool -> Attribute msg
+disclosure value =
+    Attribute <| \config -> { config | disclosure = value }
 
 
 {-| Menu/pulldown configuration:
@@ -234,7 +234,7 @@ view attributes config =
             , menuId = ""
             , zIndex = 1
             , opensOnHover = False
-            , containsForm = False
+            , disclosure = False
             }
 
         menuConfig =
@@ -430,7 +430,7 @@ viewCustom config =
                         , focus = Just config.buttonId
                         }
                     )
-                    :: (if config.containsForm then
+                    :: (if config.disclosure then
                             []
 
                         else

--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -217,7 +217,6 @@ You will need to pass in the last focusable element in the disclosed content in 
   - any focusable elements in the disclosed content to be keyboard accessible
   - the disclosure to close appropriately when the user tabs past all of the disclosed content
 
-
 -}
 disclosure : { lastId : String } -> Attribute msg
 disclosure exitFocusManager =
@@ -601,7 +600,12 @@ viewCustom config =
                 , div
                     [ classList [ ( "Content", True ), ( "ContentVisible", contentVisible ) ]
                     , styleContent contentVisible config
-                    , Role.menu
+                    , case config.purpose of
+                        NavMenu ->
+                            Role.menu
+
+                        Disclosure _ ->
+                            AttributesExtra.none
                     , Aria.labelledBy config.buttonId
                     , Attributes.id config.menuId
                     , Aria.hidden (not config.isOpen)

--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -120,7 +120,7 @@ type alias ButtonConfig =
 
 type Purpose
     = NavMenu
-    | Disclosure { lastId : Maybe String }
+    | Disclosure { lastId : String }
 
 
 
@@ -220,7 +220,7 @@ You will need to pass in the last focusable element in the disclosed content in 
 You may pass a lastId of Nothing if there is NO focusable content within the disclosure.
 
 -}
-disclosure : { lastId : Maybe String } -> Attribute msg
+disclosure : { lastId : String } -> Attribute msg
 disclosure exitFocusManager =
     Attribute (\config -> { config | purpose = Disclosure exitFocusManager })
 
@@ -473,7 +473,7 @@ viewCustom config =
                     Disclosure { lastId } ->
                         WhenFocusLeaves.toAttribute
                             { firstId = config.buttonId
-                            , lastId = Maybe.withDefault config.buttonId lastId
+                            , lastId = lastId
                             , tabBackAction =
                                 config.focusAndToggle
                                     { isOpen = False

--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -500,7 +500,12 @@ viewCustom config =
             [ let
                 buttonAttributes =
                     [ Aria.disabled config.isDisabled
-                    , Aria.hasMenuPopUp
+                    , case config.purpose of
+                        NavMenu ->
+                            Aria.hasMenuPopUp
+
+                        Disclosure _ ->
+                            AttributesExtra.none
                     , Aria.expanded config.isOpen
                     , -- Whether the menu is open or closed, move to the
                       -- first menu item if the "down" arrow is pressed

--- a/src/Nri/Ui/WhenFocusLeaves/V1.elm
+++ b/src/Nri/Ui/WhenFocusLeaves/V1.elm
@@ -17,6 +17,8 @@ what to do in reponse to tab keypresses in a part of the UI.
 The ids referenced here are expected to correspond to elements in the container
 we are adding the attribute to.
 
+NOTE: When needing to listen to multiple keys toDecoder should be used instead of toAttribute.
+
 -}
 toAttribute :
     { firstId : String
@@ -29,6 +31,22 @@ toAttribute config =
     Key.onKeyDown [ toDecoder config ]
 
 
+{-| Use this decoder to add a focus watcher to an HTML element and define
+what to do in reponse to tab keypresses in a part of the UI.
+
+The ids referenced here are expected to correspond to elements in the container
+we are adding the attribute to.
+
+NOTE: When needing to listen to multiple keys toDecoder should be used instead of toAttribute.
+
+    import Accessibility.Styled.Key as Key
+
+    Key.onKeyDown
+        [ Key.escape CloseModal
+        , toDecoder config
+        ]
+
+-}
 toDecoder :
     { firstId : String
     , lastId : String

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -321,7 +321,7 @@ controlMenuAttributes =
         |> ControlExtra.optionalBoolListItem "isDisabled" ( "Menu.isDisabled True", Menu.isDisabled True )
         |> ControlExtra.optionalListItem "menuWidth" controlMenuWidth
         |> ControlExtra.optionalBoolListItem "opensOnHover" ( "Menu.opensOnHover True", Menu.opensOnHover True )
-        |> ControlExtra.optionalBoolListItem "containsForm" ( "Menu.containsForm True", Menu.containsForm True )
+        |> ControlExtra.optionalBoolListItem "disclosure" ( "Menu.disclosure True", Menu.disclosure True )
 
 
 controlAlignment : Control ( String, Menu.Attribute msg )

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -250,12 +250,12 @@ view ellieLinkConfig state =
                             button buttonAttributes [ text "Custom Menu trigger button" ]
                 }
           )
-        , ( "Menu.button (with controls)"
+        , ( "Menu.button (with Menu.disclosure)"
           , Menu.view
                 (menuAttributes
-                    ++ List.filterMap identity
-                        [ Just <| Menu.buttonId "with_controls__button"
-                        , Just <| Menu.menuId "with_controls__menu"
+                    ++  [ Menu.buttonId "with_controls__button"
+                        , Menu.menuId "with_controls__menu"
+                        , Menu.disclosure { lastId = Nothing }
                         ]
                 )
                 { isOpen = isOpen "with_controls"
@@ -321,7 +321,6 @@ controlMenuAttributes =
         |> ControlExtra.optionalBoolListItem "isDisabled" ( "Menu.isDisabled True", Menu.isDisabled True )
         |> ControlExtra.optionalListItem "menuWidth" controlMenuWidth
         |> ControlExtra.optionalBoolListItem "opensOnHover" ( "Menu.opensOnHover True", Menu.opensOnHover True )
-        |> ControlExtra.optionalBoolListItem "disclosure" ( "Menu.disclosure True", Menu.disclosure True )
 
 
 controlAlignment : Control ( String, Menu.Attribute msg )

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -255,7 +255,7 @@ view ellieLinkConfig state =
                 (menuAttributes
                     ++  [ Menu.buttonId "with_controls__button"
                         , Menu.menuId "with_controls__menu"
-                        , Menu.disclosure { lastId = Nothing }
+                        , Menu.disclosure { lastId = Just "login__button" }
                         ]
                 )
                 { isOpen = isOpen "with_controls"
@@ -270,6 +270,7 @@ view ellieLinkConfig state =
                                 , TextInput.view "Password" []
                                 , Button.button "Log in"
                                     [ Button.primary
+                                    , Button.id "login__button"
                                     , Button.fillContainerWidth
                                     , Button.css [ Css.marginTop (Css.px 15) ]
                                     ]

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -18,11 +18,13 @@ import Debug.Control.View as ControlView
 import EllieLink
 import Example exposing (Example)
 import KeyboardSupport exposing (Key(..))
+import Nri.Ui.Button.V10 as Button
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.Extra as ColorsExtra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Menu.V3 as Menu
+import Nri.Ui.TextInput.V7 as TextInput
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Set exposing (Set)
 import Svg.Styled as Svg
@@ -246,6 +248,34 @@ view ellieLinkConfig state =
                     Menu.custom <|
                         \buttonAttributes ->
                             button buttonAttributes [ text "Custom Menu trigger button" ]
+                }
+          )
+        , ( "Menu.button (with controls)"
+          , Menu.view
+                (menuAttributes
+                    ++ List.filterMap identity
+                        [ Just <| Menu.buttonId "with_controls__button"
+                        , Just <| Menu.menuId "with_controls__menu"
+                        ]
+                )
+                { isOpen = isOpen "with_controls"
+                , focusAndToggle = FocusAndToggle "with_controls"
+                , entries =
+                    [ Menu.entry "username-input" <|
+                        \attrs ->
+                            div []
+                                [ TextInput.view "Username"
+                                    [ TextInput.id "username-input"
+                                    ]
+                                , TextInput.view "Password" []
+                                , Button.button "Log in"
+                                    [ Button.primary
+                                    , Button.fillContainerWidth
+                                    , Button.css [ Css.marginTop (Css.px 15) ]
+                                    ]
+                                ]
+                    ]
+                , button = Menu.button defaultButtonAttributes "Log In"
                 }
           )
         ]

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -253,10 +253,10 @@ view ellieLinkConfig state =
         , ( "Menu.button (with Menu.disclosure)"
           , Menu.view
                 (menuAttributes
-                    ++  [ Menu.buttonId "with_controls__button"
-                        , Menu.menuId "with_controls__menu"
-                        , Menu.disclosure { lastId = "login__button" }
-                        ]
+                    ++ [ Menu.buttonId "with_controls__button"
+                       , Menu.menuId "with_controls__menu"
+                       , Menu.disclosure { lastId = "login__button" }
+                       ]
                 )
                 { isOpen = isOpen "with_controls"
                 , focusAndToggle = FocusAndToggle "with_controls"

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -323,6 +323,7 @@ controlMenuAttributes =
         |> ControlExtra.optionalBoolListItem "opensOnHover" ( "Menu.opensOnHover True", Menu.opensOnHover True )
         |> ControlExtra.optionalBoolListItem "containsForm" ( "Menu.containsForm True", Menu.containsForm True )
 
+
 controlAlignment : Control ( String, Menu.Attribute msg )
 controlAlignment =
     Control.choice

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -255,7 +255,7 @@ view ellieLinkConfig state =
                 (menuAttributes
                     ++  [ Menu.buttonId "with_controls__button"
                         , Menu.menuId "with_controls__menu"
-                        , Menu.disclosure { lastId = Just "login__button" }
+                        , Menu.disclosure { lastId = "login__button" }
                         ]
                 )
                 { isOpen = isOpen "with_controls"

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -321,7 +321,7 @@ controlMenuAttributes =
         |> ControlExtra.optionalBoolListItem "isDisabled" ( "Menu.isDisabled True", Menu.isDisabled True )
         |> ControlExtra.optionalListItem "menuWidth" controlMenuWidth
         |> ControlExtra.optionalBoolListItem "opensOnHover" ( "Menu.opensOnHover True", Menu.opensOnHover True )
-
+        |> ControlExtra.optionalBoolListItem "containsForm" ( "Menu.containsForm True", Menu.containsForm True )
 
 controlAlignment : Control ( String, Menu.Attribute msg )
 controlAlignment =

--- a/tests/Spec/Nri/Ui/Menu.elm
+++ b/tests/Spec/Nri/Ui/Menu.elm
@@ -2,6 +2,7 @@ module Spec.Nri.Ui.Menu exposing (spec)
 
 import Html.Attributes as Attributes
 import Html.Styled as HtmlStyled
+import Json.Encode as Encode
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Menu.V3 as Menu
 import ProgramTest exposing (ProgramTest, ensureViewHas, ensureViewHasNot)
@@ -30,6 +31,15 @@ spec =
                     |> clickMenuButton
                     |> ensureViewHas (menuContentSelector menuContent)
                     |> clickMenuButton
+                    |> ensureViewHasNot (menuContentSelector menuContent)
+                    |> ProgramTest.done
+        , test "Close on tab key" <|
+            \() ->
+                program []
+                    -- Menu opens on mouse click and closes on tab key
+                    |> clickMenuButton
+                    |> ensureViewHas (menuContentSelector menuContent)
+                    |> pressTabKey
                     |> ensureViewHasNot (menuContentSelector menuContent)
                     |> ProgramTest.done
         ]
@@ -122,3 +132,20 @@ clickMenuButton =
             ]
         )
         Event.click
+
+
+pressTabKey : ProgramTest model msg effect -> ProgramTest model msg effect
+pressTabKey =
+    ProgramTest.simulateDomEvent
+        (Query.find
+            [ Selector.class "Container"
+            ]
+        )
+        (Event.custom
+            "keydown"
+            (Encode.object
+                [ ( "keyCode", Encode.int 9 )
+                , ( "shiftKey", Encode.bool False )
+                ]
+            )
+        )


### PR DESCRIPTION
The Nri.Ui.Menu.V3 does not play nice when the content is a form. The user is expected to `<tab>` to change controls, yet menu by default is closed on `<tab>`.

This PR adds a `Menu.containsForm` defaults to `False` (so it's backward compatible) that will turn off the close-on-tab behavior.

https://user-images.githubusercontent.com/459923/177409704-699c8a7c-1656-429e-8bbe-f5f09b1da9de.mp4


