### PR TITLE
Tessa/header

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -32,6 +32,7 @@
         "Nri.Ui.FocusRing.V1",
         "Nri.Ui.FocusTrap.V1",
         "Nri.Ui.Fonts.V1",
+        "Nri.Ui.Header.V1",
         "Nri.Ui.Heading.V3",
         "Nri.Ui.Highlightable.V1",
         "Nri.Ui.Highlighter.V1",

--- a/src/Nri/Ui/Header/V1.elm
+++ b/src/Nri/Ui/Header/V1.elm
@@ -1,12 +1,12 @@
 module Nri.Ui.Header.V1 exposing
     ( view
-    , Attribute, aTagAttributes, extraContent, description, extraSubheadContent, customPageWidth
+    , Attribute, aTagAttributes, extraContent, description, extraSubheadContent, customPageWidth, breadCrumbsLabel
     )
 
 {-|
 
 @docs view
-@docs Attribute, aTagAttributes, extraContent, description, extraSubheadContent, customPageWidth
+@docs Attribute, aTagAttributes, extraContent, description, extraSubheadContent, customPageWidth, breadCrumbsLabel
 
 -}
 
@@ -62,6 +62,13 @@ customPageWidth pageWidth =
     Attribute (\soFar -> { soFar | pageWidth = pageWidth })
 
 
+{-| Default label is "breadcrumbs". You will seldom need override the default.
+-}
+breadCrumbsLabel : String -> Attribute route msg
+breadCrumbsLabel label =
+    Attribute (\soFar -> { soFar | breadCrumbsLabel = label })
+
+
 type alias Config route msg =
     { aTagAttributes : route -> List (Html.Attribute msg)
     , containerAttributes : List (Html.Attribute Never)
@@ -69,6 +76,7 @@ type alias Config route msg =
     , extraSubheadContent : List (Html msg)
     , description : Maybe String
     , pageWidth : Css.Px
+    , breadCrumbsLabel : String
     }
 
 
@@ -81,6 +89,7 @@ customize =
         , extraSubheadContent = []
         , description = Nothing
         , pageWidth = MediaQuery.mobileBreakpoint
+        , breadCrumbsLabel = "breadcrumbs"
         }
 
 
@@ -124,7 +133,7 @@ view attrs { breadcrumbs, isCurrentRoute } =
                         BreadCrumbs.view
                             { isCurrentRoute = isCurrentRoute
                             , aTagAttributes = config.aTagAttributes
-                            , label = "breadcrumbs"
+                            , label = config.breadCrumbsLabel
                             }
                             breadcrumbs
                   in

--- a/src/Nri/Ui/Header/V1.elm
+++ b/src/Nri/Ui/Header/V1.elm
@@ -1,12 +1,12 @@
 module Nri.Ui.Header.V1 exposing
     ( view
-    , Attribute, aTagAttributes, extraContent, description, extraSubheadContent
+    , Attribute, aTagAttributes, extraContent, description, extraSubheadContent, customPageWidth
     )
 
 {-|
 
 @docs view
-@docs Attribute, aTagAttributes, extraContent, description, extraSubheadContent
+@docs Attribute, aTagAttributes, extraContent, description, extraSubheadContent, customPageWidth
 
 -}
 
@@ -52,12 +52,23 @@ description description_ =
     Attribute (\soFar -> { soFar | description = Just description_ })
 
 
+{-| By default, the content within the header will expand up to 1000px (the mobile breakpoint value).
+
+For some views, you may want to use MediaQuery.quizEngineBreakpoint instead.
+
+-}
+customPageWidth : Css.Px -> Attribute route msg
+customPageWidth pageWidth =
+    Attribute (\soFar -> { soFar | pageWidth = pageWidth })
+
+
 type alias Config route msg =
     { aTagAttributes : route -> List (Html.Attribute msg)
     , containerAttributes : List (Html.Attribute Never)
     , extraContent : List (Html msg)
     , extraSubheadContent : List (Html msg)
     , description : Maybe String
+    , pageWidth : Css.Px
     }
 
 
@@ -69,6 +80,7 @@ customize =
         , extraContent = []
         , extraSubheadContent = []
         , description = Nothing
+        , pageWidth = MediaQuery.mobileBreakpoint
         }
 
 
