### PR TITLE
Adds TextInput example code

### DIFF
--- a/styleguide-app/Code.elm
+++ b/styleguide-app/Code.elm
@@ -1,22 +1,26 @@
 module Code exposing
     ( string, maybeString
+    , maybe
     , maybeFloat
     , bool
     , commentInline
     , list, listMultiline
     , record, recordMultiline
     , newlineWithIndent
+    , withParens
     )
 
 {-|
 
 @docs string, maybeString
+@docs maybe
 @docs maybeFloat
 @docs bool
 @docs commentInline
 @docs list, listMultiline
 @docs record, recordMultiline
 @docs newlineWithIndent
+@docs withParens
 
 -}
 
@@ -128,3 +132,9 @@ recordMultiline items indent =
 newlineWithIndent : Int -> String
 newlineWithIndent indent =
     "\n" ++ String.repeat indent "    "
+
+
+{-| -}
+withParens : String -> String
+withParens val =
+    "(" ++ val ++ ")"

--- a/styleguide-app/Debug/Control/Extra.elm
+++ b/styleguide-app/Debug/Control/Extra.elm
@@ -16,6 +16,7 @@ module Debug.Control.Extra exposing
 
 -}
 
+import Code
 import Debug.Control as Control exposing (Control)
 
 
@@ -113,20 +114,10 @@ optionalBoolListItemDefaultTrue name f accumulator =
 {-| -}
 bool : Bool -> Control ( String, Bool )
 bool default =
-    Control.map
-        (\val ->
-            ( if val then
-                "True"
-
-              else
-                "False"
-            , val
-            )
-        )
-        (Control.bool default)
+    Control.map (\val -> ( Code.bool val, val )) (Control.bool default)
 
 
 {-| -}
 string : String -> Control ( String, String )
 string default =
-    Control.map (\val -> ( "\"" ++ val ++ "\"", val )) (Control.string default)
+    Control.map (\val -> ( Code.string val, val )) (Control.string default)

--- a/styleguide-app/Debug/Control/View.elm
+++ b/styleguide-app/Debug/Control/View.elm
@@ -28,7 +28,7 @@ view :
     , version : Int
     , update : Control a -> msg
     , settings : Control a
-    , mainType : String
+    , mainType : Maybe String
     , extraCode : List String
     , toExampleCode : a -> List { sectionName : String, code : String }
     }
@@ -63,7 +63,7 @@ view config =
 
 viewExampleCode :
     (EllieLink.SectionExample -> Html msg)
-    -> { component | name : String, version : Int, mainType : String, extraCode : List String }
+    -> { component | name : String, version : Int, mainType : Maybe String, extraCode : List String }
     -> List { sectionName : String, code : String }
     -> Html msg
 viewExampleCode ellieLink component values =

--- a/styleguide-app/EllieLink.elm
+++ b/styleguide-app/EllieLink.elm
@@ -16,7 +16,7 @@ type alias SectionExample =
     { name : String
     , fullModuleName : String
     , sectionName : String
-    , mainType : String
+    , mainType : Maybe String
     , extraCode : List String
     , code : String
     }
@@ -85,7 +85,8 @@ generateElmExampleModule config example =
     , ""
     ]
         ++ maybeErrorMessages
