### PR TITLE
Fix Modal focus

### DIFF
--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -109,17 +109,15 @@ describe("UI tests", function () {
   const modalProcessing = async (name, location) => {
     await goTo(name, location);
 
-    await forAllOptions("Theme", async (option) => {
-      await page.click("#launch-modal");
-      await page.waitForSelector('[role="dialog"]');
-      await percySnapshot(page, `${name} - ${option}`);
+    await page.click("#launch-modal");
+    await page.waitForSelector('[role="dialog"]');
+    await percySnapshot(page, `${name} - info`);
 
-      axe = await new AxePuppeteer(page).analyze();
+    axe = await new AxePuppeteer(page).analyze();
 
-      await page.click('[aria-label="Close modal"]');
+    await page.click('[aria-label="Close modal"]');
 
-      handleAxeResults(`${name} - ${option}`, axe);
-    });
+    handleAxeResults(`${name} - info`, axe);
   };
 
   const pageProcessing = async (name, location) => {

--- a/src/Nri/Ui/FocusTrap/V1.elm
+++ b/src/Nri/Ui/FocusTrap/V1.elm
@@ -28,8 +28,8 @@ type alias FocusTrap msg =
 toAttribute : FocusTrap msg -> Html.Attribute msg
 toAttribute { firstId, lastId, focus } =
     WhenFocusLeaves.toAttribute
-        { firstId = firstId
-        , lastId = lastId
+        { firstId = Debug.log "firstId" firstId
+        , lastId = Debug.log "lastId " lastId
         , -- if the user tabs back while on the first id,
           -- we want to wrap around to the last id.
           tabBackAction = focus lastId

--- a/src/Nri/Ui/WhenFocusLeaves/V1.elm
+++ b/src/Nri/Ui/WhenFocusLeaves/V1.elm
@@ -7,7 +7,6 @@ module Nri.Ui.WhenFocusLeaves.V1 exposing (toAttribute, toDecoder)
 -}
 
 import Accessibility.Styled as Html
-import Accessibility.Styled.Key as Key
 import Html.Styled.Events exposing (preventDefaultOn)
 import Json.Decode as Decode exposing (Decoder)
 

--- a/src/Nri/Ui/WhenFocusLeaves/V1.elm
+++ b/src/Nri/Ui/WhenFocusLeaves/V1.elm
@@ -8,6 +8,7 @@ module Nri.Ui.WhenFocusLeaves.V1 exposing (toAttribute, toDecoder)
 
 import Accessibility.Styled as Html
 import Accessibility.Styled.Key as Key
+import Html.Styled.Events exposing (preventDefaultOn)
 import Json.Decode as Decode exposing (Decoder)
 
 
@@ -28,7 +29,8 @@ toAttribute :
     }
     -> Html.Attribute msg
 toAttribute config =
-    Key.onKeyDown [ toDecoder config ]
+    preventDefaultOn "keydown"
+        (Decode.map (\msg -> ( msg, True )) (toDecoder config))
 
 
 {-| Use this decoder to add a focus watcher to an HTML element and define

--- a/styleguide-app/Debug/Control/View.elm
+++ b/styleguide-app/Debug/Control/View.elm
@@ -40,7 +40,7 @@ view :
     , update : Control a -> msg
     , settings : Control a
     , mainType : String
-    , extraImports : List String
+    , extraCode : List String
     , toExampleCode : a -> List { sectionName : String, code : String }
     }
     -> Html msg
@@ -74,7 +74,7 @@ view config =
 
 viewExampleCode :
     (EllieLink.SectionExample -> Html msg)
-    -> { component | name : String, version : Int, mainType : String, extraImports : List String }
+    -> { component | name : String, version : Int, mainType : String, extraCode : List String }
     -> List { sectionName : String, code : String }
     -> Html msg
 viewExampleCode ellieLink component values =
@@ -97,7 +97,7 @@ viewExampleCode ellieLink component values =
                             , name = component.name
                             , sectionName = example.sectionName
                             , mainType = component.mainType
-                            , extraImports = component.extraImports
+                            , extraCode = component.extraCode
                             , code = example.code
                             }
                         , code

--- a/styleguide-app/EllieLink.elm
+++ b/styleguide-app/EllieLink.elm
@@ -17,7 +17,7 @@ type alias SectionExample =
     , fullModuleName : String
     , sectionName : String
     , mainType : String
-    , extraImports : List String
+    , extraCode : List String
     , code : String
     }
 
@@ -80,7 +80,7 @@ generateElmExampleModule config example =
     , "import Nri.Ui.UiIcon.V1 as UiIcon"
     , "import Nri.Ui.Svg.V1 as Svg"
     , "import " ++ example.fullModuleName ++ " as " ++ example.name
-    , String.join "\n" example.extraImports
+    , String.join "\n" example.extraCode
     , ""
     , ""
     ]

