### PR TITLE
add application role

### DIFF
--- a/src/Nri/Ui/Highlighter/V1.elm
+++ b/src/Nri/Ui/Highlighter/V1.elm
@@ -595,7 +595,6 @@ view_ viewSegment { id, highlightables } =
         |> p [ Html.Styled.Attributes.id id, class "highlighter-container", attribute "role" "application" ]
 
 
-
 {-| When elements are marked, wrap them in a single `mark` html node.
 -}
 groupContainer : (Highlightable marker -> Html msg) -> List (Highlightable marker) -> List (Html msg)


### PR DESCRIPTION
Fixes A11-1718 and A11-1719

Adjusts NVDA keyboard behavior, making it match VoiceOver and ChromeVox. Prevents NVDA from navigating and reading one letter at a time. Prevents loss of focus when pressing the space key.

> "Some user agents and assistive technologies have a browse mode where standard input events, such as up and down arrow key events, are intercepted and used to control a reading cursor. This browse mode behavior prevents elements that do not have a widget role from receiving and using such keyboard and gesture events to provide interactive functionality."

https://w3c.github.io/aria/#application