### PR TITLE
A11-1357 add data-selected to tabpanel for testing purposes

### DIFF
--- a/src/TabsInternal/V2.elm
+++ b/src/TabsInternal/V2.elm
@@ -250,7 +250,9 @@ viewTabPanel tab selected =
          , Attributes.tabindex 0
          ]
             ++ (if selected then
-                    []
+                    [ -- Used as selector for test queries
+                      Attributes.attribute "data-selected" "true"
+                    ]
 
                 else
                     [ Attributes.css [ Css.display Css.none ]


### PR DESCRIPTION
This replaces `aria-hidden="false"`, which was used as a selector in test queries.