-        ++ [ "main : " ++ example.mainType
+        ++ [ Maybe.map (\type_ -> "main : " ++ type_) example.mainType
+                |> Maybe.withDefault ""
            , "main ="
            , "    " ++ example.code
            , "    |> toUnstyled"

--- a/styleguide-app/Examples/Accordion.elm
+++ b/styleguide-app/Examples/Accordion.elm
@@ -103,7 +103,7 @@ view ellieLinkConfig model =
         , version = version
         , update = UpdateControls
         , settings = model.settings
-        , mainType = "RootHtml.Html String"
+        , mainType = Just "RootHtml.Html String"
         , extraCode =
             [ "import Nri.Ui.DisclosureIndicator.V2 as DisclosureIndicator"
             , "import Nri.Ui.Svg.V1 as Svg"

--- a/styleguide-app/Examples/Balloon.elm
+++ b/styleguide-app/Examples/Balloon.elm
@@ -150,7 +150,7 @@ view ellieLinkConfig state =
         , version = version
         , update = SetAttributes
         , settings = state
-        , mainType = "RootHtml.Html msg"
+        , mainType = Just "RootHtml.Html msg"
         , extraCode = []
         , toExampleCode =
             \{ copy, attributes } ->

--- a/styleguide-app/Examples/BreadCrumbs.elm
+++ b/styleguide-app/Examples/BreadCrumbs.elm
@@ -68,7 +68,7 @@ example =
                 , version = version
                 , update = UpdateControl
                 , settings = state
-                , mainType = "RootHtml.Html msg"
+                , mainType = Just "RootHtml.Html msg"
                 , extraCode = [ "import Html.Styled.Attributes exposing (href)" ]
                 , toExampleCode = \settings -> [ { sectionName = moduleName ++ ".view", code = viewExampleCode settings } ]
                 }

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -209,7 +209,7 @@ viewButtonExamples ellieLinkConfig state =
         , version = version
         , update = SetDebugControlsState
         , settings = state.debugControlsState
-        , mainType = "RootHtml.Html msg"
+        , mainType = Just "RootHtml.Html msg"
         , extraCode = []
         , toExampleCode =
             \{ label, attributes } ->

--- a/styleguide-app/Examples/Carousel.elm
+++ b/styleguide-app/Examples/Carousel.elm
@@ -185,7 +185,7 @@ example =
                 , version = version
                 , update = SetSettings
                 , settings = model.settings
-                , mainType = "RootHtml.Html { select : Int, focus : Maybe String }"
+                , mainType = Just "RootHtml.Html { select : Int, focus : Maybe String }"
                 , extraCode = []
                 , toExampleCode =
                     \_ ->

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -65,7 +65,7 @@ example =
                 , version = version
                 , update = SetControls
                 , settings = state.settings
-                , mainType = "RootHtml.Html msg"
+                , mainType = Just "RootHtml.Html msg"
                 , extraCode = []
                 , toExampleCode =
                     \{ label, icon, attributes } ->

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -143,7 +143,7 @@ viewExamples ellieLinkConfig (State control) =
         , version = version
         , update = SetState
         , settings = control
-        , mainType = "RootHtml.Html msg"
+        , mainType = Just "RootHtml.Html msg"
         , extraCode = []
         , toExampleCode =
             \{ label, attributes } ->

--- a/styleguide-app/Examples/Confetti.elm
+++ b/styleguide-app/Examples/Confetti.elm
@@ -57,7 +57,7 @@ example =
                 , version = version
                 , update = UpdateControl
                 , settings = state.settings
-                , mainType = "RootHtml.Html msg"
+                , mainType = Just "RootHtml.Html msg"
                 , extraCode = []
                 , toExampleCode =
                     \settings -> [ { sectionName = "TODO", code = "TODO" } ]

--- a/styleguide-app/Examples/Container.elm
+++ b/styleguide-app/Examples/Container.elm
@@ -58,7 +58,7 @@ example =
                 , version = version
                 , update = UpdateControl
                 , settings = state.control
-                , mainType = "RootHtml.Html msg"
+                , mainType = Just "RootHtml.Html msg"
                 , extraCode = []
                 , toExampleCode =
                     \settings ->

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -58,7 +58,7 @@ example =
                 , version = version
                 , update = UpdateSettings
                 , settings = state.settings
-                , mainType = "RootHtml.Html msg"
+                , mainType = Just "RootHtml.Html msg"
                 , extraCode = [ "import Nri.Ui.Svg.V1 as Svg" ]
                 , toExampleCode =
                     \settings ->

--- a/styleguide-app/Examples/Heading.elm
+++ b/styleguide-app/Examples/Heading.elm
@@ -62,7 +62,7 @@ example =
                 , version = version
                 , update = UpdateControl
                 , settings = state.control
-                , mainType = "RootHtml.Html msg"
+                , mainType = Just "RootHtml.Html msg"
                 , extraCode = []
                 , toExampleCode =
                     \settings ->

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -139,7 +139,7 @@ view ellieLinkConfig state =
         , version = version
         , update = UpdateControls
         , settings = state.settings
-        , mainType = "RootHtml.Html { focus : Maybe String, isOpen : Bool }"
+        , mainType = Just "RootHtml.Html { focus : Maybe String, isOpen : Bool }"
         , extraCode = []
         , toExampleCode =
             \settings ->

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -157,7 +157,7 @@ example =
                 , version = version
                 , update = UpdateControl
                 , settings = state.control
-                , mainType = "RootHtml.Html msg"
+                , mainType = Just "RootHtml.Html msg"
                 , extraCode = []
                 , toExampleCode =
                     \settings ->

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -190,7 +190,7 @@ example =
                 , version = version
                 , update = UpdateSettings
                 , settings = state.settings
-                , mainType = "RootHtml.Html Msg"
+                , mainType = Just "RootHtml.Html Msg"
                 , extraCode = [ "type Msg = ModalMsg Modal.Msg | Focus String" ]
                 , toExampleCode =
                     \_ ->

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -100,7 +100,7 @@ example =
                 , version = version
                 , update = UpdateSettings
                 , settings = model
-                , mainType = "RootHtml.Html ()"
+                , mainType = Just "RootHtml.Html ()"
                 , extraCode = [ "import Http" ]
                 , toExampleCode =
                     \{ page, recoveryText } ->

--- a/styleguide-app/Examples/RadioButton.elm
+++ b/styleguide-app/Examples/RadioButton.elm
@@ -116,7 +116,7 @@ view ellieLinkConfig state =
         , version = version
         , update = SetSelectionSettings
         , settings = state.selectionSettings
-        , mainType = "Html msg"
+        , mainType = Just "Html msg"
         , extraCode = []
         , toExampleCode =
             \_ ->

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -70,7 +70,7 @@ example =
                 , version = version
                 , update = ChangeOptions
                 , settings = state.optionsControl
-                , mainType = "RootHtml.Html msg"
+                , mainType = Just "RootHtml.Html msg"
                 , extraCode = []
                 , toExampleCode =
                     \settings ->

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -62,7 +62,7 @@ example =
                 , version = version
                 , update = UpdateSettings
                 , settings = state
-                , mainType = "Html msg"
+                , mainType = Just "Html msg"
                 , extraCode = []
                 , toExampleCode =
                     \_ ->

--- a/styleguide-app/Examples/SideNav.elm
+++ b/styleguide-app/Examples/SideNav.elm
@@ -89,7 +89,7 @@ view ellieLinkConfig state =
         , version = version
         , update = SetControls
         , settings = state.settings
-        , mainType = "RootHtml.Html msg"
+        , mainType = Just "RootHtml.Html msg"
         , extraCode = []
         , toExampleCode =
             \{ navAttributes, entries } ->

--- a/styleguide-app/Examples/Switch.elm
+++ b/styleguide-app/Examples/Switch.elm
@@ -57,7 +57,7 @@ example =
                 , version = version
                 , update = UpdateSettings
                 , settings = state.settings
-                , mainType = "RootHtml.Html msg"
+                , mainType = Just "RootHtml.Html msg"
                 , extraCode = []
                 , toExampleCode =
                     \{ label, attributes } ->

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -83,7 +83,7 @@ example =
                 , version = version
                 , update = UpdateControl
                 , settings = state
-                , mainType = "RootHtml.Html msg"
+                , mainType = Just "RootHtml.Html msg"
                 , extraCode = [ "import Nri.Ui.Button.V10 as Button" ]
                 , toExampleCode =
                     \settings ->

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -114,7 +114,7 @@ example =
                 , version = version
                 , update = SetSettings
                 , settings = model.settings
-                , mainType = "RootHtml.Html { select : Int, focus : Maybe String }"
+                , mainType = Just "RootHtml.Html { select : Int, focus : Maybe String }"
                 , extraCode = [ "import Nri.Ui.Tooltip.V3 as Tooltip" ]
                 , toExampleCode =
                     \_ ->

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -58,7 +58,7 @@ example =
                 , version = version
                 , update = UpdateControl
                 , settings = state.control
-                , mainType = "RootHtml.Html msg"
+                , mainType = Just "RootHtml.Html msg"
                 , extraCode = []
                 , toExampleCode =
                     \settings ->

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -189,7 +189,7 @@ customizableExamples state =
                         , setShowPassword = SetShowPassword
                         }
             , inputTypeCode =
-                """TextInput.newPassword
+                """TextInput.newPassword <|
         \\onInput ->
             TextInput.newPassword
                 { onInput = onInput

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -193,8 +193,8 @@ customizableExamples state =
         \\onInput ->
             TextInput.newPassword
                 { onInput = onInput
-                , showPassword = False -- pass in whether the PW should be shown as plaintext
-                , setShowPassword = \\_ -> "TODO: wire in a set-show-password Msg"
+                , showPassword = model.showPassword -- pass in whether the PW should be shown as plaintext. You'll need to wire this in.
+                , setShowPassword = SetShowPassword -- You'll need to wire this in before the code will compile
                 }
                 """
             , inputTypeValueCode = \value -> Code.string (Maybe.withDefault "" value)

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -118,11 +118,10 @@ customizableExamples state =
                         Nothing
                     ]
                         |> List.filterMap identity
-                        -- TODO: incorporate exampleConfig.attributes
-                        |> Code.list
+                        |> (\attributes -> Code.list (attributes ++ List.map Tuple.first exampleConfig.attributes))
                    )
             , TextInput.view exampleConfig.label
-                (exampleConfig.attributes
+                (List.map Tuple.second exampleConfig.attributes
                     ++ [ TextInput.id ("text-input__" ++ name ++ "-example")
                        , inputType (toString >> SetInput index)
                             |> TextInput.map toString identity
@@ -335,7 +334,7 @@ init =
 
 type alias ExampleConfig =
     { label : String
-    , attributes : List (TextInput.Attribute String Msg)
+    , attributes : List ( String, TextInput.Attribute String Msg )
     , onFocus : Bool
     , onBlur : Bool
     , onEnter : Bool
@@ -352,31 +351,52 @@ initControl =
         |> Control.field "onEnter" (Control.bool False)
 
 
-controlAttributes : Control (List (TextInput.Attribute value msg))
+controlAttributes : Control (List ( String, TextInput.Attribute value msg ))
 controlAttributes =
     ControlExtra.list
         |> ControlExtra.optionalListItem "placeholder"
-            (Control.map TextInput.placeholder <|
-                Control.string "Learning with commas"
+            (Control.string "Learning with commas"
+                |> Control.map
+                    (\str ->
+                        ( "TextInput.placeholder " ++ Code.string str
+                        , TextInput.placeholder str
+                        )
+                    )
             )
-        |> ControlExtra.optionalListItem "hiddenLabel"
-            (Control.value TextInput.hiddenLabel)
-        |> ControlExtra.optionalListItem "errorIf"
-            (Control.map TextInput.errorIf <| Control.bool True)
+        |> ControlExtra.optionalBoolListItem "hiddenLabel"
+            ( "TextInput.hiddenLabel", TextInput.hiddenLabel )
+        |> ControlExtra.optionalBoolListItem "errorIf"
+            ( "TextInput.errorIf True", TextInput.errorIf True )
         |> ControlExtra.optionalListItem "errorMessage"
-            (Control.map (Just >> TextInput.errorMessage) <| Control.string "The statement must be true.")
+            (Control.map
+                (\str ->
+                    ( "TextInput.errorMessage " ++ Code.withParens (Code.maybeString (Just str))
+                    , TextInput.errorMessage (Just str)
+                    )
+                )
+                (Control.string "The statement must be true.")
+            )
         |> ControlExtra.optionalListItem "guidance"
-            (Control.map TextInput.guidance <| Control.string "The statement must be true.")
-        |> ControlExtra.optionalListItem "disabled"
-            (Control.value TextInput.disabled)
-        |> ControlExtra.optionalListItem "loading"
-            (Control.value TextInput.loading)
-        |> ControlExtra.optionalListItem "writing"
-            (Control.value TextInput.writing)
-        |> ControlExtra.listItem "noMargin"
-            (Control.map TextInput.noMargin (Control.bool False))
-        |> ControlExtra.optionalListItem "css"
-            (Control.value (TextInput.css [ Css.backgroundColor Colors.azure ]))
+            (Control.string "The statement must be true."
+                |> Control.map
+                    (\str ->
+                        ( "TextInput.guidance " ++ Code.string str
+                        , TextInput.guidance str
+                        )
+                    )
+            )
+        |> ControlExtra.optionalBoolListItem "disabled"
+            ( "TextInput.disabled", TextInput.disabled )
+        |> ControlExtra.optionalBoolListItem "loading"
+            ( "TextInput.loading", TextInput.loading )
+        |> ControlExtra.optionalBoolListItem "writing"
+            ( "TextInput.writing", TextInput.writing )
+        |> ControlExtra.optionalBoolListItem "noMargin"
+            ( "TextInput.noMargin True", TextInput.noMargin True )
+        |> ControlExtra.optionalBoolListItem "css"
+            ( "TextInput.css [ Css.backgroundColor Colors.azure ]"
+            , TextInput.css [ Css.backgroundColor Colors.azure ]
+            )
 
 
 {-| -}

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -471,7 +471,7 @@ viewCustomizableExample ellieLinkConfig controlSettings =
             , version = version
             , update = SetControl
             , settings = controlSettings
-            , mainType = "RootHtml.Html msg"
+            , mainType = Just "RootHtml.Html msg"
             , extraCode = [ "import Nri.Ui.ClickableSvg.V2 as ClickableSvg" ]
             , toExampleCode =
                 \controls ->


### PR DESCRIPTION
Adds example code for TextInput. All the Ellie links should be fully functional except for the newPassword one.

<img width="573" alt="Screen Shot of the TextInput.number example code" src="https://user-images.githubusercontent.com/8811312/186037766-c0971ed1-2b04-42f9-91a9-560ef318596d.png">


Fixes A11-1475