### PR TITLE
Tessa/improve ring gauge example

### DIFF
--- a/src/Nri/Ui/Colors/Extra.elm
+++ b/src/Nri/Ui/Colors/Extra.elm
@@ -2,6 +2,7 @@ module Nri.Ui.Colors.Extra exposing
     ( toCssColor, fromCssColor
     , withAlpha
     , toCssString
+    , highContrastColor
     )
 
 {-| Helpers for working with colors.
@@ -12,12 +13,19 @@ module Nri.Ui.Colors.Extra exposing
 @docs toCssColor, fromCssColor
 @docs withAlpha
 @docs toCssString
+@docs highContrastColor
 
 -}
 
 import Css
 import SolidColor exposing (SolidColor)
 import TransparentColor
+
+
+{-| -}
+highContrastColor : Css.Color -> Css.Color
+highContrastColor =
+    fromCssColor >> SolidColor.highContrast >> toCssColor
 
 
 {-| -}

--- a/styleguide-app/CommonControls.elm
+++ b/styleguide-app/CommonControls.elm
@@ -4,7 +4,7 @@ module CommonControls exposing
     , icon, iconNotCheckedByDefault
     , uiIcon, rotatedUiIcon
     , customIcon
-    , color
+    , color, rotatedColor
     , content
     , httpError
     , romeoAndJulietQuotation
@@ -18,7 +18,7 @@ module CommonControls exposing
 @docs icon, iconNotCheckedByDefault
 @docs uiIcon, rotatedUiIcon
 @docs customIcon
-@docs color
+@docs color, rotatedColor
 
 
 ### Content
@@ -45,6 +45,16 @@ import Nri.Ui.UiIcon.V1 as UiIcon
 color : Control ( String, Css.Color )
 color =
     choice "Colors" Examples.Colors.all
+
+
+rotatedColor : Int -> Control ( String, Css.Color )
+rotatedColor by =
+    Examples.Colors.all
+        |> List.map
+            (\( name, value ) ->
+                ( name, Control.value ( "Colors." ++ name, value ) )
+            )
+        |> ControlExtra.rotatedChoice by
 
 
 premiumDisplay : Control ( String, PremiumDisplay )

--- a/styleguide-app/CommonControls.elm
+++ b/styleguide-app/CommonControls.elm
@@ -4,7 +4,7 @@ module CommonControls exposing
     , icon, iconNotCheckedByDefault
     , uiIcon, rotatedUiIcon
     , customIcon
-    , color, rotatedColor
+    , color, specificColor
     , content
     , httpError
     , romeoAndJulietQuotation
@@ -18,7 +18,7 @@ module CommonControls exposing
 @docs icon, iconNotCheckedByDefault
 @docs uiIcon, rotatedUiIcon
 @docs customIcon
-@docs color, rotatedColor
+@docs color, specificColor
 
 
 ### Content
@@ -47,14 +47,14 @@ color =
     choice "Colors" Examples.Colors.all
 
 
-rotatedColor : Int -> Control ( String, Css.Color )
-rotatedColor by =
+specificColor : String -> Control ( String, Css.Color )
+specificColor match =
     Examples.Colors.all
         |> List.map
             (\( name, value ) ->
                 ( name, Control.value ( "Colors." ++ name, value ) )
             )
-        |> ControlExtra.rotatedChoice by
+        |> ControlExtra.specificChoice match
 
 
 premiumDisplay : Control ( String, PremiumDisplay )

--- a/styleguide-app/CommonControls.elm
+++ b/styleguide-app/CommonControls.elm
@@ -4,7 +4,7 @@ module CommonControls exposing
     , icon, iconNotCheckedByDefault
     , uiIcon, rotatedUiIcon
     , customIcon
-    , color, specificColor
+    , specificColor
     , content
     , httpError
     , romeoAndJulietQuotation
@@ -18,7 +18,7 @@ module CommonControls exposing
 @docs icon, iconNotCheckedByDefault
 @docs uiIcon, rotatedUiIcon
 @docs customIcon
-@docs color, specificColor
+@docs specificColor
 
 
 ### Content
@@ -40,11 +40,6 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Data.PremiumDisplay as PremiumDisplay exposing (PremiumDisplay)
 import Nri.Ui.Svg.V1 exposing (Svg)
 import Nri.Ui.UiIcon.V1 as UiIcon
-
-
-color : Control ( String, Css.Color )
-color =
-    choice "Colors" Examples.Colors.all
 
 
 specificColor : String -> Control ( String, Css.Color )

--- a/styleguide-app/Debug/Control/Extra.elm
+++ b/styleguide-app/Debug/Control/Extra.elm
@@ -3,7 +3,7 @@ module Debug.Control.Extra exposing
     , list, listItem, optionalListItem, optionalListItemDefaultChecked
     , optionalBoolListItem, optionalBoolListItemDefaultTrue
     , bool
