### PR TITLE
Use navy for hover and pressed toggle button colors

### DIFF
--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -692,7 +692,7 @@ toggleButton config =
         toggledStyles =
             if config.pressed then
                 Css.batch
-                    [ Css.color Colors.gray20
+                    [ Css.color Colors.navy
                     , Css.backgroundColor Colors.glacier
                     , Css.boxShadow5 Css.inset Css.zero (Css.px 3) Css.zero (ColorsExtra.withAlpha 0.2 Colors.gray20)
                     , Css.border3 (Css.px 1) Css.solid Colors.azure
@@ -705,7 +705,11 @@ toggleButton config =
     in
     Nri.Ui.styled Html.button
         (styledName "toggleButton")
-        [ buttonStyles Medium WidthUnbounded secondaryColors []
+        [ buttonStyles Medium
+            WidthUnbounded
+            secondaryColors
+            [ Css.hover [ Css.color Colors.navy ]
+            ]
         , toggledStyles
         , Css.verticalAlign Css.middle
         ]


### PR DESCRIPTION
Use `navy` instead of `azure` for hover toggle button states, in order to fix color contrast issue.

<img width="267" alt="Screen Shot of toggle button" src="https://user-images.githubusercontent.com/8811312/179604341-97db0db5-7a0b-4c38-9e36-e8ebf8025744.png">
