### PR TITLE
Fix space focus loss

### DIFF
--- a/src/Nri/Ui/Highlighter/V1.elm
+++ b/src/Nri/Ui/Highlighter/V1.elm
@@ -211,7 +211,7 @@ type KeyboardMsg
     | SelectionExpandLeft Int
     | SelectionExpandRight Int
     | SelectionApplyTool Int
-    | Space Int
+    | ToggleHighlight Int
 
 
 {-| Possible intents or "external effects" that the Highlighter can request (see `perform`).
@@ -404,16 +404,19 @@ keyboardEventToActions msg model =
                 Tool.Eraser _ ->
                     [ Remove, ResetSelection, Focus index ]
 
-        Space index ->
+        ToggleHighlight index ->
             case model.marker of
                 Tool.Marker marker ->
-                    [ Toggle index marker ]
+                    [ Toggle index marker
+                    , Focus index
+                    ]
 
                 Tool.Eraser _ ->
                     [ MouseOver index
                     , Hint index index
                     , MouseUp
                     , Remove
+                    , Focus index
                     ]
 
 
@@ -639,7 +642,7 @@ viewHighlightable highlighterId marker focusIndex highlightable =
                 , on "touchstart" (Pointer <| Down highlightable.groupIndex)
                 , attribute "data-interactive" ""
                 , Key.onKeyDownPreventDefault
-                    [ Key.space (Keyboard <| Space highlightable.groupIndex)
+                    [ Key.space (Keyboard <| ToggleHighlight highlightable.groupIndex)
                     , Key.right (Keyboard <| MoveRight highlightable.groupIndex)
                     , Key.left (Keyboard <| MoveLeft highlightable.groupIndex)
                     , Key.shiftRight (Keyboard <| SelectionExpandRight highlightable.groupIndex)


### PR DESCRIPTION
Fixes A11-1636

1. Tab into the highlighter area.
2. Use arrow keys to focus on a single word.
3. Press space. The word should be highlighted **and your focus should remain on the word**
4. Use tab and the arrow keys again to focus on the word that's highlighted.
5. Press space. The word should be unhighlighted **and your focus should remain on the word**


https://user-images.githubusercontent.com/8811312/192010439-a55b0f6a-0078-4d12-85b3-5584d866cabd.mov

