### PR TITLE
Respect prefers reduced motion

### DIFF
--- a/src/Nri/Ui/Loading/V1.elm
+++ b/src/Nri/Ui/Loading/V1.elm
@@ -68,12 +68,22 @@ loading_ withCss =
 {-| -}
 spinningPencil : Nri.Ui.Svg.V1.Svg
 spinningPencil =
+    let
+        diagonalLength =
+            ceiling (sqrt (2 * 100 * 100))
+
+        paddingForAnimation =
+            (toFloat diagonalLength - 100) / 2
+    in
     UiIcon.edit
         |> Nri.Ui.Svg.V1.withLabel "Loading..."
         |> Nri.Ui.Svg.V1.withColor Colors.navy
         |> Nri.Ui.Svg.V1.withWidth (Css.px 100)
         |> Nri.Ui.Svg.V1.withHeight (Css.px 100)
-        |> Nri.Ui.Svg.V1.withCss circlingCss
+        |> Nri.Ui.Svg.V1.withCss
+            (Css.margin (Css.px paddingForAnimation)
+                :: circlingCss
+            )
 
 
 {-| -}

--- a/src/Nri/Ui/Loading/V1.elm
+++ b/src/Nri/Ui/Loading/V1.elm
@@ -1,11 +1,13 @@
 module Nri.Ui.Loading.V1 exposing
     ( fadeInPage, page
+    , spinning
     , spinningPencil, spinningDots
     )
 
 {-| Loading behaviors
 
 @docs fadeInPage, page
+@docs spinning
 @docs spinningPencil, spinningDots
 
 -}
@@ -63,6 +65,19 @@ loading_ withCss =
             )
         ]
         [ Svg.toHtml spinningPencil
+        ]
+
+
+{-| -}
+spinning : List (Html.Attribute msg) -> Html msg
+spinning attributes =
+    Html.div attributes
+        [ spinningDots
+            |> Svg.withCss [ MediaQuery.anyMotion [ Css.display Css.none ] ]
+            |> Svg.toHtml
+        , spinningPencil
+            |> Svg.withCss [ MediaQuery.prefersReducedMotion [ Css.display Css.none ] ]
+            |> Svg.toHtml
         ]
 
 

--- a/src/Nri/Ui/Loading/V1.elm
+++ b/src/Nri/Ui/Loading/V1.elm
@@ -99,14 +99,14 @@ spinningDots : Svg
 spinningDots =
     let
         dotColors =
