### PR TITLE
Bat/tabs fixes

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -88,7 +88,7 @@
         "pablohirafuji/elm-markdown": "2.0.5 <= v < 3.0.0",
         "rtfeldman/elm-css": "17.0.1 <= v < 18.0.0",
         "rtfeldman/elm-sorter-experiment": "2.1.1 <= v < 3.0.0",
-        "tesk9/accessible-html-with-css": "3.3.0 <= v < 4.0.0",
+        "tesk9/accessible-html-with-css": "3.4.0 <= v < 4.0.0",
         "tesk9/palette": "3.0.1 <= v < 4.0.0"
     },
     "test-dependencies": {

--- a/src/TabsInternal.elm
+++ b/src/TabsInternal.elm
@@ -102,6 +102,7 @@ viewTab_ config tab =
             ++ [ Attributes.tabindex tabIndex
                , Aria.selected isSelected
                , Role.tab
+               , Aria.controls [ tabToBodyId tab.idString ]
                , Attributes.id (tabToId tab.idString)
                , Events.onFocus (config.onSelect tab.id)
                , Events.on "keyup" <|

--- a/src/TabsInternal.elm
+++ b/src/TabsInternal.elm
@@ -53,6 +53,7 @@ viewTabs : Config id msg -> Html msg
 viewTabs config =
     Html.div
         [ Role.tabList
+        , Aria.owns (List.map (tabToId << .idString) config.tabs)
         , Attributes.css config.tabListStyles
         ]
         (List.map (viewTab_ config) config.tabs)

--- a/src/TabsInternal/V2.elm
+++ b/src/TabsInternal/V2.elm
@@ -139,6 +139,7 @@ viewTab_ config index tab =
                          Attributes.disabled (not isSelected && tab.disabled)
                        , Aria.selected isSelected
                        , Role.tab
+                       , Aria.controls [ tabToBodyId tab.idString ]
                        , Attributes.id (tabToId tab.idString)
                        , Key.onKeyUpPreventDefault (keyEvents config tab)
                        ]

--- a/src/TabsInternal/V2.elm
+++ b/src/TabsInternal/V2.elm
@@ -82,6 +82,7 @@ viewTabs : Config id msg -> Html msg
 viewTabs config =
     Html.div
         [ Role.tabList
+        , Aria.owns (List.map (tabToId << .idString) config.tabs)
         , Attributes.css config.tabListStyles
         ]
         (List.indexedMap (viewTab_ config) config.tabs)

--- a/styleguide/elm.json
+++ b/styleguide/elm.json
@@ -27,7 +27,7 @@
             "pablohirafuji/elm-markdown": "2.0.5",
             "rtfeldman/elm-css": "17.0.5",
             "rtfeldman/elm-sorter-experiment": "2.1.1",
-            "tesk9/accessible-html-with-css": "3.3.0",
+            "tesk9/accessible-html-with-css": "3.4.0",
             "tesk9/palette": "3.0.1",
             "wernerdegroot/listzipper": "4.0.0"
         },


### PR DESCRIPTION
Adds aria-owns to connect the tablist to the tab "children".
Adds aria-controls to connect the tab and the panel that it controls.

Fixes A11-1233
Fixes A11-1232