--- a/styleguide-app/Examples/Accordion.elm
+++ b/styleguide-app/Examples/Accordion.elm
@@ -104,7 +104,7 @@ view ellieLinkConfig model =
         , update = UpdateControls
         , settings = model.settings
         , mainType = "RootHtml.Html String"
-        , extraImports =
+        , extraCode =
             [ "import Nri.Ui.DisclosureIndicator.V2 as DisclosureIndicator"
             , "import Nri.Ui.Svg.V1 as Svg"
             ]

--- a/styleguide-app/Examples/Balloon.elm
+++ b/styleguide-app/Examples/Balloon.elm
@@ -151,7 +151,7 @@ view ellieLinkConfig state =
         , update = SetAttributes
         , settings = state
         , mainType = "RootHtml.Html msg"
-        , extraImports = []
+        , extraCode = []
         , toExampleCode =
             \{ copy, attributes } ->
                 [ { sectionName = "Balloon"

--- a/styleguide-app/Examples/BreadCrumbs.elm
+++ b/styleguide-app/Examples/BreadCrumbs.elm
@@ -68,7 +68,7 @@ example =
                 , update = UpdateControl
                 , settings = state
                 , mainType = "RootHtml.Html msg"
-                , extraImports = []
+                , extraCode = []
                 , toExampleCode = \settings -> [ { sectionName = moduleName ++ ".view", code = viewExampleCode settings } ]
                 }
             , section [ css [ Css.margin2 (Css.px 20) Css.zero ] ]

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -209,7 +209,7 @@ viewButtonExamples ellieLinkConfig state =
         , update = SetDebugControlsState
         , settings = state.debugControlsState
         , mainType = "RootHtml.Html msg"
-        , extraImports = []
+        , extraCode = []
         , toExampleCode =
             \{ label, attributes } ->
                 let

--- a/styleguide-app/Examples/Carousel.elm
+++ b/styleguide-app/Examples/Carousel.elm
@@ -185,7 +185,7 @@ example =
                 , update = SetSettings
                 , settings = model.settings
                 , mainType = "RootHtml.Html { select : Int, focus : Maybe String }"
-                , extraImports = []
+                , extraCode = []
                 , toExampleCode =
                     \_ ->
                         let

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -65,7 +65,7 @@ example =
                 , update = SetControls
                 , settings = state.settings
                 , mainType = "RootHtml.Html msg"
-                , extraImports = []
+                , extraCode = []
                 , toExampleCode =
                     \{ label, icon, attributes } ->
                         let

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -143,7 +143,7 @@ viewExamples ellieLinkConfig (State control) =
         , update = SetState
         , settings = control
         , mainType = "RootHtml.Html msg"
-        , extraImports = []
+        , extraCode = []
         , toExampleCode =
             \{ label, attributes } ->
                 let

--- a/styleguide-app/Examples/Confetti.elm
+++ b/styleguide-app/Examples/Confetti.elm
@@ -58,7 +58,7 @@ example =
                 , update = UpdateControl
                 , settings = state.settings
                 , mainType = "RootHtml.Html msg"
-                , extraImports = []
+                , extraCode = []
                 , toExampleCode =
                     \settings -> [ { sectionName = "TODO", code = "TODO" } ]
                 }

--- a/styleguide-app/Examples/Container.elm
+++ b/styleguide-app/Examples/Container.elm
@@ -59,7 +59,7 @@ example =
                 , update = UpdateControl
                 , settings = state.control
                 , mainType = "RootHtml.Html msg"
