### PR TITLE
Additional tooltip directions & alignments

### DIFF
--- a/src/Nri/Ui/MediaQuery/V1.elm
+++ b/src/Nri/Ui/MediaQuery/V1.elm
@@ -1,15 +1,22 @@
 module Nri.Ui.MediaQuery.V1 exposing
     ( anyMotion, prefersReducedMotion
     , highContrastMode
+    , withViewport
     , mobile, notMobile
     , mobileBreakpoint
     , quizEngineMobile, notQuizEngineMobile
     , quizEngineBreakpoint
     , narrowMobile, notNarrowMobile
-    , narrowMobileBreakPoint
+    , narrowMobileBreakpoint, narrowMobileBreakPoint
     )
 
-{-| Standard media queries for responsive pages.
+{-| Patch changes:
+
+  - remove min-width:1 from media queries in order to support better composibility
+  - adds narrowMobileBreakpoint and deprecates narrowMobileBreakPoint
+  - adds withViewport for convenience when matching specific viewport size ranges
+
+Standard media queries for responsive pages.
 
     import Css
     import Css.Media as Media
@@ -24,6 +31,8 @@ module Nri.Ui.MediaQuery.V1 exposing
 
 @docs anyMotion, prefersReducedMotion
 @docs highContrastMode
+
+@docs withViewport
 
 
 ### 1000px breakpoint
@@ -41,12 +50,31 @@ module Nri.Ui.MediaQuery.V1 exposing
 ### 500px breakpoint
 
 @docs narrowMobile, notNarrowMobile
-@docs narrowMobileBreakPoint
+@docs narrowMobileBreakpoint, narrowMobileBreakPoint
 
 -}
 
 import Css exposing (Style, px)
-import Css.Media exposing (MediaQuery, maxWidth, minWidth, only, screen, withMediaQuery)
+import Css.Media exposing (MediaQuery, maxWidth, minWidth, only, screen, withMedia, withMediaQuery)
+
+
+{-|
+
+    MediaQuery.withViewport
+        MediaQuery.narrowMobileBreakpoint
+        MediaQuery.quizEngineBreakpoint
+        [ Css.flexDirection Css.column
+        ]
+
+-}
+withViewport : Maybe Css.Px -> Maybe Css.Px -> List Style -> Style
+withViewport maybeMin maybeMax =
+    withMedia
+        [ only screen
+            (List.filterMap identity
+                [ Maybe.map minWidth maybeMin, Maybe.map maxWidth maybeMax ]
+            )
+        ]
 
 
 {-| -}
@@ -71,12 +99,7 @@ highContrastMode =
 -}
 mobile : MediaQuery
 mobile =
-    only screen
-        [ --`minWidth (px 1)` is for a bug in IE which causes the media query to initially trigger regardless of window size
-          --See: <http://stackoverflow.com/questions/25673707/ie11-triggers-css-transition-on-page-load-when-non-applied-media-query-exists/25850649#25850649>
-          minWidth (px 1)
-        , maxWidth mobileBreakpoint
-        ]
+    only screen [ maxWidth mobileBreakpoint ]
 
 
 {-| Styles using the `mobileBreakpoint` value as the minWidth.
@@ -97,12 +120,7 @@ mobileBreakpoint =
 -}
 quizEngineMobile : MediaQuery
 quizEngineMobile =
