### PR TITLE
Add buffer for mobile modal height

### DIFF
--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -662,7 +662,7 @@ viewInnerContent ({ visibleTitle } as config) =
                     , Css.maxHeight
                         (Css.calc (Css.vh 100)
                             Css.minus
-                            (Css.px (footerMobileHeight + titleMobileHeight))
+                            (Css.px (footerMobileHeight + titleMobileHeight + 40))
                         )
                     ]
                 , if visibleTitle then


### PR DESCRIPTION
The variable viewport height of Mobile Safari means that you might not be able to see the entire modal unless you have scrolled, so this adds a buffer to avoid that. Before and after shown below.

https://user-images.githubusercontent.com/13528834/194604626-a7d7dea4-0fcf-4087-9738-114e22317065.mp4