### PR TITLE
A11-1241 remove `aria-hidden` from Menu

### DIFF
--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -602,7 +602,6 @@ viewCustom config =
                             AttributesExtra.none
                     , Aria.labelledBy config.buttonId
                     , Attributes.id config.menuId
-                    , Aria.hidden (not config.isOpen)
                     , css
                         [ Maybe.map (\w -> Css.width (Css.px (toFloat w))) config.menuWidth
                             |> Maybe.withDefault (Css.batch [])


### PR DESCRIPTION
removes `aria-hidden` from the menu because we already have `display: none`