### PR TITLE
Bat/disabled select

### DIFF
--- a/src/InputLabelInternal.elm
+++ b/src/InputLabelInternal.elm
@@ -11,13 +11,20 @@ import Accessibility.Styled.Style as Accessibility
 import Css
 import Html.Styled.Attributes as Attributes
 import InputErrorAndGuidanceInternal exposing (ErrorState)
+import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.InputStyles.V3 as InputStyles exposing (Theme)
 
 
 {-| -}
 view :
     { for : String, label : String, theme : Theme }
-    -> { config | error : ErrorState, noMarginTop : Bool, hideLabel : Bool }
+    ->
+        { config
+            | error : ErrorState
+            , noMarginTop : Bool
+            , hideLabel : Bool
+            , disabled : Bool
+        }
     -> Html msg
 view { for, label, theme } config =
     let
@@ -32,6 +39,14 @@ view { for, label, theme } config =
         ([ Attributes.for for
          , Attributes.css
             [ InputStyles.label theme (InputErrorAndGuidanceInternal.getIsInError config.error)
+            , Css.batch <|
+                if config.disabled then
+                    [ Css.backgroundColor Colors.gray92
+                    , Css.color Colors.gray20
+                    ]
+
+                else
+                    []
             , if config.noMarginTop then
                 Css.top (Css.px -InputStyles.defaultMarginTop)
 

--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -447,7 +447,7 @@ viewSelect config =
             , Css.paddingRight (Css.px 30)
 
             -- Icons
-            , selectArrowsCss
+            , selectArrowsCss config
             ]
             (onSelectHandler
                 :: Attributes.id config.id
@@ -488,11 +488,18 @@ generateId x =
     "nri-select-" ++ Nri.Ui.Util.dashify (Nri.Ui.Util.removePunctuation x)
 
 
-selectArrowsCss : Css.Style
-selectArrowsCss =
+selectArrowsCss : { config | disabled : Bool } -> Css.Style
+selectArrowsCss config =
     let
         color =
-            SolidColor.toRGBString (ColorsExtra.fromCssColor Colors.azure)
+            (if config.disabled then
+                Colors.gray20
+
+             else
+                Colors.azure
+            )
+                |> ColorsExtra.fromCssColor
+                |> SolidColor.toRGBString
     in
     Css.batch
         [ """<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="12px" height="16px" viewBox="0 0 12 16"><g fill=" """

--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -286,7 +286,7 @@ view label attributes =
                     ( Css.num 0.5, True )
 
                 ( True, _ ) ->
-                    ( Css.num 0.4, True )
+                    ( Css.num 1, True )
     in
     Html.div
         [ css

--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -415,7 +415,11 @@ viewSelect config =
                  else
                     Colors.gray75
                 )
-            , Css.borderBottomWidth (Css.px 3)
+            , if config.disabled then
+                Css.borderBottomWidth (Css.px 1)
+
+              else
+                Css.borderBottomWidth (Css.px 3)
             , Css.borderRadius (Css.px 8)
             , Css.focus
                 [ Css.borderColor Colors.azure
@@ -507,7 +511,13 @@ selectArrowsCss config =
             ++ """ "><path d="M2.10847,9.341803 C1.65347,8.886103 0.91427,8.886103 0.45857,9.341803 C0.23107,9.570003 0.11697,9.868203 0.11697,10.167103 C0.11697,10.465303 0.23107,10.763503 0.45857,10.991703 L5.12547,15.657903 C5.57977,16.114303 6.31897,16.114303 6.77537,15.657903 L11.44157,10.991703 C11.89727,10.536003 11.89727,9.797503 11.44157,9.341803 C10.98657,8.886103 10.24667,8.886103 9.79167,9.341803 L5.95007,13.182703 L2.10847,9.341803 Z"/><path d="M1.991556,6.658179 C1.536659,7.11394 0.797279,7.11394 0.3416911,6.658179 C0.1140698,6.43004 0,6.13173 0,5.83325 C0,5.53476 0.1140698,5.23645 0.3416911,5.00831 L5.008185,0.34182 C5.463081,-0.11394 6.202461,-0.11394 6.65805,0.34182 L11.32454,5.00831 C11.78031,5.4639 11.78031,6.202592 11.32454,6.658179 C10.86965,7.11394 10.13027,7.11394 9.674679,6.658179 L5.833118,2.81679 L1.991556,6.658179 Z"/></g></svg> """
             |> urlUtf8
             |> Css.property "background"
-        , Css.backgroundColor Colors.white
+        , Css.backgroundColor
+            (if config.disabled then
+                Colors.gray85
+
+             else
+                Colors.white
+            )
 
         -- "appearance: none" removes the default dropdown arrows
         , VendorPrefixed.property "appearance" "none"


### PR DESCRIPTION
Part of https://github.com/NoRedInk/noredink-ui/issues/1098

Fixes A11-1710

<img width="466" alt="Screen Shot 2022-10-04 at 5 04 13 PM" src="https://user-images.githubusercontent.com/8811312/193946397-d37373cf-2d73-494d-bea8-b396f323e126.png">


<img width="464" alt="Screen Shot 2022-10-04 at 5 04 05 PM" src="https://user-images.githubusercontent.com/8811312/193946395-90a9acd5-02c4-4983-b09c-8d8d99cd5800.png">

Should this wait to merge until TextInput and TextArea disabled style updates are also ready to merge? This PR changes the shared label styles, so the labels for textinput and textareas will also be gray-ified.

cc @NoRedInk/design 