-            [ "#004e95"
-            , "#004cc9"
-            , "#146aff"
-            , "#0af"
-            , "#d4f0ff"
-            , "#eef9ff"
+            [ "#fff"
             , "#f5f5f5"
-            , "#fff"
+            , "#eef9ff"
+            , "#d4f0ff"
+            , "#0af"
+            , "#146aff"
+            , "#004cc9"
+            , "#004e95"
             ]
 
         rotatedColors rotateWith =
@@ -124,7 +124,7 @@ spinningDots =
             Svg.Styled.circle
                 (List.filterMap identity
                     [ Maybe.map SvgAttributes.fill (List.head colors)
-                    , Just (SvgAttributes.css (colorChangeCss colors))
+                    , Just (SvgAttributes.css (colorChangeCss (List.reverse colors)))
                     ]
                     ++ attributes
                 )

--- a/src/Nri/Ui/Loading/V1.elm
+++ b/src/Nri/Ui/Loading/V1.elm
@@ -69,15 +69,20 @@ loading_ withCss =
 
 
 {-| -}
-spinning : Css.Color -> Html msg
-spinning color =
-    Html.div []
+spinning : Css.Px -> Css.Color -> Html msg
+spinning size color =
+    Html.div
+        []
         [ spinningDots
             |> Svg.withCss [ MediaQuery.anyMotion [ Css.display Css.none ] ]
+            |> Svg.withWidth size
+            |> Svg.withHeight size
             |> Svg.toHtml
         , spinningPencil
             |> Svg.withColor color
             |> Svg.withCss [ MediaQuery.prefersReducedMotion [ Css.display Css.none ] ]
+            |> Svg.withWidth size
+            |> Svg.withHeight size
             |> Svg.toHtml
         ]
 

--- a/src/Nri/Ui/Loading/V1.elm
+++ b/src/Nri/Ui/Loading/V1.elm
@@ -69,13 +69,14 @@ loading_ withCss =
 
 
 {-| -}
-spinning : List (Html.Attribute msg) -> Html msg
-spinning attributes =
-    Html.div attributes
+spinning : Css.Color -> Html msg
+spinning color =
+    Html.div []
         [ spinningDots
             |> Svg.withCss [ MediaQuery.anyMotion [ Css.display Css.none ] ]
             |> Svg.toHtml
         , spinningPencil
+            |> Svg.withColor color
             |> Svg.withCss [ MediaQuery.prefersReducedMotion [ Css.display Css.none ] ]
             |> Svg.toHtml
         ]

--- a/src/Nri/Ui/Loading/V1.elm
+++ b/src/Nri/Ui/Loading/V1.elm
@@ -14,6 +14,7 @@ import Css
 import Css.Animations
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
+import List.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Nri.Ui.Svg.V1
@@ -80,19 +81,52 @@ spinningPencil =
 {-| -}
 spinningDots : Nri.Ui.Svg.V1.Svg
 spinningDots =
-    Nri.Ui.Svg.V1.init "0 0 12.54 12.54"
-        [ Svg.circle [ SvgAttributes.fill "#004e95", SvgAttributes.cx "6.13", SvgAttributes.cy "0.98", SvgAttributes.r "0.98" ] []
-        , Svg.circle [ SvgAttributes.fill "#004cc9", SvgAttributes.cx "9.95", SvgAttributes.cy "2.47", SvgAttributes.r "0.98", SvgAttributes.transform "translate(1.12 7.67) rotate(-44.43)" ] []
-        , Svg.circle [ SvgAttributes.fill "#146aff", SvgAttributes.cx "11.56", SvgAttributes.cy "6.24", SvgAttributes.r "0.98", SvgAttributes.transform "translate(5.09 17.67) rotate(-88.86)" ] []
-        , Svg.circle [ SvgAttributes.fill "#0af", SvgAttributes.cx "10", SvgAttributes.cy "10.02", SvgAttributes.r "0.98", SvgAttributes.transform "translate(-4.15 9.58) rotate(-43.29)" ] []
-        , Svg.circle [ SvgAttributes.fill "#d4f0ff", SvgAttributes.cx "6.2", SvgAttributes.cy "11.56", SvgAttributes.r "0.98", SvgAttributes.transform "translate(-5.6 17.29) rotate(-87.71)" ] []
-        , Svg.circle [ SvgAttributes.fill "#eef9ff", SvgAttributes.cx "2.44", SvgAttributes.cy "9.92", SvgAttributes.r "0.98", SvgAttributes.transform "translate(-6.03 4.21) rotate(-42.14)" ] []
-        , Svg.circle [ SvgAttributes.fill "#f5f5f5", SvgAttributes.cx "0.98", SvgAttributes.cy "6.1", SvgAttributes.r "0.98", SvgAttributes.transform "translate(-5.16 6.71) rotate(-86.57)" ] []
-        , Svg.circle [ SvgAttributes.fill "#fff", SvgAttributes.cx "2.69", SvgAttributes.cy "2.37", SvgAttributes.r "0.98", SvgAttributes.transform "translate(-0.9 2.35) rotate(-41)" ] []
-        ]
+    let
+        dotColors =
+            [ "#004e95"
+            , "#004cc9"
+            , "#146aff"
+            , "#0af"
+            , "#d4f0ff"
+            , "#eef9ff"
+            , "#f5f5f5"
+            , "#fff"
+            ]
+
+        rotatedColors rotateWith =
+            let
+                ( before, after ) =
+                    List.Extra.splitAt rotateWith dotColors
+            in
+            after ++ before
+
+        circle index attributes =
+            let
+                colors =
+                    rotatedColors index
+            in
+            Svg.circle
+                (List.filterMap identity
+                    [ Maybe.map SvgAttributes.fill (List.head colors)
+                    , Just (SvgAttributes.css (colorChangeCss colors))
+                    ]
+                    ++ attributes
+                )
+                []
+    in
+    [ [ SvgAttributes.cx "6.13", SvgAttributes.cy "0.98", SvgAttributes.r "0.98" ]
+    , [ SvgAttributes.cx "9.95", SvgAttributes.cy "2.47", SvgAttributes.r "0.98", SvgAttributes.transform "translate(1.12 7.67) rotate(-44.43)" ]
+    , [ SvgAttributes.cx "11.56", SvgAttributes.cy "6.24", SvgAttributes.r "0.98", SvgAttributes.transform "translate(5.09 17.67) rotate(-88.86)" ]
+    , [ SvgAttributes.cx "10", SvgAttributes.cy "10.02", SvgAttributes.r "0.98", SvgAttributes.transform "translate(-4.15 9.58) rotate(-43.29)" ]
+    , [ SvgAttributes.cx "6.2", SvgAttributes.cy "11.56", SvgAttributes.r "0.98", SvgAttributes.transform "translate(-5.6 17.29) rotate(-87.71)" ]
+    , [ SvgAttributes.cx "2.44", SvgAttributes.cy "9.92", SvgAttributes.r "0.98", SvgAttributes.transform "translate(-6.03 4.21) rotate(-42.14)" ]
+    , [ SvgAttributes.cx "0.98", SvgAttributes.cy "6.1", SvgAttributes.r "0.98", SvgAttributes.transform "translate(-5.16 6.71) rotate(-86.57)" ]
+    , [ SvgAttributes.cx "2.69", SvgAttributes.cy "2.37", SvgAttributes.r "0.98", SvgAttributes.transform "translate(-0.9 2.35) rotate(-41)" ]
+    ]
+        |> List.indexedMap circle
+        |> Nri.Ui.Svg.V1.init "0 0 12.54 12.54"
         |> Nri.Ui.Svg.V1.withWidth (Css.px 100)
         |> Nri.Ui.Svg.V1.withHeight (Css.px 100)
-        |> Nri.Ui.Svg.V1.withCss circlingCss
 
 
 circlingCss : List Css.Style
@@ -104,6 +138,31 @@ circlingCss =
         , Css.property "animation-timing-function" "linear"
         ]
     ]