-    , rotatedChoice
+    , rotatedChoice, specificChoice
     )
 
 {-|
@@ -12,7 +12,7 @@ module Debug.Control.Extra exposing
 @docs list, listItem, optionalListItem, optionalListItemDefaultChecked
 @docs optionalBoolListItem, optionalBoolListItemDefaultTrue
 @docs bool
-@docs rotatedChoice
+@docs rotatedChoice, specificChoice
 
 -}
 
@@ -124,5 +124,15 @@ rotatedChoice rotateWith options =
     let
         ( before, after ) =
             List.Extra.splitAt rotateWith options
+    in
+    Control.choice (after ++ before)
+
+
+{-| -}
+specificChoice : String -> List ( String, Control a ) -> Control a
+specificChoice match options =
+    let
+        ( before, after ) =
+            List.Extra.break (Tuple.first >> (==) match) options
     in
     Control.choice (after ++ before)

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -20,7 +20,6 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Text.V6 as Text
-import SolidColor exposing (highContrast)
 
 
 type alias ColorExample =
@@ -183,6 +182,10 @@ viewColors colors =
 
 viewColor : ColorExample -> Html.Html msg
 viewColor ( name, color, description ) =
+    let
+        highContrastColor =
+            Nri.Ui.Colors.Extra.highContrastColor color
+    in
     Html.div
         [ css
             [ -- Dimensions
@@ -201,10 +204,7 @@ viewColor ( name, color, description ) =
 
             -- Colors
             , Css.backgroundColor color
-            , Nri.Ui.Colors.Extra.fromCssColor color
-                |> highContrast
-                |> Nri.Ui.Colors.Extra.toCssColor
-                |> Css.color
+            , Css.color highContrastColor
             ]
         ]
         [ Html.div

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -82,6 +82,7 @@ uncategorizedColors =
     , ( "gray85", Colors.gray85, "Alternate for divider lines and container borders" )
     , ( "gray92", Colors.gray92, "Dvdrs/rules, incomplete assmt, inactive tabs/dsbld buttons" )
     , ( "gray96", Colors.gray96, "backgrounds/alternating rows" )
+    , ( "white", Colors.white, "backgrounds, text on dark backgrounds" )
     , ( "navy", Colors.navy, "Headings, indented compts, labels, tooltip bckgrnds" )
     , ( "azure", Colors.azure, "Buttons, other clickable stuff, links" )
     , ( "azureDark", Colors.azureDark, "Azure button shadow" )

--- a/styleguide-app/Examples/RingGauge.elm
+++ b/styleguide-app/Examples/RingGauge.elm
@@ -174,7 +174,7 @@ type alias Settings =
 controlSettings : Control Settings
 controlSettings =
     Control.record Settings
-        |> Control.field "backgroundColor" (CommonControls.rotatedColor 7)
-        |> Control.field "emptyColor" (CommonControls.rotatedColor 10)
-        |> Control.field "filledColor" (CommonControls.rotatedColor 13)
+        |> Control.field "backgroundColor" (CommonControls.specificColor "white")
+        |> Control.field "emptyColor" (CommonControls.specificColor "gray92")
+        |> Control.field "filledColor" (CommonControls.specificColor "cornflower")
         |> Control.field "percentage" (ControlExtra.float 15)

--- a/styleguide-app/Examples/RingGauge.elm
+++ b/styleguide-app/Examples/RingGauge.elm
@@ -174,7 +174,7 @@ type alias Settings =
 controlSettings : Control Settings
 controlSettings =
     Control.record Settings
-        |> Control.field "backgroundColor" CommonControls.color
-        |> Control.field "emptyColor" CommonControls.color
-        |> Control.field "filledColor" CommonControls.color
+        |> Control.field "backgroundColor" (CommonControls.rotatedColor 7)
+        |> Control.field "emptyColor" (CommonControls.rotatedColor 10)
+        |> Control.field "filledColor" (CommonControls.rotatedColor 13)
         |> Control.field "percentage" (ControlExtra.float 15)


### PR DESCRIPTION
Improve the default-selected options in the ring gauge example, so that the ring gauge shape is apparent.

### Before

<img width="259" alt="Screen Shot 2022-10-04 at 2 42 29 PM" src="https://user-images.githubusercontent.com/8811312/193923533-5cdcaff9-ef53-4041-9a13-53336bbbe596.png">


### After

<img width="248" alt="Screen Shot 2022-10-04 at 2 42 23 PM" src="https://user-images.githubusercontent.com/8811312/193923529-ee804751-1fb7-42bc-b49c-ccb862214e34.png">
