### PR TITLE
Remove errorIf options from styleguide examples

### DIFF
--- a/styleguide-app/Examples/RadioButton.elm
+++ b/styleguide-app/Examples/RadioButton.elm
@@ -292,16 +292,6 @@ controlAttributes =
                 ]
             )
         |> ControlExtra.optionalListItem "disclosure" controlDisclosure
-        |> ControlExtra.optionalListItem "errorIf"
-            (Control.map
-                (\inError ->
-                    ( "RadioButton.errorIf " ++ Debug.toString inError
-                    , RadioButton.errorIf inError
-                    )
-                )
-             <|
-                Control.bool True
-            )
         |> ControlExtra.optionalListItem "errorMessage"
             (Control.map
                 (\message ->

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -151,15 +151,6 @@ initControls =
                 )
                 (Control.bool True)
             )
-        |> ControlExtra.optionalListItem "errorIf"
-            (Control.map
-                (\bool ->
-                    ( "Select.errorIf " ++ Debug.toString bool
-                    , Select.errorIf bool
-                    )
-                )
-                (Control.bool True)
-            )
         |> ControlExtra.optionalListItem "errorMessage"
             (Control.map
                 (\str ->

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -375,8 +375,6 @@ controlAttributes =
             )
         |> ControlExtra.optionalBoolListItem "hiddenLabel"
             ( "TextInput.hiddenLabel", TextInput.hiddenLabel )
-        |> ControlExtra.optionalBoolListItem "errorIf"
-            ( "TextInput.errorIf True", TextInput.errorIf True )
         |> ControlExtra.optionalListItem "errorMessage"
             (Control.map
                 (\str ->


### PR DESCRIPTION
Fixes A11-1244

Removes `errorIf` examples from RadioButton, TextInput, and Select. The helper can still be used, but hopefully this change will discourage its use in favor of `errorMessage`.