-                , extraImports = []
+                , extraCode = []
                 , toExampleCode =
                     \settings ->
                         let

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -59,7 +59,7 @@ example =
                 , update = UpdateSettings
                 , settings = state.settings
                 , mainType = "RootHtml.Html msg"
-                , extraImports = [ "import Nri.Ui.Svg.V1 as Svg" ]
+                , extraCode = [ "import Nri.Ui.Svg.V1 as Svg" ]
                 , toExampleCode =
                     \settings ->
                         let

--- a/styleguide-app/Examples/Heading.elm
+++ b/styleguide-app/Examples/Heading.elm
@@ -63,7 +63,7 @@ example =
                 , update = UpdateControl
                 , settings = state.control
                 , mainType = "RootHtml.Html msg"
-                , extraImports = []
+                , extraCode = []
                 , toExampleCode =
                     \settings ->
                         let

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -139,7 +139,7 @@ view ellieLinkConfig state =
         , update = UpdateControls
         , settings = state.settings
         , mainType = "RootHtml.Html msg"
-        , extraImports = []
+        , extraCode = []
         , toExampleCode =
             \settings ->
                 let

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -158,7 +158,7 @@ example =
                 , update = UpdateControl
                 , settings = state.control
                 , mainType = "RootHtml.Html msg"
-                , extraImports = []
+                , extraCode = []
                 , toExampleCode =
                     \settings ->
                         let

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -10,6 +10,7 @@ import Accessibility.Styled exposing (Html, div, text)
 import Accessibility.Styled.Key as Key
 import Browser.Dom as Dom
 import Category exposing (Category(..))
+import Code
 import Css exposing (..)
 import Debug.Control as Control exposing (Control)
 import Debug.Control.View as ControlView
@@ -190,9 +191,63 @@ example =
                 , version = version
                 , update = UpdateSettings
                 , settings = state.settings
-                , mainType = "RootHtml.Html ModalMsg"
-                , extraImports = []
-                , toExampleCode = \_ -> []
+                , mainType = "RootHtml.Html Msg"
+                , extraCode = [ "type Msg = ModalMsg Modal.Msg | Focus String" ]
+                , toExampleCode =
+                    \_ ->
+                        let
+                            code =
+                                [ "Modal.view"
+                                , "\n\t{ title = " ++ Code.string settings.title
+                                , "\n\t, wrapMsg = ModalMsg"
+                                , "\n\t, content = [] -- The body of the modal goes in here"
+                                , "\n\t-- Use elements with Button.modal and ClickableText.modal for standardized footer elements"
+                                , "\n\t-- Remember to add an id to the first and final focusable element!"
+                                , "\n\t, footer = [] "
+                                , "\n\t, focusTrap ="
+                                , "\n\t\t{ focus = Focus"
+                                , "\n\t\t, firstId = "
+                                    ++ (if settings.showX then
+                                            Code.string Modal.closeButtonId
+
+                                        else if settings.showContinue then
+                                            Code.string continueButtonId
+
+                                        else
+                                            Code.string closeClickableTextId
+                                       )
+                                , "\n\t\t, lastId ="
+                                    ++ (if settings.showSecondary then
+                                            Code.string closeClickableTextId
+
+                                        else if settings.showContinue then
+                                            Code.string continueButtonId
+
+                                        else
+                                            Code.string Modal.closeButtonId
+                                       )
+                                , "\n\t\t}"
+                                , "\n\t}"
+                                , if settings.showX then
+                                    -- TODO: add in other attributes!!!
+                                    -- settings.titleVisibility
+                                    --, settings.theme
+                                    --, settings.customCss
+                                    "\n\t[Modal.closeButton]"
+
+                                  else
+                                    -- TODO: add in other attributes!!!
+                                    --[ settings.titleVisibility
+                                    --, settings.theme
+                                    --, settings.customCss
+                                    --]
+                                    "\n\t[]"
+                                , "\n\t-- you should use the actual state, NEVER hardcode it open like this:"
+                                , "\n\t(Modal.open { startFocusOn = \"\", returnFocusTo = \"\"} |> Tuple.first)"
+                                ]
+                                    |> String.join ""
+                        in
+                        [ { sectionName = "Example", code = code } ]
                 }
             , launchModalButton settings
             , Modal.view

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -11,6 +11,7 @@ import Accessibility.Styled.Key as Key
 import Browser.Dom as Dom
 import Category exposing (Category(..))
 import Code
