### PR TITLE
Deprecate Container.invalid

### DIFF
--- a/src/Nri/Ui/Container/V2.elm
+++ b/src/Nri/Ui/Container/V2.elm
@@ -10,6 +10,11 @@ module Nri.Ui.Container.V2 exposing
 {-| Common NoRedInk Containers
 
 
+# TODO in next version:
+
+  - remove `invalid`
+
+
 # Changelog
 
 
@@ -249,7 +254,8 @@ disabledStyles =
     ]
 
 
-{-| -}
+{-| DEPRECATED -- this will be removed in the next version of this component.
+-}
 invalid : Attribute msg
 invalid =
     Attribute <|

--- a/styleguide-app/Examples/Container.elm
+++ b/styleguide-app/Examples/Container.elm
@@ -42,10 +42,6 @@ example =
     , preview =
         [ Container.view []
         , Container.view
-            [ Container.invalid
-            , Container.css [ Css.marginTop (Css.px 8) ]
-            ]
-        , Container.view
             [ Container.disabled
             , Container.css [ Css.marginTop (Css.px 8) ]
             ]
@@ -85,9 +81,6 @@ example =
                         , { sectionName = "Disabled Container"
                           , code = viewExampleCode ("Container.disabled" :: stringAttributes)
                           }
-                        , { sectionName = "Invalid Container"
-                          , code = viewExampleCode ("Container.invalid" :: stringAttributes)
-                          }
                         ]
                 }
             , viewExample
@@ -115,11 +108,6 @@ example =
                 , description = "Used to indicate content is locked/inaccessible"
                 }
                 (Container.disabled :: attributes)
-            , viewExample
-                { name = "Invalid Container"
-                , description = "Used to indicate content is invalid"
-                }
-                (Container.invalid :: attributes)
             ]
     }
 


### PR DESCRIPTION
`Message.error` and `Container.invalid` don’t compose nicely, since they're both the same colors... which essentially means that Container.invalid is unusable with the main useful inputs of noredink-ui.

`Container.invalid` is now marked as deprecated and will be removed in the next Container version.