### PR TITLE
Bat/remove inline comments specific code

### DIFF
--- a/src/Nri/Ui/Highlighter/V1.elm
+++ b/src/Nri/Ui/Highlighter/V1.elm
@@ -1,5 +1,5 @@
 module Nri.Ui.Highlighter.V1 exposing
-    ( Model, Msg(..), PointerMsg(..), OnClickAction(..)
+    ( Model, Msg(..), PointerMsg(..)
     , init, update, view, static
     , Intent, emptyIntent, hasChanged, HasChanged(..)
     , removeHighlights
@@ -28,7 +28,7 @@ Currently, highlighter is used in the following places:
 
 # Types
 
-@docs Model, Msg, PointerMsg, OnClickAction
+@docs Model, Msg, PointerMsg
 
 
 # Init/View/Update
@@ -89,7 +89,6 @@ type alias Model marker =
       id : String
     , highlightables : List (Highlightable marker) -- The actual highlightable elements
     , marker : Tool.Tool marker -- Currently used marker
-    , onClickAction : OnClickAction -- What happens when a user clicks on a highlight
 
     -- Internal state to track user's interactions
     , mouseDownIndex : Maybe Int
@@ -105,12 +104,6 @@ type HasChanged
     | NotChanged
 
 
-{-| -}
-type OnClickAction
-    = ToggleOnClick
-    | SaveOnClick
-
-
 type Initialized
     = Initialized
     | NotInitialized
@@ -122,14 +115,12 @@ init :
     { id : String
     , highlightables : List (Highlightable marker)
     , marker : Tool.Tool marker
-    , onClickAction : OnClickAction
     }
     -> Model marker
 init config =
     { id = config.id
     , highlightables = config.highlightables
     , marker = config.marker
-    , onClickAction = config.onClickAction
     , mouseDownIndex = Nothing
     , mouseOverIndex = Nothing
     , isInitialized = NotInitialized
@@ -335,19 +326,11 @@ pointerEventToActions msg model =
 
         Up _ ->
             let
-                onClick index marker =
-                    case model.onClickAction of
-                        ToggleOnClick ->
-                            [ Toggle index marker ]
-
-                        SaveOnClick ->
-                            [ Save marker ]
-
                 save marker =
                     case ( model.mouseOverIndex, model.mouseDownIndex ) of
                         ( Just overIndex, Just downIndex ) ->
                             if overIndex == downIndex then
-                                onClick downIndex marker
+                                [ Toggle downIndex marker ]
 
                             else
                                 [ Save marker ]

--- a/src/Nri/Ui/HighlighterTool/V1.elm
+++ b/src/Nri/Ui/HighlighterTool/V1.elm
@@ -52,44 +52,33 @@ buildMarker :
     , hoverColor : Css.Color
     , hoverHighlightColor : Css.Color
     , kind : kind
-    , rounded : Bool
     }
     -> MarkerModel kind
-buildMarker { highlightColor, hoverColor, hoverHighlightColor, kind, rounded } =
+buildMarker { highlightColor, hoverColor, hoverHighlightColor, kind } =
     { hoverClass = hoverStyles hoverColor
     , hintClass = hoverStyles hoverColor
-    , startGroupClass = startGroupStyles rounded
-    , endGroupClass = endGroupStyles rounded
+    , startGroupClass = startGroupStyles
+    , endGroupClass = endGroupStyles
     , highlightClass = highlightStyles highlightColor
     , hoverHighlightClass = highlightStyles hoverHighlightColor
     , kind = kind
     }
 
 
-startGroupStyles : Bool -> List Css.Style
-startGroupStyles rounded =
+startGroupStyles : List Css.Style
+startGroupStyles =
     Css.paddingLeft (Css.px 4)
-        :: (if rounded then
-                [ Css.borderTopLeftRadius (Css.px 4)
-                , Css.borderBottomLeftRadius (Css.px 4)
-                ]
-
-            else
-                []
-           )
+        :: [ Css.borderTopLeftRadius (Css.px 4)
+           , Css.borderBottomLeftRadius (Css.px 4)
+           ]
 
 
-endGroupStyles : Bool -> List Css.Style
-endGroupStyles rounded =
+endGroupStyles : List Css.Style
+endGroupStyles =
     Css.paddingRight (Css.px 4)
-        :: (if rounded then
-                [ Css.borderTopRightRadius (Css.px 4)
-                , Css.borderBottomRightRadius (Css.px 4)
-                ]
-
-            else
-                []
-           )
+        :: [ Css.borderTopRightRadius (Css.px 4)
+           , Css.borderBottomRightRadius (Css.px 4)
+           ]
 
 
 highlightStyles : Css.Color -> List Css.Style

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -151,7 +151,6 @@ exampleMarker =
         , hoverColor = Colors.highlightMagenta
         , hoverHighlightColor = Colors.highlightPurpleDark
         , kind = ()
-        , rounded = True
         }
 
 
@@ -162,7 +161,6 @@ claimMarker =
         , hoverColor = Colors.highlightMagenta
         , hoverHighlightColor = Colors.highlightPurpleDark
         , kind = ()
-        , rounded = True
         }
 
 
@@ -173,7 +171,6 @@ evidenceMarker =
         , hoverColor = Colors.highlightMagenta
         , hoverHighlightColor = Colors.highlightPurpleDark
         , kind = ()
-        , rounded = True
         }
 
 
@@ -184,7 +181,6 @@ reasoningMarker =
         , hoverColor = Colors.highlightMagenta
         , hoverHighlightColor = Colors.highlightPurpleDark
         , kind = ()
-        , rounded = True
         }
 
 
@@ -252,12 +248,19 @@ controlSettings =
 
 controlMarker : Control (Tool.MarkerModel ())
 controlMarker =
-    Control.record (\a b c d e -> Tool.buildMarker { highlightColor = a, hoverColor = b, hoverHighlightColor = c, kind = d, rounded = e })
+    Control.record
+        (\a b c d ->
+            Tool.buildMarker
+                { highlightColor = a
+                , hoverColor = b
+                , hoverHighlightColor = c
+                , kind = d
+                }
+        )
         |> Control.field "highlightColor" backgroundHighlightColors
         |> Control.field "hoverColor" backgroundHighlightColors
         |> Control.field "hoverHighlightColor" backgroundHighlightColors
         |> Control.field "kind" (Control.value ())
-        |> Control.field "rounded" (Control.bool True)
 
 
 backgroundHighlightColors : Control Color

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -211,13 +211,11 @@ initHighlighter settings highlightables =
         { id = "example-romeo-and-juliet"
         , highlightables = highlightables
         , marker = settings.tool
-        , onClickAction = settings.onClickAction
         }
 
 
 type alias Settings =
     { tool : Tool.Tool ()
-    , onClickAction : Highlighter.OnClickAction
     }
 
 
@@ -236,12 +234,6 @@ controlSettings =
                         }
                         |> Control.value
                   )
-                ]
-            )
-        |> Control.field "onClickAction"
-            (Control.choice
-                [ ( "ToggleOnClick", Control.value Highlighter.ToggleOnClick )
-                , ( "SaveOnClick", Control.value Highlighter.SaveOnClick )
                 ]
             )
 


### PR DESCRIPTION
Non-rounded edges and SaveOnClick onClickAction were both for inline comments. We're not aiming to make this highlighter work for inline comments, so there's no need to keep these attributes around.

Fixes A11-1577