### PR TITLE
Fix Tab and Menu keyboard behavior

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -79,7 +79,7 @@
         "elm-community/string-extra": "4.0.1 <= v < 5.0.0",
         "pablohirafuji/elm-markdown": "2.0.5 <= v < 3.0.0",
         "rtfeldman/elm-css": "17.0.1 <= v < 18.0.0",
-        "tesk9/accessible-html-with-css": "3.1.0 <= v < 4.0.0",
+        "tesk9/accessible-html-with-css": "3.2.0 <= v < 4.0.0",
         "tesk9/palette": "3.0.1 <= v < 4.0.0"
     },
     "test-dependencies": {

--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -446,7 +446,7 @@ viewCustom config =
     in
     div
         (Attributes.id (config.buttonId ++ "__container")
-            :: Key.onKeyDown
+            :: Key.onKeyDownPreventDefault
                 (Key.escape
                     (config.focusAndToggle
                         { isOpen = False
@@ -540,7 +540,7 @@ viewCustom config =
                       -- as long as it's not a Disclosed
                       case ( config.purpose, maybeFirstFocusableElementId, maybeLastFocusableElementId ) of
                         ( NavMenu, Just firstFocusableElementId, Just lastFocusableElementId ) ->
-                            onKeyDownPreventDefault
+                            Key.onKeyDownPreventDefault
                                 [ Key.down
                                     (config.focusAndToggle
                                         { isOpen = True

--- a/src/TabsInternal/V2.elm
+++ b/src/TabsInternal/V2.elm
@@ -188,22 +188,21 @@ keyEvents { focusAndSelect, tabs } thisTab =
 
                 ( True, Nothing ) ->
                     ( True
-                    , if tab.disabled then
-                        Nothing
-
-                      else
-                        Just { select = tab.id, focus = Just (tabToId tab.idString) }
+                    , Just { select = tab.id, focus = Just (tabToId tab.idString) }
                     )
 
                 ( False, Nothing ) ->
                     ( tab.id == thisTab.id, Nothing )
 
+        nonDisabledTabs =
+            List.filter (not << .disabled) tabs
+
         nextTab =
-            List.foldl findAdjacentTab ( False, Nothing ) tabs
+            List.foldl findAdjacentTab ( False, Nothing ) nonDisabledTabs
                 |> Tuple.second
 
         previousTab =
-            List.foldr findAdjacentTab ( False, Nothing ) tabs
+            List.foldr findAdjacentTab ( False, Nothing ) nonDisabledTabs
                 |> Tuple.second
     in
     [ Maybe.map (Key.right << focusAndSelect) nextTab

--- a/src/TabsInternal/V2.elm
+++ b/src/TabsInternal/V2.elm
@@ -181,18 +181,14 @@ viewTab_ config index tab =
 keyEvents : Config id msg -> Tab id msg -> List (Json.Decode.Decoder msg)
 keyEvents { focusAndSelect, tabs } thisTab =
     let
-        findAdjacentTab tab acc =
-            case acc of
-                ( _, Just _ ) ->
-                    acc
+        findAdjacentTab tab ( isAdjacentTab, acc ) =
+            if isAdjacentTab then
+                ( False
+                , Just { select = tab.id, focus = Just (tabToId tab.idString) }
+                )
 
-                ( True, Nothing ) ->
-                    ( True
-                    , Just { select = tab.id, focus = Just (tabToId tab.idString) }
-                    )
-
-                ( False, Nothing ) ->
-                    ( tab.id == thisTab.id, Nothing )
+            else
+                ( tab.id == thisTab.id, acc )
 
         nonDisabledTabs =
             List.filter (not << .disabled) tabs

--- a/src/TabsInternal/V2.elm
+++ b/src/TabsInternal/V2.elm
@@ -199,12 +199,22 @@ keyEvents { focusAndSelect, tabs } thisTab =
 
         goToNextTab : Maybe msg
         goToNextTab =
-            List.foldl findAdjacentTab ( False, Nothing ) activeTabs
+            List.foldl findAdjacentTab
+                ( False
+                , -- if there is no adjacent tab, default to the first tab
+                  Maybe.map onFocus (List.head activeTabs)
+                )
+                activeTabs
                 |> Tuple.second
 
         goToPreviousTab : Maybe msg
         goToPreviousTab =
-            List.foldr findAdjacentTab ( False, Nothing ) activeTabs
+            List.foldr findAdjacentTab
+                ( False
+                , -- if there is no adjacent tab, default to the last tab
+                  Maybe.map onFocus (List.head (List.reverse activeTabs))
+                )
+                activeTabs
                 |> Tuple.second
     in
     List.filterMap identity

--- a/styleguide/elm.json
+++ b/styleguide/elm.json
@@ -25,7 +25,7 @@
             "pablohirafuji/elm-markdown": "2.0.5",
             "rtfeldman/elm-css": "17.0.5",
             "rtfeldman/elm-sorter-experiment": "2.1.1",
-            "tesk9/accessible-html-with-css": "3.1.0",
+            "tesk9/accessible-html-with-css": "3.2.0",
             "tesk9/palette": "3.0.1",
             "wernerdegroot/listzipper": "4.0.0"
         },


### PR DESCRIPTION
## 1. prevent default on Menu and Tab interactions

This should prevent "jitter" when the user is using arrows to navigate the page.

## 2. wrap the selected tab

Instead of users hitting a wall, wrap their focus back around to the first tab/segmented control/carousel.

Fixes A11-948
Fixes A11-1229
Fixes A11-1230

https://user-images.githubusercontent.com/8811312/186787032-ce0cd2c7-e8ea-48c7-b9e3-91735b60ba90.mov

