### PR TITLE
Increase z-index of modals

### DIFF
--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -519,7 +519,7 @@ view config attrsList model =
                 |> Root.div
                     (List.concat
                         [ [ FocusTrap.toAttribute config.focusTrap ]
-                        , [ Attrs.css [ Css.position Css.relative, Css.zIndex (Css.int 1) ] ]
+                        , [ Attrs.css [ Css.position Css.relative, Css.zIndex (Css.int 100) ] ]
                         ]
                     )
 
@@ -733,7 +733,6 @@ viewCloseButton closeModal =
             , Css.right Css.zero
 
             -- make appear above lesson content
-            , Css.zIndex (Css.int 10)
             , Css.backgroundColor (rgba 255 255 255 0.5)
             , Css.borderRadius (pct 50)
 


### PR DESCRIPTION
I feel like there must be some backstory to why modals of all things have a z-index of 1, so LMK if this is the wrong move.

This is prompted by https://noredink.slack.com/archives/C02JPNAHEPN/p1659648695838389?thread_ts=1659622356.924599&cid=C02JPNAHEPN