### PR TITLE
A11-1640 remove hint when releasing shift before arrow

### DIFF
--- a/src/Nri/Ui/Highlighter/V1.elm
+++ b/src/Nri/Ui/Highlighter/V1.elm
@@ -407,7 +407,7 @@ keyboardEventToActions msg model =
                     [ Remove, ResetSelection, Focus index ]
 
         SelectionReset index ->
-            [ ResetSelection, Hint 0 0, Focus index ]
+            [ ResetSelection, Remove, Focus index ]
 
         ToggleHighlight index ->
             case model.marker of


### PR DESCRIPTION
When expanding selection on highlighter using shift + left/right arrow, shift can be released before the arrow key. In this case, we want to reset the selection and remove the hint.