### PR TITLE
Add menu alignment offset

### DIFF
--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -1,7 +1,7 @@
 module Nri.Ui.Menu.V3 exposing
     ( view, button, custom, Config
     , Attribute, Button, ButtonAttribute
-    , alignment, isDisabled, menuWidth, buttonId, menuId, menuZIndex, opensOnHover, disclosure
+    , alignment, alignmentWithOffset, isDisabled, menuWidth, buttonId, menuId, menuZIndex, opensOnHover, disclosure
     , Alignment(..)
     , icon, wrapping, hasBorder, buttonWidth
     , TitleWrapping(..)
@@ -30,7 +30,7 @@ A togglable menu view and related buttons.
 
 ## Menu attributes
 
-@docs alignment, isDisabled, menuWidth, buttonId, menuId, menuZIndex, opensOnHover, disclosure
+@docs alignment, alignmentWithOffset, isDisabled, menuWidth, buttonId, menuId, menuZIndex, opensOnHover, disclosure
 @docs Alignment
 
 
@@ -100,6 +100,7 @@ type alias MenuConfig msg =
 
     -- These are set using Attribute
     , alignment : Alignment
+    , alignmentOffset : Float
     , isDisabled : Bool
     , menuWidth : Maybe Int
     , buttonId : String
@@ -164,6 +165,13 @@ buttonWidth value =
 alignment : Alignment -> Attribute msg
 alignment value =
     Attribute <| \config -> { config | alignment = value }
+
+
+{-| Where the mneu popover should appear relative to the button with an offset
+-}
+alignmentWithOffset : Alignment -> Float -> Attribute msg
+alignmentWithOffset value offset =
+    Attribute <| \config -> { config | alignment = value, alignmentOffset = offset }
 
 
 {-| Whether the menu can be openned
@@ -242,6 +250,7 @@ view attributes config =
             , isOpen = config.isOpen
             , focusAndToggle = config.focusAndToggle
             , alignment = Right
+            , alignmentOffset = 0
             , isDisabled = False
             , menuWidth = Nothing
             , buttonId = ""
@@ -850,10 +859,10 @@ styleOuterContent contentVisible config =
         , zIndex (int <| config.zIndex + 1)
         , case config.alignment of
             Left ->
-                left zero
+                left (px config.alignmentOffset)
 
             Right ->
-                right zero
+                right (px config.alignmentOffset)
         ]
 
 

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -319,6 +319,7 @@ controlMenuAttributes : Control (List ( String, Menu.Attribute msg ))
 controlMenuAttributes =
     ControlExtra.list
         |> ControlExtra.optionalListItem "alignment" controlAlignment
+        |> ControlExtra.optionalListItem "alignmentWithOffset" controlAlignmentWithOffset
         |> ControlExtra.optionalBoolListItem "isDisabled" ( "Menu.isDisabled True", Menu.isDisabled True )
         |> ControlExtra.optionalListItem "menuWidth" controlMenuWidth
         |> ControlExtra.optionalBoolListItem "opensOnHover" ( "Menu.opensOnHover True", Menu.opensOnHover True )
@@ -332,6 +333,30 @@ controlAlignment =
           )
         , ( "Right"
           , Control.value ( "Menu.alignment Menu.Right", Menu.alignment Menu.Right )
+          )
+        ]
+
+
+controlAlignmentWithOffset : Control ( String, Menu.Attribute msg )
+controlAlignmentWithOffset =
+    Control.choice
+        [ ( "Left"
+          , ControlExtra.int 0
+                |> Control.map
+                    (\offset ->
+                        ( "Menu.alignment Menu.Left " ++ String.fromInt offset
+                        , Menu.alignmentWithOffset Menu.Left (toFloat offset)
+                        )
+                    )
+          )
+        , ( "Right"
+          , ControlExtra.int 0
+                |> Control.map
+                    (\offset ->
+                        ( "Menu.alignment Menu.Right " ++ String.fromInt offset
+                        , Menu.alignmentWithOffset Menu.Right (toFloat offset)
+                        )
+                    )
           )
         ]
 


### PR DESCRIPTION
We want our new kebab menu popout to look like below.  This PR adds a new function attribute generator called `alignmentWithOffset`.  This should not requiring bumping the menu version.

<img width="346" alt="image" src="https://user-images.githubusercontent.com/12899207/183143646-8560685c-e6bf-419e-a949-3d012023b73c.png">

<img width="358" alt="image" src="https://user-images.githubusercontent.com/12899207/183143475-3998e02b-f1cd-4856-9fbd-583602d65970.png">