@@ -94,7 +106,7 @@ view attrs { breadcrumbs, isCurrentRoute } =
         ]
         [ Html.div
             (css
-                [ Spacing.centeredContentWithSidePadding
+                [ Spacing.centeredContentWithSidePaddingAndCustomWidth config.pageWidth
                 , Css.alignItems Css.center
                 , Css.displayFlex
                 , Css.paddingTop (Css.px 30)
@@ -125,15 +137,15 @@ view attrs { breadcrumbs, isCurrentRoute } =
                 ]
                 :: config.extraContent
             )
-        , viewJust viewDescription config.description
+        , viewJust (viewDescription config.pageWidth) config.description
         ]
 
 
-viewDescription : String -> Html msg
-viewDescription description_ =
+viewDescription : Css.Px -> String -> Html msg
+viewDescription pageWidth description_ =
     Text.mediumBody
         [ Text.css
-            [ Spacing.centeredContentWithSidePadding
+            [ Spacing.centeredContentWithSidePaddingAndCustomWidth pageWidth
             , Css.color Colors.gray45
             , Css.important (Css.margin Css.auto)
             , Css.important (Css.paddingBottom (Css.px 20))

--- a/src/Nri/Ui/Header/V1.elm
+++ b/src/Nri/Ui/Header/V1.elm
@@ -1,12 +1,12 @@
 module Nri.Ui.Header.V1 exposing
     ( view
-    , Attribute, aTagAttributes, extraContent
+    , Attribute, aTagAttributes, extraContent, description, extraSubheadContent
     )
 
 {-|
 
 @docs view
-@docs Attribute, aTagAttributes, extraContent
+@docs Attribute, aTagAttributes, extraContent, description, extraSubheadContent
 
 -}
 
@@ -27,6 +27,8 @@ import Nri.Ui.Text.V6 as Text
 type Attribute route msg
     = ATagAttributes (route -> List (Html.Attribute msg))
     | ExtraContent (List (Html msg))
+    | ExtraSubheadContent (List (Html msg))
+    | Description String
 
 
 {-| -}
@@ -39,6 +41,18 @@ aTagAttributes =
 extraContent : List (Html msg) -> Attribute route msg
 extraContent =
     ExtraContent
+
+
+{-| -}
+extraSubheadContent : List (Html msg) -> Attribute route msg
+extraSubheadContent =
+    ExtraSubheadContent
+
+
+{-| -}
+description : String -> Attribute route msg
+description =
+    Description
 
 
 type alias Config route msg =
@@ -70,6 +84,12 @@ customize =
 
                 ExtraContent extraContent_ ->
                     { soFar | extraContent = extraContent_ }
+
+                ExtraSubheadContent extraSubheadContent_ ->
+                    { soFar | extraSubheadContent = extraSubheadContent_ }
+
+                Description description_ ->
+                    { soFar | description = Just description_ }
         )
 
 

--- a/src/Nri/Ui/Header/V1.elm
+++ b/src/Nri/Ui/Header/V1.elm
@@ -1,35 +1,41 @@
-module Nri.Header exposing
-    ( Attribute
-    , aTagAttributes
-    , extraContent
-    , view
+module Nri.Ui.Header.V1 exposing
+    ( view
+    , Attribute, aTagAttributes, extraContent
     )
 
-{-| -}
+{-|
+
+@docs view
+@docs Attribute, aTagAttributes, extraContent
+
+-}
 
 import Accessibility.Styled as Html exposing (Html)
 import Css
 import Css.Media as Media
 import Html.Styled.Attributes exposing (css)
-import Nri.Layout as Layout
 import Nri.Ui.BreadCrumbs.V2 as BreadCrumbs exposing (BreadCrumbs)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
 import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.MediaQuery.V1 as MediaQuery
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Text.V6 as Text
 
 
+{-| -}
 type Attribute route msg
     = ATagAttributes (route -> List (Html.Attribute msg))
     | ExtraContent (List (Html msg))
 
 
+{-| -}
 aTagAttributes : (route -> List (Html.Attribute msg)) -> Attribute route msg
 aTagAttributes =
     ATagAttributes
 
 
+{-| -}
 extraContent : List (Html msg) -> Attribute route msg
 extraContent =
     ExtraContent
@@ -89,7 +95,7 @@ view attrs { breadcrumbs, isCurrentRoute } =
         ]
         [ Html.div
             (css
-                [ Layout.content
+                [ Spacing.centeredContentWithSidePadding
                 , Css.alignItems Css.center
                 , Css.displayFlex
                 , Css.paddingTop (Css.px 30)
@@ -128,7 +134,7 @@ viewDescription : String -> Html msg
 viewDescription description_ =
     Text.mediumBody
         [ Text.css
-            [ Layout.content
+            [ Spacing.centeredContentWithSidePadding
             , Css.color Colors.gray45
             , Css.important (Css.margin Css.auto)
             , Css.important (Css.paddingBottom (Css.px 20))

--- a/src/Nri/Ui/Header/V1.elm
+++ b/src/Nri/Ui/Header/V1.elm
@@ -97,11 +97,11 @@ customize =
 view :
     List (Attribute route msg)
     ->
-        { breadcrumbs : BreadCrumbs route
+        { breadCrumbs : BreadCrumbs route
         , isCurrentRoute : route -> Bool
         }
     -> Html msg
-view attrs { breadcrumbs, isCurrentRoute } =
+view attrs { breadCrumbs, isCurrentRoute } =
     let
         config =
             customize attrs
@@ -135,7 +135,7 @@ view attrs { breadcrumbs, isCurrentRoute } =
                             , aTagAttributes = config.aTagAttributes
                             , label = config.breadCrumbsLabel
                             }
-                            breadcrumbs
+                            breadCrumbs
                   in
                   case config.extraSubheadContent of
                     [] ->

--- a/src/Nri/Ui/Header/V1.elm
+++ b/src/Nri/Ui/Header/V1.elm
@@ -1,0 +1,137 @@
+module Nri.Header exposing
+    ( Attribute
+    , aTagAttributes
+    , extraContent
+    , view
+    )
+
+{-| -}
+
+import Accessibility.Styled as Html exposing (Html)
+import Css
+import Css.Media as Media
+import Html.Styled.Attributes exposing (css)
+import Nri.Layout as Layout
+import Nri.Ui.BreadCrumbs.V2 as BreadCrumbs exposing (BreadCrumbs)
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Html.Attributes.V2 as AttributesExtra
+import Nri.Ui.Html.V3 exposing (viewJust)
+import Nri.Ui.MediaQuery.V1 as MediaQuery
+import Nri.Ui.Text.V6 as Text
+
+
+type Attribute route msg
+    = ATagAttributes (route -> List (Html.Attribute msg))
+    | ExtraContent (List (Html msg))
+
+
+aTagAttributes : (route -> List (Html.Attribute msg)) -> Attribute route msg
+aTagAttributes =
+    ATagAttributes
+
+
+extraContent : List (Html msg) -> Attribute route msg
+extraContent =
+    ExtraContent
+
+
+type alias Config route msg =
+    { aTagAttributes : route -> List (Html.Attribute msg)
+    , containerAttributes : List (Html.Attribute Never)
+    , extraContent : List (Html msg)
+    , extraSubheadContent : List (Html msg)
+    , description : Maybe String
+    }
+
+
+defaultConfig : Config route msg
+defaultConfig =
+    { aTagAttributes = \_ -> []
+    , containerAttributes = []
+    , extraContent = []
+    , extraSubheadContent = []
+    , description = Nothing
+    }
+
+
+customize : Config route msg -> List (Attribute route msg) -> Config route msg
+customize =
+    List.foldl
+        (\attr soFar ->
+            case attr of
+                ATagAttributes aTagAttributes_ ->
+                    { soFar | aTagAttributes = aTagAttributes_ }
+
+                ExtraContent extraContent_ ->
+                    { soFar | extraContent = extraContent_ }
+        )
+
+
+{-| -}
+view :
+    List (Attribute route msg)
+    ->
+        { breadcrumbs : BreadCrumbs route
+        , isCurrentRoute : route -> Bool
+        }
+    -> Html msg
+view attrs { breadcrumbs, isCurrentRoute } =
+    let
+        config =
+            customize defaultConfig attrs
+    in
+    Html.div
+        [ css
+            [ Css.backgroundColor Colors.gray96
+            , Css.borderBottom3 (Css.px 1) Css.solid Colors.gray92
+            ]
+        , AttributesExtra.nriDescription "Nri-Header"
+        ]
+        [ Html.div
+            (css
+                [ Layout.content
+                , Css.alignItems Css.center
+                , Css.displayFlex
+                , Css.paddingTop (Css.px 30)
+                , Css.paddingBottom (Css.px 20)
+                , Media.withMedia [ MediaQuery.mobile ]
+                    [ Css.important (Css.padding2 (Css.px 20) (Css.px 15))
+                    , Css.flexDirection Css.column
+                    ]
+                ]
+                :: config.containerAttributes
+            )
+            (Html.div [ css [ Css.flexGrow (Css.num 1) ] ]
+                [ let
+                    breadcrumbsView =
+                        BreadCrumbs.view
+                            { isCurrentRoute = isCurrentRoute
+                            , aTagAttributes = config.aTagAttributes
+                            , label = "breadcrumbs"
+                            }
+                            breadcrumbs
+                  in
+                  case config.extraSubheadContent of
+                    [] ->
+                        breadcrumbsView
+
+                    _ ->
+                        Html.div [] (breadcrumbsView :: config.extraSubheadContent)
+                ]
+                :: config.extraContent
+            )
+        , viewJust viewDescription config.description
+        ]
+
+
+viewDescription : String -> Html msg
+viewDescription description_ =
+    Text.mediumBody
+        [ Text.css
+            [ Layout.content
+            , Css.color Colors.gray45
+            , Css.important (Css.margin Css.auto)
+            , Css.important (Css.paddingBottom (Css.px 20))
+            ]
+        , Text.plaintext description_
+        ]

--- a/src/Nri/Ui/Header/V1.elm
+++ b/src/Nri/Ui/Header/V1.elm
@@ -25,34 +25,31 @@ import Nri.Ui.Text.V6 as Text
 
 {-| -}
 type Attribute route msg
-    = ATagAttributes (route -> List (Html.Attribute msg))
-    | ExtraContent (List (Html msg))
-    | ExtraSubheadContent (List (Html msg))
-    | Description String
+    = Attribute (Config route msg -> Config route msg)
 
 
 {-| -}
 aTagAttributes : (route -> List (Html.Attribute msg)) -> Attribute route msg
-aTagAttributes =
-    ATagAttributes
+aTagAttributes aTagAttributes_ =
+    Attribute (\soFar -> { soFar | aTagAttributes = aTagAttributes_ })
 
 
 {-| -}
 extraContent : List (Html msg) -> Attribute route msg
-extraContent =
-    ExtraContent
+extraContent value =
+    Attribute (\soFar -> { soFar | extraContent = value })
 
 
 {-| -}
 extraSubheadContent : List (Html msg) -> Attribute route msg
-extraSubheadContent =
-    ExtraSubheadContent
+extraSubheadContent value =
+    Attribute (\soFar -> { soFar | extraSubheadContent = value })
 
 
 {-| -}
 description : String -> Attribute route msg
-description =
-    Description
+description description_ =
+    Attribute (\soFar -> { soFar | description = Just description_ })
 
 
 type alias Config route msg =
@@ -64,33 +61,15 @@ type alias Config route msg =
     }
 
 
-defaultConfig : Config route msg
-defaultConfig =
-    { aTagAttributes = \_ -> []
-    , containerAttributes = []
-    , extraContent = []
-    , extraSubheadContent = []
-    , description = Nothing
-    }
-
-
-customize : Config route msg -> List (Attribute route msg) -> Config route msg
+customize : List (Attribute route msg) -> Config route msg
 customize =
-    List.foldl
-        (\attr soFar ->
-            case attr of
-                ATagAttributes aTagAttributes_ ->
-                    { soFar | aTagAttributes = aTagAttributes_ }
-
-                ExtraContent extraContent_ ->
-                    { soFar | extraContent = extraContent_ }
-
-                ExtraSubheadContent extraSubheadContent_ ->
-                    { soFar | extraSubheadContent = extraSubheadContent_ }
-
-                Description description_ ->
-                    { soFar | description = Just description_ }
-        )
+    List.foldl (\(Attribute f) -> f)
+        { aTagAttributes = \_ -> []
+        , containerAttributes = []
+        , extraContent = []
+        , extraSubheadContent = []
+        , description = Nothing
+        }
 
 
 {-| -}
@@ -104,7 +83,7 @@ view :
 view attrs { breadcrumbs, isCurrentRoute } =
     let
         config =
-            customize defaultConfig attrs
+            customize attrs
     in
     Html.div
         [ css

--- a/styleguide-app/App.elm
+++ b/styleguide-app/App.elm
@@ -277,7 +277,10 @@ viewExample : Model key -> Example a Examples.Msg -> Html Msg
 viewExample model example =
     Example.view { packageDependencies = model.elliePackageDependencies } example
         |> Html.map (UpdateModuleStates example.name)
-        |> withSideNav model
+        |> viewLayout model
+            [ Example.extraSubheadContent example
+                |> Html.map (UpdateModuleStates example.name)
+            ]
 
 
 notFound : Html Msg
@@ -290,7 +293,7 @@ notFound =
 
 viewAll : Model key -> Html Msg
 viewAll model =
-    withSideNav model <|
+    viewLayout model [] <|
         viewPreviews "all"
             { navigate = Routes.Doodad >> ChangeRoute
             , exampleHref = Routes.Doodad >> Routes.toString
@@ -300,7 +303,7 @@ viewAll model =
 
 viewCategory : Model key -> Category -> Html Msg
 viewCategory model category =
-    withSideNav model
+    viewLayout model [] <|
         (model.moduleStates
             |> Dict.values
             |> List.filter
@@ -316,10 +319,10 @@ viewCategory model category =
         )
 
 
-withSideNav : Model key -> Html Msg -> Html Msg
-withSideNav model content =
+viewLayout : Model key -> List (Html Msg) -> Html Msg -> Html Msg
+viewLayout model headerExtras content =
     Html.div []
-        [ Routes.viewHeader model.route
+        [ Routes.viewHeader model.route headerExtras
         , Html.div
             [ css
                 [ displayFlex

--- a/styleguide-app/App.elm
+++ b/styleguide-app/App.elm
@@ -278,7 +278,7 @@ viewExample model example =
     Example.view { packageDependencies = model.elliePackageDependencies } example
         |> Html.map (UpdateModuleStates example.name)
         |> viewLayout model
-            [ Example.extraSubheadContent example
+            [ Example.extraLinks example
                 |> Html.map (UpdateModuleStates example.name)
             ]
 

--- a/styleguide-app/App.elm
+++ b/styleguide-app/App.elm
@@ -240,7 +240,10 @@ view model =
                 [ view_
                 , Html.map never Sprite.attach
                 , Css.Global.global (InputMethod.styles model.inputMethod)
-                , Css.Global.global [ Css.Global.everything [ Css.boxSizing Css.borderBox ] ]
+                , Css.Global.global
+                    [ Css.Global.everything [ Css.boxSizing Css.borderBox ]
+                    , Css.Global.body [ Css.margin Css.zero ]
+                    ]
                 ]
     in
     case model.route of
@@ -315,23 +318,26 @@ viewCategory model category =
 
 withSideNav : Model key -> Html Msg -> Html Msg
 withSideNav model content =
-    Html.div
-        [ css
-            [ displayFlex
-            , withMedia [ mobile ] [ flexDirection column, alignItems stretch ]
-            , alignItems flexStart
-            , Spacing.centeredContentWithSidePaddingAndCustomWidth (Css.px 1400)
-            , Spacing.pageBottomWhitespace
+    Html.div []
+        [ Routes.viewHeader model.route
+        , Html.div
+            [ css
+                [ displayFlex
+                , withMedia [ mobile ] [ flexDirection column, alignItems stretch ]
+                , alignItems flexStart
+                , Spacing.centeredContentWithSidePaddingAndCustomWidth (Css.px 1400)
+                , Spacing.pageTopWhitespace
+                , Spacing.pageBottomWhitespace
+                ]
             ]
-        ]
-        [ navigation model
-        , Html.main_
-            [ css [ flexGrow (int 1) ]
-            , id "maincontent"
-            , Key.tabbable False
-            ]
-            [ Routes.viewHeader model.route
-            , content
+            [ navigation model
+            , Html.main_
+                [ css [ flexGrow (int 1) ]
+                , id "maincontent"
+                , Key.tabbable False
+                ]
+                [ content
+                ]
             ]
         ]
 
@@ -354,7 +360,6 @@ viewPreviews containerId navConfig examples =
                 , Css.flexWrap Css.wrap
                 , Css.property "row-gap" (.value Spacing.verticalSpacerPx)
                 , Css.property "column-gap" (.value Spacing.horizontalSpacerPx)
-                , Spacing.pageTopWhitespace
                 ]
             ]
 

--- a/styleguide-app/App.elm
+++ b/styleguide-app/App.elm
@@ -330,7 +330,7 @@ withSideNav model content =
             , id "maincontent"
             , Key.tabbable False
             ]
-            [ Routes.viewBreadCrumbs model.route
+            [ Routes.viewHeader model.route
             , content
             ]
         ]

--- a/styleguide-app/CommonControls.elm
+++ b/styleguide-app/CommonControls.elm
@@ -5,7 +5,7 @@ module CommonControls exposing
     , uiIcon, rotatedUiIcon
     , customIcon
     , specificColor
-    , content
+    , content, exampleHtml
     , httpError
     , romeoAndJulietQuotation
     , disabledListItem, premiumDisplay
@@ -23,7 +23,7 @@ module CommonControls exposing
 
 ### Content
 
-@docs content
+@docs content, exampleHtml
 @docs httpError
 @docs romeoAndJulietQuotation
 

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -1,4 +1,4 @@
-module Example exposing (Example, extraSubheadContent, fullName, preview, view, wrapMsg, wrapState)
+module Example exposing (Example, extraLinks, fullName, preview, view, wrapMsg, wrapState)
 
 import Accessibility.Styled.Aria as Aria
 import Category exposing (Category)
@@ -154,8 +154,8 @@ view_ ellieLinkConfig example =
     ]
 
 
-extraSubheadContent : Example state msg -> Html msg
-extraSubheadContent example =
+extraLinks : Example state msg -> Html msg
+extraLinks example =
     Html.nav [ Aria.label (fullName example) ]
         [ Html.ul
             [ Attributes.css

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -12,7 +12,6 @@ import KeyboardSupport exposing (KeyboardSupport)
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
-import Nri.Ui.Spacing.V1 as Spacing
 
 
 type alias Example state msg =

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -1,4 +1,4 @@
-module Example exposing (Example, fullName, preview, view, wrapMsg, wrapState)
+module Example exposing (Example, extraSubheadContent, fullName, preview, view, wrapMsg, wrapState)
 
 import Accessibility.Styled.Aria as Aria
 import Category exposing (Category)
@@ -149,42 +149,35 @@ view ellieLinkConfig example =
 
 view_ : EllieLink.Config -> Example state msg -> List (Html msg)
 view_ ellieLinkConfig example =
-    let
-        navMenu items =
-            Html.nav [ Aria.label (fullName example) ]
-                [ Html.ul
-                    [ Attributes.css
-                        [ margin zero
-                        , padding zero
-                        , displayFlex
-                        , alignItems center
-                        , justifyContent flexStart
-                        , flexWrap Css.wrap
-                        ]
-                    ]
-                    (List.map
-                        (\i ->
-                            Html.li
-                                [ Attributes.css
-                                    [ Css.listStyle Css.none ]
-                                ]
-                                [ i ]
-                        )
-                        items
-                    )
-                ]
-    in
-    [ Html.div
-        [ Attributes.css
-            [ Css.padding2 Spacing.verticalSpacerPx Css.zero
-            , Css.borderBottom3 (Css.px 1) Css.solid Colors.gray92
-            ]
-        ]
-        [ navMenu [ docsLink example, srcLink example ]
-        ]
-    , KeyboardSupport.view example.keyboardSupport
+    [ KeyboardSupport.view example.keyboardSupport
     , Html.div [] (example.view ellieLinkConfig example.state)
     ]
+
+
+extraSubheadContent : Example state msg -> Html msg
+extraSubheadContent example =
+    Html.nav [ Aria.label (fullName example) ]
+        [ Html.ul
+            [ Attributes.css
+                [ margin zero
+                , padding zero
+                , displayFlex
+                , alignItems center
+                , justifyContent flexStart
+                , flexWrap Css.wrap
+                ]
+            ]
+            (List.map
+                (\i ->
+                    Html.li
+                        [ Attributes.css
+                            [ Css.listStyle Css.none ]
+                        ]
+                        [ i ]
+                )
+                [ docsLink example, srcLink example ]
+            )
+        ]
 
 
 docsLink : Example state msg -> Html msg

--- a/styleguide-app/Examples.elm
+++ b/styleguide-app/Examples.elm
@@ -17,6 +17,7 @@ import Examples.Container as Container
 import Examples.DisclosureIndicator as DisclosureIndicator
 import Examples.Divider as Divider
 import Examples.Fonts as Fonts
+import Examples.Header as Header
 import Examples.Heading as Heading
 import Examples.Highlighter as Highlighter
 import Examples.HighlighterToolbar as HighlighterToolbar
@@ -349,6 +350,25 @@ all =
             (\msg ->
                 case msg of
                     FontsState childState ->
+                        Just childState
+
+                    _ ->
+                        Nothing
+            )
+    , Header.example
+        |> Example.wrapMsg HeaderMsg
+            (\msg ->
+                case msg of
+                    HeaderMsg childMsg ->
+                        Just childMsg
+
+                    _ ->
+                        Nothing
+            )
+        |> Example.wrapState HeaderState
+            (\msg ->
+                case msg of
+                    HeaderState childState ->
                         Just childState
 
                     _ ->
@@ -925,6 +945,7 @@ type State
     | DisclosureIndicatorState DisclosureIndicator.State
     | DividerState Divider.State
     | FontsState Fonts.State
+    | HeaderState Header.State
     | HeadingState Heading.State
     | HighlighterState Highlighter.State
     | HighlighterToolbarState HighlighterToolbar.State
@@ -973,6 +994,7 @@ type Msg
     | DisclosureIndicatorMsg DisclosureIndicator.Msg
     | DividerMsg Divider.Msg
     | FontsMsg Fonts.Msg
+    | HeaderMsg Header.Msg
     | HeadingMsg Heading.Msg
     | HighlighterMsg Highlighter.Msg
     | HighlighterToolbarMsg HighlighterToolbar.Msg

--- a/styleguide-app/Examples/Header.elm
+++ b/styleguide-app/Examples/Header.elm
@@ -51,9 +51,6 @@ example =
     , view =
         \ellieLinkConfig state ->
             let
-                examples =
-                    []
-
                 attributes =
                     List.map Tuple.second (Control.currentValue state.control)
             in
@@ -68,19 +65,28 @@ example =
                 , renderExample = Code.unstyledView
                 , toExampleCode =
                     \settings ->
-                        let
-                            toExampleCode ( name, _ ) =
-                                { sectionName = name
-                                , code =
-                                    moduleName
-                                        ++ "."
-                                        ++ name
-                                        ++ "\n    [ "
-                                        ++ String.join "\n    , " (List.map Tuple.first settings)
-                                        ++ "\n    ]"
-                                }
-                        in
-                        List.map toExampleCode examples
+                        [ { sectionName = "Example"
+                          , code =
+                                Code.fromModule moduleName "view "
+                                    ++ Code.list (List.map Tuple.first settings)
+                                    ++ Code.newlineWithIndent 1
+                                    ++ Code.commentInline "See the BreadCrumbs example to more fully customize the main data in the Header"
+                                    ++ Code.recordMultiline
+                                        [ ( "breadcrumbs"
+                                          , Code.newlineWithIndent 2
+                                                ++ Code.fromModule "BreadCrumbs" "init "
+                                                ++ Code.record
+                                                    [ ( "id", Code.string "page-header" )
+                                                    , ( "text", Code.string "Page" )
+                                                    , ( "route", "()" )
+                                                    ]
+                                                ++ Code.list []
+                                          )
+                                        , ( "isCurrentRoute", Code.always "True" )
+                                        ]
+                                        1
+                          }
+                        ]
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
             , Header.view
@@ -94,9 +100,6 @@ example =
                         []
                 , isCurrentRoute = \_ -> True
                 }
-            , examples
-                |> List.map (\( name, view ) -> ( name, view attributes ))
-                |> viewExamples
             ]
     }
 

--- a/styleguide-app/Examples/Header.elm
+++ b/styleguide-app/Examples/Header.elm
@@ -89,7 +89,7 @@ example =
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
             , Header.view
-                attributes
+                (Header.breadCrumbsLabel "header example breadcrumbs" :: attributes)
                 { breadcrumbs =
                     BreadCrumbs.init
                         { id = "page-header"

--- a/styleguide-app/Examples/Header.elm
+++ b/styleguide-app/Examples/Header.elm
@@ -71,7 +71,7 @@ example =
                                     ++ Code.newlineWithIndent 1
                                     ++ Code.commentInline "See the BreadCrumbs example to more fully customize the main data in the Header"
                                     ++ Code.recordMultiline
-                                        [ ( "breadcrumbs"
+                                        [ ( "breadCrumbs"
                                           , Code.newlineWithIndent 2
                                                 ++ Code.fromModule "BreadCrumbs" "init "
                                                 ++ Code.record
@@ -90,7 +90,7 @@ example =
             , Heading.h2 [ Heading.plaintext "Example" ]
             , Header.view
                 (Header.breadCrumbsLabel "header example breadcrumbs" :: attributes)
-                { breadcrumbs =
+                { breadCrumbs =
                     BreadCrumbs.init
                         { id = "page-header"
                         , text = "Page"

--- a/styleguide-app/Examples/Header.elm
+++ b/styleguide-app/Examples/Header.elm
@@ -6,14 +6,22 @@ module Examples.Header exposing (example, State, Msg)
 
 -}
 
+import Accessibility.Styled.Role as Role
 import Category exposing (Category(..))
 import Code
 import CommonControls
+import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
+import Html.Styled exposing (..)
+import Html.Styled.Attributes exposing (css)
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Header.V1 as Header
+import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.UiIcon.V1 as UiIcon
 import ViewHelpers exposing (viewExamples)
 
 
@@ -37,7 +45,7 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview = [ viewPreview ]
     , view =
         \ellieLinkConfig state ->
             let
@@ -77,6 +85,43 @@ example =
                 |> viewExamples
             ]
     }
+
+
+viewPreview : Html msg
+viewPreview =
+    div
+        [ css
+            [ Css.height (Css.px 80)
+            , Css.backgroundColor Colors.white
+            , Css.padding (Css.px 8)
+            ]
+        , Role.presentation
+        ]
+        [ div
+            [ css
+                [ Css.backgroundColor Colors.gray96
+                ]
+            ]
+            [ div
+                [ css
+                    [ Css.color Colors.navy
+                    , Css.fontSize (Css.px 10)
+                    , Css.fontWeight Css.bold
+                    , Fonts.baseFont
+                    , Css.padding (Css.px 3)
+                    ]
+                ]
+                [ text "All"
+                , UiIcon.arrowRight
+                    |> Svg.withWidth (Css.px 8)
+                    |> Svg.withHeight (Css.px 8)
+                    |> Svg.withColor Colors.gray75
+                    |> Svg.withCss [ Css.margin2 Css.zero (Css.px 3) ]
+                    |> Svg.toHtml
+                , text "Category 1"
+                ]
+            ]
+        ]
 
 
 {-| -}

--- a/styleguide-app/Examples/Header.elm
+++ b/styleguide-app/Examples/Header.elm
@@ -17,7 +17,7 @@ import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
-import Nri.Ui.BreadCrumbs.V2 as BreadCrumbs exposing (BreadCrumbAttribute, BreadCrumbs)
+import Nri.Ui.BreadCrumbs.V2 as BreadCrumbs
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Header.V1 as Header
@@ -84,15 +84,15 @@ example =
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
             , Header.view
-                []
+                attributes
                 { breadcrumbs =
                     BreadCrumbs.init
-                        { id = "category-breadcrumb-id-1"
+                        { id = "page-header"
                         , text = "Page"
-                        , route = "/breadcrumb-category-1"
+                        , route = ()
                         }
                         []
-                , isCurrentRoute = \_ -> False
+                , isCurrentRoute = \_ -> True
                 }
             , examples
                 |> List.map (\( name, view ) -> ( name, view attributes ))
@@ -146,7 +146,38 @@ type alias State =
 
 init : State
 init =
-    { control = ControlExtra.list
+    { control =
+        ControlExtra.list
+            |> ControlExtra.optionalListItem "extraContent"
+                (Control.value
+                    ( "Header.extraContent [ Html.text \"…\" ]"
+                    , Header.extraContent CommonControls.exampleHtml
+                    )
+                )
+            |> ControlExtra.optionalListItem "description"
+                (Control.map
+                    (\value ->
+                        ( "Header.description " ++ Code.string value
+                        , Header.description value
+                        )
+                    )
+                    (Control.string "This page has some good content.")
+                )
+            |> ControlExtra.optionalListItem "extraSubheadContent"
+                (Control.value
+                    ( "Header.extraSubheadContent [ Html.text \"…\" ]"
+                    , Header.extraSubheadContent CommonControls.exampleHtml
+                    )
+                )
+            |> ControlExtra.optionalListItem "customPageWidth"
+                (Control.map
+                    (\width ->
+                        ( "Header.customPageWidth (Css.px" ++ String.fromFloat width ++ ")"
+                        , Header.customPageWidth (Css.px width)
+                        )
+                    )
+                    (ControlExtra.float 750)
+                )
     }
 
 

--- a/styleguide-app/Examples/Header.elm
+++ b/styleguide-app/Examples/Header.elm
@@ -24,7 +24,6 @@ import Nri.Ui.Header.V1 as Header
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.UiIcon.V1 as UiIcon
-import ViewHelpers exposing (viewExamples)
 
 
 moduleName : String

--- a/styleguide-app/Examples/Header.elm
+++ b/styleguide-app/Examples/Header.elm
@@ -1,0 +1,107 @@
+module Examples.Header exposing (example, State, Msg)
+
+{-|
+
+@docs example, State, Msg
+
+-}
+
+import Category exposing (Category(..))
+import Code
+import CommonControls
+import Debug.Control as Control exposing (Control)
+import Debug.Control.Extra as ControlExtra
+import Debug.Control.View as ControlView
+import Example exposing (Example)
+import Nri.Ui.Header.V1 as Header
+import ViewHelpers exposing (viewExamples)
+
+
+moduleName : String
+moduleName =
+    "Header"
+
+
+version : Int
+version =
+    1
+
+
+{-| -}
+example : Example State Msg
+example =
+    { name = moduleName
+    , version = version
+    , categories = [ Layout ]
+    , keyboardSupport = []
+    , state = init
+    , update = update
+    , subscriptions = \_ -> Sub.none
+    , preview = []
+    , view =
+        \ellieLinkConfig state ->
+            let
+                examples =
+                    []
+
+                attributes =
+                    List.map Tuple.second (Control.currentValue state.control)
+            in
+            [ ControlView.view
+                { ellieLinkConfig = ellieLinkConfig
+                , name = moduleName
+                , version = version
+                , update = UpdateControl
+                , settings = state.control
+                , mainType = Just "RootHtml.Html msg"
+                , extraCode = []
+                , renderExample = Code.unstyledView
+                , toExampleCode =
+                    \settings ->
+                        let
+                            toExampleCode ( name, _ ) =
+                                { sectionName = name
+                                , code =
+                                    moduleName
+                                        ++ "."
+                                        ++ name
+                                        ++ "\n    [ "
+                                        ++ String.join "\n    , " (List.map Tuple.first settings)
+                                        ++ "\n    ]"
+                                }
+                        in
+                        List.map toExampleCode examples
+                }
+            , examples
+                |> List.map (\( name, view ) -> ( name, view attributes ))
+                |> viewExamples
+            ]
+    }
+
+
+{-| -}
+type alias State =
+    { control : Control Settings
+    }
+
+
+init : State
+init =
+    { control = ControlExtra.list
+    }
+
+
+type alias Settings =
+    List ( String, Header.Attribute () Msg )
+
+
+{-| -}
+type Msg
+    = UpdateControl (Control Settings)
+
+
+update : Msg -> State -> ( State, Cmd Msg )
+update msg state =
+    case msg of
+        UpdateControl settings ->
+            ( { state | control = settings }, Cmd.none )

--- a/styleguide-app/Examples/Header.elm
+++ b/styleguide-app/Examples/Header.elm
@@ -17,9 +17,11 @@ import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
+import Nri.Ui.BreadCrumbs.V2 as BreadCrumbs exposing (BreadCrumbAttribute, BreadCrumbs)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Header.V1 as Header
+import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.UiIcon.V1 as UiIcon
 import ViewHelpers exposing (viewExamples)
@@ -79,6 +81,18 @@ example =
                                 }
                         in
                         List.map toExampleCode examples
+                }
+            , Heading.h2 [ Heading.plaintext "Example" ]
+            , Header.view
+                []
+                { breadcrumbs =
+                    BreadCrumbs.init
+                        { id = "category-breadcrumb-id-1"
+                        , text = "Page"
+                        , route = "/breadcrumb-category-1"
+                        }
+                        []
+                , isCurrentRoute = \_ -> False
                 }
             , examples
                 |> List.map (\( name, view ) -> ( name, view attributes ))

--- a/styleguide-app/Routes.elm
+++ b/styleguide-app/Routes.elm
@@ -102,13 +102,14 @@ fromLocation examples location =
         |> Result.withDefault All
 
 
-viewHeader : Route state msg -> Html msg2
-viewHeader currentRoute =
+viewHeader : Route state msg -> List (Html msg2) -> Html msg2
+viewHeader currentRoute subheadExtras =
     breadCrumbs currentRoute
         |> Maybe.map
             (\crumbs ->
                 Header.view
                     [ Header.aTagAttributes (\r -> [ Attributes.href ("/" ++ toString r) ])
+                    , Header.extraSubheadContent subheadExtras
                     ]
                     { breadcrumbs = crumbs
                     , isCurrentRoute = (==) currentRoute

--- a/styleguide-app/Routes.elm
+++ b/styleguide-app/Routes.elm
@@ -2,6 +2,7 @@ module Routes exposing (Route(..), fromLocation, headerId, toString, updateExamp
 
 import Accessibility.Styled as Html exposing (Html)
 import Category
+import Css
 import Dict exposing (Dict)
 import Example exposing (Example)
 import Html.Styled.Attributes as Attributes
@@ -110,6 +111,7 @@ viewHeader currentRoute extraContent =
                 Header.view
                     [ Header.aTagAttributes (\r -> [ Attributes.href ("/" ++ toString r) ])
                     , Header.extraContent extraContent
+                    , Header.customPageWidth (Css.px 1400)
                     ]
                     { breadcrumbs = crumbs
                     , isCurrentRoute = (==) currentRoute

--- a/styleguide-app/Routes.elm
+++ b/styleguide-app/Routes.elm
@@ -1,4 +1,4 @@
-module Routes exposing (Route(..), fromLocation, headerId, toString, updateExample, viewBreadCrumbs)
+module Routes exposing (Route(..), fromLocation, headerId, toString, updateExample, viewHeader)
 
 import Accessibility.Styled as Html exposing (Html)
 import Category
@@ -6,6 +6,7 @@ import Dict exposing (Dict)
 import Example exposing (Example)
 import Html.Styled.Attributes as Attributes
 import Nri.Ui.BreadCrumbs.V2 as BreadCrumbs exposing (BreadCrumbs)
+import Nri.Ui.Header.V1 as Header
 import Nri.Ui.Util exposing (dashify)
 import Parser exposing ((|.), (|=), Parser)
 import Url exposing (Url)
@@ -101,15 +102,17 @@ fromLocation examples location =
         |> Result.withDefault All
 
 
-viewBreadCrumbs : Route state msg -> Html msg2
-viewBreadCrumbs currentRoute =
+viewHeader : Route state msg -> Html msg2
+viewHeader currentRoute =
     breadCrumbs currentRoute
         |> Maybe.map
-            (BreadCrumbs.view
-                { aTagAttributes = \r -> [ Attributes.href ("/" ++ toString r) ]
-                , isCurrentRoute = (==) currentRoute
-                , label = "breadcrumbs"
-                }
+            (\crumbs ->
+                Header.view
+                    [ Header.aTagAttributes (\r -> [ Attributes.href ("/" ++ toString r) ])
+                    ]
+                    { breadcrumbs = crumbs
+                    , isCurrentRoute = (==) currentRoute
+                    }
             )
         |> Maybe.withDefault (Html.text "")
 

--- a/styleguide-app/Routes.elm
+++ b/styleguide-app/Routes.elm
@@ -113,7 +113,7 @@ viewHeader currentRoute extraContent =
                     , Header.extraContent extraContent
                     , Header.customPageWidth (Css.px 1400)
                     ]
-                    { breadcrumbs = crumbs
+                    { breadCrumbs = crumbs
                     , isCurrentRoute = (==) currentRoute
                     }
             )

--- a/styleguide-app/Routes.elm
+++ b/styleguide-app/Routes.elm
@@ -103,13 +103,13 @@ fromLocation examples location =
 
 
 viewHeader : Route state msg -> List (Html msg2) -> Html msg2
-viewHeader currentRoute subheadExtras =
+viewHeader currentRoute extraContent =
     breadCrumbs currentRoute
         |> Maybe.map
             (\crumbs ->
                 Header.view
                     [ Header.aTagAttributes (\r -> [ Attributes.href ("/" ++ toString r) ])
-                    , Header.extraSubheadContent subheadExtras
+                    , Header.extraContent extraContent
                     ]
                     { breadcrumbs = crumbs
                     , isCurrentRoute = (==) currentRoute

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -28,6 +28,7 @@
         "Nri.Ui.FocusRing.V1",
         "Nri.Ui.FocusTrap.V1",
         "Nri.Ui.Fonts.V1",
+        "Nri.Ui.Header.V1",
         "Nri.Ui.Heading.V3",
         "Nri.Ui.Highlightable.V1",
         "Nri.Ui.Highlighter.V1",

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -46,6 +46,7 @@
         "Nri.Ui.Modal.V11",
         "Nri.Ui.Page.V3",
         "Nri.Ui.Palette.V1",
+        "Nri.Ui.Panel.V1",
         "Nri.Ui.Pennant.V2",
         "Nri.Ui.PremiumCheckbox.V8",
         "Nri.Ui.RadioButton.V4",


### PR DESCRIPTION
Fixes https://github.com/NoRedInk/noredink-ui/issues/922

Extracts Nri.Header from the monolith.
Sets up for use as a reusable component, including adding an example on the styleguide.

And finally, changes the styleguide to actually _use_ the new Header component.

<img width="1536" alt="Screen Shot 2022-10-05 at 3 04 06 PM" src="https://user-images.githubusercontent.com/8811312/194163392-a77d3a14-08bb-4655-8aa3-a438bc36d3e6.png">

cc @NoRedInk/design 