+import CommonControls
 import Css exposing (..)
 import Debug.Control as Control exposing (Control)
 import Debug.Control.View as ControlView
@@ -46,7 +47,7 @@ init =
 
 type alias ViewSettings =
     { title : String
-    , titleVisibility : Modal.Attribute
+    , titleVisibility : Maybe ( String, Modal.Attribute )
     , theme : Modal.Attribute
     , customCss : Modal.Attribute
     , showX : Bool
@@ -61,7 +62,7 @@ initViewSettings : Control ViewSettings
 initViewSettings =
     Control.record ViewSettings
         |> Control.field "Modal title" (Control.string "Modal Title")
-        |> Control.field "Title visibility" controlTitleVisibility
+        |> Control.field "Title visibility" (Control.maybe False controlTitleVisibility)
         |> Control.field "Theme" controlTheme
         |> Control.field "Custom css" controlCss
         |> Control.field "X button" (Control.bool True)
@@ -78,11 +79,11 @@ initViewSettings =
             )
 
 
-controlTitleVisibility : Control Modal.Attribute
+controlTitleVisibility : Control ( String, Modal.Attribute )
 controlTitleVisibility =
-    Control.choice
-        [ ( "showTitle", Control.value Modal.showTitle )
-        , ( "hideTitle", Control.value Modal.hideTitle )
+    CommonControls.choice moduleName
+        [ ( "hideTitle", Modal.hideTitle )
+        , ( "showTitle", Modal.showTitle )
         ]
 
 
@@ -228,20 +229,19 @@ example =
                                        )
                                 , "\n\t\t}"
                                 , "\n\t}"
-                                , if settings.showX then
-                                    -- TODO: add in other attributes!!!
-                                    -- settings.titleVisibility
-                                    --, settings.theme
-                                    --, settings.customCss
-                                    "\n\t[Modal.closeButton]"
+                                , [ if settings.showX then
+                                        Just "Modal.closeButton"
 
-                                  else
-                                    -- TODO: add in other attributes!!!
-                                    --[ settings.titleVisibility
-                                    --, settings.theme
-                                    --, settings.customCss
-                                    --]
-                                    "\n\t[]"
+                                    else
+                                        Nothing
+                                  , Maybe.map Tuple.first settings.titleVisibility
+
+                                  -- TODO: add in other attributes!!!
+                                  --, Just settings.theme
+                                  --, Just settings.customCss
+                                  ]
+                                    |> List.filterMap identity
+                                    |> ControlView.codeFromListSimple
                                 , "\n\t-- you should use the actual state, NEVER hardcode it open like this:"
                                 , "\n\t(Modal.open { startFocusOn = \"\", returnFocusTo = \"\"} |> Tuple.first)"
                                 ]
@@ -289,18 +289,16 @@ example =
                             Modal.closeButtonId
                     }
                 }
-                (if settings.showX then
-                    [ Modal.closeButton
-                    , settings.titleVisibility
-                    , settings.theme
-                    , settings.customCss
-                    ]
+                ([ if settings.showX then
+                    Just Modal.closeButton
 
-                 else
-                    [ settings.titleVisibility
-                    , settings.theme
-                    , settings.customCss
-                    ]
+                   else
+                    Nothing
+                 , Maybe.map Tuple.second settings.titleVisibility
+                 , Just settings.theme
+                 , Just settings.customCss
+                 ]
+                    |> List.filterMap identity
                 )
                 state.state
             ]

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -49,7 +49,7 @@ type alias ViewSettings =
     { title : String
     , titleVisibility : Maybe ( String, Modal.Attribute )
     , theme : Maybe ( String, Modal.Attribute )
-    , customCss : Modal.Attribute
+    , customCss : Maybe ( String, Modal.Attribute )
     , showX : Bool
     , showContinue : Bool
     , showSecondary : Bool
@@ -64,7 +64,7 @@ initViewSettings =
         |> Control.field "Modal title" (Control.string "Modal Title")
         |> Control.field "Title visibility" (Control.maybe False controlTitleVisibility)
         |> Control.field "Theme" (Control.maybe False controlTheme)
-        |> Control.field "Custom css" controlCss
+        |> Control.field "Custom css" (Control.maybe False controlCss)
         |> Control.field "X button" (Control.bool True)
         |> Control.field "Continue button" (Control.bool True)
         |> Control.field "Close button" (Control.bool True)
@@ -95,14 +95,12 @@ controlTheme =
         ]
 
 
