### PR TITLE
Fix radio group styles for segmented controls

### DIFF
--- a/src/Nri/Ui/FocusRing/V1.elm
+++ b/src/Nri/Ui/FocusRing/V1.elm
@@ -56,6 +56,12 @@ forMouseUsers =
     , Css.Global.selector ":focus-within .Nri-RadioButton-RadioButtonIcon"
         [ Css.important (Css.boxShadow Css.none)
         ]
+    , Css.Global.selector ".segmented-control-radio-element:focus-within"
+        [ Css.important (Css.boxShadow Css.none)
+        ]
+    , Css.Global.selector ":focus-within .Nri-RadioButton-RadioButtonIcon"
+        [ Css.important (Css.boxShadow Css.none)
+        ]
     , Css.Global.selector ".nri-ui-input:focus"
         [ applyBoxShadows [ InputStyles.focusedInputBoxShadow ]
         ]

--- a/src/Nri/Ui/SegmentedControl/V14.elm
+++ b/src/Nri/Ui/SegmentedControl/V14.elm
@@ -93,8 +93,9 @@ viewRadioGroup config =
                 inner extraAttrs =
                     Html.Styled.label
                         (css
-                            (styles config.positioning numOptions index isSelected)
+                            (styles "focus-within" config.positioning numOptions index isSelected)
                             :: Attributes.class FocusRing.customClass
+                            :: Attributes.class "segmented-control-radio-element"
                             :: extraAttrs
                         )
                         [ radio name option.idString isSelected <|
@@ -222,7 +223,7 @@ view config =
                         Center ->
                             justifyContent center
                     ]
-                , tabStyles = styles config.positioning (List.length config.options)
+                , tabStyles = styles "focus-visible" config.positioning (List.length config.options)
                 }
     in
     div []
@@ -250,8 +251,8 @@ viewIcon icon =
                 |> Svg.toHtml
 
 
-styles : Positioning -> Int -> Int -> Bool -> List Style
-styles positioning numEntries index isSelected =
+styles : String -> Positioning -> Int -> Int -> Bool -> List Style
+styles focusSelector positioning numEntries index isSelected =
     [ sharedSegmentStyles numEntries index
     , if isSelected then
         focusedSegmentStyles
@@ -269,7 +270,7 @@ styles positioning numEntries index isSelected =
             _ ->
                 []
     , -- ensure that the focus state is visible & looks nice
-      Css.pseudoClass "focus-visible"
+      Css.pseudoClass focusSelector
         [ FocusRing.boxShadows [ focusedSegmentBoxShadowValue ]
         , outline none
         , zIndex (int 1)


### PR DESCRIPTION
I missed that the radiogroup version of segmented controls works differently in https://github.com/NoRedInk/noredink-ui/pull/1080.

Both the tabs version and the radio group version of segmented controls should:
- show the focus ring nicely when using the keyboard
- not show the focus ring when using the mouse

Fixes A11-1539