### PR TITLE
Tighten and standardize heading line heights

### DIFF
--- a/src/Nri/Ui/Heading/V3.elm
+++ b/src/Nri/Ui/Heading/V3.elm
@@ -192,7 +192,6 @@ type alias Customizations msg =
 {-| `top` headings are Colors.navy and have:
 
     font-size: 30px
-    line-height: 38px
     font-weight: 700
 
 By default.
@@ -203,14 +202,12 @@ top =
     (css << headingStyles)
         { color = Colors.navy
         , size = 30
-        , lineHeight = 38
         }
 
 
 {-| `subhead` headings are Colors.navy and have:
 
     font-size: 20px
-    line-height: 26px
     font-weight: 700
 
 By default.
@@ -221,14 +218,12 @@ subhead =
     (css << headingStyles)
         { color = Colors.navy
         , size = 20
-        , lineHeight = 26
         }
 
 
 {-| `small` headings are Colors.gray20 and have:
 
     font-size: 16px
-    line-height: 21px
     font-weight: 700
 
 By default.
@@ -243,14 +238,12 @@ small =
             :: headingStyles
                 { color = Colors.gray20
                 , size = 16
-                , lineHeight = 21
                 }
         )
 
 
 headingStyles :
     { color : Color
-    , lineHeight : Float
     , size : Float
     }
     -> List Css.Style
@@ -258,7 +251,7 @@ headingStyles config =
     [ Fonts.baseFont
     , fontSize (px config.size)
     , color config.color
-    , lineHeight (px config.lineHeight)
+    , lineHeight (num 1.2)
     , fontWeight (int 700)
     , padding zero
     , textAlign left


### PR DESCRIPTION
Want to get away from using custom pixel values for line height because it's easier to make consistent across time and space using proportional values. Also headings (1.2) should be a little tighter than body copy (1.5) I think. Will probably change my mind about those values at some point in the future and overrides are always a possibility.

## Before and After
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/13528834/184194563-d126f40c-b275-469b-91e9-d31122379c70.png">
