### PR TITLE
Disabled checkbox styles

### DIFF
--- a/src/Nri/Ui/Checkbox/V6.elm
+++ b/src/Nri/Ui/Checkbox/V6.elm
@@ -257,10 +257,13 @@ viewDisabledLabel model labelView icon =
             , textStyle
             , outline none
             , cursor auto
+            , color Colors.gray45
             , Css.batch model.disabledLabelCss
             ]
         ]
-        [ viewIcon [ opacity (num 0.4) ] icon
+        [ viewIcon
+            [ property "filter" "grayscale(1)" ]
+            icon
         , labelView model.label
         ]
 


### PR DESCRIPTION
Approximates fix for checkbox item of https://github.com/NoRedInk/noredink-ui/issues/1098

Approximates because using a grayscale filter means the colors in the checkbox are inexact.

<img width="406" alt="image" src="https://user-images.githubusercontent.com/13528834/192342409-10d23403-580f-4dba-8dca-01f42d17d4ad.png">