### PR TITLE
Bat/highlighter example improvements

### DIFF
--- a/src/Nri/Ui/Highlighter/V1.elm
+++ b/src/Nri/Ui/Highlighter/V1.elm
@@ -455,7 +455,8 @@ groupContainer viewSegment highlightables =
                           --so we will be able to tell how it will read
                           tabindex 0
                         , css
-                            [ Css.Global.children
+                            [ Css.backgroundColor Css.transparent
+                            , Css.Global.children
                                 [ Css.Global.selector ":first-child"
                                     (MediaQuery.highContrastMode
                                         [ Maybe.map

--- a/src/Nri/Ui/Highlighter/V1.elm
+++ b/src/Nri/Ui/Highlighter/V1.elm
@@ -404,9 +404,9 @@ performAction action model =
 
 
 {-| -}
-removeHighlights : List (Highlightable marker) -> List (Highlightable marker)
-removeHighlights =
-    Internal.removeHighlights
+removeHighlights : Model marker -> Model marker
+removeHighlights model =
+    { model | highlightables = Internal.removeHighlights model.highlightables }
 
 
 

--- a/styleguide-app/Debug/Control/Extra.elm
+++ b/styleguide-app/Debug/Control/Extra.elm
@@ -4,6 +4,7 @@ module Debug.Control.Extra exposing
     , optionalBoolListItem, optionalBoolListItemDefaultTrue
     , bool
     , string
+    , rotatedChoice
     )
 
 {-|
@@ -13,11 +14,13 @@ module Debug.Control.Extra exposing
 @docs optionalBoolListItem, optionalBoolListItemDefaultTrue
 @docs bool
 @docs string
+@docs rotatedChoice
 
 -}
 
 import Code
 import Debug.Control as Control exposing (Control)
+import List.Extra
 
 
 {-| -}
@@ -121,3 +124,13 @@ bool default =
 string : String -> Control ( String, String )
 string default =
     Control.map (\val -> ( Code.string val, val )) (Control.string default)
+
+
+{-| -}
+rotatedChoice : Int -> List ( String, Control a ) -> Control a
+rotatedChoice rotateWith options =
+    let
+        ( before, after ) =
+            List.Extra.splitAt rotateWith options
+    in
+    Control.choice (after ++ before)

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -22,7 +22,6 @@ import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Highlightable.V1 as Highlightable exposing (Highlightable)
 import Nri.Ui.Highlighter.V1 as Highlighter
 import Nri.Ui.HighlighterTool.V1 as Tool
-import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V6 as Table
 
 

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -11,11 +11,11 @@ import Code
 import CommonControls
 import Css exposing (Color)
 import Debug.Control as Control exposing (Control)
+import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Examples.Colors
 import Html.Styled exposing (..)
-import List.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Highlightable.V1 as Highlightable exposing (Highlightable)
@@ -266,13 +266,9 @@ controlMarker =
 
 backgroundHighlightColors : Int -> Control Color
 backgroundHighlightColors rotateWith =
-    let
-        ( before, after ) =
-            List.Extra.splitAt rotateWith Examples.Colors.backgroundHighlightColors
-    in
-    (after ++ before)
+    Examples.Colors.backgroundHighlightColors
         |> List.map (\( name, value, _ ) -> ( name, Control.value value ))
-        |> Control.choice
+        |> ControlExtra.rotatedChoice rotateWith
 
 
 {-| -}

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -275,13 +275,7 @@ controlSettings =
             (Control.choice
                 [ ( "Marker", Control.map Tool.Marker controlMarker )
                 , ( "Eraser"
-                  , Tool.Eraser
-                        { hoverClass = [ Css.opacity (Css.num 0.4) ]
-                        , hintClass = [ Css.opacity (Css.num 0.4) ]
-                        , startGroupClass = [ Css.opacity (Css.num 0.4) ]
-                        , endGroupClass = [ Css.opacity (Css.num 0.4) ]
-                        }
-                        |> Control.value
+                  , Control.map Tool.Eraser controlEraser
                   )
                 ]
             )
@@ -290,20 +284,28 @@ controlSettings =
 controlMarker : Control (Tool.MarkerModel ())
 controlMarker =
     Control.record
-        (\a b c d e ->
+        (\a b c d ->
             Tool.buildMarker
                 { highlightColor = a
                 , hoverColor = b
                 , hoverHighlightColor = c
-                , kind = d
-                , name = e
+                , kind = ()
+                , name = d
                 }
         )
         |> Control.field "highlightColor" (backgroundHighlightColors 0)
         |> Control.field "hoverColor" (backgroundHighlightColors 2)
         |> Control.field "hoverHighlightColor" (backgroundHighlightColors 4)
-        |> Control.field "kind" (Control.value ())
         |> Control.field "name" (Control.maybe True (Control.string "Claim"))
+
+
+controlEraser : Control Tool.EraserModel
+controlEraser =
+    Control.record Tool.EraserModel
+        |> Control.field "hoverClass" (Control.value [ Css.border3 (Css.px 4) Css.dashed Colors.red ])
+        |> Control.field "hintClass" (Control.value [ Css.border3 (Css.px 4) Css.dotted Colors.orange ])
+        |> Control.field "startGroupClass" (Control.value [ Css.opacity (Css.num 0.4) ])
+        |> Control.field "endGroupClass" (Control.value [ Css.opacity (Css.num 0.4) ])
 
 
 backgroundHighlightColors : Int -> Control Color

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -16,11 +16,13 @@ import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Examples.Colors
 import Html.Styled exposing (..)
+import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Highlightable.V1 as Highlightable exposing (Highlightable)
 import Nri.Ui.Highlighter.V1 as Highlighter
 import Nri.Ui.HighlighterTool.V1 as Tool
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V6 as Table
 
 
@@ -58,8 +60,15 @@ example =
                 , toExampleCode = \_ -> []
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
+            , Button.button "Clear all highlights"
+                [ Button.onClick ClearHighlights
+                , Button.secondary
+                , Button.small
+                , Button.css [ Css.marginTop (Css.px 10) ]
+                ]
             , Highlighter.view state.highlighter
                 |> map HighlighterMsg
+            , Heading.h2 [ Heading.plaintext "Non-interactive Examples" ]
             , Table.view
                 [ Table.string
                     { header = "Description"
@@ -275,6 +284,7 @@ backgroundHighlightColors rotateWith =
 type Msg
     = UpdateControls (Control Settings)
     | HighlighterMsg (Highlighter.Msg ())
+    | ClearHighlights
 
 
 {-| -}
@@ -295,5 +305,10 @@ update msg state =
                     Highlighter.update highlighterMsg state.highlighter
             in
             ( { state | highlighter = newHighlighter }
+            , Cmd.none
+            )
+
+        ClearHighlights ->
+            ( { state | highlighter = Highlighter.removeHighlights state.highlighter }
             , Cmd.none
             )

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -15,6 +15,7 @@ import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Examples.Colors
 import Html.Styled exposing (..)
+import List.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Highlightable.V1 as Highlightable exposing (Highlightable)
@@ -256,16 +257,20 @@ controlMarker =
                 , name = e
                 }
         )
-        |> Control.field "highlightColor" backgroundHighlightColors
-        |> Control.field "hoverColor" backgroundHighlightColors
-        |> Control.field "hoverHighlightColor" backgroundHighlightColors
+        |> Control.field "highlightColor" (backgroundHighlightColors 0)
+        |> Control.field "hoverColor" (backgroundHighlightColors 2)
+        |> Control.field "hoverHighlightColor" (backgroundHighlightColors 4)
         |> Control.field "kind" (Control.value ())
         |> Control.field "name" (Control.maybe True (Control.string "Claim"))
 
 
-backgroundHighlightColors : Control Color
-backgroundHighlightColors =
-    Examples.Colors.backgroundHighlightColors
+backgroundHighlightColors : Int -> Control Color
+backgroundHighlightColors rotateWith =
+    let
+        ( before, after ) =
+            List.Extra.splitAt rotateWith Examples.Colors.backgroundHighlightColors
+    in
+    (after ++ before)
         |> List.map (\( name, value, _ ) -> ( name, Control.value value ))
         |> Control.choice
 

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -302,10 +302,14 @@ controlMarker =
 controlEraser : Control Tool.EraserModel
 controlEraser =
     Control.record Tool.EraserModel
-        |> Control.field "hoverClass" (Control.value [ Css.border3 (Css.px 4) Css.dashed Colors.red ])
-        |> Control.field "hintClass" (Control.value [ Css.border3 (Css.px 4) Css.dotted Colors.orange ])
-        |> Control.field "startGroupClass" (Control.value [ Css.opacity (Css.num 0.4) ])
-        |> Control.field "endGroupClass" (Control.value [ Css.opacity (Css.num 0.4) ])
+        |> Control.field "hoverClass"
+            (Control.choice [ ( "[ Css.border3 (Css.px 4) Css.dashed Colors.red ]", Control.value [ Css.border3 (Css.px 4) Css.dashed Colors.red ] ) ])
+        |> Control.field "hintClass"
+            (Control.choice [ ( "[ Css.border3 (Css.px 4) Css.dotted Colors.orange ]", Control.value [ Css.border3 (Css.px 4) Css.dotted Colors.orange ] ) ])
+        |> Control.field "startGroupClass"
+            (Control.choice [ ( "[ Css.opacity (Css.num 0.4) ]", Control.value [ Css.opacity (Css.num 0.4) ] ) ])
+        |> Control.field "endGroupClass"
+            (Control.choice [ ( "[ Css.opacity (Css.num 0.4) ]", Control.value [ Css.opacity (Css.num 0.4) ] ) ])
 
 
 backgroundHighlightColors : Int -> Control Color

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -52,6 +52,7 @@
         "Nri.Ui.Shadows.V1",
         "Nri.Ui.SideNav.V4",
         "Nri.Ui.SortableTable.V3",
+        "Nri.Ui.Spacing.V1",
         "Nri.Ui.Sprite.V1",
         "Nri.Ui.Svg.V1",
         "Nri.Ui.Switch.V2",


### PR DESCRIPTION
Adds:
- distinct color defaults
- more clear eraser styles
- removed default mark styles
- splitting the interactive example on sentences or by word
- a "clear all highlights" button

Fixes A11-1608
Fixes A11-1609
Fixes A11-1604

Paired with @krinhorn 