### PR TITLE
A11-1247 add `role="switch"` to Switch checkbox

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -85,7 +85,7 @@
         "elm-community/string-extra": "4.0.1 <= v < 5.0.0",
         "pablohirafuji/elm-markdown": "2.0.5 <= v < 3.0.0",
         "rtfeldman/elm-css": "17.0.1 <= v < 18.0.0",
-        "tesk9/accessible-html-with-css": "3.0.0 <= v < 4.0.0",
+        "tesk9/accessible-html-with-css": "3.1.0 <= v < 4.0.0",
         "tesk9/palette": "3.0.1 <= v < 4.0.0"
     },
     "test-dependencies": {

--- a/src/Nri/Ui/Switch/V2.elm
+++ b/src/Nri/Ui/Switch/V2.elm
@@ -19,6 +19,7 @@ module Nri.Ui.Switch.V2 exposing
     - REQUIRE label and id always
     - Move custom attributes to the container
     - change disabled to take a bool (which I think is the slighty more common pattern)
+    - Adds `role="switch"`
 
 @docs view
 
@@ -214,6 +215,7 @@ viewCheckbox config =
     Html.checkbox config.id
         (Just config.selected)
         [ Attributes.id config.id
+        , Attributes.attribute "role" "switch"
         , Attributes.css
             [ Css.position Css.absolute
             , Css.top (Css.px 10)

--- a/src/Nri/Ui/Switch/V2.elm
+++ b/src/Nri/Ui/Switch/V2.elm
@@ -35,6 +35,7 @@ module Nri.Ui.Switch.V2 exposing
 
 import Accessibility.Styled as Html exposing (Html)
 import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Role as Role
 import Css exposing (Color, Style)
 import Css.Global as Global
 import Html.Styled.Attributes as Attributes
@@ -215,7 +216,7 @@ viewCheckbox config =
     Html.checkbox config.id
         (Just config.selected)
         [ Attributes.id config.id
-        , Attributes.attribute "role" "switch"
+        , Role.switch
         , Attributes.css
             [ Css.position Css.absolute
             , Css.top (Css.px 10)

--- a/styleguide/elm.json
+++ b/styleguide/elm.json
@@ -25,7 +25,7 @@
             "pablohirafuji/elm-markdown": "2.0.5",
             "rtfeldman/elm-css": "17.0.5",
             "rtfeldman/elm-sorter-experiment": "2.1.1",
-            "tesk9/accessible-html-with-css": "3.0.0",
+            "tesk9/accessible-html-with-css": "3.1.0",
             "tesk9/palette": "3.0.1",
             "wernerdegroot/listzipper": "4.0.0"
         },


### PR DESCRIPTION
Makes the SR interpret the Switch checkbox input as a switch (on/off as opposed to checked/unchecked)

<img width="704" alt="Screen Shot 2022-08-04 at 17 37 54" src="https://user-images.githubusercontent.com/5647344/182948116-d8b739e1-aa95-4582-a63d-dd0d2364f928.png">