-    only screen
-        [ --`minWidth (px 1)` is for a bug in IE which causes the media query to initially trigger regardless of window size
-          --See: <http://stackoverflow.com/questions/25673707/ie11-triggers-css-transition-on-page-load-when-non-applied-media-query-exists/25850649#25850649>
-          minWidth (px 1)
-        , maxWidth quizEngineBreakpoint
-        ]
+    only screen [ maxWidth quizEngineBreakpoint ]
 
 
 {-| Styles using the `quizEngineBreakpoint` value as the minWidth.
@@ -119,26 +137,28 @@ quizEngineBreakpoint =
     px 750
 
 
-{-| Styles using the `narrowMobileBreakPoint` value as the maxWidth
+{-| Styles using the `narrowMobileBreakpoint` value as the maxWidth
 -}
 narrowMobile : MediaQuery
 narrowMobile =
-    only screen
-        [ --`minWidth (px 1)` is for a bug in IE which causes the media query to initially trigger regardless of window size
-          --See: <http://stackoverflow.com/questions/25673707/ie11-triggers-css-transition-on-page-load-when-non-applied-media-query-exists/25850649#25850649>
-          minWidth (px 1)
-        , maxWidth narrowMobileBreakPoint
-        ]
+    only screen [ maxWidth narrowMobileBreakpoint ]
 
 
 {-| Styles using the `quizEngineBreakpoint` value as the minWidth.
 -}
 notNarrowMobile : MediaQuery
 notNarrowMobile =
-    only screen [ minWidth narrowMobileBreakPoint ]
+    only screen [ minWidth narrowMobileBreakpoint ]
 
 
 {-| 500px
+-}
+narrowMobileBreakpoint : Css.Px
+narrowMobileBreakpoint =
+    px 500
+
+
+{-| DEPRECATED: prefer narrowMobileBreakpoint, which follows other casing conventions.
 -}
 narrowMobileBreakPoint : Css.Px
 narrowMobileBreakPoint =

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -4,8 +4,12 @@ module Nri.Ui.Tooltip.V3 exposing
     , plaintext, html
     , withoutTail
     , onTop, onBottom, onLeft, onRight
+    , onTopForQuizEngineMobile, onBottomForQuizEngineMobile, onLeftForQuizEngineMobile, onRightForQuizEngineMobile
+    , onTopForNarrowMobile, onBottomForNarrowMobile, onLeftForNarrowMobile, onRightForNarrowMobile
     , onTopForMobile, onBottomForMobile, onLeftForMobile, onRightForMobile
     , alignStart, alignMiddle, alignEnd
+    , alignStartForQuizEngineMobile, alignMiddleForQuizEngineMobile, alignEndForQuizEngineMobile
+    , alignStartForNarrowMobile, alignMiddleForNarrowMobile, alignEndForNarrowMobile
     , alignStartForMobile, alignMiddleForMobile, alignEndForMobile
     , exactWidth, fitToContent
     , smallPadding, normalPadding, customPadding
@@ -20,6 +24,10 @@ module Nri.Ui.Tooltip.V3 exposing
 {-| Patch changes:
 
   - defaults mobile-specific alignment and direction to the non-mobile version, rather than top and middle
+  - adds onTopForQuizEngineMobile, onBottomForQuizEngineMobile, onLeftForQuizEngineMobile, onRightForQuizEngineMobile
+  - adds onTopForNarrowMobile, onBottomForNarrowMobile, onLeftForNarrowMobile, onRightForNarrowMobile
+  - adds alignStartForQuizEngineMobile, alignMiddleForQuizEngineMobile, alignEndForQuizEngineMobile
+  - adds alignStartForNarrowMobile, alignMiddleForNarrowMobile, alignEndForNarrowMobile
 
 Changes from V2:
 
@@ -44,10 +52,17 @@ These tooltips aim to follow the accessibility recommendations from:
 @docs Attribute
 @docs plaintext, html
 @docs withoutTail
+
 @docs onTop, onBottom, onLeft, onRight
+@docs onTopForQuizEngineMobile, onBottomForQuizEngineMobile, onLeftForQuizEngineMobile, onRightForQuizEngineMobile
+@docs onTopForNarrowMobile, onBottomForNarrowMobile, onLeftForNarrowMobile, onRightForNarrowMobile
 @docs onTopForMobile, onBottomForMobile, onLeftForMobile, onRightForMobile
+
 @docs alignStart, alignMiddle, alignEnd
+@docs alignStartForQuizEngineMobile, alignMiddleForQuizEngineMobile, alignEndForQuizEngineMobile
+@docs alignStartForNarrowMobile, alignMiddleForNarrowMobile, alignEndForNarrowMobile
 @docs alignStartForMobile, alignMiddleForMobile, alignEndForMobile
+
 @docs exactWidth, fitToContent
 @docs smallPadding, normalPadding, customPadding
 @docs onToggle
@@ -91,6 +106,10 @@ type alias Tooltip msg =
     , alignment : Alignment
     , mobileDirection : Maybe Direction
     , mobileAlignment : Maybe Alignment
+    , quizEngineMobileDirection : Maybe Direction
+    , quizEngineMobileAlignment : Maybe Alignment
+    , narrowMobileDirection : Maybe Direction
+    , narrowMobileAlignment : Maybe Alignment
     , tail : Tail
     , content : List (Html msg)
     , attributes : List (Html.Attribute Never)
@@ -114,6 +133,10 @@ buildAttributes =
             , alignment = Middle
             , mobileDirection = Nothing
             , mobileAlignment = Nothing
+            , quizEngineMobileDirection = Nothing
+            , quizEngineMobileAlignment = Nothing
+            , narrowMobileDirection = Nothing
+            , narrowMobileAlignment = Nothing
             , tail = WithTail
             , content = []
             , attributes = []
@@ -257,6 +280,96 @@ alignEndForMobile position =
     withMobileAligment (End position)
 
 
+withQuizEngineMobileAligment : Alignment -> Attribute msg
+withQuizEngineMobileAligment alignment =
+    Attribute (\config -> { config | quizEngineMobileAlignment = Just alignment })
+
+
+{-| Put the tail at the "start" of the tooltip when the viewport has a quiz engine mobile (750px) width or narrower.
+For onTop & onBottom tooltips, this means "left".
+For onLeft & onRight tooltip, this means "top".
+
+     __________
+    |_  ______|
+      \/
+
+-}
+alignStartForQuizEngineMobile : Px -> Attribute msg
+alignStartForQuizEngineMobile position =
+    withQuizEngineMobileAligment (Start position)
+
+
+{-| Put the tail at the "middle" of the tooltip when the viewport has a quiz engine mobile (750px) width or narrower.
+
+     __________
+    |___  ____|
+        \/
+
+-}
+alignMiddleForQuizEngineMobile : Attribute msg
+alignMiddleForQuizEngineMobile =
+    withQuizEngineMobileAligment Middle
+
+
+{-| Put the tail at the "end" of the tooltip when the viewport has a quiz engine mobile (750px) width or narrower.
+For onTop & onBottom tooltips, this means "right".
+For onLeft & onRight tooltip, this means "bottom".
+
+     __________
+    |______  _|
+           \/
+
+-}
+alignEndForQuizEngineMobile : Px -> Attribute msg
+alignEndForQuizEngineMobile position =
+    withQuizEngineMobileAligment (End position)
+
+
+withNarrowMobileAligment : Alignment -> Attribute msg
+withNarrowMobileAligment alignment =
+    Attribute (\config -> { config | narrowMobileAlignment = Just alignment })
+
+
+{-| Put the tail at the "start" of the tooltip when the viewport has a narrow mobile (500px) width or narrower.
+For onTop & onBottom tooltips, this means "left".
+For onLeft & onRight tooltip, this means "top".
+
+     __________
+    |_  ______|
+      \/
+
+-}
+alignStartForNarrowMobile : Px -> Attribute msg
+alignStartForNarrowMobile position =
+    withNarrowMobileAligment (Start position)
+
+
+{-| Put the tail at the "middle" of the tooltip when the viewport has a narrow mobile (500px) width or narrower.
+
+     __________
+    |___  ____|
+        \/
+
+-}
+alignMiddleForNarrowMobile : Attribute msg
+alignMiddleForNarrowMobile =
+    withNarrowMobileAligment Middle
+
+
+{-| Put the tail at the "end" of the tooltip when the viewport has a narrow mobile (500px) width or narrower.
+For onTop & onBottom tooltips, this means "right".
+For onLeft & onRight tooltip, this means "bottom".
+
+     __________
+    |______  _|
+           \/
+
+-}
+alignEndForNarrowMobile : Px -> Attribute msg
+alignEndForNarrowMobile position =
+    withQuizEngineMobileAligment (End position)
+
+
 {-| Where should this tooltip be positioned relative to the trigger?
 -}
 type Direction
@@ -376,6 +489,118 @@ onBottomForMobile =
 onLeftForMobile : Attribute msg
 onLeftForMobile =
     withPositionForMobile OnLeft
+
+
+withPositionForQuizEngineMobile : Direction -> Attribute msg
+withPositionForQuizEngineMobile direction =
+    Attribute (\config -> { config | quizEngineMobileDirection = Just direction })
+
+
+{-| Set the position of the tooltip when the quiz engine breakpoint (750px) applies.
+
+     __________
+    |         |
+    |___  ____|
+        \/
+
+-}
+onTopForQuizEngineMobile : Attribute msg
+onTopForQuizEngineMobile =
+    withPositionForQuizEngineMobile OnTop
+
+
+{-| Set the position of the tooltip when the quiz engine breakpoint (750px) applies.
+
+      __________
+     |         |
+    <          |
+     |_________|
+
+-}
+onRightForQuizEngineMobile : Attribute msg
+onRightForQuizEngineMobile =
+    withPositionForQuizEngineMobile OnRight
+
+
+{-| Set the position of the tooltip when the quiz engine breakpoint (750px) applies.
+
+     ___/\_____
+    |         |
+    |_________|
+
+-}
+onBottomForQuizEngineMobile : Attribute msg
+onBottomForQuizEngineMobile =
+    withPositionForQuizEngineMobile OnBottom
+
+
+{-| Set the position of the tooltip when the quiz engine breakpoint (750px) applies.
+
+      __________
+     |         |
+     |          >
+     |_________|
+
+-}
+onLeftForQuizEngineMobile : Attribute msg
+onLeftForQuizEngineMobile =
+    withPositionForQuizEngineMobile OnLeft
+
+
+withPositionForNarrowMobile : Direction -> Attribute msg
+withPositionForNarrowMobile direction =
+    Attribute (\config -> { config | narrowMobileDirection = Just direction })
+
+
+{-| Set the position of the tooltip when the narrow mobile breakpoint (500px) applies.
+
+     __________
+    |         |
+    |___  ____|
+        \/
+
+-}
+onTopForNarrowMobile : Attribute msg
+onTopForNarrowMobile =
+    withPositionForNarrowMobile OnTop
+
+
+{-| Set the position of the tooltip when the narrow mobile breakpoint (500px) applies.
+
+      __________
+     |         |
+    <          |
+     |_________|
+
+-}
+onRightForNarrowMobile : Attribute msg
+onRightForNarrowMobile =
+    withPositionForNarrowMobile OnRight
+
+
+{-| Set the position of the tooltip when the narrow mobile breakpoint (500px) applies.
+
+     ___/\_____
+    |         |
+    |_________|
+
+-}
+onBottomForNarrowMobile : Attribute msg
+onBottomForNarrowMobile =
+    withPositionForNarrowMobile OnBottom
+
+
+{-| Set the position of the tooltip when the narrow mobile breakpoint (500px) applies.
+
+      __________
+     |         |
+     |          >
+     |_________|
+
+-}
+onLeftForNarrowMobile : Attribute msg
+onLeftForNarrowMobile =
+    withPositionForQuizEngineMobile OnLeft
 
 
 {-| Set some custom styles on the tooltip.

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -1022,16 +1022,32 @@ viewTooltip tooltipId config =
         mobileDirection =
             Maybe.withDefault config.direction config.mobileDirection
 
+        quizEngineMobileDirection =
+            Maybe.withDefault mobileDirection config.quizEngineMobileDirection
+
         mobileAlignment =
             Maybe.withDefault config.alignment config.mobileAlignment
+
+        quizEngineMobileAlignment =
+            Maybe.withDefault mobileAlignment config.quizEngineMobileAlignment
+
+        applyTail direction =
+            case config.tail of
+                WithTail ->
+                    tailForDirection direction
+
+                WithoutTail ->
+                    Css.batch []
     in
     Html.div
         [ Attributes.css
             [ Css.position Css.absolute
             , Css.Media.withMedia [ MediaQuery.notMobile ]
                 (positionTooltip config.direction config.alignment)
-            , Css.Media.withMedia [ MediaQuery.mobile ]
+            , Css.Media.withMedia [ MediaQuery.notQuizEngineMobile, MediaQuery.mobile ]
                 (positionTooltip mobileDirection mobileAlignment)
+            , Css.Media.withMedia [ MediaQuery.quizEngineMobile ]
+                (positionTooltip quizEngineMobileDirection quizEngineMobileAlignment)
             , Css.boxSizing Css.borderBox
             , if config.isOpen then
                 Css.batch []
@@ -1068,21 +1084,15 @@ viewTooltip tooltipId config =
                  , Css.border3 (Css.px 1) Css.solid Colors.navy
                  , Css.Media.withMedia [ MediaQuery.notMobile ]
                     [ positioning config.direction config.alignment
-                    , case config.tail of
-                        WithTail ->
-                            tailForDirection config.direction
-
-                        WithoutTail ->
-                            Css.batch []
+                    , applyTail config.direction
                     ]
-                 , Css.Media.withMedia [ MediaQuery.mobile ]
+                 , Css.Media.withMedia [ MediaQuery.notQuizEngineMobile, MediaQuery.mobile ]
                     [ positioning mobileDirection mobileAlignment
-                    , case config.tail of
-                        WithTail ->
-                            tailForDirection mobileDirection
-
-                        WithoutTail ->
-                            Css.batch []
+                    , applyTail mobileDirection
+                    ]
+                 , Css.Media.withMedia [ MediaQuery.quizEngineMobile ]
+                    [ positioning quizEngineMobileDirection quizEngineMobileAlignment
+                    , applyTail quizEngineMobileDirection
                     ]
                  , Fonts.baseFont
                  , Css.fontSize (Css.px 16)
@@ -1119,11 +1129,11 @@ viewTooltip tooltipId config =
                         [ Attributes.css
                             [ Css.position Css.absolute
                             , Css.Media.withMedia [ MediaQuery.notMobile ]
-                                [ Css.batch (hoverAreaForDirection config.direction)
-                                ]
-                            , Css.Media.withMedia [ MediaQuery.mobile ]
-                                [ Css.batch (hoverAreaForDirection mobileDirection)
-                                ]
+                                (hoverAreaForDirection config.direction)
+                            , Css.Media.withMedia [ MediaQuery.notQuizEngineMobile, MediaQuery.mobile ]
+                                (hoverAreaForDirection mobileDirection)
+                            , Css.Media.withMedia [ MediaQuery.quizEngineMobile ]
+                                (hoverAreaForDirection quizEngineMobileDirection)
                             ]
                         ]
                         []

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -15,7 +15,7 @@ module Nri.Ui.Tooltip.V3 exposing
     , smallPadding, normalPadding, customPadding
     , onToggle
     , open
-    , css, notMobileCss, mobileCss, quizEngineMobileCss, containerCss
+    , css, notMobileCss, mobileCss, quizEngineMobileCss, narrowMobileCss, containerCss
     , custom
     , nriDescription, testId
     , primaryLabel, auxiliaryDescription, disclosure
@@ -28,6 +28,7 @@ module Nri.Ui.Tooltip.V3 exposing
   - adds onTopForNarrowMobile, onBottomForNarrowMobile, onLeftForNarrowMobile, onRightForNarrowMobile
   - adds alignStartForQuizEngineMobile, alignMiddleForQuizEngineMobile, alignEndForQuizEngineMobile
   - adds alignStartForNarrowMobile, alignMiddleForNarrowMobile, alignEndForNarrowMobile
+  - adds narrowMobileCss
 
 Changes from V2:
 
@@ -67,7 +68,7 @@ These tooltips aim to follow the accessibility recommendations from:
 @docs smallPadding, normalPadding, customPadding
 @docs onToggle
 @docs open
-@docs css, notMobileCss, mobileCss, quizEngineMobileCss, containerCss
+@docs css, notMobileCss, mobileCss, quizEngineMobileCss, narrowMobileCss, containerCss
 @docs custom
 @docs nriDescription, testId
 @docs primaryLabel, auxiliaryDescription, disclosure
@@ -647,6 +648,19 @@ Equivalent to:
 quizEngineMobileCss : List Style -> Attribute msg
 quizEngineMobileCss styles =
     css [ Css.Media.withMedia [ MediaQuery.quizEngineMobile ] styles ]
+
+
+{-| Set styles that will only apply if the viewport is narrower than NRI's narrow mobile breakpoint.
+
+Equivalent to:
+
+    Tooltip.css
+        [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.narrowMobile ] styles ]
+
+-}
+narrowMobileCss : List Style -> Attribute msg
+narrowMobileCss styles =
+    css [ Css.Media.withMedia [ MediaQuery.narrowMobile ] styles ]
 
 
 {-| Use this helper to add custom attributes.

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -1025,11 +1025,17 @@ viewTooltip tooltipId config =
         quizEngineMobileDirection =
             Maybe.withDefault mobileDirection config.quizEngineMobileDirection
 
+        narrowMobileDirection =
+            Maybe.withDefault quizEngineMobileDirection config.narrowMobileDirection
+
         mobileAlignment =
             Maybe.withDefault config.alignment config.mobileAlignment
 
         quizEngineMobileAlignment =
             Maybe.withDefault mobileAlignment config.quizEngineMobileAlignment
+
+        narrowMobileAlignment =
+            Maybe.withDefault quizEngineMobileAlignment config.narrowMobileAlignment
 
         applyTail direction =
             case config.tail of
@@ -1046,8 +1052,10 @@ viewTooltip tooltipId config =
                 (positionTooltip config.direction config.alignment)
             , Css.Media.withMedia [ MediaQuery.notQuizEngineMobile, MediaQuery.mobile ]
                 (positionTooltip mobileDirection mobileAlignment)
-            , Css.Media.withMedia [ MediaQuery.quizEngineMobile ]
+            , Css.Media.withMedia [ MediaQuery.notNarrowMobile, MediaQuery.quizEngineMobile ]
                 (positionTooltip quizEngineMobileDirection quizEngineMobileAlignment)
+            , Css.Media.withMedia [ MediaQuery.narrowMobile ]
+                (positionTooltip narrowMobileDirection narrowMobileAlignment)
             , Css.boxSizing Css.borderBox
             , if config.isOpen then
                 Css.batch []
@@ -1090,9 +1098,13 @@ viewTooltip tooltipId config =
                     [ positioning mobileDirection mobileAlignment
                     , applyTail mobileDirection
                     ]
-                 , Css.Media.withMedia [ MediaQuery.quizEngineMobile ]
+                 , Css.Media.withMedia [ MediaQuery.notNarrowMobile, MediaQuery.quizEngineMobile ]
                     [ positioning quizEngineMobileDirection quizEngineMobileAlignment
                     , applyTail quizEngineMobileDirection
+                    ]
+                 , Css.Media.withMedia [ MediaQuery.narrowMobile ]
+                    [ positioning narrowMobileDirection narrowMobileAlignment
+                    , applyTail narrowMobileDirection
                     ]
                  , Fonts.baseFont
                  , Css.fontSize (Css.px 16)
@@ -1132,8 +1144,10 @@ viewTooltip tooltipId config =
                                 (hoverAreaForDirection config.direction)
                             , Css.Media.withMedia [ MediaQuery.notQuizEngineMobile, MediaQuery.mobile ]
                                 (hoverAreaForDirection mobileDirection)
-                            , Css.Media.withMedia [ MediaQuery.quizEngineMobile ]
+                            , Css.Media.withMedia [ MediaQuery.notNarrowMobile, MediaQuery.quizEngineMobile ]
                                 (hoverAreaForDirection quizEngineMobileDirection)
+                            , Css.Media.withMedia [ MediaQuery.narrowMobile ]
+                                (hoverAreaForDirection narrowMobileDirection)
                             ]
                         ]
                         []

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -89,7 +89,7 @@ import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
-import Nri.Ui.MediaQuery.V1 as MediaQuery
+import Nri.Ui.MediaQuery.V1 as MediaQuery exposing (mobileBreakpoint, narrowMobileBreakpoint, quizEngineBreakpoint)
 import Nri.Ui.Shadows.V1 as Shadows
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Nri.Ui.WhenFocusLeaves.V1 as WhenFocusLeaves
@@ -1048,14 +1048,14 @@ viewTooltip tooltipId config =
     Html.div
         [ Attributes.css
             [ Css.position Css.absolute
-            , Css.Media.withMedia [ MediaQuery.notMobile ]
-                (positionTooltip config.direction config.alignment)
-            , Css.Media.withMedia [ MediaQuery.notQuizEngineMobile, MediaQuery.mobile ]
-                (positionTooltip mobileDirection mobileAlignment)
-            , Css.Media.withMedia [ MediaQuery.notNarrowMobile, MediaQuery.quizEngineMobile ]
-                (positionTooltip quizEngineMobileDirection quizEngineMobileAlignment)
-            , Css.Media.withMedia [ MediaQuery.narrowMobile ]
-                (positionTooltip narrowMobileDirection narrowMobileAlignment)
+            , MediaQuery.withViewport (Just mobileBreakpoint) Nothing <|
+                positionTooltip config.direction config.alignment
+            , MediaQuery.withViewport (Just quizEngineBreakpoint) (Just mobileBreakpoint) <|
+                positionTooltip mobileDirection mobileAlignment
+            , MediaQuery.withViewport (Just narrowMobileBreakpoint) (Just quizEngineBreakpoint) <|
+                positionTooltip quizEngineMobileDirection quizEngineMobileAlignment
+            , MediaQuery.withViewport Nothing (Just narrowMobileBreakpoint) <|
+                positionTooltip narrowMobileDirection narrowMobileAlignment
             , Css.boxSizing Css.borderBox
             , if config.isOpen then
                 Css.batch []
@@ -1090,19 +1090,19 @@ viewTooltip tooltipId config =
                  , Css.zIndex (Css.int 100)
                  , Css.backgroundColor Colors.navy
                  , Css.border3 (Css.px 1) Css.solid Colors.navy
-                 , Css.Media.withMedia [ MediaQuery.notMobile ]
+                 , MediaQuery.withViewport (Just mobileBreakpoint) Nothing <|
                     [ positioning config.direction config.alignment
                     , applyTail config.direction
                     ]
-                 , Css.Media.withMedia [ MediaQuery.notQuizEngineMobile, MediaQuery.mobile ]
+                 , MediaQuery.withViewport (Just quizEngineBreakpoint) (Just mobileBreakpoint) <|
                     [ positioning mobileDirection mobileAlignment
                     , applyTail mobileDirection
                     ]
-                 , Css.Media.withMedia [ MediaQuery.notNarrowMobile, MediaQuery.quizEngineMobile ]
+                 , MediaQuery.withViewport (Just narrowMobileBreakpoint) (Just quizEngineBreakpoint) <|
                     [ positioning quizEngineMobileDirection quizEngineMobileAlignment
                     , applyTail quizEngineMobileDirection
                     ]
-                 , Css.Media.withMedia [ MediaQuery.narrowMobile ]
+                 , MediaQuery.withViewport Nothing (Just narrowMobileBreakpoint) <|
                     [ positioning narrowMobileDirection narrowMobileAlignment
                     , applyTail narrowMobileDirection
                     ]
@@ -1140,14 +1140,14 @@ viewTooltip tooltipId config =
                 ++ [ Html.div
                         [ Attributes.css
                             [ Css.position Css.absolute
-                            , Css.Media.withMedia [ MediaQuery.notMobile ]
-                                (hoverAreaForDirection config.direction)
-                            , Css.Media.withMedia [ MediaQuery.notQuizEngineMobile, MediaQuery.mobile ]
-                                (hoverAreaForDirection mobileDirection)
-                            , Css.Media.withMedia [ MediaQuery.notNarrowMobile, MediaQuery.quizEngineMobile ]
-                                (hoverAreaForDirection quizEngineMobileDirection)
-                            , Css.Media.withMedia [ MediaQuery.narrowMobile ]
-                                (hoverAreaForDirection narrowMobileDirection)
+                            , MediaQuery.withViewport (Just mobileBreakpoint) Nothing <|
+                                hoverAreaForDirection config.direction
+                            , MediaQuery.withViewport (Just quizEngineBreakpoint) (Just mobileBreakpoint) <|
+                                hoverAreaForDirection mobileDirection
+                            , MediaQuery.withViewport (Just narrowMobileBreakpoint) (Just quizEngineBreakpoint) <|
+                                hoverAreaForDirection quizEngineMobileDirection
+                            , MediaQuery.withViewport Nothing (Just narrowMobileBreakpoint) <|
+                                hoverAreaForDirection narrowMobileDirection
                             ]
                         ]
                         []

--- a/styleguide-app/CommonControls.elm
+++ b/styleguide-app/CommonControls.elm
@@ -1,5 +1,5 @@
 module CommonControls exposing
-    ( css, mobileCss, quizEngineMobileCss, notMobileCss, css_
+    ( css, mobileCss, quizEngineMobileCss, narrowMobileCss, notMobileCss, css_
     , choice
     , icon, iconNotCheckedByDefault, uiIcon
     , color
@@ -11,7 +11,7 @@ module CommonControls exposing
 
 {-|
 
-@docs css, mobileCss, quizEngineMobileCss, notMobileCss, css_
+@docs css, mobileCss, quizEngineMobileCss, narrowMobileCss, notMobileCss, css_
 @docs choice
 @docs icon, iconNotCheckedByDefault, uiIcon
 @docs color
@@ -310,6 +310,17 @@ quizEngineMobileCss =
     css_ "quizEngineMobileCss"
         ( "[ Css.border3 (Css.px 4) Css.solid Colors.aqua |> Css.important ]"
         , [ Css.border3 (Css.px 4) Css.solid Colors.aqua |> Css.important ]
+        )
+
+
+narrowMobileCss :
+    { moduleName : String, use : List Css.Style -> b }
+    -> Control (List ( String, b ))
+    -> Control (List ( String, b ))
+narrowMobileCss =
+    css_ "narrowMobileCss"
+        ( "[ Css.border3 (Css.px 8) Css.solid Colors.magenta |> Css.important ]"
+        , [ Css.border3 (Css.px 8) Css.solid Colors.magenta |> Css.important ]
         )
 
 

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -352,6 +352,7 @@ initStaticExampleSettings =
         |> CommonControls.css { moduleName = moduleName, use = Tooltip.css }
         |> CommonControls.mobileCss { moduleName = moduleName, use = Tooltip.mobileCss }
         |> CommonControls.quizEngineMobileCss { moduleName = moduleName, use = Tooltip.quizEngineMobileCss }
+        |> CommonControls.narrowMobileCss { moduleName = moduleName, use = Tooltip.narrowMobileCss }
         |> CommonControls.notMobileCss { moduleName = moduleName, use = Tooltip.notMobileCss }
 
 

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -343,7 +343,9 @@ initStaticExampleSettings =
         |> ControlExtra.optionalListItem "direction -- viewport up to 750px" controlDirectionForQuizEngineMobile
         |> ControlExtra.optionalListItem "direction -- viewport up to 500px" controlDirectionForNarrowMobile
         |> ControlExtra.optionalListItem "alignment" controlAlignment
-        |> ControlExtra.optionalListItem "alignment -- mobile" controlAlignmentForMobile
+        |> ControlExtra.optionalListItem "alignment -- viewport up to 1000px" controlAlignmentForMobile
+        |> ControlExtra.optionalListItem "alignment -- viewport up to 750px" controlAlignmentForQuizEngineMobile
+        |> ControlExtra.optionalListItem "alignment -- viewport up to 500px" controlAlignmentForNarrowMobile
         |> ControlExtra.optionalBoolListItem "withoutTail" ( "Tooltip.withoutTail", Tooltip.withoutTail )
         |> ControlExtra.optionalListItem "width" controlWidth
         |> ControlExtra.optionalListItem "padding" controlPadding
@@ -404,53 +406,62 @@ controlDirectionForNarrowMobile =
         ]
 
 
+controlAlignment_ :
+    ( String, Tooltip.Attribute Never )
+    -> List ( String, Css.Px -> Tooltip.Attribute Never )
+    -> Control ( String, Tooltip.Attribute Never )
+controlAlignment_ ( middleName, middleValue ) others =
+    Control.choice
+        (( middleName, Control.value ( "Tooltip." ++ middleName, middleValue ) )
+            :: List.map
+                (\( name, val ) ->
+                    ( name
+                    , Control.map
+                        (\float ->
+                            ( "Tooltip." ++ name ++ " (Css.px " ++ String.fromFloat float ++ ")"
+                            , val (Css.px float)
+                            )
+                        )
+                        (ControlExtra.float 0)
+                    )
+                )
+                others
+        )
+
+
 controlAlignment : Control ( String, Tooltip.Attribute Never )
 controlAlignment =
-    Control.choice
-        [ ( "alignMiddle (default)", Control.value ( "Tooltip.alignMiddle", Tooltip.alignMiddle ) )
-        , ( "alignStart"
-          , Control.map
-                (\float ->
-                    ( "Tooltip.alignStart (Css.px " ++ String.fromFloat float ++ ")"
-                    , Tooltip.alignStart (Css.px float)
-                    )
-                )
-                (ControlExtra.float 0)
-          )
-        , ( "alignEnd"
-          , Control.map
-                (\float ->
-                    ( "Tooltip.alignEnd (Css.px " ++ String.fromFloat float ++ ")"
-                    , Tooltip.alignEnd (Css.px float)
-                    )
-                )
-                (ControlExtra.float 0)
-          )
+    controlAlignment_
+        ( "alignMiddle", Tooltip.alignMiddle )
+        [ ( "alignStart", Tooltip.alignStart )
+        , ( "alignEnd", Tooltip.alignEnd )
         ]
 
 
 controlAlignmentForMobile : Control ( String, Tooltip.Attribute Never )
 controlAlignmentForMobile =
-    Control.choice
-        [ ( "alignMiddleForMobile (default)", Control.value ( "Tooltip.alignMiddleForMobile", Tooltip.alignMiddleForMobile ) )
-        , ( "alignStartForMobile"
-          , Control.map
-                (\float ->
-                    ( "Tooltip.alignStartForMobile (Css.px " ++ String.fromFloat float ++ ")"
-                    , Tooltip.alignStartForMobile (Css.px float)
-                    )
-                )
-                (ControlExtra.float 0)
-          )
-        , ( "alignEndForMobile"
-          , Control.map
-                (\float ->
-                    ( "Tooltip.alignEndForMobile (Css.px " ++ String.fromFloat float ++ ")"
-                    , Tooltip.alignEndForMobile (Css.px float)
-                    )
-                )
-                (ControlExtra.float 0)
-          )
+    controlAlignment_
+        ( "alignMiddleForMobile", Tooltip.alignMiddleForMobile )
+        [ ( "alignStartForMobile", Tooltip.alignStartForMobile )
+        , ( "alignEndForMobile", Tooltip.alignEndForMobile )
+        ]
+
+
+controlAlignmentForQuizEngineMobile : Control ( String, Tooltip.Attribute Never )
+controlAlignmentForQuizEngineMobile =
+    controlAlignment_
+        ( "alignMiddleForQuizEngineMobile", Tooltip.alignMiddleForQuizEngineMobile )
+        [ ( "alignStartForQuizEngineMobile", Tooltip.alignStartForQuizEngineMobile )
+        , ( "alignEndForQuizEngineMobile", Tooltip.alignEndForQuizEngineMobile )
+        ]
+
+
+controlAlignmentForNarrowMobile : Control ( String, Tooltip.Attribute Never )
+controlAlignmentForNarrowMobile =
+    controlAlignment_
+        ( "alignMiddleForNarrowMobile", Tooltip.alignMiddleForNarrowMobile )
+        [ ( "alignStartForNarrowMobile", Tooltip.alignStartForNarrowMobile )
+        , ( "alignEndForNarrowMobile", Tooltip.alignEndForNarrowMobile )
         ]
 
 

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -339,7 +339,9 @@ initStaticExampleSettings =
     ControlExtra.list
         |> ControlExtra.listItem "content" controlContent
         |> ControlExtra.optionalListItem "direction" controlDirection
-        |> ControlExtra.optionalListItem "direction -- mobile" controlDirectionForMobile
+        |> ControlExtra.optionalListItem "direction -- viewport up to 1000px" controlDirectionForMobile
+        |> ControlExtra.optionalListItem "direction -- viewport up to 750px" controlDirectionForQuizEngineMobile
+        |> ControlExtra.optionalListItem "direction -- viewport up to 500px" controlDirectionForNarrowMobile
         |> ControlExtra.optionalListItem "alignment" controlAlignment
         |> ControlExtra.optionalListItem "alignment -- mobile" controlAlignmentForMobile
         |> ControlExtra.optionalBoolListItem "withoutTail" ( "Tooltip.withoutTail", Tooltip.withoutTail )
@@ -379,6 +381,26 @@ controlDirectionForMobile =
         , ( "onBottomForMobile", Tooltip.onBottomForMobile )
         , ( "onLeftForMobile", Tooltip.onLeftForMobile )
         , ( "onRightForMobile", Tooltip.onRightForMobile )
+        ]
+
+
+controlDirectionForQuizEngineMobile : Control ( String, Tooltip.Attribute Never )
+controlDirectionForQuizEngineMobile =
+    CommonControls.choice "Tooltip"
+        [ ( "onTopForQuizEngineMobile", Tooltip.onTopForQuizEngineMobile )
+        , ( "onBottomForQuizEngineMobile", Tooltip.onBottomForQuizEngineMobile )
+        , ( "onLeftForQuizEngineMobile", Tooltip.onLeftForQuizEngineMobile )
+        , ( "onRightForQuizEngineMobile", Tooltip.onRightForQuizEngineMobile )
+        ]
+
+
+controlDirectionForNarrowMobile : Control ( String, Tooltip.Attribute Never )
+controlDirectionForNarrowMobile =
+    CommonControls.choice "Tooltip"
+        [ ( "onTopForNarrowMobile", Tooltip.onTopForNarrowMobile )
+        , ( "onBottomForNarrowMobile", Tooltip.onBottomForNarrowMobile )
+        , ( "onLeftForNarrowMobile", Tooltip.onLeftForNarrowMobile )
+        , ( "onRightForNarrowMobile", Tooltip.onRightForNarrowMobile )
         ]
 
 


### PR DESCRIPTION
Adds additional breakpoint helpers for tooltips, so that we can customize positioning and styles specifically for the narrow mobile viewport (< 500px).

For the first item in https://github.com/NoRedInk/NoRedInk/pull/40370#issuecomment-1248761408