### PR TITLE
Bat/segmented control focus ring

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "18.2.1",
+    "version": "18.3.0",
     "exposed-modules": [
         "Nri.Ui",
         "Nri.Ui.Accordion.V3",

--- a/src/Nri/Ui/Accordion/V3.elm
+++ b/src/Nri/Ui/Accordion/V3.elm
@@ -68,6 +68,7 @@ import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events exposing (onClick)
 import Html.Styled.Keyed
 import Json.Decode as Decode
+import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
 
@@ -101,6 +102,7 @@ styleAccordion styleOptions =
              , Css.backgroundColor Css.unset
              , borderWidth Css.zero
              , margin zero
+             , Css.pseudoClass "focus-visible" [ FocusRing.insetBoxShadows [] ]
 
              -- fonts & text
              , textAlign left
@@ -336,6 +338,7 @@ viewEntry focus arrows ({ headerId, headerLevel, caret, headerContent, entryClas
                     , ( entryClass, True )
                     , ( accordionEntryHeaderExpandedClass, isExpanded )
                     , ( accordionEntryHeaderCollapsedClass, not isExpanded )
+                    , ( FocusRing.customClass, True )
                     ]
                 , Aria.disabled (config.toggle == Nothing)
                 , Aria.expanded isExpanded

--- a/src/Nri/Ui/FocusRing/V1.elm
+++ b/src/Nri/Ui/FocusRing/V1.elm
@@ -1,7 +1,7 @@
 module Nri.Ui.FocusRing.V1 exposing
     ( forKeyboardUsers, forMouseUsers
     , styles, tightStyles
-    , boxShadows, outerBoxShadow, insetBoxShadow
+    , boxShadows, insetBoxShadows, outerBoxShadow, insetBoxShadow
     , customClass
     , outerColor, innerColor
     )
@@ -10,7 +10,7 @@ module Nri.Ui.FocusRing.V1 exposing
 
 @docs forKeyboardUsers, forMouseUsers
 @docs styles, tightStyles
-@docs boxShadows, outerBoxShadow, insetBoxShadow
+@docs boxShadows, insetBoxShadows, outerBoxShadow, insetBoxShadow
 @docs customClass
 @docs outerColor, innerColor
 
@@ -102,6 +102,23 @@ boxShadows existingBoxShadows =
     existingBoxShadows
         ++ [ "0 0 0 3px " ++ innerColorString
            , "0 0 0 6px " ++ outerColorString
+           ]
+        |> applyBoxShadows
+
+
+{-| Please be sure that the padding on the element you add this style too is sufficient (at least 6px on all sides) that the inset box shadow won't cover any content.
+
+    focus
+        [ FocusRing.insetBoxShadows [ "inset 0 3px 0 0 " ++ ColorsExtra.toCssString glacier ]
+        , outline none
+        ]
+
+-}
+insetBoxShadows : List String -> Css.Style
+insetBoxShadows existingBoxShadows =
+    existingBoxShadows
+        ++ [ "inset 0 0 0 3px " ++ outerColorString
+           , "inset 0 0 0 6px " ++ innerColorString
            ]
         |> applyBoxShadows
 

--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -446,7 +446,7 @@ viewCustom config =
     in
     div
         (Attributes.id (config.buttonId ++ "__container")
-            :: Key.onKeyDownPreventDefault
+            :: Key.onKeyDown
                 (Key.escape
                     (config.focusAndToggle
                         { isOpen = False

--- a/src/Nri/Ui/SegmentedControl/V14.elm
+++ b/src/Nri/Ui/SegmentedControl/V14.elm
@@ -270,7 +270,7 @@ styles positioning numEntries index isSelected =
                 []
     , -- ensure that the focus state is visible & looks nice
       Css.pseudoClass "focus-within"
-        [ FocusRing.boxShadows [ focusedSegmentBoxShadowValue ]
+        [ FocusRing.insetBoxShadows [ focusedSegmentBoxShadowValue ]
         , outline none
         ]
     ]

--- a/styleguide-app/Examples/Accordion.elm
+++ b/styleguide-app/Examples/Accordion.elm
@@ -26,6 +26,7 @@ import Nri.Ui.Accordion.V3 as Accordion exposing (AccordionEntry(..))
 import Nri.Ui.Colors.Extra as ColorsExtra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.DisclosureIndicator.V2 as DisclosureIndicator
+import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -306,6 +307,11 @@ view ellieLinkConfig model =
                 [ Css.backgroundColor Colors.gray96
                 , Css.borderRadius (Css.px 8)
                 , Css.boxShadow5 Css.zero Css.zero (px 10) zero (ColorsExtra.withAlpha 0.2 Colors.gray20)
+                , Css.pseudoClass "focus-visible"
+                    [ FocusRing.insetBoxShadows
+                        [ "0 0 10px 0 " ++ ColorsExtra.toCssString (ColorsExtra.withAlpha 0.2 Colors.gray20)
+                        ]
+                    ]
                 ]
             ]
         , headerClosedStyles = []


### PR DESCRIPTION
I am actually okay with the Before, and would be fine with leaving it as-is -- I like that the box shadows indicating selection status are nice and clear.

If we want to 100% not have overlap/hidden content, then we can use the inset styles instead. I think it's maybe harder to tell which part of the switch is selected, now -- focus is clear, but the non-color indicator of selection is less clear. Your call, @NoRedInk/design ! Or if you have other ideas, they're also welcome too (especially if they're easy 😛)

Fixes https://linear.app/noredink/issue/A11-1539/focus-ring-overlap-on-segmented-controls

## Before
<img width="352" alt="Screen Shot 2022-08-31 at 3 58 58 PM" src="https://user-images.githubusercontent.com/8811312/187792946-1b5783e7-1bf3-409d-942b-d556a2a5d480.png">

## After
<img width="406" alt="image" src="https://user-images.githubusercontent.com/8811312/187792990-4ee888fd-43e3-4a55-ad06-c70cbf755403.png">


