### PR TITLE
Permit row headers in `Nri.Ui.Table`

### DIFF
--- a/src/Nri/Ui/Table/V6.elm
+++ b/src/Nri/Ui/Table/V6.elm
@@ -2,6 +2,7 @@ module Nri.Ui.Table.V6 exposing
     ( Column, SortDirection(..), custom, string
     , view, viewWithoutHeader
     , viewLoading, viewLoadingWithoutHeader
+    , rowHeader
     )
 
 {-| Upgrading from V5:

--- a/src/Nri/Ui/Table/V6.elm
+++ b/src/Nri/Ui/Table/V6.elm
@@ -1,8 +1,7 @@
 module Nri.Ui.Table.V6 exposing
-    ( Column, SortDirection(..), custom, string
+    ( Column, SortDirection(..), custom, string, rowHeader
     , view, viewWithoutHeader
     , viewLoading, viewLoadingWithoutHeader
-    , rowHeader
     )
 
 {-| Upgrading from V5:
@@ -10,7 +9,7 @@ module Nri.Ui.Table.V6 exposing
   - The columns take an additional `sort` property that allows
     you to specify ARIA sorting
 
-@docs Column, SortDirection, custom, string
+@docs Column, SortDirection, custom, string, rowHeader
 
 @docs view, viewWithoutHeader
 

--- a/src/Nri/Ui/Table/V6.elm
+++ b/src/Nri/Ui/Table/V6.elm
@@ -52,7 +52,7 @@ cell : CellType -> List (Attribute msg) -> List (Html msg) -> Html msg
 cell cellType attrs =
     case cellType of
         RowHeaderCell ->
-            th (Attributes.scope "col" :: attrs)
+            th (Attributes.scope "row" :: attrs)
 
         DataCell ->
             td attrs

--- a/src/Nri/Ui/Table/V6.elm
+++ b/src/Nri/Ui/Table/V6.elm
@@ -151,7 +151,7 @@ stylesLoadingColumn rowIndex colIndex width =
 tableWithoutHeader : List Style -> List (Column data msg) -> (a -> Html msg) -> List a -> Html msg
 tableWithoutHeader styles columns toRow data =
     table styles
-        [ thead [] [ tr Style.invisible (List.map tableRowHeader columns) ]
+        [ thead [] [ tr Style.invisible (List.map tableColHeader columns) ]
         , tableBody toRow data
         ]
 
@@ -173,12 +173,12 @@ tableHeader : List (Column data msg) -> Html msg
 tableHeader columns =
     thead []
         [ tr [ css headersStyles ]
-            (List.map tableRowHeader columns)
+            (List.map tableColHeader columns)
         ]
 
 
-tableRowHeader : Column data msg -> Html msg
-tableRowHeader (Column header _ width _ sort) =
+tableColHeader : Column data msg -> Html msg
+tableColHeader (Column header _ width _ sort) =
     th
         [ Attributes.scope "col"
         , css (width :: headerStyles)

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -155,15 +155,17 @@ controlSettings =
 
 
 type alias Datum =
-    { firstName : String
+    { userId : Int
+    , firstName : String
     , lastName : String
     , submitted : Int
     }
 
 
 datumToString : Datum -> String
-datumToString { firstName, lastName, submitted } =
-    ("{ firstName = " ++ str firstName)
+datumToString { userId, firstName, lastName, submitted } =
+    ("{ userId = " ++ String.fromInt userId)
+        ++ (", firstName = " ++ str firstName)
         ++ (", lastName = " ++ str lastName)
         ++ (", submitted = " ++ String.fromInt 10)
         ++ "}"
@@ -176,17 +178,34 @@ str s =
 
 data : List Datum
 data =
-    [ { firstName = "Monique", lastName = "Garcia", submitted = 10 }
-    , { firstName = "Gabriel", lastName = "Smith", submitted = 0 }
-    , { firstName = "Mariah", lastName = "Lopez", submitted = 3 }
-    , { firstName = "Amber", lastName = "Brown", submitted = 15 }
-    , { firstName = "Carlos", lastName = "Martinez", submitted = 8 }
+    [ { userId = 1, firstName = "Monique", lastName = "Garcia", submitted = 10 }
+    , { userId = 2, firstName = "Gabriel", lastName = "Smith", submitted = 0 }
+    , { userId = 3, firstName = "Mariah", lastName = "Lopez", submitted = 3 }
+    , { userId = 4, firstName = "Amber", lastName = "Brown", submitted = 15 }
+    , { userId = 5, firstName = "Carlos", lastName = "Martinez", submitted = 8 }
     ]
 
 
 columnsWithCode : List ( String, Column Datum Msg )
 columnsWithCode =
-    [ ( [ "Table.string"
+    [ ( [ "Table.rowHeader"
+        , "  { header = text \"User ID\""
+        , "  , view = text << String.fromInt << .userId"
+        , "  , width = Css.px 80"
+        , "  , cellStyles = always []"
+        , "  , sort = Nothing"
+        , "  }"
+        ]
+            |> String.join "\n\t  "
+      , Table.rowHeader
+            { header = text "User ID"
+            , view = text << String.fromInt << .userId
+            , width = Css.px 80
+            , cellStyles = always []
+            , sort = Nothing
+            }
+      )
+    , ( [ "Table.string"
         , "  { header = \"First Name\""
         , "  , value = .firstName"
         , "  , width = Css.calc (Css.pct 50) Css.minus (Css.px 250)"


### PR DESCRIPTION
This adds`rowHeader` (alongside the existing `string` and `custom`) to the `Nri.Ui.Table` interface for creating columns whose cells are row headers -- IE `th`s with `scope = "row"`.

I encountered this need in the course of [ADM-1](https://linear.app/noredink/issue/ADM-1/implement-a11y-notes-on-admin-tools-page).