### PR TITLE
Bump to remove Debug.log

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "18.0.0",
+    "version": "18.0.1",
     "exposed-modules": [
         "Nri.Ui",
         "Nri.Ui.Accordion.V3",


### PR DESCRIPTION
FocusTrap accidentally had Debug.log in it. This bumps with the fix.