### PR TITLE
Fix high contrast highlight

### DIFF
--- a/src/Nri/Ui/Highlighter/V1.elm
+++ b/src/Nri/Ui/Highlighter/V1.elm
@@ -615,19 +615,22 @@ groupContainer viewSegment highlightables =
                             , Css.Global.children
                                 [ Css.Global.selector ":first-child"
                                     (Css.before
-                                        [ Css.property "content" ("\" [start " ++ (Maybe.map (\name -> name) markedWith.name |> Maybe.withDefault "highlight") ++ "] \"")
-                                        , invisibleStyle
-                                        ]
-                                        :: MediaQuery.highContrastMode
-                                            [ Maybe.map
-                                                (\name ->
-                                                    Css.before
-                                                        [ Css.property "content" ("\"[" ++ name ++ "] \"")
-                                                        ]
-                                                )
-                                                markedWith.name
-                                                |> Maybe.withDefault (Css.batch [])
-                                            ]
+                                        (case markedWith.name of
+                                            Just name ->
+                                                [ MediaQuery.notHighContrastMode
+                                                    [ Css.property "content" ("\" [start " ++ name ++ " highlight] \"")
+                                                    , invisibleStyle
+                                                    ]
+                                                , MediaQuery.highContrastMode
+                                                    [ Css.property "content" ("\"[" ++ name ++ "] \"")
+                                                    ]
+                                                ]
+
+                                            Nothing ->
+                                                [ Css.property "content" "\" [start highlight] \""
+                                                , invisibleStyle
+                                                ]
+                                        )
                                         :: markedWith.startGroupClass
                                     )
                                 , Css.Global.selector ":last-child"

--- a/src/Nri/Ui/MediaQuery/V1.elm
+++ b/src/Nri/Ui/MediaQuery/V1.elm
@@ -1,6 +1,6 @@
 module Nri.Ui.MediaQuery.V1 exposing
     ( anyMotion, prefersReducedMotion
-    , highContrastMode
+    , highContrastMode, notHighContrastMode
     , withViewport
     , mobile, notMobile
     , mobileBreakpoint
@@ -30,7 +30,7 @@ Standard media queries for responsive pages.
             ]
 
 @docs anyMotion, prefersReducedMotion
-@docs highContrastMode
+@docs highContrastMode, notHighContrastMode
 
 @docs withViewport
 
@@ -87,6 +87,12 @@ anyMotion =
 prefersReducedMotion : List Style -> Style
 prefersReducedMotion =
     withMediaQuery [ "(prefers-reduced-motion)" ]
+
+
+{-| -}
+notHighContrastMode : List Style -> Style
+notHighContrastMode =
+    withMediaQuery [ "(forced-colors: none)" ]
 
 
 {-| -}


### PR DESCRIPTION
The before element for screenreaders included invisibleStyle, so that the " [Start claim highlight] " text wouldn't be rendered on the screen. However, we need the before element to render for users when the high contrast mode is on. This PR fixes the implementation to only add the invisible style when high contrast mode is _not_ on.

Please check that:
- high contrast mode shows _which_ kind of highlight is being used, when there are multiple possible highlighters
- not in high-contrast mode, screenreaders read out when a highlight starts
- not in high-contrast mode, there's no visible text within the highlight specifying the highlight type

Fixes A11-1716