### PR TITLE
Tessa/organize colors

### DIFF
--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -301,4 +301,16 @@ viewColor ( name, color, description ) =
                 ]
             ]
             [ Html.text color.value ]
+        , Html.p
+            [ css
+                [ Css.fontSize (Css.px 14)
+                , Fonts.baseFont
+                , Css.margin Css.zero
+                ]
+            ]
+            [ color
+                |> Nri.Ui.Colors.Extra.fromCssColor
+                |> SolidColor.toRGBString
+                |> Html.text
+            ]
         ]

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -54,7 +54,8 @@ example =
             |> List.map viewPreviewSwatch
     , view =
         \ellieLinkConfig _ ->
-            [ viewGroupedColors colorGroupings
+            [ Heading.h2 [ Heading.plaintext "General Colors" ]
+            , viewGroupedColors colorGroupings
             , Heading.h2 [ Heading.plaintext "Background Highlight Colors" ]
             , Text.mediumBody [ Text.plaintext "Background highlights should be used as the default highlight style because they are more noticeable and readable. The dark colors should be used in the case where headings need to harmonize with highlighted containers, such as in Guided Drafts." ]
             , viewColors backgroundHighlightColors

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -62,6 +62,11 @@ example =
             , Heading.h2 [ Heading.plaintext "Text Highlight Colors" ]
             , Text.mediumBody [ Text.plaintext "Colors for highlighting text on a white background.  These colors are readable at 14px bold and bigger." ]
             , viewColors textHighlightColors
+            , Heading.h2 [ Heading.plaintext "Deprecated colors" ]
+            , viewColors
+                [ ( "magenta", Colors.magenta, "Pink highlighter" )
+                , ( "cyan", Colors.cyan, "Blue Highlighter" )
+                ]
             ]
     }
 
@@ -104,7 +109,6 @@ blueColors =
     , ( "turquoise", Colors.turquoise, "Master level 3, writing cycles" )
     , ( "turquoiseDark", Colors.turquoiseDark, "Text to pair with turquoise elements" )
     , ( "turquoiseLight", Colors.turquoiseLight, "Background to pair with turquoise elements" )
-    , ( "cyan", Colors.cyan, "Blue Highlighter" )
     ]
 
 
@@ -133,7 +137,6 @@ redColors =
     [ ( "red", Colors.red, "NoRedInk red, form warnings, practice" )
     , ( "redDark", Colors.redDark, "Red links/text, red button shadow" )
     , ( "redLight", Colors.redLight, "Red backgrounds" )
-    , ( "magenta", Colors.magenta, "Pink highlighter" )
     ]
 
 

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -15,11 +15,12 @@ import Css
 import Example exposing (Example)
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes exposing (css)
-import Nri.Ui.Colors.Extra
+import Nri.Ui.Colors.Extra exposing (fromCssColor)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Text.V6 as Text
+import SolidColor exposing (highContrast, luminance)
 
 
 type alias ColorExample =
@@ -53,7 +54,7 @@ example =
             |> List.map viewPreviewSwatch
     , view =
         \ellieLinkConfig _ ->