+
+
+colorChangeCss : List String -> List Css.Style
+colorChangeCss colors =
+    [ Css.property "animation-duration" "2s"
+    , Css.property "animation-iteration-count" "infinite"
+    , Css.animationName (colorChangeKeyFrames colors)
+    , Css.property "animation-timing-function" "linear"
+    ]
+
+
+colorChangeKeyFrames : List String -> Css.Animations.Keyframes {}
+colorChangeKeyFrames colors =
+    let
+        colorCount =
+            List.length colors
+    in
+    colors
+        |> List.indexedMap
+            (\index color ->
+                ( round (100 * (toFloat index + 1) / toFloat colorCount)
+                , [ Css.Animations.property "fill" color ]
+                )
+            )
+        |> Css.Animations.keyframes
 
 
 rotateKeyframes : Css.Animations.Keyframes {}

--- a/src/Nri/Ui/Loading/V1.elm
+++ b/src/Nri/Ui/Loading/V1.elm
@@ -141,8 +141,8 @@ spinningDots =
     ]
         |> List.indexedMap circle
         |> Svg.init "0 0 12.54 12.54"
-        |> Svg.withWidth (Css.px 100)
-        |> Svg.withHeight (Css.px 100)
+        |> Svg.withWidth (Css.px 140)
+        |> Svg.withHeight (Css.px 140)
 
 
 circlingCss : List Css.Style

--- a/src/Nri/Ui/Loading/V1.elm
+++ b/src/Nri/Ui/Loading/V1.elm
@@ -15,6 +15,7 @@ import Css.Animations
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Nri.Ui.Svg.V1
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Svg.Styled as Svg
@@ -95,10 +96,12 @@ spinningDots =
 
 circlingCss : List Css.Style
 circlingCss =
-    [ Css.property "animation-duration" "1s"
-    , Css.property "animation-iteration-count" "infinite"
-    , Css.animationName rotateKeyframes
-    , Css.property "animation-timing-function" "linear"
+    [ MediaQuery.anyMotion
+        [ Css.property "animation-duration" "1s"
+        , Css.property "animation-iteration-count" "infinite"
+        , Css.animationName rotateKeyframes
+        , Css.property "animation-timing-function" "linear"
+        ]
     ]
 
 

--- a/src/Nri/Ui/Loading/V1.elm
+++ b/src/Nri/Ui/Loading/V1.elm
@@ -68,22 +68,13 @@ loading_ withCss =
 {-| -}
 spinningPencil : Nri.Ui.Svg.V1.Svg
 spinningPencil =
-    let
-        diagonalLength =
-            ceiling (sqrt (2 * 100 * 100))
-
-        paddingForAnimation =
-            (toFloat diagonalLength - 100) / 2
-    in
     UiIcon.edit
         |> Nri.Ui.Svg.V1.withLabel "Loading..."
         |> Nri.Ui.Svg.V1.withColor Colors.navy
-        |> Nri.Ui.Svg.V1.withWidth (Css.px 100)
-        |> Nri.Ui.Svg.V1.withHeight (Css.px 100)
-        |> Nri.Ui.Svg.V1.withCss
-            (Css.margin (Css.px paddingForAnimation)
-                :: circlingCss
-            )
+        |> Nri.Ui.Svg.V1.withWidth (Css.px 140)
+        |> Nri.Ui.Svg.V1.withHeight (Css.px 140)
+        |> Nri.Ui.Svg.V1.withViewBox "-20 -20 140 140"
+        |> Nri.Ui.Svg.V1.withCss circlingCss
 
 
 {-| -}

--- a/src/Nri/Ui/Svg/V1.elm
+++ b/src/Nri/Ui/Svg/V1.elm
@@ -1,13 +1,13 @@
 module Nri.Ui.Svg.V1 exposing
     ( Svg
-    , withColor, withLabel, withWidth, withHeight, withCss, withCustom
+    , withColor, withLabel, withWidth, withHeight, withCss, withCustom, withViewBox
     , init, toHtml
     )
 
 {-|
 
 @docs Svg
-@docs withColor, withLabel, withWidth, withHeight, withCss, withCustom
+@docs withColor, withLabel, withWidth, withHeight, withCss, withCustom, withViewBox
 @docs init, toHtml
 
 -}
@@ -93,6 +93,12 @@ withCss css (Svg record) =
 withCustom : List (Svg.Styled.Attribute Never) -> Svg -> Svg
 withCustom attributes (Svg record) =
     Svg { record | attributes = record.attributes ++ attributes }
+
+
+{-| -}
+withViewBox : String -> Svg -> Svg
+withViewBox viewBox (Svg record) =
+    Svg { record | viewBox = viewBox }
 
 
 {-| render an svg.

--- a/styleguide-app/Examples/Loading.elm
+++ b/styleguide-app/Examples/Loading.elm
@@ -114,10 +114,10 @@ example =
                 Html.text ""
             , button "Loading.fadeInPage" ShowLoadingFadeIn showLoadingFadeIn
             , if showSpinners then
-                div [] [ Svg.toHtml Loading.spinningPencil ]
+                Loading.spinning []
 
               else
-                button "Loading.spinningPencil" ShowSpinners showLoadingFadeIn
+                button "Loading.spinning" ShowSpinners showLoadingFadeIn
             ]
     }
 

