### PR TITLE
A11-1242 remove `aria-describedby` when `disclosure` is not rendered in the RadioButton

### DIFF
--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -329,7 +329,11 @@ view { label, name, value, valueToString, selectedValue } attributes =
                     Nothing ->
                         Extra.none
                  , class "Nri-RadioButton-HiddenRadioInput"
-                 , Aria.describedBy disclosureIds
+                 , if List.length disclosureIds > 0 then
+                    Aria.describedBy disclosureIds
+
+                   else
+                    classList []
                  , css
                     [ position absolute
                     , top (pct 50)

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -333,7 +333,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
                     Aria.describedBy disclosureIds
 
                    else
-                    classList []
+                    Extra.none
                  , css
                     [ position absolute
                     , top (pct 50)


### PR DESCRIPTION
`aria-describedby` references [disclosure](https://package.elm-lang.org/packages/NoRedInk/noredink-ui/latest/Nri-Ui-RadioButton-V4#disclosure) and should be added when disclosure is rendered.