### PR TITLE
ask Bors to check the tests

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,1 @@
+status = ["tests"]


### PR DESCRIPTION
This sets up Bors, which will automatically merge PRs that pass all the checks. It works like Homu did, but batches PRs into bigger groups for efficiency's sake.

Once this merges, you can talk to it the same way we do @NoRedInkBot in the monorepo, except we call it "duet" instead (for now... we just don't want to cause a conflict with two merge robots running on the same triggers!) So for example, `duet r+` will add the PR to the merge batch, `duet r-` will remove it, et cetera.

Fixes FXN-1289
