### PR TITLE
Use white-space: pre-wrap for page error messages to keep line breaks

### DIFF
--- a/src/Nri/Ui/Page/V3.elm
+++ b/src/Nri/Ui/Page/V3.elm
@@ -269,7 +269,7 @@ viewDetails detailsForEngineers =
                 [ Html.text "Details for NoRedInk engineers" ]
             , Html.styled Html.code
                 [ display block
-                , whiteSpace normal
+                , whiteSpace preWrap
                 , overflowWrap breakWord
                 , textAlign left
                 , marginTop (px 10)


### PR DESCRIPTION
Preserver line breaks when showing error messages for page errors.

### Before
![image](https://user-images.githubusercontent.com/15899938/179228527-beac17ee-cd73-455e-a318-11998c9a1e94.png)

### After
![image](https://user-images.githubusercontent.com/15899938/179228464-b3c3959d-1350-4549-8634-97b0013f410b.png)
