### PR TITLE
Adds checkbox example code

### DIFF
--- a/src/Nri/Ui/Checkbox/V6.elm
+++ b/src/Nri/Ui/Checkbox/V6.elm
@@ -42,6 +42,7 @@ import Html.Styled.Attributes as Attributes exposing (css)
 import Html.Styled.Events as Events
 import Json.Decode
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Svg.V1 exposing (Svg)
 
@@ -169,13 +170,16 @@ checkboxContainer model =
             , marginLeft (px -4)
             , pseudoClass "focus-within"
                 [ Css.Global.descendants
-                    [ Css.Global.class "checkbox-icon-container"
-                        [ borderColor (rgb 0 95 204)
-                        ]
+                    [ Css.Global.class "checkbox-icon-container" FocusRing.tightStyles
                     ]
                 ]
             , Css.Global.descendants
-                [ Css.Global.input [ position absolute, top (calc (pct 50) minus (px 10)), left (px 10) ]
+                [ Css.Global.input
+                    [ position absolute
+                    , top (calc (pct 50) minus (px 10))
+                    , left (px 10)
+                    , boxShadow none |> Css.important
+                    ]
                 ]
             , Css.batch model.containerCss
             ]

--- a/styleguide-app/CommonControls.elm
+++ b/styleguide-app/CommonControls.elm
@@ -1,5 +1,5 @@
 module CommonControls exposing
-    ( css, mobileCss, quizEngineMobileCss, notMobileCss
+    ( css, mobileCss, quizEngineMobileCss, notMobileCss, css_
     , choice
     , icon, iconNotCheckedByDefault, uiIcon
     , content
@@ -9,7 +9,7 @@ module CommonControls exposing
 
 {-|
 
-@docs css, mobileCss, quizEngineMobileCss, notMobileCss
+@docs css, mobileCss, quizEngineMobileCss, notMobileCss, css_
 @docs choice
 @docs icon, iconNotCheckedByDefault, uiIcon
 

--- a/styleguide-app/Examples.elm
+++ b/styleguide-app/Examples.elm
@@ -24,6 +24,7 @@ import Examples.Message as Message
 import Examples.Modal as Modal
 import Examples.Page as Page
 import Examples.Pennant as Pennant
+import Examples.PremiumCheckbox as PremiumCheckbox
 import Examples.RadioButton as RadioButton
 import Examples.SegmentedControl as SegmentedControl
 import Examples.Select as Select
@@ -480,6 +481,25 @@ all =
                     _ ->
                         Nothing
             )
+    , PremiumCheckbox.example
+        |> Example.wrapMsg PremiumCheckboxMsg
+            (\msg ->
+                case msg of
+                    PremiumCheckboxMsg childMsg ->
+                        Just childMsg
+
+                    _ ->
+                        Nothing
+            )
+        |> Example.wrapState PremiumCheckboxState
+            (\msg ->
+                case msg of
+                    PremiumCheckboxState childState ->
+                        Just childState
+
+                    _ ->
+                        Nothing
+            )
     , RadioButton.example
         |> Example.wrapMsg RadioButtonMsg
             (\msg ->
@@ -792,6 +812,7 @@ type State
     | ModalState Modal.State
     | PageState Page.State
     | PennantState Pennant.State
+    | PremiumCheckboxState PremiumCheckbox.State
     | RadioButtonState RadioButton.State
     | SegmentedControlState SegmentedControl.State
     | SelectState Select.State
@@ -833,6 +854,7 @@ type Msg
     | ModalMsg Modal.Msg
     | PageMsg Page.Msg
     | PennantMsg Pennant.Msg
+    | PremiumCheckboxMsg PremiumCheckbox.Msg
     | RadioButtonMsg RadioButton.Msg
     | SegmentedControlMsg SegmentedControl.Msg
     | SelectMsg Select.Msg

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -8,7 +8,7 @@ module Examples.Checkbox exposing (Msg, State, example)
 
 import Category exposing (Category(..))
 import CheckboxIcons
-import Css
+import Css exposing (Style)
 import Debug.Control as Control exposing (Control)
 import Debug.Control.View as ControlView
 import Example exposing (Example)
@@ -46,6 +46,10 @@ example =
     , preview = preview
     , view =
         \ellieLinkConfig state ->
+            let
+                settings =
+                    Control.currentValue state.settings
+            in
             [ ControlView.view
                 { ellieLinkConfig = ellieLinkConfig
                 , name = moduleName
@@ -56,6 +60,8 @@ example =
                 , extraCode = []
                 , toExampleCode = \_ -> [ { sectionName = "TODO", code = "TODO" } ]
                 }
+            , Heading.h2 [ Heading.plaintext "Example" ]
+            , viewExample state settings
             , viewInteractableCheckbox "styleguide-checkbox-interactable" state
             , viewIndeterminateCheckbox "styleguide-checkbox-indeterminate" state
             , viewLockedOnInsideCheckbox "styleguide-locked-on-inside-checkbox" state
@@ -119,10 +125,61 @@ init =
 controlSettings : Control Settings
 controlSettings =
     Control.record Settings
+        |> Control.field "label" (Control.string "Enable Text to Speech")
+        |> Control.field "disabled" (Control.bool False)
+        |> Control.field "theme"
+            (Control.choice
+                [ ( "Square", Control.value Checkbox.Square )
+                , ( "Locked", Control.value Checkbox.Locked )
+                ]
+            )
+        |> Control.field "containerCss"
+            (Control.choice
+                [ ( "[]", Control.value [] )
+                , ( "Red dashed border", Control.value [ Css.border3 (Css.px 4) Css.dashed Colors.red ] )
+                ]
+            )
+        |> Control.field "enabledLabelCss"
+            (Control.choice
+                [ ( "[]", Control.value [] )
+                , ( "Orange dotted border", Control.value [ Css.border3 (Css.px 4) Css.dotted Colors.orange ] )
+                ]
+            )
+        |> Control.field "disabledLabelCss"
+            (Control.choice
+                [ ( "[]", Control.value [] )
+                , ( "strikethrough", Control.value [ Css.textDecoration Css.lineThrough ] )
+                ]
+            )
 
 
 type alias Settings =
-    {}
+    { label : String
+    , disabled : Bool
+    , theme : Checkbox.Theme
+    , containerCss : List Style
+    , enabledLabelCss : List Style
+    , disabledLabelCss : List Style
+    }
+
+
+viewExample : State -> Settings -> Html Msg
+viewExample state settings =
+    let
+        id =
+            "unique-example-id"
+    in
+    Checkbox.viewWithLabel
+        { identifier = id
+        , label = settings.label
+        , setterMsg = ToggleCheck id
+        , selected = isSelected id state
+        , disabled = settings.disabled
+        , theme = settings.theme
+        , containerCss = settings.containerCss
+        , enabledLabelCss = settings.enabledLabelCss
+        , disabledLabelCss = settings.disabledLabelCss
+        }
 
 
 {-| -}

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -92,8 +92,8 @@ preview =
                 , text label_
                 ]
     in
-    [ ( CheckboxIcons.unchecked "unchecked-preview-unchecked", "Unchecked" )
-    , ( CheckboxIcons.checkedPartially "checkedPartially-preview-checkedPartially", "Part checked" )
+    [ ( CheckboxIcons.checkedPartially "checkedPartially-preview-checkedPartially", "Part checked" )
+    , ( CheckboxIcons.unchecked "unchecked-preview-unchecked", "Unchecked" )
     , ( CheckboxIcons.checked "checkbox-preview-checked", "Checked" )
     ]
         |> List.map renderPreview

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -114,10 +114,20 @@ init =
     }
 
 
+type alias Settings =
+    { label : String
+    , disabled : Bool
+    , theme : Checkbox.Theme
+    , containerCss : ( String, List Style )
+    , enabledLabelCss : ( String, List Style )
+    , disabledLabelCss : ( String, List Style )
+    }
+
+
 controlSettings : Control Settings
 controlSettings =
     Control.record Settings
-        |> Control.field "label" (Control.string "Enable Text to Speech")
+        |> Control.field "label" (Control.string "Enable Text-to-Speech")
         |> Control.field "disabled" (Control.bool False)
         |> Control.field "theme"
             (Control.choice
@@ -158,16 +168,6 @@ controlSettings =
                   )
                 ]
             )
-
-
-type alias Settings =
-    { label : String
-    , disabled : Bool
-    , theme : Checkbox.Theme
-    , containerCss : ( String, List Style )
-    , enabledLabelCss : ( String, List Style )
-    , disabledLabelCss : ( String, List Style )
-    }
 
 
 viewExampleWithCode : State -> Settings -> ( String, Html Msg )

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -9,6 +9,8 @@ module Examples.Checkbox exposing (Msg, State, example)
 import Category exposing (Category(..))
 import CheckboxIcons
 import Css
+import Debug.Control as Control exposing (Control)
+import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes exposing (css)
@@ -23,16 +25,14 @@ import Nri.Ui.Svg.V1 as Svg
 import Set exposing (Set)
 
 
-{-| -}
-type Msg
-    = ToggleCheck Id Bool
-    | NoOp
+moduleName : String
+moduleName =
+    "Checkbox"
 
 
-{-| -}
-type alias State =
-    { isChecked : Set String
-    }
+version : Int
+version =
+    6
 
 
 {-| -}
@@ -46,7 +46,17 @@ example =
     , preview = preview
     , view =
         \ellieLinkConfig state ->
-            [ viewInteractableCheckbox "styleguide-checkbox-interactable" state
+            [ ControlView.view
+                { ellieLinkConfig = ellieLinkConfig
+                , name = moduleName
+                , version = version
+                , update = UpdateControls
+                , settings = state.settings
+                , mainType = Nothing
+                , extraCode = []
+                , toExampleCode = \_ -> [ { sectionName = "TODO", code = "TODO" } ]
+                }
+            , viewInteractableCheckbox "styleguide-checkbox-interactable" state
             , viewIndeterminateCheckbox "styleguide-checkbox-indeterminate" state
             , viewLockedOnInsideCheckbox "styleguide-locked-on-inside-checkbox" state
             , viewDisabledCheckbox "styleguide-checkbox-disabled" state
@@ -92,10 +102,34 @@ preview =
 
 
 {-| -}
+type alias State =
+    { isChecked : Set String
+    , settings : Control Settings
+    }
+
+
+{-| -}
 init : State
 init =
     { isChecked = Set.empty
+    , settings = controlSettings
     }
+
+
+controlSettings : Control Settings
+controlSettings =
+    Control.record Settings
+
+
+type alias Settings =
+    {}
+
+
+{-| -}
+type Msg
+    = ToggleCheck Id Bool
+    | UpdateControls (Control Settings)
+    | NoOp
 
 
 {-| -}
@@ -112,6 +146,9 @@ update msg state =
                         Set.remove id state.isChecked
             in
             ( { state | isChecked = isChecked }, Cmd.none )
+
+        UpdateControls settings ->
+            ( { state | settings = settings }, Cmd.none )
 
         NoOp ->
             ( state, Cmd.none )

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -62,14 +62,8 @@ example =
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
             , viewExample state settings
-            , viewInteractableCheckbox "styleguide-checkbox-interactable" state
-            , viewIndeterminateCheckbox "styleguide-checkbox-indeterminate" state
-            , viewLockedOnInsideCheckbox "styleguide-locked-on-inside-checkbox" state
-            , viewDisabledCheckbox "styleguide-checkbox-disabled" state
-            , viewMultilineCheckboxes state
             , Heading.h2 [ Heading.plaintext "Premium Checkboxes" ]
             , viewPremiumCheckboxes state
-            , viewCustomStyledCheckbox state
             , viewCustomStyledPremiumCheckboxes state
             ]
     , categories = [ Inputs ]
@@ -215,122 +209,6 @@ update msg state =
 -- INTERNAL
 
 
-viewInteractableCheckbox : Id -> State -> Html Msg
-viewInteractableCheckbox id state =
-    Checkbox.viewWithLabel
-        { identifier = id
-        , label = "This is an interactable checkbox!"
-        , setterMsg = ToggleCheck id
-        , selected = isSelected id state
-        , disabled = False
-        , theme = Checkbox.Square
-        , containerCss = []
-        , enabledLabelCss = []
-        , disabledLabelCss = []
-        }
-
-
-viewIndeterminateCheckbox : Id -> State -> Html Msg
-viewIndeterminateCheckbox id state =
-    Checkbox.viewWithLabel
-        { identifier = id
-        , label = "This Checkbox is set in an indeterminate state"
-        , setterMsg = ToggleCheck id
-        , selected = Checkbox.PartiallySelected
-        , disabled = True
-        , theme = Checkbox.Square
-        , containerCss = []
-        , enabledLabelCss = []
-        , disabledLabelCss = []
-        }
-
-
-viewLockedOnInsideCheckbox : Id -> State -> Html Msg
-viewLockedOnInsideCheckbox id state =
-    Checkbox.viewWithLabel
-        { identifier = id
-        , label = "I'm a locked Checkbox"
-        , setterMsg = ToggleCheck id
-        , selected = Checkbox.NotSelected
-        , disabled = True
-        , theme = Checkbox.Locked
-        , containerCss = []
-        , enabledLabelCss = []
-        , disabledLabelCss = []
-        }
-
-
-viewDisabledCheckbox : Id -> State -> Html Msg
-viewDisabledCheckbox id state =
-    Checkbox.viewWithLabel
-        { identifier = id
-        , label = "Disabled theme"
-        , setterMsg = ToggleCheck id
-        , selected = isSelected id state
-        , disabled = True
-        , theme = Checkbox.Square
-        , containerCss = []
-        , enabledLabelCss = []
-        , disabledLabelCss = []
-        }
-
-
-viewMultilineCheckboxes : State -> Html Msg
-viewMultilineCheckboxes state =
-    Html.section
-        [ css [ Css.width (Css.px 500) ] ]
-        [ Heading.h2 [ Heading.plaintext "Multiline Text in Checkboxes" ]
-        , let
-            id =
-                "styleguide-checkbox-multiline"
-          in
-          Checkbox.viewWithLabel
-            { identifier = id
-            , label = "Ut nobis et vel. Nulla rerum sit eos accusamus placeat. Iure sunt earum voluptatibus autem ratione soluta sint.\n\nIste perferendis eum corporis ullam magnam incidunt eos."
-            , setterMsg = ToggleCheck id
-            , selected = isSelected id state
-            , disabled = False
-            , theme = Checkbox.Square
-            , containerCss = []
-            , enabledLabelCss = []
-            , disabledLabelCss = []
-            }
-        , Checkbox.viewWithLabel
-            { identifier = "fake-partially-selected"
-            , label = "Ut nobis et vel. Nulla rerum sit eos accusamus placeat. Iure sunt earum voluptatibus autem ratione soluta sint.\n\nIste perferendis eum corporis ullam magnam incidunt eos."
-            , setterMsg = ToggleCheck "fake"
-            , selected = Checkbox.PartiallySelected
-            , disabled = True
-            , theme = Checkbox.Square
-            , containerCss = []
-            , enabledLabelCss = []
-            , disabledLabelCss = []
-            }
-        , Checkbox.viewWithLabel
-            { identifier = "fake-not-selected-locked"
-            , label = "Ut nobis et vel. Nulla rerum sit eos accusamus placeat. Iure sunt earum voluptatibus autem ratione soluta sint.\n\nIste perferendis eum corporis ullam magnam incidunt eos."
-            , setterMsg = ToggleCheck "fake"
-            , selected = Checkbox.NotSelected
-            , disabled = True
-            , theme = Checkbox.Locked
-            , containerCss = []
-            , enabledLabelCss = []
-            , disabledLabelCss = []
-            }
-        , Checkbox.viewWithLabel
-            { identifier = "fake-not-selected-square"
-            , label = "Ut nobis et vel. Nulla rerum sit eos accusamus placeat. Iure sunt earum voluptatibus autem ratione soluta sint.\n\nIste perferendis eum corporis ullam magnam incidunt eos."
-            , setterMsg = ToggleCheck "fake"
-            , selected = Checkbox.NotSelected
-            , disabled = True
-            , theme = Checkbox.Square
-            , containerCss = []
-            , enabledLabelCss = []
-            , disabledLabelCss = []
-            }
-        ]
-
-
 viewPremiumCheckboxes : State -> Html Msg
 viewPremiumCheckboxes state =
     Html.div []
@@ -358,29 +236,6 @@ viewPremiumCheckboxes state =
             , PremiumCheckbox.onLockedClick (Debug.log "Locked" NoOp)
             , PremiumCheckbox.selected (Set.member "premium-3" state.isChecked)
             ]
-        ]
-
-
-viewCustomStyledCheckbox : State -> Html Msg
-viewCustomStyledCheckbox state =
-    Html.section
-        [ css [ Css.width (Css.px 500) ] ]
-        [ Heading.h2 [ Heading.plaintext "Custom-styled Checkboxes" ]
-        , let
-            id =
-                "styleguide-checkbox-custom-style"
-          in
-          Checkbox.viewWithLabel
-            { identifier = id
-            , label = "This is a custom-styled Checkbox"
-            , setterMsg = ToggleCheck id
-            , selected = isSelected id state
-            , disabled = False
-            , theme = Checkbox.Square
-            , containerCss = [ Css.backgroundColor Colors.navy ]
-            , enabledLabelCss = [ Css.color Colors.white ]
-            , disabledLabelCss = []
-            }
         ]
 
 

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -20,7 +20,6 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Svg.V1 as Svg
-import Set exposing (Set)
 
 
 moduleName : String
@@ -98,7 +97,7 @@ preview =
 
 {-| -}
 type alias State =
-    { isChecked : Set String
+    { isChecked : Checkbox.IsSelected
     , settings : Control Settings
     }
 
@@ -106,7 +105,7 @@ type alias State =
 {-| -}
 init : State
 init =
-    { isChecked = Set.empty
+    { isChecked = Checkbox.PartiallySelected
     , settings = controlSettings
     }
 
@@ -162,7 +161,7 @@ viewExample state settings =
         { identifier = id
         , label = settings.label
         , setterMsg = ToggleCheck id
-        , selected = isSelected id state
+        , selected = state.isChecked
         , disabled = settings.disabled
         , theme = settings.theme
         , containerCss = settings.containerCss
@@ -185,10 +184,10 @@ update msg state =
             let
                 isChecked =
                     if checked then
-                        Set.insert id state.isChecked
+                        Checkbox.Selected
 
                     else
-                        Set.remove id state.isChecked
+                        Checkbox.NotSelected
             in
             ( { state | isChecked = isChecked }, Cmd.none )
 
@@ -198,12 +197,3 @@ update msg state =
 
 type alias Id =
     String
-
-
-isSelected : Id -> State -> Checkbox.IsSelected
-isSelected id state =
-    if Set.member id state.isChecked then
-        Checkbox.Selected
-
-    else
-        Checkbox.NotSelected

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -8,6 +8,7 @@ module Examples.Checkbox exposing (Msg, State, example)
 
 import Category exposing (Category(..))
 import CheckboxIcons
+import Code
 import Css exposing (Style)
 import Debug.Control as Control exposing (Control)
 import Debug.Control.View as ControlView
@@ -46,6 +47,9 @@ example =
             let
                 settings =
                     Control.currentValue state.settings
+
+                ( exampleCode, exampleView ) =
+                    viewExampleWithCode state settings
             in
             [ ControlView.view
                 { ellieLinkConfig = ellieLinkConfig
@@ -53,12 +57,12 @@ example =
                 , version = version
                 , update = UpdateControls
                 , settings = state.settings
-                , mainType = Nothing
+                , mainType = Just "RootHtml.Html Bool"
                 , extraCode = []
-                , toExampleCode = \_ -> [ { sectionName = "TODO", code = "TODO" } ]
+                , toExampleCode = \_ -> [ { sectionName = "viewWithLabel", code = exampleCode } ]
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
-            , viewExample state settings
+            , exampleView
             ]
     , categories = [ Inputs ]
     , keyboardSupport =
@@ -123,20 +127,35 @@ controlSettings =
             )
         |> Control.field "containerCss"
             (Control.choice
-                [ ( "[]", Control.value [] )
-                , ( "Red dashed border", Control.value [ Css.border3 (Css.px 4) Css.dashed Colors.red ] )
+                [ ( "[]", Control.value ( "[]", [] ) )
+                , ( "Red dashed border"
+                  , Control.value
+                        ( "[ Css.border3 (Css.px 4) Css.dashed Colors.red ]"
+                        , [ Css.border3 (Css.px 4) Css.dashed Colors.red ]
+                        )
+                  )
                 ]
             )
         |> Control.field "enabledLabelCss"
             (Control.choice
-                [ ( "[]", Control.value [] )
-                , ( "Orange dotted border", Control.value [ Css.border3 (Css.px 4) Css.dotted Colors.orange ] )
+                [ ( "[]", Control.value ( "[]", [] ) )
+                , ( "Orange dotted border"
+                  , Control.value
+                        ( "[ Css.border3 (Css.px 4) Css.dotted Colors.orange ]"
+                        , [ Css.border3 (Css.px 4) Css.dotted Colors.orange ]
+                        )
+                  )
                 ]
             )
         |> Control.field "disabledLabelCss"
             (Control.choice
-                [ ( "[]", Control.value [] )
-                , ( "strikethrough", Control.value [ Css.textDecoration Css.lineThrough ] )
+                [ ( "[]", Control.value ( "[]", [] ) )
+                , ( "strikethrough"
+                  , Control.value
+                        ( "[ Css.textDecoration Css.lineThrough ]"
+                        , [ Css.textDecoration Css.lineThrough ]
+                        )
+                  )
                 ]
             )
 
@@ -145,29 +164,44 @@ type alias Settings =
     { label : String
     , disabled : Bool
     , theme : Checkbox.Theme
-    , containerCss : List Style
-    , enabledLabelCss : List Style
-    , disabledLabelCss : List Style
+    , containerCss : ( String, List Style )
+    , enabledLabelCss : ( String, List Style )
+    , disabledLabelCss : ( String, List Style )
     }
 
 
-viewExample : State -> Settings -> Html Msg
-viewExample state settings =
+viewExampleWithCode : State -> Settings -> ( String, Html Msg )
+viewExampleWithCode state settings =
     let
         id =
             "unique-example-id"
     in
-    Checkbox.viewWithLabel
+    ( [ "Checkbox.viewWithLabel"
+      , Code.record
+            [ ( "identifier", Code.string id )
+            , ( "label", Code.string settings.label )
+            , ( "setterMsg", "identity" )
+            , ( "selected", "Checkbox." ++ Debug.toString state.isChecked )
+            , ( "disabled", Code.bool settings.disabled )
+            , ( "theme", "Checkbox." ++ Debug.toString settings.theme )
+            , ( "containerCss", Tuple.first settings.containerCss )
+            , ( "enabledLabelCss", Tuple.first settings.enabledLabelCss )
+            , ( "disabledLabelCss", Tuple.first settings.disabledLabelCss )
+            ]
+      ]
+        |> String.join ""
+    , Checkbox.viewWithLabel
         { identifier = id
         , label = settings.label
         , setterMsg = ToggleCheck id
         , selected = state.isChecked
         , disabled = settings.disabled
         , theme = settings.theme
-        , containerCss = settings.containerCss
-        , enabledLabelCss = settings.enabledLabelCss
-        , disabledLabelCss = settings.disabledLabelCss
+        , containerCss = Tuple.second settings.containerCss
+        , enabledLabelCss = Tuple.second settings.enabledLabelCss
+        , disabledLabelCss = Tuple.second settings.disabledLabelCss
         }
+    )
 
 
 {-| -}

--- a/styleguide-app/Examples/PremiumCheckbox.elm
+++ b/styleguide-app/Examples/PremiumCheckbox.elm
@@ -142,6 +142,7 @@ controlSettings =
 controlAttributes : Control (List ( String, PremiumCheckbox.Attribute msg ))
 controlAttributes =
     ControlExtra.list
+        |> ControlExtra.optionalBoolListItem "PremiumCheckbox.disabled" ( "PremiumCheckbox.disabled", PremiumCheckbox.disabled )
         |> CommonControls.css_ "setCheckboxContainerCss"
             ( "[ Css.border3 (Css.px 4) Css.dashed Colors.red ]"
             , [ Css.border3 (Css.px 4) Css.dashed Colors.red ]

--- a/styleguide-app/Examples/PremiumCheckbox.elm
+++ b/styleguide-app/Examples/PremiumCheckbox.elm
@@ -15,11 +15,10 @@ import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
-import Html.Styled as Html exposing (..)
+import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.Data.PremiumDisplay as PremiumDisplay
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Pennant.V2 as Pennant

--- a/styleguide-app/Examples/PremiumCheckbox.elm
+++ b/styleguide-app/Examples/PremiumCheckbox.elm
@@ -8,6 +8,7 @@ module Examples.PremiumCheckbox exposing (Msg, State, example)
 
 import Category exposing (Category(..))
 import CheckboxIcons
+import Code
 import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.View as ControlView
@@ -49,6 +50,9 @@ example =
             let
                 settings =
                     Control.currentValue state.settings
+
+                ( exampleCode, exampleView ) =
+                    viewExampleWithCode state settings
             in
             [ ControlView.view
                 { ellieLinkConfig = ellieLinkConfig
@@ -58,10 +62,10 @@ example =
                 , settings = state.settings
                 , mainType = Nothing
                 , extraCode = []
-                , toExampleCode = \_ -> [ { sectionName = "TODO", code = "TODO" } ]
+                , toExampleCode = \_ -> [ { sectionName = "view", code = exampleCode } ]
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
-            , viewExample state settings
+            , exampleView
             , Heading.h2 [ Heading.plaintext "Premium Checkboxes" ]
             , viewPremiumCheckboxes state
             , viewCustomStyledPremiumCheckboxes state
@@ -120,18 +124,42 @@ init =
     }
 
 
+type alias Settings =
+    { label : String
+    }
+
+
 controlSettings : Control Settings
 controlSettings =
     Control.record Settings
+        |> Control.field "label" (Control.string "Identify Adjectives 1")
 
 
-type alias Settings =
-    {}
-
-
-viewExample : State -> Settings -> Html Msg
-viewExample state settings =
-    text "TODO"
+viewExampleWithCode : State -> Settings -> ( String, Html Msg )
+viewExampleWithCode state settings =
+    let
+        id =
+            "unique-premium-example-id"
+    in
+    ( [ "Checkbox.viewWithLabel"
+      , Code.record
+            [ ( "label", Code.string settings.label )
+            , ( "onChange", "identity" )
+            ]
+      , Code.list
+            [ "PremiumCheckbox.selected " ++ Code.bool (Set.member id state.isChecked)
+            ]
+      ]
+        |> String.join ""
+    , PremiumCheckbox.view
+        { label = settings.label
+        , onChange = ToggleCheck id
+        }
+        [ PremiumCheckbox.premium PremiumDisplay.PremiumUnlocked
+        , PremiumCheckbox.onLockedClick NoOp
+        , PremiumCheckbox.selected (Set.member id state.isChecked)
+        ]
+    )
 
 
 {-| -}

--- a/styleguide-app/Examples/PremiumCheckbox.elm
+++ b/styleguide-app/Examples/PremiumCheckbox.elm
@@ -98,10 +98,9 @@ preview =
                 , text label_
                 ]
     in
-    [ ( CheckboxIcons.unchecked "unchecked-preview-unchecked", "Unchecked" )
-    , ( CheckboxIcons.checkedPartially "checkedPartially-preview-checkedPartially", "Part checked" )
+    [ ( CheckboxIcons.lockOnInside "lockOnInside-preview-lockOnInside", "Locked" )
+    , ( CheckboxIcons.unchecked "unchecked-preview-unchecked", "Unchecked" )
     , ( CheckboxIcons.checked "checkbox-preview-checked", "Checked" )
-    , ( CheckboxIcons.lockOnInside "lockOnInside-preview-lockOnInside", "Locked" )
     ]
         |> List.map renderPreview
 

--- a/styleguide-app/Examples/PremiumCheckbox.elm
+++ b/styleguide-app/Examples/PremiumCheckbox.elm
@@ -1,4 +1,4 @@
-module Examples.Checkbox exposing (Msg, State, example)
+module Examples.PremiumCheckbox exposing (Msg, State, example)
 
 {-|
 
@@ -8,29 +8,31 @@ module Examples.Checkbox exposing (Msg, State, example)
 
 import Category exposing (Category(..))
 import CheckboxIcons
-import Css exposing (Style)
+import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.View as ControlView
 import Example exposing (Example)
-import Html.Styled exposing (..)
+import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Key(..))
-import Nri.Ui.Checkbox.V6 as Checkbox
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Data.PremiumDisplay as PremiumDisplay
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Pennant.V2 as Pennant
+import Nri.Ui.PremiumCheckbox.V8 as PremiumCheckbox
 import Nri.Ui.Svg.V1 as Svg
 import Set exposing (Set)
 
 
 moduleName : String
 moduleName =
-    "Checkbox"
+    "PremiumCheckbox"
 
 
 version : Int
 version =
-    6
+    8
 
 
 {-| -}
@@ -60,6 +62,9 @@ example =
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
             , viewExample state settings
+            , Heading.h2 [ Heading.plaintext "Premium Checkboxes" ]
+            , viewPremiumCheckboxes state
+            , viewCustomStyledPremiumCheckboxes state
             ]
     , categories = [ Inputs ]
     , keyboardSupport =
@@ -82,16 +87,21 @@ preview =
                     , Css.fontWeight (Css.int 600)
                     , Css.displayFlex
                     , Css.alignItems Css.center
-                    , Css.minHeight (Css.px 30)
                     ]
                 ]
-                [ Svg.toHtml (Svg.withCss [ Css.marginRight (Css.px 8) ] icon)
+                [ Pennant.premiumFlag
+                    |> Svg.withCss [ Css.marginRight (Css.px 8) ]
+                    |> Svg.withWidth (Css.px 25)
+                    |> Svg.withHeight (Css.px 30)
+                    |> Svg.toHtml
+                , Svg.toHtml (Svg.withCss [ Css.marginRight (Css.px 8) ] icon)
                 , text label_
                 ]
     in
     [ ( CheckboxIcons.unchecked "unchecked-preview-unchecked", "Unchecked" )
     , ( CheckboxIcons.checkedPartially "checkedPartially-preview-checkedPartially", "Part checked" )
     , ( CheckboxIcons.checked "checkbox-preview-checked", "Checked" )
+    , ( CheckboxIcons.lockOnInside "lockOnInside-preview-lockOnInside", "Locked" )
     ]
         |> List.map renderPreview
 
@@ -114,67 +124,22 @@ init =
 controlSettings : Control Settings
 controlSettings =
     Control.record Settings
-        |> Control.field "label" (Control.string "Enable Text to Speech")
-        |> Control.field "disabled" (Control.bool False)
-        |> Control.field "theme"
-            (Control.choice
-                [ ( "Square", Control.value Checkbox.Square )
-                , ( "Locked", Control.value Checkbox.Locked )
-                ]
-            )
-        |> Control.field "containerCss"
-            (Control.choice
-                [ ( "[]", Control.value [] )
-                , ( "Red dashed border", Control.value [ Css.border3 (Css.px 4) Css.dashed Colors.red ] )
-                ]
-            )
-        |> Control.field "enabledLabelCss"
-            (Control.choice
-                [ ( "[]", Control.value [] )
-                , ( "Orange dotted border", Control.value [ Css.border3 (Css.px 4) Css.dotted Colors.orange ] )
-                ]
-            )
-        |> Control.field "disabledLabelCss"
-            (Control.choice
-                [ ( "[]", Control.value [] )
-                , ( "strikethrough", Control.value [ Css.textDecoration Css.lineThrough ] )
-                ]
-            )
 
 
 type alias Settings =
-    { label : String
-    , disabled : Bool
-    , theme : Checkbox.Theme
-    , containerCss : List Style
-    , enabledLabelCss : List Style
-    , disabledLabelCss : List Style
-    }
+    {}
 
 
 viewExample : State -> Settings -> Html Msg
 viewExample state settings =
-    let
-        id =
-            "unique-example-id"
-    in
-    Checkbox.viewWithLabel
-        { identifier = id
-        , label = settings.label
-        , setterMsg = ToggleCheck id
-        , selected = isSelected id state
-        , disabled = settings.disabled
-        , theme = settings.theme
-        , containerCss = settings.containerCss
-        , enabledLabelCss = settings.enabledLabelCss
-        , disabledLabelCss = settings.disabledLabelCss
-        }
+    text "TODO"
 
 
 {-| -}
 type Msg
     = ToggleCheck Id Bool
     | UpdateControls (Control Settings)
+    | NoOp
 
 
 {-| -}
@@ -195,15 +160,61 @@ update msg state =
         UpdateControls settings ->
             ( { state | settings = settings }, Cmd.none )
 
+        NoOp ->
+            ( state, Cmd.none )
+
+
+
+-- INTERNAL
+
+
+viewPremiumCheckboxes : State -> Html Msg
+viewPremiumCheckboxes state =
+    Html.div []
+        [ PremiumCheckbox.view
+            { label = "Identify Adjectives 1 (Premium, Unlocked)"
+            , onChange = ToggleCheck "premium-1"
+            }
+            [ PremiumCheckbox.premium PremiumDisplay.PremiumUnlocked
+            , PremiumCheckbox.onLockedClick NoOp
+            , PremiumCheckbox.selected (Set.member "premium-1" state.isChecked)
+            ]
+        , PremiumCheckbox.view
+            { label = "Identify Adjectives 2 (Free)"
+            , onChange = ToggleCheck "premium-2"
+            }
+            [ PremiumCheckbox.premium PremiumDisplay.Free
+            , PremiumCheckbox.onLockedClick NoOp
+            , PremiumCheckbox.selected (Set.member "premium-2" state.isChecked)
+            ]
+        , PremiumCheckbox.view
+            { label = "Revising Wordy Phrases 3 (Premium, Locked)"
+            , onChange = ToggleCheck "premium-3"
+            }
+            [ PremiumCheckbox.premium PremiumDisplay.PremiumLocked
+            , PremiumCheckbox.onLockedClick (Debug.log "Locked" NoOp)
+            , PremiumCheckbox.selected (Set.member "premium-3" state.isChecked)
+            ]
+        ]
+
+
+viewCustomStyledPremiumCheckboxes : State -> Html Msg
+viewCustomStyledPremiumCheckboxes state =
+    Html.section
+        [ css [ Css.width (Css.px 500) ] ]
+        [ Heading.h2 [ Heading.plaintext "Custom-styled Premium Checkboxes" ]
+        , PremiumCheckbox.view
+            { label = "This is a custom-styled Premium Checkbox"
+            , onChange = ToggleCheck "premium-custom"
+            }
+            [ PremiumCheckbox.premium PremiumDisplay.PremiumUnlocked
+            , PremiumCheckbox.onLockedClick NoOp
+            , PremiumCheckbox.selected (Set.member "premium-custom" state.isChecked)
+            , PremiumCheckbox.setCheckboxContainerCss [ Css.backgroundColor Colors.navy ]
+            , PremiumCheckbox.setCheckboxEnabledLabelCss [ Css.color Colors.white ]
+            ]
+        ]
+
 
 type alias Id =
     String
-
-
-isSelected : Id -> State -> Checkbox.IsSelected
-isSelected id state =
-    if Set.member id state.isChecked then
-        Checkbox.Selected
-
-    else
-        Checkbox.NotSelected

--- a/styleguide-app/Examples/PremiumCheckbox.elm
+++ b/styleguide-app/Examples/PremiumCheckbox.elm
@@ -9,8 +9,10 @@ module Examples.PremiumCheckbox exposing (Msg, State, example)
 import Category exposing (Category(..))
 import CheckboxIcons
 import Code
+import CommonControls
 import Css
 import Debug.Control as Control exposing (Control)
+import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled as Html exposing (..)
@@ -126,6 +128,7 @@ init =
 
 type alias Settings =
     { label : String
+    , attributes : List ( String, PremiumCheckbox.Attribute Msg )
     }
 
 
@@ -133,6 +136,33 @@ controlSettings : Control Settings
 controlSettings =
     Control.record Settings
         |> Control.field "label" (Control.string "Identify Adjectives 1")
+        |> Control.field "attributes" controlAttributes
+
+
+controlAttributes : Control (List ( String, PremiumCheckbox.Attribute msg ))
+controlAttributes =
+    ControlExtra.list
+        |> CommonControls.css_ "setCheckboxContainerCss"
+            ( "[ Css.border3 (Css.px 4) Css.dashed Colors.red ]"
+            , [ Css.border3 (Css.px 4) Css.dashed Colors.red ]
+            )
+            { moduleName = moduleName
+            , use = PremiumCheckbox.setCheckboxContainerCss
+            }
+        |> CommonControls.css_ "setCheckboxEnabledLabelCss"
+            ( "[ Css.border3 (Css.px 4) Css.dotted Colors.orange ]"
+            , [ Css.border3 (Css.px 4) Css.dotted Colors.orange ]
+            )
+            { moduleName = moduleName
+            , use = PremiumCheckbox.setCheckboxEnabledLabelCss
+            }
+        |> CommonControls.css_ "setCheckboxDisabledLabelCss"
+            ( "[ Css.textDecoration Css.lineThrough ]"
+            , [ Css.textDecoration Css.lineThrough ]
+            )
+            { moduleName = moduleName
+            , use = PremiumCheckbox.setCheckboxDisabledLabelCss
+            }
 
 
 viewExampleWithCode : State -> Settings -> ( String, Html Msg )
@@ -147,18 +177,23 @@ viewExampleWithCode state settings =
             , ( "onChange", "identity" )
             ]
       , Code.list
-            [ "PremiumCheckbox.selected " ++ Code.bool (Set.member id state.isChecked)
-            ]
+            (("PremiumCheckbox.selected " ++ Code.bool (Set.member id state.isChecked))
+                :: List.map Tuple.first settings.attributes
+            )
       ]
         |> String.join ""
     , PremiumCheckbox.view
         { label = settings.label
         , onChange = ToggleCheck id
         }
-        [ PremiumCheckbox.premium PremiumDisplay.PremiumUnlocked
-        , PremiumCheckbox.onLockedClick NoOp
-        , PremiumCheckbox.selected (Set.member id state.isChecked)
-        ]
+        ([ [ PremiumCheckbox.premium PremiumDisplay.PremiumUnlocked
+           , PremiumCheckbox.onLockedClick NoOp
+           , PremiumCheckbox.selected (Set.member id state.isChecked)
+           ]
+         , List.map Tuple.second settings.attributes
+         ]
+            |> List.concat
+        )
     )
 
 

--- a/styleguide-app/Examples/PremiumCheckbox.elm
+++ b/styleguide-app/Examples/PremiumCheckbox.elm
@@ -142,6 +142,11 @@ controlSettings =
 controlAttributes : Control (List ( String, PremiumCheckbox.Attribute msg ))
 controlAttributes =
     ControlExtra.list
+        |> ControlExtra.optionalListItem "premiumDisplay"
+            (Control.map
+                (\( str, val ) -> ( "PremiumCheckbox.premium " ++ str, PremiumCheckbox.premium val ))
+                CommonControls.premiumDisplay
+            )
         |> ControlExtra.optionalBoolListItem "PremiumCheckbox.disabled" ( "PremiumCheckbox.disabled", PremiumCheckbox.disabled )
         |> CommonControls.css_ "setCheckboxContainerCss"
             ( "[ Css.border3 (Css.px 4) Css.dashed Colors.red ]"
@@ -172,7 +177,7 @@ viewExampleWithCode state settings =
         id =
             "unique-premium-example-id"
     in
-    ( [ "Checkbox.viewWithLabel"
+    ( [ "PremiumCheckbox.view "
       , Code.record
             [ ( "label", Code.string settings.label )
             , ( "onChange", "identity" )
@@ -187,8 +192,7 @@ viewExampleWithCode state settings =
         { label = settings.label
         , onChange = ToggleCheck id
         }
-        ([ [ PremiumCheckbox.premium PremiumDisplay.PremiumUnlocked
-           , PremiumCheckbox.onLockedClick NoOp
+        ([ [ PremiumCheckbox.onLockedClick NoOp
            , PremiumCheckbox.selected (Set.member id state.isChecked)
            ]
          , List.map Tuple.second settings.attributes


### PR DESCRIPTION
In order to get PremiumCheckbox examples with working Ellie links, I also split the checkbox and premium examples into 2 separate examples.

Fixes A11-1470

## Checkbox

<img width="1099" alt="screenshot of rendered checkbox example" src="https://user-images.githubusercontent.com/8811312/186550399-15f64394-1b72-429d-8f9a-c3d2e66ee677.png">


## PremiumCheckbox

<img width="1094" alt="screenshot of rendered premium checkbox example" src="https://user-images.githubusercontent.com/8811312/186550354-9d57348e-5f7d-4d5a-b4c1-aff0901282dc.png">