-controlCss : Control Modal.Attribute
+controlCss : Control ( String, Modal.Attribute )
 controlCss =
-    Control.map Modal.css <|
-        Control.choice
-            [ ( "[]", Control.value [] )
-            , ( "[ Css.borderRadius Css.zero ]", Control.value [ Css.borderRadius Css.zero ] )
-            , ( "[ Css.width (Css.px 900) ]", Control.value [ Css.width (Css.px 900) ] )
-            ]
+    CommonControls.choice moduleName
+        [ ( "css [ Css.borderRadius Css.zero ]", Modal.css [ Css.borderRadius Css.zero ] )
+        , ( "css [ Css.width (Css.px 900) ]", Modal.css [ Css.width (Css.px 900) ] )
+        ]
 
 
 moduleName : String
@@ -236,9 +234,7 @@ example =
                                         Nothing
                                   , Maybe.map Tuple.first settings.titleVisibility
                                   , Maybe.map Tuple.first settings.theme
-
-                                  -- TODO: add in other attributes!!!
-                                  --, Just settings.customCss
+                                  , Maybe.map Tuple.first settings.customCss
                                   ]
                                     |> List.filterMap identity
                                     |> ControlView.codeFromListSimple
@@ -296,7 +292,7 @@ example =
                     Nothing
                  , Maybe.map Tuple.second settings.titleVisibility
                  , Maybe.map Tuple.second settings.theme
-                 , Just settings.customCss
+                 , Maybe.map Tuple.second settings.customCss
                  ]
                     |> List.filterMap identity
                 )

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -48,7 +48,7 @@ init =
 type alias ViewSettings =
     { title : String
     , titleVisibility : Maybe ( String, Modal.Attribute )
-    , theme : Modal.Attribute
+    , theme : Maybe ( String, Modal.Attribute )
     , customCss : Modal.Attribute
     , showX : Bool
     , showContinue : Bool
@@ -63,7 +63,7 @@ initViewSettings =
     Control.record ViewSettings
         |> Control.field "Modal title" (Control.string "Modal Title")
         |> Control.field "Title visibility" (Control.maybe False controlTitleVisibility)
-        |> Control.field "Theme" controlTheme
+        |> Control.field "Theme" (Control.maybe False controlTheme)
         |> Control.field "Custom css" controlCss
         |> Control.field "X button" (Control.bool True)
         |> Control.field "Continue button" (Control.bool True)
@@ -87,11 +87,11 @@ controlTitleVisibility =
         ]
 
 
-controlTheme : Control Modal.Attribute
+controlTheme : Control ( String, Modal.Attribute )
 controlTheme =
-    Control.choice
-        [ ( "info", Control.value Modal.info )
-        , ( "warning", Control.value Modal.warning )
+    CommonControls.choice moduleName
+        [ ( "warning", Modal.warning )
+        , ( "info", Modal.info )
         ]
 
 
@@ -235,9 +235,9 @@ example =
                                     else
                                         Nothing
                                   , Maybe.map Tuple.first settings.titleVisibility
+                                  , Maybe.map Tuple.first settings.theme
 
                                   -- TODO: add in other attributes!!!
-                                  --, Just settings.theme
                                   --, Just settings.customCss
                                   ]
                                     |> List.filterMap identity
@@ -295,7 +295,7 @@ example =
                    else
                     Nothing
                  , Maybe.map Tuple.second settings.titleVisibility
-                 , Just settings.theme
+                 , Maybe.map Tuple.second settings.theme
                  , Just settings.customCss
                  ]
                     |> List.filterMap identity

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -101,7 +101,7 @@ example =
                 , update = UpdateSettings
                 , settings = model
                 , mainType = "RootHtml.Html ()"
