### PR TITLE
A11-1340 add `"country-name"` autocomplete to TextInput

### DIFF
--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -1,6 +1,6 @@
 module Nri.Ui.TextInput.V7 exposing
     ( view, generateId
-    , number, float, text, newPassword, currentPassword, email, search, addressLevel2, addressLine1, familyName, givenName, organization, organizationTitle, postalCode, sex, tel
+    , number, float, text, newPassword, currentPassword, email, search, addressLevel2, addressLine1, countryName, familyName, givenName, organization, organizationTitle, postalCode, sex, tel
     , readOnlyText
     , value, map
     , onFocus, onBlur, onEnter
@@ -27,7 +27,7 @@ module Nri.Ui.TextInput.V7 exposing
 
 ### Input types
 
-@docs number, float, text, newPassword, currentPassword, email, search, addressLevel2, addressLine1, familyName, givenName, organization, organizationTitle, postalCode, sex, tel
+@docs number, float, text, newPassword, currentPassword, email, search, addressLevel2, addressLine1, countryName, familyName, givenName, organization, organizationTitle, postalCode, sex, tel
 @docs readOnlyText
 
 
@@ -379,6 +379,25 @@ addressLevel2 onInput_ =
                 | fieldType = Just "text"
                 , inputMode = Nothing
                 , autocomplete = Just "address-level2"
+            }
+        )
+
+
+{-| An input that allows country-name entry
+-}
+countryName : (String -> msg) -> Attribute String msg
+countryName onInput_ =
+    Attribute
+        { emptyEventsAndValues
+            | toString = Just identity
+            , fromString = Just identity
+            , onInput = Just (identity >> onInput_)
+        }
+        (\config ->
+            { config
+                | fieldType = Just "text"
+                , inputMode = Nothing
+                , autocomplete = Just "country-name"
             }
         )
 

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -283,6 +283,16 @@ customizableExamples state =
             , onEnter = "Entered!!!"
             }
         , toExample
+            { name = "countryName"
+            , toString = identity
+            , inputType = TextInput.countryName
+            , inputTypeCode = "TextInput.countryName"
+            , inputTypeValueCode = \value -> Code.string (Maybe.withDefault "" value)
+            , onFocus = "Focused!!!"
+            , onBlur = "Blurred!!!"
+            , onEnter = "Entered!!!"
+            }
+        , toExample
             { name = "postalCode"
             , toString = identity
             , inputType = TextInput.postalCode


### PR DESCRIPTION
Adds `"country-name"` autocomplete value to be used on `/teach/tour > outside the US`, part of [A11-1117](https://linear.app/noredink/issue/A11-1117).