### PR TITLE
Fix Menu tab behavior

### DIFF
--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -446,7 +446,7 @@ viewCustom config =
     in
     div
         (Attributes.id (config.buttonId ++ "__container")
-            :: Key.onKeyDownPreventDefault
+            :: Key.onKeyDown
                 (Key.escape
                     (config.focusAndToggle
                         { isOpen = False


### PR DESCRIPTION
Fix mistaken onKeyDownPreventDefault use on the Menu container, when it ought to have only been added to the Menu entries. This caused forward and backward navigation from each Menu to break.

Fixes A11-1531