### PR TITLE
Fix Tabs focus ring behavior

### DIFF
--- a/src/Nri/Ui/Tabs/V7.elm
+++ b/src/Nri/Ui/Tabs/V7.elm
@@ -286,7 +286,7 @@ tabStyles customSpacing index isSelected =
                 , borderRightColor Colors.azure
                 , borderLeftColor Colors.azure
                 ]
-            , focus
+            , pseudoClass "focus-visible"
                 [ FocusRing.outerBoxShadow
                 , outline none
                 ]


### PR DESCRIPTION
Fixes A11-1519

Only show the focus ring when focus rings should be visible:

https://user-images.githubusercontent.com/8811312/187511396-2ce35af5-941d-4513-b842-d443a1ec38d8.mov