-            [ viewColors uncategorizedColors
+            [ viewGroupedColors colorGroupings
             , Heading.h2 [ Heading.plaintext "Background Highlight Colors" ]
             , Text.mediumBody [ Text.plaintext "Background highlights should be used as the default highlight style because they are more noticeable and readable. The dark colors should be used in the case where headings need to harmonize with highlighted containers, such as in Guided Drafts." ]
             , viewColors backgroundHighlightColors
@@ -74,8 +75,8 @@ all =
         |> List.map (\( name, val, _ ) -> ( name, val ))
 
 
-uncategorizedColors : List ( String, Css.Color, String )
-uncategorizedColors =
+grayscaleColors : List ColorExample
+grayscaleColors =
     [ ( "gray20", Colors.gray20, "Main text" )
     , ( "gray45", Colors.gray45, "Secondary text, 0-69 score" )
     , ( "gray75", Colors.gray75, "Border of form elements and tabs" )
@@ -83,18 +84,16 @@ uncategorizedColors =
     , ( "gray92", Colors.gray92, "Dvdrs/rules, incomplete assmt, inactive tabs/dsbld buttons" )
     , ( "gray96", Colors.gray96, "backgrounds/alternating rows" )
     , ( "white", Colors.white, "backgrounds, text on dark backgrounds" )
-    , ( "navy", Colors.navy, "Headings, indented compts, labels, tooltip bckgrnds" )
+    ]
+
+
+blueColors : List ColorExample
+blueColors =
+    [ ( "navy", Colors.navy, "Headings, indented compts, labels, tooltip bckgrnds" )
     , ( "azure", Colors.azure, "Buttons, other clickable stuff, links" )
     , ( "azureDark", Colors.azureDark, "Azure button shadow" )
     , ( "frost", Colors.frost, "Blue backgrounds pairing with Navy and Azure" )
     , ( "glacier", Colors.glacier, "Blue highlights/selected elements" )
-    , ( "lichen", Colors.lichen, "70-79 score" )
-    , ( "grassland", Colors.grassland, "80-89 score" )
-    , ( "green", Colors.green, "90-100 score" )
-    , ( "greenDark", Colors.greenDark, "Green button, swathes of green" )
-    , ( "greenDarkest", Colors.greenDarkest, "Green text, green button shadow" )
-    , ( "greenLight", Colors.greenLight, "Green backgrounds" )
-    , ( "greenLightest", Colors.greenLightest, "Green backgrounds" )
     , ( "cornflower", Colors.cornflower, "Mastery level 1" )
     , ( "cornflowerDark", Colors.cornflowerDark, "Mastery level 1 text" )
     , ( "cornflowerLight", Colors.cornflowerLight, "Background to pair with Cornflower elements" )
@@ -104,22 +103,65 @@ uncategorizedColors =
     , ( "turquoise", Colors.turquoise, "Master level 3, writing cycles" )
     , ( "turquoiseDark", Colors.turquoiseDark, "Text to pair with turquoise elements" )
     , ( "turquoiseLight", Colors.turquoiseLight, "Background to pair with turquoise elements" )
-    , ( "purple", Colors.purple, "Wrong, form errors, diagnostics, purple button" )
+    , ( "cyan", Colors.cyan, "Blue Highlighter" )
+    ]
+
+
+greenColors : List ColorExample
+greenColors =
+    [ ( "lichen", Colors.lichen, "70-79 score" )
+    , ( "grassland", Colors.grassland, "80-89 score" )
+    , ( "green", Colors.green, "90-100 score" )
+    , ( "greenDark", Colors.greenDark, "Green button, swathes of green" )
+    , ( "greenDarkest", Colors.greenDarkest, "Green text, green button shadow" )
+    , ( "greenLight", Colors.greenLight, "Green backgrounds" )
+    , ( "greenLightest", Colors.greenLightest, "Green backgrounds" )
+    ]
+
+
+purpleColors : List ColorExample
+purpleColors =
+    [ ( "purple", Colors.purple, "Wrong, form errors, diagnostics, purple button" )
     , ( "purpleDark", Colors.purpleDark, "Purple text, purple button shadow" )
     , ( "purpleLight", Colors.purpleLight, "Purple backgrounds" )
-    , ( "red", Colors.red, "NoRedInk red, form warnings, practice" )
+    ]
+
+
+redColors : List ColorExample
+redColors =
+    [ ( "red", Colors.red, "NoRedInk red, form warnings, practice" )
     , ( "redDark", Colors.redDark, "Red links/text, red button shadow" )
     , ( "redLight", Colors.redLight, "Red backgrounds" )
-    , ( "cyan", Colors.cyan, "Blue Highlighter" )
     , ( "magenta", Colors.magenta, "Pink highlighter" )
-    , ( "mustard", Colors.mustard, "Diagnostic assignments, some Premium elements" )
+    ]
+
+
+yellowColors : List ColorExample
+yellowColors =
+    [ ( "mustard", Colors.mustard, "Diagnostic assignments, some Premium elements" )
     , ( "ochre", Colors.ochre, "Practice assignments background color, some Premium elements" )
     , ( "ochreDark", Colors.ochreDark, "Practice assignments text color" )
     , ( "sunshine", Colors.sunshine, "Yellow highlights, tips" )
     ]
 
 
-backgroundHighlightColors : List ( String, Css.Color, String )
+colorGroupings : List ( String, List ColorExample )
+colorGroupings =
+    [ ( "Grays", grayscaleColors )
+    , ( "Blues", blueColors )
+    , ( "Greens", greenColors )
+    , ( "Purples", purpleColors )
+    , ( "Reds", redColors )
+    , ( "Yellows", yellowColors )
+    ]
+
+
+uncategorizedColors : List ColorExample
+uncategorizedColors =
+    List.concatMap Tuple.second colorGroupings
+
+
+backgroundHighlightColors : List ColorExample
 backgroundHighlightColors =
     [ ( "highlightYellow", Colors.highlightYellow, "Yellow background highlights" )
     , ( "highlightYellowDark", Colors.highlightYellowDark, "Dark yellow background highlights" )
@@ -138,7 +180,7 @@ backgroundHighlightColors =
     ]
 
 
-textHighlightColors : List ( String, Css.Color, String )
+textHighlightColors : List ColorExample
 textHighlightColors =
     [ ( "textHighlightYellow", Colors.textHighlightYellow, "Neutral text highlight #1" )
     , ( "textHighlightCyan", Colors.textHighlightCyan, "Neutral text highlight #2" )
@@ -164,6 +206,33 @@ viewPreviewSwatch ( name, color ) =
             ]
         ]
         [ Html.text name ]
+
+
+viewGroupedColors : List ( String, List ColorExample ) -> Html.Html msg
+viewGroupedColors groups =
+    let
+        viewGroup ( groupName, group ) =
+            Html.article
+                [ css
+                    [ Css.displayFlex
+                    , Css.flexWrap Css.wrap
+                    , Css.property "gap" "20px"
+                    , Css.marginBottom (Css.px 20)
+                    ]
+                ]
+                (Heading.h3
+                    [ Heading.plaintext groupName
+                    , Heading.css [ Css.width (Css.pct 100) ]
+                    ]
+                    :: (group
+                            |> List.sortBy (\( _, color, _ ) -> luminance (fromCssColor color))
+                            |> List.map viewColor
+                       )
+                )
+    in
+    groups
+        |> List.map viewGroup
+        |> Html.div [ css [ Css.margin3 (Css.px 10) Css.zero (Css.px 30) ] ]
 
 
 viewColors : List ColorExample -> Html.Html msg

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -20,7 +20,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Text.V6 as Text
-import SolidColor exposing (highContrast, luminance)
+import SolidColor exposing (luminance)
 
 
 type alias ColorExample =

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -242,6 +242,7 @@ viewGroupedColors groups =
 viewColors : List ColorExample -> Html.Html msg
 viewColors colors =
     colors
+        |> List.sortBy (\( _, color, _ ) -> luminance (fromCssColor color))
         |> List.map viewColor
         |> Html.div
             [ css

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -45,6 +45,7 @@
         "Nri.Ui.Modal.V11",
         "Nri.Ui.Page.V3",
         "Nri.Ui.Palette.V1",
+        "Nri.Ui.Panel.V1",
         "Nri.Ui.Pennant.V2",
         "Nri.Ui.PremiumCheckbox.V8",
         "Nri.Ui.RadioButton.V4",


### PR DESCRIPTION
Begin organizing color examples into smaller groups that are sorted by luminance. Also adds rgb version of the color, just in case someone is looking for a color that way instead of by hex.

### Before
<img width="374" alt="Screen Shot 2022-10-06 at 12 16 09 PM" src="https://user-images.githubusercontent.com/8811312/194388660-a5b01820-3ebd-4c78-a67b-5ed2a541ad18.png">

### After
<img width="371" alt="Screen Shot 2022-10-06 at 12 15 57 PM" src="https://user-images.githubusercontent.com/8811312/194388664-b88a1086-0020-45e8-b95b-0cb51cb62e6a.png">

cc @NoRedInk/design 