### PR TITLE
Adds disabled and loading attributes/config

### DIFF
--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -429,7 +429,13 @@ viewSelect config =
             , Css.whiteSpace Css.noWrap
 
             -- Interaction
-            , Css.cursor Css.pointer
+            , Css.cursor
+                (if config.disabled then
+                    Css.default
+
+                 else
+                    Css.pointer
+                )
 
             -- Size and spacing
             , Css.height (Css.px 45)

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -179,6 +179,10 @@ initControls =
              <|
                 Control.string "The right item must be selected."
             )
+        |> ControlExtra.optionalListItem "disabled"
+            (Control.value ( "Select.disabled", Select.disabled ))
+        |> ControlExtra.optionalListItem "loading"
+            (Control.value ( "Select.loading", Select.loading ))
 
 
 initChoices : Control ( String, List (Choice String) )


### PR DESCRIPTION
This implements similar attributes to how it is being done over in
TextInput.

### Motivation
For hackday I was updating the sign up with email form and adding the disabled / loading attributes for the TextInputs. I noticed that the Select did not have similar functionality and thought it might be worth adding 😄.

One odd thing to note, when adding the fields to the examples app, I noticed that I needed to flip the order in the list of the select input and its label. If I did not the styles did not work out for some reason. I was pairing with @charbelrami at the time and we decided to hold off on spending a bunch of time trying to figure out why this was happening.

This update only incurs a minor change!