-                , extraImports = [ "import Http" ]
+                , extraCode = [ "import Http" ]
                 , toExampleCode =
                     \{ page, recoveryText } ->
                         [ { sectionName = "Example"

--- a/styleguide-app/Examples/RadioButton.elm
+++ b/styleguide-app/Examples/RadioButton.elm
@@ -117,7 +117,7 @@ view ellieLinkConfig state =
         , update = SetSelectionSettings
         , settings = state.selectionSettings
         , mainType = "Html msg"
-        , extraImports = []
+        , extraCode = []
         , toExampleCode =
             \_ ->
                 [ { sectionName = "Example"

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -70,7 +70,7 @@ example =
                 , update = ChangeOptions
                 , settings = state.optionsControl
                 , mainType = "RootHtml.Html msg"
-                , extraImports = []
+                , extraCode = []
                 , toExampleCode =
                     \settings ->
                         [ { sectionName = "view"

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -63,7 +63,7 @@ example =
                 , update = UpdateSettings
                 , settings = state
                 , mainType = "Html msg"
-                , extraImports = []
+                , extraCode = []
                 , toExampleCode =
                     \_ ->
                         [ { sectionName = "Example"

--- a/styleguide-app/Examples/SideNav.elm
+++ b/styleguide-app/Examples/SideNav.elm
@@ -89,7 +89,7 @@ view ellieLinkConfig state =
         , update = SetControls
         , settings = state.settings
         , mainType = "RootHtml.Html msg"
-        , extraImports = []
+        , extraCode = []
         , toExampleCode =
             \{ navAttributes, entries } ->
                 [ { sectionName = "View"

--- a/styleguide-app/Examples/Switch.elm
+++ b/styleguide-app/Examples/Switch.elm
@@ -57,7 +57,7 @@ example =
                 , update = UpdateSettings
                 , settings = state.settings
                 , mainType = "RootHtml.Html msg"
-                , extraImports = []
+                , extraCode = []
                 , toExampleCode =
                     \{ label, attributes } ->
                         [ { sectionName = "Example"

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -83,7 +83,7 @@ example =
                 , update = UpdateControl
                 , settings = state
                 , mainType = "RootHtml.Html msg"
-                , extraImports = [ "import Nri.Ui.Button.V10 as Button" ]
+                , extraCode = [ "import Nri.Ui.Button.V10 as Button" ]
                 , toExampleCode =
                     \settings ->
                         let

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -115,7 +115,7 @@ example =
                 , update = SetSettings
                 , settings = model.settings
                 , mainType = "RootHtml.Html { select : Int, focus : Maybe String }"
-                , extraImports = [ "import Nri.Ui.Tooltip.V3 as Tooltip" ]
+                , extraCode = [ "import Nri.Ui.Tooltip.V3 as Tooltip" ]
                 , toExampleCode =
                     \_ ->
                         let

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -59,7 +59,7 @@ example =
                 , update = UpdateControl
                 , settings = state.control
                 , mainType = "RootHtml.Html msg"
-                , extraImports = []
+                , extraCode = []
                 , toExampleCode =
                     \settings ->
                         let

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -59,7 +59,7 @@ example =
                 , update = UpdateControl
                 , settings = state.control
                 , mainType = "Html msg"
-                , extraImports = []
+                , extraCode = []
                 , toExampleCode = \_ -> []
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -472,7 +472,7 @@ viewCustomizableExample ellieLinkConfig controlSettings =
             , update = SetControl
             , settings = controlSettings
             , mainType = "RootHtml.Html msg"
-            , extraImports = [ "import Nri.Ui.ClickableSvg.V2 as ClickableSvg" ]
+            , extraCode = [ "import Nri.Ui.ClickableSvg.V2 as ClickableSvg" ]
             , toExampleCode =
                 \controls ->
                     [ { sectionName = "Example"


### PR DESCRIPTION
When focus leaves the final focusable element in the modal, the first element in the modal should be re-focused. This behavior was broken due to browser defaults -- not sure when it broken exactly, but 🤷‍♀️ .

@juanedi and @mandla-noredink -- tagging you as reviewers since you reported the issue! 🙏 

Edit: and @adauguet ! 