### PR TITLE
Resolves A11-1254, A11-1235, and A11-1277: remove roving tabindex and `aria-hidden` from tab panels, add a fixed `tabindex="0"`

### DIFF
--- a/src/TabsInternal/V2.elm
+++ b/src/TabsInternal/V2.elm
@@ -247,16 +247,13 @@ viewTabPanel tab selected =
         ([ Role.tabPanel
          , Aria.labelledBy (tabToId tab.idString)
          , Attributes.id (tabToBodyId tab.idString)
+         , Attributes.tabindex 0
          ]
             ++ (if selected then
-                    [ Aria.hidden False
-                    , Attributes.tabindex 0
-                    ]
+                    []
 
                 else
                     [ Attributes.css [ Css.display Css.none ]
-                    , Aria.hidden True
-                    , Attributes.tabindex -1
                     ]
                )
         )


### PR DESCRIPTION
Roving tabindex is not necessary on the panels. Panels with `display: none` are not focusable even with `tabindex="0"`. Added a fixed `tabindex="0"` to all panels to ensure they are focusable even when there are no focusable descendants.