### PR TITLE
Bat/highlighter example copy

### DIFF
--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -74,15 +74,16 @@ example =
                 [ Table.string
                     { header = "Description"
                     , value = .description
-                    , width = Css.pct 20
-                    , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.top ]
+                    , width = Css.pct 30
+                    -- , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.top ]
+                    , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle, Css.fontWeight Css.bold ]
                     , sort = Nothing
                     }
                 , Table.custom
                     { header = text "Example"
                     , view = .example
                     , width = Css.px 150
-                    , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.top ]
+                    , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
                     , sort = Nothing
                     }
                 ]

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -75,7 +75,6 @@ example =
                     { header = "Description"
                     , value = .description
                     , width = Css.pct 30
-                    -- , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.top ]
                     , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle, Css.fontWeight Css.bold ]
                     , sort = Nothing
                     }

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -86,7 +86,7 @@ example =
                     , sort = Nothing
                     }
                 ]
-                [ { description = "Non-interactive sentence with one word highlighted"
+                [ { description = "One word highlighted"
                   , example =
                         Highlighter.static
                             { id = "example-0"
@@ -103,7 +103,7 @@ example =
                                     |> List.indexedMap (\i ( word, marker ) -> Highlightable.init Highlightable.Static marker i ( [], word ))
                             }
                   }
-                , { description = "Non-interactive sentence with multiple words highlighted separately"
+                , { description = "Multiple words highlighted separately"
                   , example =
                         Highlighter.static
                             { id = "example-1"
@@ -120,7 +120,7 @@ example =
                                     |> List.indexedMap (\i ( word, marker ) -> Highlightable.init Highlightable.Static marker i ( [], word ))
                             }
                   }
-                , { description = "Non-interactive sentence with multiple words highlighted & joined"
+                , { description = "Multiple words highlighted & joined"
                   , example =
                         Highlighter.static
                             { id = "example-2"

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -59,6 +59,7 @@ example =
                 , toExampleCode = \_ -> []
                 }
             , Heading.h2 [ Heading.plaintext "Interactive example" ]
+            , Heading.h3 [ Heading.plaintext "This example updates based on the settings you configure on this page." ]
             , Button.button "Clear all highlights"
                 [ Button.onClick ClearHighlights
                 , Button.secondary
@@ -68,6 +69,7 @@ example =
             , Highlighter.view state.highlighter
                 |> map HighlighterMsg
             , Heading.h2 [ Heading.plaintext "Non-interactive examples" ]
+            , Heading.h3 [ Heading.plaintext "These are examples of some different ways the highlighter can appear to users." ]
             , Table.view
                 [ Table.string
                     { header = "Description"

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -58,7 +58,7 @@ example =
                 , renderExample = Code.unstyledView
                 , toExampleCode = \_ -> []
                 }
-            , Heading.h2 [ Heading.plaintext "Example" ]
+            , Heading.h2 [ Heading.plaintext "Interactive example" ]
             , Button.button "Clear all highlights"
                 [ Button.onClick ClearHighlights
                 , Button.secondary
@@ -67,7 +67,7 @@ example =
                 ]
             , Highlighter.view state.highlighter
                 |> map HighlighterMsg
-            , Heading.h2 [ Heading.plaintext "Non-interactive Examples" ]
+            , Heading.h2 [ Heading.plaintext "Non-interactive examples" ]
             , Table.view
                 [ Table.string
                     { header = "Description"


### PR DESCRIPTION
Fixes A11-1610 + makes the table look nicer
- Updated H2 copy for example sections
- Added clarifying h3s for each example section
- Made the "Descriptions" less wordy
- Made the table look nicer / copied some styling from the tooltip table for consistency

# Before
![image](https://user-images.githubusercontent.com/31359690/190449032-9f79cb96-7d0f-40ae-907a-b2d7167e5cc1.png)

# After
![image](https://user-images.githubusercontent.com/31359690/190449046-bddb74cd-e236-40f0-8a9f-d50ff9e7793a.png)