--- a/styleguide-app/Examples/Loading.elm
+++ b/styleguide-app/Examples/Loading.elm
@@ -115,8 +115,8 @@ example =
             , button "Loading.fadeInPage" ShowLoadingFadeIn showLoadingFadeIn
             , if showSpinners then
                 Html.div []
-                    [ Svg.toHtml Loading.spinningPencil
-                    , Svg.toHtml Loading.spinningDots
+                    [ Html.div [] [ Svg.toHtml Loading.spinningPencil ]
+                    , Html.div [] [ Svg.toHtml Loading.spinningDots ]
                     ]
 
               else

--- a/styleguide-app/Examples/Loading.elm
+++ b/styleguide-app/Examples/Loading.elm
@@ -17,7 +17,6 @@ import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Loading.V1 as Loading
 import Nri.Ui.Svg.V1 as Svg
-import Nri.Ui.Text.V6 as Text
 
 
 {-| -}

--- a/styleguide-app/Examples/Loading.elm
+++ b/styleguide-app/Examples/Loading.elm
@@ -113,7 +113,7 @@ example =
                 Html.text ""
             , button "Loading.fadeInPage" ShowLoadingFadeIn showLoadingFadeIn
             , if showSpinners then
-                Loading.spinning Colors.navy
+                Loading.spinning (Css.px 140) Colors.navy
 
               else
                 button "Loading.spinning Colors.navy" ShowSpinners showLoadingFadeIn

--- a/styleguide-app/Examples/Loading.elm
+++ b/styleguide-app/Examples/Loading.elm
@@ -115,12 +115,8 @@ example =
             , button "Loading.fadeInPage" ShowLoadingFadeIn showLoadingFadeIn
             , if showSpinners then
                 Html.div []
-                    [ Loading.spinningPencil
-                        |> Svg.withColor Colors.azure
-                        |> Svg.toHtml
-                    , Text.caption [ Text.plaintext "By default, the spinningPencil is white. Showing as blue for visibility." ]
-                    , Loading.spinningDots
-                        |> Svg.toHtml
+                    [ Svg.toHtml Loading.spinningPencil
+                    , Svg.toHtml Loading.spinningDots
                     ]
 
               else

--- a/styleguide-app/Examples/Loading.elm
+++ b/styleguide-app/Examples/Loading.elm
@@ -114,10 +114,10 @@ example =
                 Html.text ""
             , button "Loading.fadeInPage" ShowLoadingFadeIn showLoadingFadeIn
             , if showSpinners then
-                Loading.spinning []
+                Loading.spinning Colors.navy
 
               else
-                button "Loading.spinning" ShowSpinners showLoadingFadeIn
+                button "Loading.spinning Colors.navy" ShowSpinners showLoadingFadeIn
             ]
     }
 


### PR DESCRIPTION
Adjusts spinningPencil and spinningDots and adds spinning in order to reduce motion when requested, while still providing a visual loading indicator.

<details><summary>Previous version of the description, before discussion on PR</summary>

The spinningPencil is a LOT when it just keeps rendered. This PR makes it respect prefers reduced motion settings. ... Which makes it much _less_ clear that it's meant to be a loading state. 

<img width="208" alt="image" src="https://user-images.githubusercontent.com/8811312/190829093-4d943ac2-8966-466c-bfdf-ae9b3ed31c1b.png">

cc @NoRedInk/design 

</details>