### PR TITLE
Fix Tooltip focus management for disclosure tooltips.

### DIFF
--- a/src/Nri/Ui/FocusTrap/V1.elm
+++ b/src/Nri/Ui/FocusTrap/V1.elm
@@ -7,6 +7,7 @@ module Nri.Ui.FocusTrap.V1 exposing (FocusTrap, toAttribute)
 -}
 
 import Accessibility.Styled as Html
+import Accessibility.Styled.Key as Key
 import Nri.Ui.WhenFocusLeaves.V1 as WhenFocusLeaves
 
 
@@ -27,13 +28,15 @@ type alias FocusTrap msg =
 -}
 toAttribute : FocusTrap msg -> Html.Attribute msg
 toAttribute { firstId, lastId, focus } =
-    WhenFocusLeaves.toAttribute
-        { firstId = firstId
-        , lastId = lastId
-        , -- if the user tabs back while on the first id,
-          -- we want to wrap around to the last id.
-          tabBackAction = focus lastId
-        , -- if the user tabs forward while on the last id,
-          -- we want to wrap around to the first id.
-          tabForwardAction = focus firstId
-        }
+    Key.onKeyDownPreventDefault
+        [ WhenFocusLeaves.toDecoder
+            { firstId = firstId
+            , lastId = lastId
+            , -- if the user tabs back while on the first id,
+              -- we want to wrap around to the last id.
+              tabBackAction = focus lastId
+            , -- if the user tabs forward while on the last id,
+              -- we want to wrap around to the first id.
+              tabForwardAction = focus firstId
+            }
+        ]

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -670,12 +670,14 @@ viewTooltip_ { trigger, id } tooltip =
                         Disclosure { triggerId, lastId } ->
                             ( [ Events.onMouseEnter (msg True)
                               , Events.onMouseLeave (msg False)
-                              , WhenFocusLeaves.toAttribute
-                                    { firstId = triggerId
-                                    , lastId = Maybe.withDefault triggerId lastId
-                                    , tabBackAction = msg False
-                                    , tabForwardAction = msg False
-                                    }
+                              , Key.onKeyDown
+                                    [ WhenFocusLeaves.toDecoder
+                                        { firstId = triggerId
+                                        , lastId = Maybe.withDefault triggerId lastId
+                                        , tabBackAction = msg False
+                                        , tabForwardAction = msg False
+                                        }
+                                    ]
                               ]
                             , [ Events.onClick (msg (not tooltip.isOpen))
                               , Key.onKeyDown [ Key.escape (msg False) ]

--- a/src/Nri/Ui/WhenFocusLeaves/V1.elm
+++ b/src/Nri/Ui/WhenFocusLeaves/V1.elm
@@ -1,6 +1,8 @@
 module Nri.Ui.WhenFocusLeaves.V1 exposing (toAttribute, toDecoder)
 
-{-| Listen for when the focus leaves the area, and then do an action.
+{-| TODO in next major version: remove `toAttribute`.
+
+Listen for when the focus leaves the area, and then do an action.
 
 @docs toAttribute, toDecoder
 
@@ -11,13 +13,13 @@ import Html.Styled.Events exposing (preventDefaultOn)
 import Json.Decode as Decode exposing (Decoder)
 
 
-{-| Attach this attribute to add a focus watcher to an HTML element and define
+{-| DEPRECATED: Use `toDecoder` instead
+
+Attach this attribute to add a focus watcher to an HTML element and define
 what to do in reponse to tab keypresses in a part of the UI.
 
 The ids referenced here are expected to correspond to elements in the container
 we are adding the attribute to.
-
-NOTE: When needing to listen to multiple keys toDecoder should be used instead of toAttribute.
 
 -}
 toAttribute :


### PR DESCRIPTION
We need to prevent default for modals, but preventing default for tooltips breaks the browser's focus management.

Fixes A11-1518

Tooltip and Modal focus management should both work correctly.