### PR TITLE
A11-1543 Extends the hover area of tooltips

### DIFF
--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -878,7 +878,21 @@ viewTooltip tooltipId config =
                 ++ config.attributes
                 ++ [ Attributes.id tooltipId ]
             )
-            config.content
+            (config.content
+                ++ [ Html.div
+                        [ Attributes.css
+                            [ Css.position Css.absolute
+                            , Css.Media.withMedia [ MediaQuery.notMobile ]
+                                [ Css.batch (hoverAreaForDirection config.direction)
+                                ]
+                            , Css.Media.withMedia [ MediaQuery.mobile ]
+                                [ Css.batch (hoverAreaForDirection config.mobileDirection)
+                                ]
+                            ]
+                        ]
+                        []
+                   ]
+            )
         ]
 
 
@@ -1027,6 +1041,58 @@ tailForDirection direction =
 
         OnLeft ->
             rightTail
+
+
+hoverAreaForDirection : Direction -> List Style
+hoverAreaForDirection direction =
+    case direction of
+        OnTop ->
+            bottomHoverArea
+
+        OnBottom ->
+            topHoverArea
+
+        OnLeft ->
+            rightHoverArea
+
+        OnRight ->
+            leftHoverArea
+
+
+topHoverArea : List Style
+topHoverArea =
+    [ Css.bottom (Css.pct 100)
+    , Css.left Css.zero
+    , Css.right Css.zero
+    , Css.height (Css.px (tailSize * 2))
+    ]
+
+
+bottomHoverArea : List Style
+bottomHoverArea =
+    [ Css.top (Css.pct 100)
+    , Css.left Css.zero
+    , Css.right Css.zero
+    , Css.height (Css.px (tailSize * 2))
+    ]
+
+
+leftHoverArea : List Style
+leftHoverArea =
+    [ Css.right (Css.pct 100)
+    , Css.top Css.zero
+    , Css.bottom Css.zero
+    , Css.width (Css.px (tailSize * 2))
+    ]
+
+
+rightHoverArea : List Style
+rightHoverArea =
+    [ Css.left (Css.pct 100)
+    , Css.top Css.zero
+    , Css.bottom Css.zero
+    , Css.width (Css.px (tailSize * 2))
+    ]
 
 
 bottomTail : Style


### PR DESCRIPTION
Since the tooltip appears when hovering over the trigger and disappears on mouse out, we want to extend the hover area to make it easier to get from the trigger to the tooltip.

[See more on motivation here.](https://noredink.slack.com/archives/C02NVG4M45U/p1662038535083739)


<img width="427" alt="Visible extra hover area below the tooltip" src="https://user-images.githubusercontent.com/5647344/188139177-140c9421-629d-45b8-97cd-5e1d6e4f0ff5.png">
<img width="229" alt="Visible extra hover area to the left of the tooltip" src="https://user-images.githubusercontent.com/5647344/188139298-48487703-ec5b-4175-95d8-a134728dc3f0.png">

The background color is only visible in the screenshots.