### PR TITLE
TextArea.V5

### DIFF
--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -1,4 +1,5 @@
 Nri.Ui.BreadCrumbs.V1,upgrade to V2
 Nri.Ui.Checkbox.V5,upgrade to V6
+Nri.Ui.InputStyles.V3,upgrade to V4
 Nri.Ui.Tabs.V6,upgrade to V7
 Nri.Ui.TextArea.V4,upgrade to V5

--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -1,3 +1,4 @@
 Nri.Ui.BreadCrumbs.V1,upgrade to V2
 Nri.Ui.Checkbox.V5,upgrade to V6
 Nri.Ui.Tabs.V6,upgrade to V7
+Nri.Ui.TextArea.V4,upgrade to V5

--- a/elm.json
+++ b/elm.json
@@ -69,6 +69,7 @@
         "Nri.Ui.Text.V6",
         "Nri.Ui.Text.Writing.V1",
         "Nri.Ui.TextArea.V4",
+        "Nri.Ui.TextArea.V5",
         "Nri.Ui.TextInput.V7",
         "Nri.Ui.Tooltip.V3",
         "Nri.Ui.UiIcon.V1"

--- a/elm.json
+++ b/elm.json
@@ -40,6 +40,7 @@
         "Nri.Ui.Html.Attributes.V2",
         "Nri.Ui.Html.V3",
         "Nri.Ui.InputStyles.V3",
+        "Nri.Ui.InputStyles.V4",
         "Nri.Ui.Loading.V1",
         "Nri.Ui.Logo.V1",
         "Nri.Ui.MasteryIcon.V1",

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -163,6 +163,9 @@ usages = [
 [forbidden."Nri.Ui.Text.V5"]
 hint = 'upgrade to V6'
 
+[forbidden."Nri.Ui.TextArea.V4"]
+hint = 'upgrade to V5'
+
 [forbidden."Nri.Ui.TextInput.V6"]
 hint = 'upgrade to V7'
 

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -68,6 +68,10 @@ hint = 'upgrade to V5'
 [forbidden."Nri.Ui.InputStyles.V2"]
 hint = 'upgrade to V3'
 
+[forbidden."Nri.Ui.InputStyles.V3"]
+hint = 'upgrade to V4'
+usages = ['styleguide/../src/Nri/Ui/TextArea/V4.elm']
+
 [forbidden."Nri.Ui.Menu.V1"]
 hint = 'upgrade to V3'
 

--- a/lib/TextArea/V5.js
+++ b/lib/TextArea/V5.js
@@ -1,0 +1,67 @@
+CustomElement = require("../CustomElement");
+
+CustomElement.create({
+  tagName: "nri-textarea-v4",
+
+  initialize: function () {
+    this._autoresize = false;
+  },
+
+  onConnect: function () {
+    this._textarea = this.querySelector("textarea");
+    this._updateListener();
+  },
+
+  observedAttributes: ["data-autoresize"],
+
+  onAttributeChange: function (name, previous, next) {
+    if (name === "data-autoresize") {
+      this._autoresize = next !== null;
+      if (!this._textarea) return;
+      this._updateListener();
+    }
+  },
+
+  methods: {
+    _updateListener: function () {
+      if (this._autoresize) {
+        this._textarea.addEventListener("input", this._resize);
+        this._resize();
+      } else {
+        this._textarea.removeEventListener("input", this._resize);
+      }
+    },
+
+    _resize: function () {
+      var minHeight = null;
+      var computedStyles = window.getComputedStyle(this._textarea);
+
+      if (this._textarea.style.minHeight) {
+        minHeight = parseInt(this._textarea.style.minHeight, 10);
+      } else {
+        minHeight = parseInt(computedStyles.minHeight, 10);
+      }
+
+      if (minHeight === 0) {
+        minHeight = parseInt(computedStyles.height, 10);
+      }
+
+      this._textarea.style.overflowY = "hidden";
+      this._textarea.style.minHeight = minHeight + "px";
+      this._textarea.style.transition = "none";
+
+      // the browser does not include border widths in `.scrollHeight`, but we
+      // sometimes use `box-sizing: border-box` on these elements so we need to
+      // take it into account when setting the CSS `height`.
+      var borderOffset = 0;
+      if (computedStyles.boxSizing === "border-box") {
+        borderOffset =
+          parseInt(computedStyles.borderTopWidth, 10) +
+          parseInt(computedStyles.borderBottomWidth, 10);
+      }
+
+      this._textarea.style.height =
+        Math.max(minHeight, this._textarea.scrollHeight + borderOffset) + "px";
+    },
+  },
+});

--- a/lib/TextArea/V5.js
+++ b/lib/TextArea/V5.js
@@ -36,11 +36,7 @@ CustomElement.create({
       var minHeight = null;
       var computedStyles = window.getComputedStyle(this._textarea);
 
-      if (this._textarea.style.minHeight) {
-        minHeight = parseInt(this._textarea.style.minHeight, 10);
-      } else {
-        minHeight = parseInt(computedStyles.minHeight, 10);
-      }
+      minHeight = parseInt(this._textarea.style.minHeight ?? computedStyles.minHeight, 10);
 
       if (minHeight === 0) {
         minHeight = parseInt(computedStyles.height, 10);

--- a/lib/TextArea/V5.js
+++ b/lib/TextArea/V5.js
@@ -1,7 +1,7 @@
 CustomElement = require("../CustomElement");
 
 CustomElement.create({
-  tagName: "nri-textarea-v4",
+  tagName: "nri-textarea-v45",
 
   initialize: function () {
     this._autoresize = false;

--- a/lib/TextArea/V5.js
+++ b/lib/TextArea/V5.js
@@ -36,7 +36,11 @@ CustomElement.create({
       var minHeight = null;
       var computedStyles = window.getComputedStyle(this._textarea);
 
-      minHeight = parseInt(this._textarea.style.minHeight ?? computedStyles.minHeight, 10);
+      if (this._textarea.style.minHeight) {
+        minHeight = parseInt(this._textarea.style.minHeight, 10);
+      } else {
+        minHeight = parseInt(computedStyles.minHeight, 10);
+      }
 
       if (minHeight === 0) {
         minHeight = parseInt(computedStyles.height, 10);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
 require("./TextArea/V4");
+require("./TextArea/V5");
 
 exports.CustomElement = require("./CustomElement");

--- a/src/InputLabelInternal.elm
+++ b/src/InputLabelInternal.elm
@@ -12,7 +12,7 @@ import Css
 import Html.Styled.Attributes as Attributes
 import InputErrorAndGuidanceInternal exposing (ErrorState)
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.InputStyles.V3 as InputStyles exposing (Theme)
+import Nri.Ui.InputStyles.V4 as InputStyles exposing (Theme)
 
 
 {-| -}

--- a/src/Nri/Ui/FocusRing/V1.elm
+++ b/src/Nri/Ui/FocusRing/V1.elm
@@ -20,7 +20,7 @@ import Css exposing (Color)
 import Css.Global exposing (Snippet)
 import Nri.Ui.Colors.Extra exposing (toCssString)
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.InputStyles.V3 as InputStyles exposing (focusedErrorInputBoxShadow, focusedInputBoxShadow)
+import Nri.Ui.InputStyles.V4 as InputStyles exposing (focusedErrorInputBoxShadow, focusedInputBoxShadow)
 
 
 {-| When :focus-visible, add the two-tone focus ring.

--- a/src/Nri/Ui/InputStyles/V4.elm
+++ b/src/Nri/Ui/InputStyles/V4.elm
@@ -1,0 +1,277 @@
+module Nri.Ui.InputStyles.V3 exposing
+    ( label, Theme(..), input
+    , inputPaddingVertical, inputLineHeight, textAreaHeight, writingLineHeight, writingPadding, writingPaddingTop, writingMinHeight, defaultMarginTop
+    , focusedInputBoxShadow, focusedErrorInputBoxShadow, errorClass, inputClass
+    )
+
+{-| InputStyles used by the TextInput and TextArea widgets.
+
+@docs label, Theme, input
+
+
+## Shared hardcoded values
+
+@docs inputPaddingVertical, inputLineHeight, textAreaHeight, writingLineHeight, writingPadding, writingPaddingTop, writingMinHeight, defaultMarginTop
+@docs focusedInputBoxShadow, focusedErrorInputBoxShadow, errorClass, inputClass
+
+
+## Changelog
+
+  - patch: expose defaultMarginTop
+
+  - V3: add UserGenerated
+
+-}
+
+import Css exposing (..)
+import Css.Global
+import Nri.Ui.Colors.Extra as ColorsExtra
+import Nri.Ui.Colors.V1 exposing (..)
+import Nri.Ui.Fonts.V1
+
+
+{-| -}
+type Theme
+    = ContentCreation
+    | Standard
+    | UserGenerated
+    | Writing
+
+
+{-| -}
+label : Theme -> Bool -> Style
+label theme inError =
+    let
+        sharedStyles =
+            batch
+                [ backgroundColor white
+                , left (px 10)
+                , top zero
+                , fontSize (px 12)
+                , Nri.Ui.Fonts.V1.baseFont
+                , position absolute
+                , fontWeight (int 600)
+                , borderRadius (px 4)
+                , property "transition" "all 0.4s ease"
+                ]
+    in
+    case theme of
+        Standard ->
+            batch
+                [ sharedStyles
+                , padding2 (px 2) (px 5)
+                , fontSize (px 12)
+                , color navy
+                , if inError then
+                    batch [ color purple ]
+
+                  else
+                    batch []
+                ]
+
+        UserGenerated ->
+            batch
+                [ sharedStyles
+                , padding2 zero (px 5)
+                , fontSize (px 12)
+                , color navy
+                , if inError then
+                    batch [ color purple ]
+
+                  else
+                    batch []
+                ]
+
+        ContentCreation ->
+            batch
+                [ sharedStyles
+                , border3 (px 1) solid gray75
+                , borderRadius (px 4)
+                , padding2 zero (px 5)
+                , fontSize (Css.px 11)
+                , color gray45
+                , padding2 (px 2) (px 5)
+                ]
+
+        Writing ->
+            batch
+                [ sharedStyles
+                , padding2 zero (px 5)
+                , border3 (px 1) solid gray75
+                , borderRadius (px 4)
+                , fontSize (px 15)
+                , color navy
+                , if inError then
+                    batch
+                        [ color purple
+                        , backgroundColor white
+                        , borderColor purple
+                        ]
+
+                  else
+                    batch []
+                ]
+
+
+{-| -}
+defaultMarginTop : Float
+defaultMarginTop =
+    9
+
+
+{-| -}
+focusedInputBoxShadow : String
+focusedInputBoxShadow =
+    "inset 0 3px 0 0 " ++ ColorsExtra.toCssString glacier
+
+
+{-| -}
+focusedErrorInputBoxShadow : String
+focusedErrorInputBoxShadow =
+    "inset 0 3px 0 0 " ++ ColorsExtra.toCssString purpleLight
+
+
+{-| -}
+inputClass : String
+inputClass =
+    "nri-input"
+
+
+{-| -}
+errorClass : String
+errorClass =
+    "nri-input-error"
+
+
+{-| In order to use these styles in an input module, you will need to add the class "override-sass-styles". This is because sass styles in the monolith have higher precendence than the class styles here.
+-}
+input : Theme -> Style
+input theme =
+    let
+        sharedStyles =
+            batch
+                [ border3 (px 1) solid gray75
+                , width (pct 100)
+                , borderRadius (px 8)
+                , pseudoClass "placeholder"
+                    [ color gray45
+                    ]
+                , color gray20
+
+                -- fix bootstrap
+                , display inlineBlock
+                , verticalAlign top
+                , marginBottom zero
+                , marginTop (px defaultMarginTop)
+                , boxShadow6 inset zero (px 3) zero zero gray92
+                , property "transition" "border-color 0.4s ease"
+                , boxSizing borderBox
+                , focus
+                    [ borderColor azure
+                    , outline none
+                    , property "box-shadow" focusedInputBoxShadow
+                    ]
+                , Css.Global.withClass errorClass
+                    [ borderColor purple
+                    , boxShadow6 inset zero (px 3) zero zero purpleLight
+                    , focus
+                        [ borderColor purple
+                        , property "box-shadow" focusedErrorInputBoxShadow
+                        ]
+                    ]
+                ]
+    in
+    batch
+        [ Css.Global.withClass "override-sass-styles"
+            [ case theme of
+                Standard ->
+                    batch
+                        [ sharedStyles
+                        , padding2 inputPaddingVertical (px 15)
+                        , fontSize (px 15)
+                        , Nri.Ui.Fonts.V1.baseFont
+                        ]
+
+                UserGenerated ->
+                    batch
+                        [ sharedStyles
+                        , padding2 inputPaddingVertical (px 15)
+                        , fontSize (px 15)
+                        , Nri.Ui.Fonts.V1.ugFont
+                        ]
+
+                Writing ->
+                    batch
+                        [ sharedStyles
+                        , Nri.Ui.Fonts.V1.quizFont
+                        , fontSize (px 18)
+                        , lineHeight writingLineHeight
+                        , padding writingPadding
+                        , paddingTop writingPaddingTop
+                        , focus
+                            [ Css.Global.adjacentSiblings
+                                [ Css.Global.label
+                                    [ backgroundColor azure
+                                    , color white
+                                    , borderColor azure
+                                    , Css.Global.withClass errorClass
+                                        [ backgroundColor purple
+                                        , color white
+                                        , borderColor purple
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+
+                ContentCreation ->
+                    batch
+                        [ sharedStyles
+                        , padding2 inputPaddingVertical (px 15)
+                        , fontSize (px 15)
+                        , Nri.Ui.Fonts.V1.baseFont
+                        ]
+            ]
+        ]
+
+
+{-| -}
+inputPaddingVertical : Px
+inputPaddingVertical =
+    px 12
+
+
+{-| -}
+inputLineHeight : Px
+inputLineHeight =
+    px 21
+
+
+{-| -}
+textAreaHeight : Px
+textAreaHeight =
+    px 100
+
+
+{-| -}
+writingLineHeight : Px
+writingLineHeight =
+    px 27
+
+
+{-| -}
+writingPadding : Px
+writingPadding =
+    px 15
+
+
+{-| -}
+writingPaddingTop : Px
+writingPaddingTop =
+    px 20
+
+
+{-| -}
+writingMinHeight : Px
+writingMinHeight =
+    px 150

--- a/src/Nri/Ui/InputStyles/V4.elm
+++ b/src/Nri/Ui/InputStyles/V4.elm
@@ -1,10 +1,27 @@
-module Nri.Ui.InputStyles.V3 exposing
+module Nri.Ui.InputStyles.V4 exposing
     ( label, Theme(..), input
     , inputPaddingVertical, inputLineHeight, textAreaHeight, writingLineHeight, writingPadding, writingPaddingTop, writingMinHeight, defaultMarginTop
     , focusedInputBoxShadow, focusedErrorInputBoxShadow, errorClass, inputClass
     )
 
-{-| InputStyles used by the TextInput and TextArea widgets.
+{-|
+
+
+### Changes from V3
+
+    - Remove ContentCreation theme
+
+
+### Patch changes
+
+  - expose defaultMarginTop
+
+
+### Changes from V2
+
+  - adds UserGenerated
+
+InputStyles used by the TextInput and TextArea widgets.
 
 @docs label, Theme, input
 
@@ -13,13 +30,6 @@ module Nri.Ui.InputStyles.V3 exposing
 
 @docs inputPaddingVertical, inputLineHeight, textAreaHeight, writingLineHeight, writingPadding, writingPaddingTop, writingMinHeight, defaultMarginTop
 @docs focusedInputBoxShadow, focusedErrorInputBoxShadow, errorClass, inputClass
-
-
-## Changelog
-
-  - patch: expose defaultMarginTop
-
-  - V3: add UserGenerated
 
 -}
 
@@ -32,8 +42,7 @@ import Nri.Ui.Fonts.V1
 
 {-| -}
 type Theme
-    = ContentCreation
-    | Standard
+    = Standard
     | UserGenerated
     | Writing
 
@@ -80,17 +89,6 @@ label theme inError =
 
                   else
                     batch []
-                ]
-
-        ContentCreation ->
-            batch
-                [ sharedStyles
-                , border3 (px 1) solid gray75
-                , borderRadius (px 4)
-                , padding2 zero (px 5)
-                , fontSize (Css.px 11)
-                , color gray45
-                , padding2 (px 2) (px 5)
                 ]
 
         Writing ->
@@ -222,14 +220,6 @@ input theme =
                                     ]
                                 ]
                             ]
-                        ]
-
-                ContentCreation ->
-                    batch
-                        [ sharedStyles
-                        , padding2 inputPaddingVertical (px 15)
-                        , fontSize (px 15)
-                        , Nri.Ui.Fonts.V1.baseFont
                         ]
             ]
         ]

--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -57,7 +57,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.CssVendorPrefix.V1 as VendorPrefixed
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
-import Nri.Ui.InputStyles.V3 as InputStyles
+import Nri.Ui.InputStyles.V4 as InputStyles
 import Nri.Ui.Util
 import SolidColor
 

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -30,6 +30,7 @@ custom element, or else autosizing will break! This means doing the following:
 
 -}
 
+import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Style as Style
 import Css exposing (px)
 import Html.Styled as Html exposing (Html)
@@ -132,12 +133,7 @@ view_ theme model =
                     [ ( InputStyles.inputClass, True )
                     , ( InputStyles.errorClass, model.isInError )
                     ]
-                , Attributes.attribute "aria-invalid" <|
-                    if model.isInError then
-                        "true"
-
-                    else
-                        "false"
+                , Aria.invalid model.isInError
                 ]
                 []
             , Html.label

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -36,7 +36,7 @@ import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Nri.Ui.Html.Attributes.V2 as Extra
-import Nri.Ui.InputStyles.V3 as InputStyles
+import Nri.Ui.InputStyles.V4 as InputStyles
     exposing
         ( Theme(..)
         )
@@ -102,9 +102,6 @@ view_ theme model =
                     InputStyles.textAreaHeight
 
                 UserGenerated ->
-                    InputStyles.textAreaHeight
-
-                ContentCreation ->
                     InputStyles.textAreaHeight
 
                 Writing ->
@@ -191,9 +188,6 @@ calculateMinHeight textAreaStyle specifiedHeight =
                 Writing ->
                     writingSingleLineHeight
 
-                ContentCreation ->
-                    singleLineHeight
-
         DefaultHeight ->
             case textAreaStyle of
                 Standard ->
@@ -204,9 +198,6 @@ calculateMinHeight textAreaStyle specifiedHeight =
 
                 Writing ->
                     InputStyles.writingMinHeight
-
-                ContentCreation ->
-                    InputStyles.textAreaHeight
 
 
 singleLineHeight : Css.Px

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -1,7 +1,4 @@
-module Nri.Ui.TextArea.V5 exposing
-    ( view, writing, Height(..), HeightBehavior(..), Model, generateId
-    , contentCreation
-    )
+module Nri.Ui.TextArea.V5 exposing (view, writing, Height(..), HeightBehavior(..), Model, generateId)
 
 {-|
 
@@ -9,7 +6,6 @@ module Nri.Ui.TextArea.V5 exposing
 ## The next version of TextArea should:
 
   - switch to a list-based API
-  - _remove_ `contentCreation`
   - add support for `guidance`
   - add support for `errorMessage`
 
@@ -31,10 +27,6 @@ custom element, or else autosizing will break! This means doing the following:
 2.  Requiring that module in `lib/index.js`
 
 @docs view, writing, Height, HeightBehavior, Model, generateId
-
-DEPRECATED:
-
-@docs contentCreation
 
 -}
 
@@ -90,13 +82,6 @@ view model =
 writing : Model msg -> Html msg
 writing model =
     view_ Writing model
-
-
-{-| DEPRECATED: use `view` instead.
--}
-contentCreation : Model msg -> Html msg
-contentCreation model =
-    view_ ContentCreation model
 
 
 {-| -}

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -77,12 +77,12 @@ custom element, or else autosizing will break! This means doing the following:
 -}
 
 import Accessibility.Styled.Aria as Aria
-import Accessibility.Styled.Style as Style
 import Css exposing (px)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import InputErrorAndGuidanceInternal exposing (ErrorState, Guidance)
+import InputLabelInternal
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.InputStyles.V4 as InputStyles exposing (Theme(..))
 import Nri.Ui.Util exposing (dashify, removePunctuation)
@@ -105,6 +105,7 @@ type alias Config msg =
     , custom : List (Html.Attribute Never)
     , id : Maybe String
     , height : HeightBehavior
+    , disabled : Bool
     }
 
 
@@ -124,6 +125,7 @@ defaultConfig =
     , custom = []
     , id = Nothing
     , height = Fixed
+    , disabled = False
     }
 
 
@@ -370,17 +372,12 @@ view_ label config =
                 ++ List.map (Attributes.map never) config.custom
             )
             []
-        , Html.label
-            [ Attributes.for idValue
-            , Attributes.css
-                [ if config.hideLabel then
-                    Style.invisibleStyle
-
-                  else
-                    InputStyles.label config.theme isInError
-                ]
-            ]
-            [ Html.text label ]
+        , InputLabelInternal.view
+            { for = idValue
+            , label = label
+            , theme = config.theme
+            }
+            config
         , InputErrorAndGuidanceInternal.view idValue config
         ]
 

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -9,7 +9,7 @@ module Nri.Ui.TextArea.V5 exposing
     , autoResize, autoResizeSingleLine
     , custom, nriDescription, id, testId
     , placeholder, autofocus
-    , errorIf, errorMessage, guidance
+    , disabled, errorIf, errorMessage, guidance
     )
 
 {-|
@@ -24,6 +24,7 @@ module Nri.Ui.TextArea.V5 exposing
   - Changes to a list-based API
   - Adds guidance and errorMessage support
   - Adds id, custom, nriDescription, testId, css, and noMargin
+  - Adds disabled support
 
 
 ## The next version of TextArea should:
@@ -72,7 +73,7 @@ custom element, or else autosizing will break! This means doing the following:
 
 @docs custom, nriDescription, id, testId
 @docs placeholder, autofocus
-@docs errorIf, errorMessage, guidance
+@docs disabled, errorIf, errorMessage, guidance
 
 -}
 
@@ -83,6 +84,7 @@ import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import InputErrorAndGuidanceInternal exposing (ErrorState, Guidance)
 import InputLabelInternal
+import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.InputStyles.V4 as InputStyles exposing (Theme(..))
 import Nri.Ui.Util exposing (dashify, removePunctuation)
@@ -177,6 +179,13 @@ value value_ =
 placeholder : String -> Attribute msg
 placeholder text_ =
     Attribute (\soFar -> { soFar | placeholder = Just text_ })
+
+
+{-| This disables the textarea.
+-}
+disabled : Attribute msg
+disabled =
+    Attribute (\config -> { config | disabled = True })
 
 
 {-| Sets whether or not the field will be highlighted as having a validation error.
@@ -351,12 +360,22 @@ view_ label config =
 
               else
                 Css.batch []
+            , Css.batch
+                (if config.disabled then
+                    [ Css.boxShadow Css.none |> Css.important
+                    , Css.backgroundColor Colors.gray85
+                    ]
+
+                 else
+                    []
+                )
             ]
             ([ Maybe.map Events.onInput config.onInput
                 |> Maybe.withDefault Extra.none
              , Maybe.map Events.onBlur config.onBlur
                 |> Maybe.withDefault Extra.none
              , Attributes.value config.value
+             , Attributes.disabled config.disabled
              , Attributes.id idValue
              , Attributes.autofocus config.autofocus
              , Attributes.placeholder (Maybe.withDefault label config.placeholder)

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -1,6 +1,17 @@
-module Nri.Ui.TextArea.V5 exposing (view, writing, Height(..), HeightBehavior(..), Model, generateId)
+module Nri.Ui.TextArea.V5 exposing
+    ( view, Model, generateId
+    , Attribute
+    , standard, writing
+    , Height(..), HeightBehavior(..)
+    )
 
 {-|
+
+
+### Changes from V4
+
+  - Removed contentCreation view styles
+  - Changed to a list-based API
 
 
 ## The next version of TextArea should:
@@ -8,6 +19,7 @@ module Nri.Ui.TextArea.V5 exposing (view, writing, Height(..), HeightBehavior(..
   - switch to a list-based API
   - add support for `guidance`
   - add support for `errorMessage`
+  - update the disabled styles
 
 
 ## Upgrading to V4
@@ -26,7 +38,14 @@ custom element, or else autosizing will break! This means doing the following:
 1.  Creating a new module in `lib/TextArea`
 2.  Requiring that module in `lib/index.js`
 
-@docs view, writing, Height, HeightBehavior, Model, generateId
+@docs view, Model, generateId
+@docs Attribute
+
+
+## Visual behavior
+
+@docs standard, writing
+@docs Height, HeightBehavior
 
 -}
 
@@ -69,17 +88,53 @@ type Height
     | SingleLine
 
 
-{-| -}
-view : Model msg -> Html msg
-view model =
-    view_ Standard model
-
-
-{-| Used for Writing Cycles
+{-| This is private. The public API only exposes `Attribute`.
 -}
-writing : Model msg -> Html msg
-writing model =
-    view_ Writing model
+type alias Config =
+    { theme : Theme
+    }
+
+
+defaultConfig : Config
+defaultConfig =
+    { theme = Standard
+    }
+
+
+applyConfig : List Attribute -> Config
+applyConfig =
+    List.foldl (\(Attribute update) config -> update config) defaultConfig
+
+
+{-| Customizations for the TextArea.
+-}
+type Attribute
+    = Attribute (Config -> Config)
+
+
+{-| Use the Standard theme for the TextArea. This is the default.
+-}
+standard : Attribute
+standard =
+    Attribute (\soFar -> { soFar | theme = InputStyles.Standard })
+
+
+{-| Use the Writing theme for the TextArea.
+-}
+writing : Attribute
+writing =
+    Attribute (\soFar -> { soFar | theme = InputStyles.Writing })
+
+
+{-| -}
+view : Model msg -> List Attribute -> Html msg
+view model attributes =
+    let
+        config : Config
+        config =
+            applyConfig attributes
+    in
+    view_ config.theme model
 
 
 {-| -}

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -1,4 +1,4 @@
-module Nri.Ui.TextArea.V4 exposing
+module Nri.Ui.TextArea.V5 exposing
     ( view, writing, Height(..), HeightBehavior(..), Model, generateId
     , contentCreation
     )
@@ -128,7 +128,7 @@ view_ theme model =
     Html.styled Html.div
         [ Css.position Css.relative ]
         []
-        [ Html.styled (Html.node "nri-textarea-v4")
+        [ Html.styled (Html.node "nri-textarea-v5")
             [ Css.display Css.block ]
             autoresizeAttrs
             [ Html.styled Html.textarea

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -1,5 +1,5 @@
 module Nri.Ui.TextArea.V5 exposing
-    ( view, Model, generateId
+    ( view, generateId
     , Attribute
     , value
     , onInput, onBlur
@@ -50,7 +50,7 @@ custom element, or else autosizing will break! This means doing the following:
 
 ## API
 
-@docs view, Model, generateId
+@docs view, generateId
 @docs Attribute
 @docs value
 
@@ -85,11 +85,6 @@ import InputErrorAndGuidanceInternal exposing (ErrorState, Guidance)
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.InputStyles.V4 as InputStyles exposing (Theme(..))
 import Nri.Ui.Util exposing (dashify, removePunctuation)
-
-
-{-| -}
-type alias Model =
-    {}
 
 
 {-| This is private. The public API only exposes `Attribute`.
@@ -257,14 +252,14 @@ writing =
 
 
 {-| -}
-view : String -> Model -> List (Attribute msg) -> Html msg
-view label model attributes =
-    view_ label (applyConfig attributes) model
+view : String -> List (Attribute msg) -> Html msg
+view label attributes =
+    view_ label (applyConfig attributes)
 
 
 {-| -}
-view_ : String -> Config msg -> Model -> Html msg
-view_ label config model =
+view_ : String -> Config msg -> Html msg
+view_ label config =
     let
         autoresizeAttrs =
             case config.height of

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -6,6 +6,7 @@ module Nri.Ui.TextArea.V5 exposing
     , hiddenLabel, visibleLabel
     , standard, writing
     , Height(..), HeightBehavior(..)
+    , id
     , autofocus
     )
 
@@ -67,6 +68,7 @@ custom element, or else autosizing will break! This means doing the following:
 
 ### Other
 
+@docs id
 @docs autofocus
 
 -}
@@ -113,6 +115,7 @@ type alias Config msg =
     , autofocus : Bool
     , onInput : Maybe (String -> msg)
     , onBlur : Maybe msg
+    , id : Maybe String
     }
 
 
@@ -124,6 +127,7 @@ defaultConfig =
     , autofocus = False
     , onInput = Nothing
     , onBlur = Nothing
+    , id = Nothing
     }
 
 
@@ -179,6 +183,16 @@ autofocus =
     Attribute (\soFar -> { soFar | autofocus = True })
 
 
+{-| Set a custom ID for this text area. If you don't set the id explicitly,
+we'll automatically generate one from the label you pass in, but this can
+cause problems if you have more than one textarea with the same label on
+the page. Use this to be more specific and avoid issues with duplicate IDs.
+-}
+id : String -> Attribute msg
+id id_ =
+    Attribute (\soFar -> { soFar | id = Just id_ })
+
+
 {-| Use the Standard theme for the TextArea. This is the default.
 -}
 standard : Attribute msg
@@ -221,6 +235,10 @@ view_ label config model =
 
                 Writing ->
                     InputStyles.writingMinHeight
+
+        idValue : String
+        idValue =
+            Maybe.withDefault (generateId label) config.id
     in
     Html.styled (Html.node "nri-textarea-v5")
         [ Css.display Css.block, Css.position Css.relative ]
@@ -240,7 +258,7 @@ view_ label config model =
             , Maybe.map Events.onBlur config.onBlur
                 |> Maybe.withDefault Extra.none
             , Attributes.value config.value
-            , Attributes.id (generateId label)
+            , Attributes.id idValue
             , Attributes.autofocus config.autofocus
             , Attributes.placeholder model.placeholder
             , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
@@ -253,7 +271,7 @@ view_ label config model =
             ]
             []
         , Html.label
-            [ Attributes.for (generateId label)
+            [ Attributes.for idValue
             , Attributes.css
                 [ if config.hideLabel then
                     Style.invisibleStyle

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -30,16 +30,13 @@ custom element, or else autosizing will break! This means doing the following:
 
 -}
 
-import Accessibility.Styled.Style
+import Accessibility.Styled.Style as Style
 import Css exposing (px)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Nri.Ui.Html.Attributes.V2 as Extra
-import Nri.Ui.InputStyles.V4 as InputStyles
-    exposing
-        ( Theme(..)
-        )
+import Nri.Ui.InputStyles.V4 as InputStyles exposing (Theme(..))
 import Nri.Ui.Util exposing (dashify, removePunctuation)
 
 
@@ -143,20 +140,17 @@ view_ theme model =
                         "false"
                 ]
                 []
-            , if not model.showLabel then
-                Html.label
-                    ([ Attributes.for (generateId model.label)
-                     ]
-                        ++ Accessibility.Styled.Style.invisible
-                    )
-                    [ Html.text model.label ]
+            , Html.label
+                [ Attributes.for (generateId model.label)
+                , Attributes.css
+                    [ if not model.showLabel then
+                        Style.invisibleStyle
 
-              else
-                Html.label
-                    [ Attributes.for (generateId model.label)
-                    , Attributes.css [ InputStyles.label theme model.isInError ]
+                      else
+                        InputStyles.label theme model.isInError
                     ]
-                    [ Html.text model.label ]
+                ]
+                [ Html.text model.label ]
             ]
         ]
 

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -5,6 +5,7 @@ module Nri.Ui.TextArea.V5 exposing
     , hiddenLabel, visibleLabel
     , standard, writing
     , Height(..), HeightBehavior(..)
+    , autofocus
     )
 
 {-|
@@ -51,6 +52,11 @@ custom element, or else autosizing will break! This means doing the following:
 @docs standard, writing
 @docs Height, HeightBehavior
 
+
+## Other
+
+@docs autofocus
+
 -}
 
 import Accessibility.Styled.Aria as Aria
@@ -66,8 +72,7 @@ import Nri.Ui.Util exposing (dashify, removePunctuation)
 
 {-| -}
 type alias Model msg =
-    { autofocus : Bool
-    , onInput : String -> msg
+    { onInput : String -> msg
     , onBlur : Maybe msg
     , isInError : Bool
     , height : HeightBehavior
@@ -96,6 +101,7 @@ type alias Config =
     { theme : Theme
     , hideLabel : Bool
     , value : String
+    , autofocus : Bool
     }
 
 
@@ -104,6 +110,7 @@ defaultConfig =
     { theme = Standard
     , hideLabel = False
     , value = ""
+    , autofocus = False
     }
 
 
@@ -136,6 +143,13 @@ hiddenLabel =
 visibleLabel : Attribute
 visibleLabel =
     Attribute (\soFar -> { soFar | hideLabel = False })
+
+
+{-| Sets the `autofocus` attribute of the textarea to true.
+-}
+autofocus : Attribute
+autofocus =
+    Attribute (\soFar -> { soFar | autofocus = True })
 
 
 {-| Use the Standard theme for the TextArea. This is the default.
@@ -198,7 +212,7 @@ view_ config model =
             , Maybe.withDefault Extra.none (Maybe.map Events.onBlur model.onBlur)
             , Attributes.value config.value
             , Attributes.id (generateId model.label)
-            , Attributes.autofocus model.autofocus
+            , Attributes.autofocus config.autofocus
             , Attributes.placeholder model.placeholder
             , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
             , Attributes.class "override-sass-styles custom-focus-ring"

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -1,0 +1,240 @@
+module Nri.Ui.TextArea.V4 exposing
+    ( view, writing, Height(..), HeightBehavior(..), Model, generateId
+    , contentCreation
+    )
+
+{-|
+
+
+## The next version of TextArea should:
+
+  - switch to a list-based API
+  - _remove_ `contentCreation`
+  - add support for `guidance`
+  - add support for `errorMessage`
+
+
+## Upgrading to V4
+
+  - Adds field for onBlur
+
+
+## The Nri styleguide-specified textarea with overlapping label
+
+
+## Creating New Versions
+
+When upgrading this module, we need to make sure to also include a new
+custom element, or else autosizing will break! This means doing the following:
+
+1.  Creating a new module in `lib/TextArea`
+2.  Requiring that module in `lib/index.js`
+
+@docs view, writing, Height, HeightBehavior, Model, generateId
+
+DEPRECATED:
+
+@docs contentCreation
+
+-}
+
+import Accessibility.Styled.Style
+import Css exposing (px)
+import Html.Styled as Html exposing (Html)
+import Html.Styled.Attributes as Attributes
+import Html.Styled.Events as Events
+import Nri.Ui.Html.Attributes.V2 as Extra
+import Nri.Ui.InputStyles.V3 as InputStyles
+    exposing
+        ( Theme(..)
+        )
+import Nri.Ui.Util exposing (dashify, removePunctuation)
+
+
+{-| -}
+type alias Model msg =
+    { value : String
+    , autofocus : Bool
+    , onInput : String -> msg
+    , onBlur : Maybe msg
+    , isInError : Bool
+    , height : HeightBehavior
+    , placeholder : String
+    , label : String
+    , showLabel : Bool
+    }
+
+
+{-| Control whether to auto-expand the height.
+-}
+type HeightBehavior
+    = Fixed
+    | AutoResize Height
+
+
+{-| For specifying the actual height.
+-}
+type Height
+    = DefaultHeight
+    | SingleLine
+
+
+{-| -}
+view : Model msg -> Html msg
+view model =
+    view_ Standard model
+
+
+{-| Used for Writing Cycles
+-}
+writing : Model msg -> Html msg
+writing model =
+    view_ Writing model
+
+
+{-| DEPRECATED: use `view` instead.
+-}
+contentCreation : Model msg -> Html msg
+contentCreation model =
+    view_ ContentCreation model
+
+
+{-| -}
+view_ : Theme -> Model msg -> Html msg
+view_ theme model =
+    let
+        autoresizeAttrs =
+            case model.height of
+                AutoResize _ ->
+                    [ Attributes.attribute "data-autoresize" "" ]
+
+                Fixed ->
+                    []
+
+        heightForStyle =
+            case theme of
+                Standard ->
+                    InputStyles.textAreaHeight
+
+                UserGenerated ->
+                    InputStyles.textAreaHeight
+
+                ContentCreation ->
+                    InputStyles.textAreaHeight
+
+                Writing ->
+                    InputStyles.writingMinHeight
+    in
+    Html.styled Html.div
+        [ Css.position Css.relative ]
+        []
+        [ Html.styled (Html.node "nri-textarea-v4")
+            [ Css.display Css.block ]
+            autoresizeAttrs
+            [ Html.styled Html.textarea
+                [ InputStyles.input theme
+                , Css.boxSizing Css.borderBox
+                , case model.height of
+                    AutoResize minimumHeight ->
+                        Css.minHeight (calculateMinHeight theme minimumHeight)
+
+                    Fixed ->
+                        Css.minHeight heightForStyle
+                ]
+                [ Events.onInput model.onInput
+                , Maybe.withDefault Extra.none (Maybe.map Events.onBlur model.onBlur)
+                , Attributes.value model.value
+                , Attributes.id (generateId model.label)
+                , Attributes.autofocus model.autofocus
+                , Attributes.placeholder model.placeholder
+                , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
+                , Attributes.class "override-sass-styles custom-focus-ring"
+                , Attributes.classList
+                    [ ( InputStyles.inputClass, True )
+                    , ( InputStyles.errorClass, model.isInError )
+                    ]
+                , Attributes.attribute "aria-invalid" <|
+                    if model.isInError then
+                        "true"
+
+                    else
+                        "false"
+                ]
+                []
+            , if not model.showLabel then
+                Html.label
+                    ([ Attributes.for (generateId model.label)
+                     ]
+                        ++ Accessibility.Styled.Style.invisible
+                    )
+                    [ Html.text model.label ]
+
+              else
+                Html.label
+                    [ Attributes.for (generateId model.label)
+                    , Attributes.css [ InputStyles.label theme model.isInError ]
+                    ]
+                    [ Html.text model.label ]
+            ]
+        ]
+
+
+calculateMinHeight : Theme -> Height -> Css.Px
+calculateMinHeight textAreaStyle specifiedHeight =
+    {- On including padding in this calculation:
+
+       When the textarea is autoresized, TextArea.js updates the textarea's
+       height by taking its scrollHeight. Because scrollHeight's calculation
+       includes the element's padding no matter what [1], we need to set the
+       textarea's box-sizing to border-box in order to use the same measurement
+       for its height as scrollHeight.
+
+       So, min-height also needs to be specified in terms of padding + content
+       height.
+
+       [1] https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight
+    -}
+    case specifiedHeight of
+        SingleLine ->
+            case textAreaStyle of
+                Standard ->
+                    singleLineHeight
+
+                UserGenerated ->
+                    singleLineHeight
+
+                Writing ->
+                    writingSingleLineHeight
+
+                ContentCreation ->
+                    singleLineHeight
+
+        DefaultHeight ->
+            case textAreaStyle of
+                Standard ->
+                    InputStyles.textAreaHeight
+
+                UserGenerated ->
+                    InputStyles.textAreaHeight
+
+                Writing ->
+                    InputStyles.writingMinHeight
+
+                ContentCreation ->
+                    InputStyles.textAreaHeight
+
+
+singleLineHeight : Css.Px
+singleLineHeight =
+    px (.numericValue InputStyles.inputPaddingVertical + .numericValue InputStyles.inputLineHeight + .numericValue InputStyles.inputPaddingVertical)
+
+
+writingSingleLineHeight : Css.Px
+writingSingleLineHeight =
+    px (.numericValue InputStyles.writingPaddingTop + .numericValue InputStyles.writingLineHeight + .numericValue InputStyles.writingPadding)
+
+
+{-| -}
+generateId : String -> String
+generateId labelText =
+    "nri-ui-text-area-" ++ (dashify <| removePunctuation labelText)

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -87,7 +87,6 @@ type alias Model =
     { isInError : Bool
     , height : HeightBehavior
     , placeholder : String
-    , label : String
     }
 
 
@@ -195,14 +194,14 @@ writing =
 
 
 {-| -}
-view : Model -> List (Attribute msg) -> Html msg
-view model attributes =
-    view_ (applyConfig attributes) model
+view : String -> Model -> List (Attribute msg) -> Html msg
+view label model attributes =
+    view_ label (applyConfig attributes) model
 
 
 {-| -}
-view_ : Config msg -> Model -> Html msg
-view_ config model =
+view_ : String -> Config msg -> Model -> Html msg
+view_ label config model =
     let
         autoresizeAttrs =
             case model.height of
@@ -241,7 +240,7 @@ view_ config model =
             , Maybe.map Events.onBlur config.onBlur
                 |> Maybe.withDefault Extra.none
             , Attributes.value config.value
-            , Attributes.id (generateId model.label)
+            , Attributes.id (generateId label)
             , Attributes.autofocus config.autofocus
             , Attributes.placeholder model.placeholder
             , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
@@ -254,7 +253,7 @@ view_ config model =
             ]
             []
         , Html.label
-            [ Attributes.for (generateId model.label)
+            [ Attributes.for (generateId label)
             , Attributes.css
                 [ if config.hideLabel then
                     Style.invisibleStyle
@@ -263,7 +262,7 @@ view_ config model =
                     InputStyles.label config.theme model.isInError
                 ]
             ]
-            [ Html.text model.label ]
+            [ Html.text label ]
         ]
 
 

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -7,7 +7,7 @@ module Nri.Ui.TextArea.V5 exposing
     , standard, writing
     , Height(..), HeightBehavior(..)
     , id
-    , autofocus
+    , placeholder, autofocus
     )
 
 {-|
@@ -69,7 +69,7 @@ custom element, or else autosizing will break! This means doing the following:
 ### Other
 
 @docs id
-@docs autofocus
+@docs placeholder, autofocus
 
 -}
 
@@ -88,7 +88,6 @@ import Nri.Ui.Util exposing (dashify, removePunctuation)
 type alias Model =
     { isInError : Bool
     , height : HeightBehavior
-    , placeholder : String
     }
 
 
@@ -115,6 +114,7 @@ type alias Config msg =
     , autofocus : Bool
     , onInput : Maybe (String -> msg)
     , onBlur : Maybe msg
+    , placeholder : Maybe String
     , id : Maybe String
     }
 
@@ -127,6 +127,7 @@ defaultConfig =
     , autofocus = False
     , onInput = Nothing
     , onBlur = Nothing
+    , placeholder = Nothing
     , id = Nothing
     }
 
@@ -146,6 +147,13 @@ type Attribute msg
 value : String -> Attribute msg
 value value_ =
     Attribute (\soFar -> { soFar | value = value_ })
+
+
+{-| If no explicit placeholder is given, the input label will be used as the placeholder.
+-}
+placeholder : String -> Attribute msg
+placeholder text_ =
+    Attribute (\soFar -> { soFar | placeholder = Just text_ })
 
 
 {-| Hides the visible label. (There will still be an invisible label for screen readers.)
@@ -260,7 +268,7 @@ view_ label config model =
             , Attributes.value config.value
             , Attributes.id idValue
             , Attributes.autofocus config.autofocus
-            , Attributes.placeholder model.placeholder
+            , Attributes.placeholder (Maybe.withDefault label config.placeholder)
             , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
             , Attributes.class "override-sass-styles custom-focus-ring"
             , Attributes.classList

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -105,49 +105,45 @@ view_ theme model =
                 Writing ->
                     InputStyles.writingMinHeight
     in
-    Html.styled Html.div
-        [ Css.position Css.relative ]
-        []
-        [ Html.styled (Html.node "nri-textarea-v5")
-            [ Css.display Css.block ]
-            autoresizeAttrs
-            [ Html.styled Html.textarea
-                [ InputStyles.input theme
-                , Css.boxSizing Css.borderBox
-                , case model.height of
-                    AutoResize minimumHeight ->
-                        Css.minHeight (calculateMinHeight theme minimumHeight)
+    Html.styled (Html.node "nri-textarea-v5")
+        [ Css.display Css.block, Css.position Css.relative ]
+        autoresizeAttrs
+        [ Html.styled Html.textarea
+            [ InputStyles.input theme
+            , Css.boxSizing Css.borderBox
+            , case model.height of
+                AutoResize minimumHeight ->
+                    Css.minHeight (calculateMinHeight theme minimumHeight)
 
-                    Fixed ->
-                        Css.minHeight heightForStyle
-                ]
-                [ Events.onInput model.onInput
-                , Maybe.withDefault Extra.none (Maybe.map Events.onBlur model.onBlur)
-                , Attributes.value model.value
-                , Attributes.id (generateId model.label)
-                , Attributes.autofocus model.autofocus
-                , Attributes.placeholder model.placeholder
-                , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
-                , Attributes.class "override-sass-styles custom-focus-ring"
-                , Attributes.classList
-                    [ ( InputStyles.inputClass, True )
-                    , ( InputStyles.errorClass, model.isInError )
-                    ]
-                , Aria.invalid model.isInError
-                ]
-                []
-            , Html.label
-                [ Attributes.for (generateId model.label)
-                , Attributes.css
-                    [ if not model.showLabel then
-                        Style.invisibleStyle
-
-                      else
-                        InputStyles.label theme model.isInError
-                    ]
-                ]
-                [ Html.text model.label ]
+                Fixed ->
+                    Css.minHeight heightForStyle
             ]
+            [ Events.onInput model.onInput
+            , Maybe.withDefault Extra.none (Maybe.map Events.onBlur model.onBlur)
+            , Attributes.value model.value
+            , Attributes.id (generateId model.label)
+            , Attributes.autofocus model.autofocus
+            , Attributes.placeholder model.placeholder
+            , Attributes.attribute "data-gramm" "false" -- disables grammarly to prevent https://github.com/NoRedInk/NoRedInk/issues/14859
+            , Attributes.class "override-sass-styles custom-focus-ring"
+            , Attributes.classList
+                [ ( InputStyles.inputClass, True )
+                , ( InputStyles.errorClass, model.isInError )
+                ]
+            , Aria.invalid model.isInError
+            ]
+            []
+        , Html.label
+            [ Attributes.for (generateId model.label)
+            , Attributes.css
+                [ if not model.showLabel then
+                    Style.invisibleStyle
+
+                  else
+                    InputStyles.label theme model.isInError
+                ]
+            ]
+            [ Html.text model.label ]
         ]
 
 

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -89,8 +89,7 @@ import Nri.Ui.Util exposing (dashify, removePunctuation)
 
 {-| -}
 type alias Model =
-    { isInError : Bool
-    }
+    {}
 
 
 {-| This is private. The public API only exposes `Attribute`.
@@ -318,7 +317,7 @@ view_ label config model =
             , Attributes.class "override-sass-styles custom-focus-ring"
             , Attributes.classList
                 [ ( InputStyles.inputClass, True )
-                , ( InputStyles.errorClass, model.isInError )
+                , ( InputStyles.errorClass, isInError )
                 ]
             , Aria.invalid isInError
             , InputErrorAndGuidanceInternal.describedBy idValue config
@@ -331,7 +330,7 @@ view_ label config model =
                     Style.invisibleStyle
 
                   else
-                    InputStyles.label config.theme model.isInError
+                    InputStyles.label config.theme isInError
                 ]
             ]
             [ Html.text label ]

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -1,6 +1,7 @@
 module Nri.Ui.TextArea.V5 exposing
     ( view, Model, generateId
     , Attribute
+    , value
     , hiddenLabel, visibleLabel
     , standard, writing
     , Height(..), HeightBehavior(..)
@@ -41,6 +42,7 @@ custom element, or else autosizing will break! This means doing the following:
 
 @docs view, Model, generateId
 @docs Attribute
+@docs value
 
 
 ## Visual behavior
@@ -64,8 +66,7 @@ import Nri.Ui.Util exposing (dashify, removePunctuation)
 
 {-| -}
 type alias Model msg =
-    { value : String
-    , autofocus : Bool
+    { autofocus : Bool
     , onInput : String -> msg
     , onBlur : Maybe msg
     , isInError : Bool
@@ -94,6 +95,7 @@ type Height
 type alias Config =
     { theme : Theme
     , hideLabel : Bool
+    , value : String
     }
 
 
@@ -101,6 +103,7 @@ defaultConfig : Config
 defaultConfig =
     { theme = Standard
     , hideLabel = False
+    , value = ""
     }
 
 
@@ -113,6 +116,12 @@ applyConfig =
 -}
 type Attribute
     = Attribute (Config -> Config)
+
+
+{-| -}
+value : String -> Attribute
+value value_ =
+    Attribute (\soFar -> { soFar | value = value_ })
 
 
 {-| Hides the visible label. (There will still be an invisible label for screen readers.)
@@ -187,7 +196,7 @@ view_ config model =
             ]
             [ Events.onInput model.onInput
             , Maybe.withDefault Extra.none (Maybe.map Events.onBlur model.onBlur)
-            , Attributes.value model.value
+            , Attributes.value config.value
             , Attributes.id (generateId model.label)
             , Attributes.autofocus model.autofocus
             , Attributes.placeholder model.placeholder

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -465,7 +465,7 @@ value value_ =
     Attribute { emptyEventsAndValues | currentValue = Just value_ } identity
 
 
-{-| If not explicit placeholder is given, the input label will be used as the placeholder.
+{-| If no explicit placeholder is given, the input label will be used as the placeholder.
 -}
 placeholder : String -> Attribute value msg
 placeholder text_ =

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -63,7 +63,7 @@ import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as Extra
-import Nri.Ui.InputStyles.V3 as InputStyles exposing (defaultMarginTop)
+import Nri.Ui.InputStyles.V4 as InputStyles exposing (defaultMarginTop)
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Nri.Ui.Util exposing (dashify)

--- a/styleguide-app/CommonControls.elm
+++ b/styleguide-app/CommonControls.elm
@@ -8,6 +8,7 @@ module CommonControls exposing
     , content
     , httpError
     , romeoAndJulietQuotation
+    , guidanceAndErrorMessage
     , disabledListItem, premiumDisplay
     )
 
@@ -26,9 +27,11 @@ module CommonControls exposing
 @docs content
 @docs httpError
 @docs romeoAndJulietQuotation
+@docs guidanceAndErrorMessage
 
 -}
 
+import Code
 import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
@@ -394,3 +397,32 @@ css_ helperName ( styles, default ) { moduleName, use } =
             , use default
             )
         )
+
+
+guidanceAndErrorMessage :
+    { moduleName : String
+    , guidance : String -> b
+    , errorMessage : Maybe String -> b
+    , message : String
+    }
+    -> Control (List ( String, b ))
+    -> Control (List ( String, b ))
+guidanceAndErrorMessage { moduleName, guidance, errorMessage, message } =
+    ControlExtra.optionalListItem "guidance"
+        (Control.string message
+            |> Control.map
+                (\str ->
+                    ( Code.fromModule moduleName "guidance " ++ Code.string str
+                    , guidance str
+                    )
+                )
+        )
+        >> ControlExtra.optionalListItem "errorMessage"
+            (Control.map
+                (\str ->
+                    ( Code.fromModule moduleName "errorMessage " ++ Code.withParens (Code.maybeString (Just str))
+                    , errorMessage (Just str)
+                    )
+                )
+                (Control.string message)
+            )

--- a/styleguide-app/Examples/RadioButton.elm
+++ b/styleguide-app/Examples/RadioButton.elm
@@ -294,26 +294,12 @@ controlAttributes =
                 ]
             )
         |> ControlExtra.optionalListItem "disclosure" controlDisclosure
-        |> ControlExtra.optionalListItem "errorMessage"
-            (Control.map
-                (\message ->
-                    ( "RadioButton.errorMessage (Just \"" ++ message ++ "\")"
-                    , RadioButton.errorMessage (Just message)
-                    )
-                )
-             <|
-                Control.string "The statement must be true."
-            )
-        |> ControlExtra.optionalListItem "guidance"
-            (Control.map
-                (\content ->
-                    ( "RadioButton.guidance \"" ++ content ++ "\""
-                    , RadioButton.guidance content
-                    )
-                )
-             <|
-                Control.string "The statement must be true."
-            )
+        |> CommonControls.guidanceAndErrorMessage
+            { moduleName = moduleName
+            , guidance = RadioButton.guidance
+            , errorMessage = RadioButton.errorMessage
+            , message = "The statement must be true."
+            }
 
 
 labelVisibility : Control ( String, RadioButton.Attribute Selection Msg )

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -9,6 +9,7 @@ module Examples.Select exposing (Msg, State, example)
 import Accessibility.Styled.Key as Key
 import Category exposing (Category(..))
 import Code
+import CommonControls
 import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
@@ -153,25 +154,12 @@ initControls =
                 )
                 (Control.bool True)
             )
-        |> ControlExtra.optionalListItem "errorMessage"
-            (Control.map
-                (\str ->
-                    ( "Select.errorMessage (Just \"" ++ str ++ "\")"
-                    , Select.errorMessage (Just str)
-                    )
-                )
-                (Control.string "The right item must be selected.")
-            )
-        |> ControlExtra.optionalListItem "guidance"
-            (Control.map
-                (\str ->
-                    ( "Select.guidance \"" ++ str ++ "\""
-                    , Select.guidance str
-                    )
-                )
-             <|
-                Control.string "The right item must be selected."
-            )
+        |> CommonControls.guidanceAndErrorMessage
+            { moduleName = moduleName
+            , guidance = Select.guidance
+            , errorMessage = Select.errorMessage
+            , message = "The right item must be selected."
+            }
         |> ControlExtra.optionalListItem "disabled"
             (Control.value ( "Select.disabled", Select.disabled ))
         |> ControlExtra.optionalListItem "loading"

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -17,7 +17,7 @@ import Html.Styled.Attributes as Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.InputStyles.V3 as InputStyles exposing (Theme(..))
-import Nri.Ui.TextArea.V4 as TextArea
+import Nri.Ui.TextArea.V5 as TextArea
 
 
 moduleName : String
@@ -27,7 +27,7 @@ moduleName =
 
 version : Int
 version =
-    4
+    5
 
 
 {-| -}

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -16,7 +16,7 @@ import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
-import Nri.Ui.InputStyles.V3 as InputStyles exposing (Theme(..))
+import Nri.Ui.InputStyles.V4 as InputStyles exposing (Theme(..))
 import Nri.Ui.TextArea.V5 as TextArea
 
 

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -8,6 +8,7 @@ module Examples.TextArea exposing (Msg, State, example)
 
 import Category exposing (Category(..))
 import Code
+import CommonControls
 import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
@@ -72,10 +73,7 @@ example =
 
                 toExampleCode name =
                     [ moduleName ++ "." ++ name ++ " " ++ Code.string settings.label
-                    , Code.record
-                        [ ( "isInError", Code.bool settings.isInError )
-                        , ( "height", Tuple.first settings.height )
-                        ]
+                    , Code.record [ ( "isInError", Code.bool settings.isInError ) ]
                     , Code.list <|
                         ("TextArea.value " ++ Code.string state.value)
                             :: "TextArea.onInput identity"
@@ -102,7 +100,6 @@ example =
             , Heading.h2 [ Heading.plaintext "Example" ]
             , TextArea.view settings.label
                 { isInError = settings.isInError
-                , height = Tuple.second settings.height
                 }
                 (TextArea.value state.value
                     :: TextArea.onInput UpdateValue
@@ -136,7 +133,6 @@ type alias Settings =
 type alias Settings_ =
     { label : String
     , isInError : Bool
-    , height : ( String, TextArea.HeightBehavior )
     }
 
 
@@ -145,9 +141,9 @@ controlAttributes =
     ControlExtra.list
         |> ControlExtra.optionalListItem
             "theme"
-            (Control.choice
-                [ ( "standard", Control.value ( "TextArea.standard", TextArea.standard ) )
-                , ( "writing", Control.value ( "TextArea.writing", TextArea.writing ) )
+            (CommonControls.choice moduleName
+                [ ( "standard", TextArea.standard )
+                , ( "writing", TextArea.writing )
                 ]
             )
         |> ControlExtra.optionalBoolListItem "onBlur"
@@ -163,38 +159,25 @@ controlAttributes =
                         )
                     )
             )
+        |> ControlExtra.optionalListItem "height"
+            (CommonControls.choice moduleName
+                [ ( "autoResize", TextArea.autoResize )
+                , ( "autoResizeSingleLine", TextArea.autoResizeSingleLine )
+                ]
+            )
 
 
 initControls : Control Settings
 initControls =
     Control.record
-        (\attributes label isInError height ->
-            ( Settings_ label isInError height
+        (\attributes label isInError ->
+            ( Settings_ label isInError
             , attributes
             )
         )
         |> Control.field "attributes" controlAttributes
         |> Control.field "label" (Control.string "Introductory paragraph")
         |> Control.field "isInError" (Control.bool False)
-        |> Control.field "height"
-            (Control.choice
-                [ ( "fixed"
-                  , Control.value ( "TextArea.Fixed", TextArea.Fixed )
-                  )
-                , ( "autoresize default"
-                  , Control.value
-                        ( Code.withParens "TextArea.AutoResize TextArea.DefaultHeight"
-                        , TextArea.AutoResize TextArea.DefaultHeight
-                        )
-                  )
-                , ( "autoresize singleline"
-                  , Control.value
-                        ( Code.withParens "TextArea.AutoResize TextArea.SingleLine"
-                        , TextArea.AutoResize TextArea.SingleLine
-                        )
-                  )
-                ]
-            )
 
 
 {-| -}

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -73,7 +73,7 @@ example =
 
                 toExampleCode name =
                     [ moduleName ++ "." ++ name ++ " " ++ Code.string settings.label
-                    , Code.record [ ( "isInError", Code.bool settings.isInError ) ]
+                    , Code.record []
                     , Code.list <|
                         ("TextArea.value " ++ Code.string state.value)
                             :: "TextArea.onInput identity"
@@ -99,8 +99,7 @@ example =
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
             , TextArea.view settings.label
-                { isInError = settings.isInError
-                }
+                {}
                 (TextArea.value state.value
                     :: TextArea.onInput UpdateValue
                     :: List.map Tuple.second attributes
@@ -132,7 +131,6 @@ type alias Settings =
 
 type alias Settings_ =
     { label : String
-    , isInError : Bool
     }
 
 
@@ -165,19 +163,24 @@ controlAttributes =
                 , ( "autoResizeSingleLine", TextArea.autoResizeSingleLine )
                 ]
             )
+        |> CommonControls.guidanceAndErrorMessage
+            { moduleName = moduleName
+            , guidance = TextArea.guidance
+            , errorMessage = TextArea.errorMessage
+            , message = "The statement must be true."
+            }
 
 
 initControls : Control Settings
 initControls =
     Control.record
-        (\attributes label isInError ->
-            ( Settings_ label isInError
+        (\attributes label ->
+            ( Settings_ label
             , attributes
             )
         )
         |> Control.field "attributes" controlAttributes
         |> Control.field "label" (Control.string "Introductory paragraph")
-        |> Control.field "isInError" (Control.bool False)
 
 
 {-| -}

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -162,6 +162,8 @@ controlAttributes =
             , errorMessage = TextArea.errorMessage
             , message = "The statement must be true."
             }
+        |> ControlExtra.optionalBoolListItem "disabled"
+            ( "TextArea.disabled", TextArea.disabled )
         |> ControlExtra.optionalBoolListItem "noMargin"
             ( "TextArea.noMargin True", TextArea.noMargin True )
         |> ControlExtra.optionalBoolListItem "css"

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -75,7 +75,6 @@ example =
                     , Code.record
                         [ ( "isInError", Code.bool settings.isInError )
                         , ( "height", Tuple.first settings.height )
-                        , ( "placeholder", Code.string settings.placeholder )
                         ]
                     , Code.list <|
                         ("TextArea.value " ++ Code.string state.value)
@@ -104,7 +103,6 @@ example =
             , TextArea.view settings.label
                 { isInError = settings.isInError
                 , height = Tuple.second settings.height
-                , placeholder = settings.placeholder
                 }
                 (TextArea.value state.value
                     :: TextArea.onInput UpdateValue
@@ -137,7 +135,6 @@ type alias Settings =
 
 type alias Settings_ =
     { label : String
-    , placeholder : String
     , isInError : Bool
     , height : ( String, TextArea.HeightBehavior )
     }
@@ -157,19 +154,27 @@ controlAttributes =
             ( "TextArea.onBlur " ++ Code.string "Neener neener Blur happened"
             , TextArea.onBlur (UpdateValue "Neener neener Blur happened")
             )
+        |> ControlExtra.optionalListItem "placeholder"
+            (Control.string "A long time ago, in a galaxy pretty near here actually..."
+                |> Control.map
+                    (\str ->
+                        ( "TextArea.placeholder " ++ Code.string str
+                        , TextArea.placeholder str
+                        )
+                    )
+            )
 
 
 initControls : Control Settings
 initControls =
     Control.record
-        (\attributes label placeholder isInError height ->
-            ( Settings_ label placeholder isInError height
+        (\attributes label isInError height ->
+            ( Settings_ label isInError height
             , attributes
             )
         )
         |> Control.field "attributes" controlAttributes
         |> Control.field "label" (Control.string "Introductory paragraph")
-        |> Control.field "placeholder" (Control.string "A long time ago, in a galaxy pretty near here actually...")
         |> Control.field "isInError" (Control.bool False)
         |> Control.field "height"
             (Control.choice

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -10,6 +10,7 @@ import Category exposing (Category(..))
 import Code
 import Css
 import Debug.Control as Control exposing (Control)
+import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled as Html
@@ -87,7 +88,6 @@ example =
                         , ( "label", Code.string settings.label )
                         , ( "height", Tuple.first settings.height )
                         , ( "placeholder", Code.string settings.placeholder )
-                        , ( "showLabel", Code.bool settings.showLabel )
                         ]
                     , Code.list <| List.map Tuple.first attributes
                     ]
@@ -124,7 +124,6 @@ example =
                 , label = settings.label
                 , height = Tuple.second settings.height
                 , placeholder = settings.placeholder
-                , showLabel = settings.showLabel
                 }
                 (List.map Tuple.second attributes)
             ]
@@ -154,7 +153,6 @@ type alias Settings =
 
 type alias Settings_ =
     { label : String
-    , showLabel : Bool
     , placeholder : String
     , isInError : Bool
     , onBlur : Bool
@@ -162,23 +160,30 @@ type alias Settings_ =
     }
 
 
-initControls : Control Settings
-initControls =
-    Control.record
-        (\theme label showLabel placeholder isInError onBlur height ->
-            ( Settings_ label showLabel placeholder isInError onBlur height
-            , [ theme ]
-            )
-        )
-        |> -- TODO: make this field inclusion optional
-           Control.field "theme"
+controlAttributes : Control (List ( String, TextArea.Attribute ))
+controlAttributes =
+    ControlExtra.list
+        |> ControlExtra.optionalListItem
+            "theme"
             (Control.choice
                 [ ( "standard", Control.value ( "TextArea.standard", TextArea.standard ) )
                 , ( "writing", Control.value ( "TextArea.writing", TextArea.writing ) )
                 ]
             )
+        |> ControlExtra.optionalBoolListItem "hiddenLabel"
+            ( "TextArea.hiddenLabel", TextArea.hiddenLabel )
+
+
+initControls : Control Settings
+initControls =
+    Control.record
+        (\attributes label placeholder isInError onBlur height ->
+            ( Settings_ label placeholder isInError onBlur height
+            , attributes
+            )
+        )
+        |> Control.field "attributes" controlAttributes
         |> Control.field "label" (Control.string "Introductory paragraph")
-        |> Control.field "showLabel" (Control.bool True)
         |> Control.field "placeholder" (Control.string "A long time ago, in a galaxy pretty near here actually...")
         |> Control.field "isInError" (Control.bool False)
         |> Control.field "onBlur" (Control.bool False)

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -71,10 +71,9 @@ example =
                     Control.currentValue state.settings
 
                 toExampleCode name =
-                    [ moduleName ++ "." ++ name
+                    [ moduleName ++ "." ++ name ++ " " ++ Code.string settings.label
                     , Code.record
                         [ ( "isInError", Code.bool settings.isInError )
-                        , ( "label", Code.string settings.label )
                         , ( "height", Tuple.first settings.height )
                         , ( "placeholder", Code.string settings.placeholder )
                         ]
@@ -102,9 +101,8 @@ example =
                         ]
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
-            , TextArea.view
+            , TextArea.view settings.label
                 { isInError = settings.isInError
-                , label = settings.label
                 , height = Tuple.second settings.height
                 , placeholder = settings.placeholder
                 }

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -12,7 +12,7 @@ import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.View as ControlView
 import Example exposing (Example)
-import Html.Styled as Html exposing (Html)
+import Html.Styled as Html
 import Html.Styled.Attributes as Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
@@ -66,7 +66,7 @@ example =
     , view =
         \ellieLinkConfig state ->
             let
-                settings =
+                ( settings, attributes ) =
                     Control.currentValue state.settings
 
                 toExampleCode name =
@@ -89,6 +89,7 @@ example =
                         , ( "placeholder", Code.string settings.placeholder )
                         , ( "showLabel", Code.bool settings.showLabel )
                         ]
+                    , Code.list <| List.map Tuple.first attributes
                     ]
                         |> String.join ""
             in
@@ -106,13 +107,10 @@ example =
                         [ { sectionName = "view"
                           , code = toExampleCode "view"
                           }
-                        , { sectionName = "writing"
-                          , code = toExampleCode "writing"
-                          }
                         ]
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
-            , settings.theme
+            , TextArea.view
                 { value = state.value
                 , autofocus = False
                 , onInput = UpdateValue
@@ -128,6 +126,7 @@ example =
                 , placeholder = settings.placeholder
                 , showLabel = settings.showLabel
                 }
+                (List.map Tuple.second attributes)
             ]
     }
 
@@ -148,8 +147,13 @@ init =
 
 
 type alias Settings =
-    { theme : TextArea.Model Msg -> Html Msg
-    , label : String
+    ( Settings_
+    , List ( String, TextArea.Attribute )
+    )
+
+
+type alias Settings_ =
+    { label : String
     , showLabel : Bool
     , placeholder : String
     , isInError : Bool
@@ -160,11 +164,17 @@ type alias Settings =
 
 initControls : Control Settings
 initControls =
-    Control.record Settings
-        |> Control.field "theme"
+    Control.record
+        (\theme label showLabel placeholder isInError onBlur height ->
+            ( Settings_ label showLabel placeholder isInError onBlur height
+            , [ theme ]
+            )
+        )
+        |> -- TODO: make this field inclusion optional
+           Control.field "theme"
             (Control.choice
-                [ ( "view", Control.value TextArea.view )
-                , ( "writing", Control.value TextArea.writing )
+                [ ( "standard", Control.value ( "TextArea.standard", TextArea.standard ) )
+                , ( "writing", Control.value ( "TextArea.writing", TextArea.writing ) )
                 ]
             )
         |> Control.field "label" (Control.string "Introductory paragraph")

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -68,12 +68,11 @@ example =
     , view =
         \ellieLinkConfig state ->
             let
-                ( settings, attributes ) =
+                { label, attributes } =
                     Control.currentValue state.settings
 
                 toExampleCode name =
-                    [ moduleName ++ "." ++ name ++ " " ++ Code.string settings.label
-                    , Code.record []
+                    [ moduleName ++ "." ++ name ++ " " ++ Code.string label
                     , Code.list <|
                         ("TextArea.value " ++ Code.string state.value)
                             :: "TextArea.onInput identity"
@@ -98,8 +97,7 @@ example =
                         ]
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
-            , TextArea.view settings.label
-                {}
+            , TextArea.view label
                 (TextArea.value state.value
                     :: TextArea.onInput UpdateValue
                     :: List.map Tuple.second attributes
@@ -124,13 +122,8 @@ init =
 
 
 type alias Settings =
-    ( Settings_
-    , List ( String, TextArea.Attribute Msg )
-    )
-
-
-type alias Settings_ =
     { label : String
+    , attributes : List ( String, TextArea.Attribute Msg )
     }
 
 
@@ -173,14 +166,9 @@ controlAttributes =
 
 initControls : Control Settings
 initControls =
-    Control.record
-        (\attributes label ->
-            ( Settings_ label
-            , attributes
-            )
-        )
-        |> Control.field "attributes" controlAttributes
+    Control.record Settings
         |> Control.field "label" (Control.string "Introductory paragraph")
+        |> Control.field "attributes" controlAttributes
 
 
 {-| -}

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -162,6 +162,12 @@ controlAttributes =
             , errorMessage = TextArea.errorMessage
             , message = "The statement must be true."
             }
+        |> ControlExtra.optionalBoolListItem "noMargin"
+            ( "TextArea.noMargin True", TextArea.noMargin True )
+        |> ControlExtra.optionalBoolListItem "css"
+            ( "TextArea.css [ Css.backgroundColor Colors.azure ]"
+            , TextArea.css [ Css.backgroundColor Colors.azure ]
+            )
 
 
 initControls : Control Settings

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -73,8 +73,7 @@ example =
                 toExampleCode name =
                     [ moduleName ++ "." ++ name
                     , Code.record
-                        [ ( "autofocus", Code.bool False )
-                        , ( "onInput", "identity" )
+                        [ ( "onInput", "identity" )
                         , ( "onBlur"
                           , Code.maybe <|
                                 if settings.onBlur then
@@ -112,8 +111,7 @@ example =
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
             , TextArea.view
-                { autofocus = False
-                , onInput = UpdateValue
+                { onInput = UpdateValue
                 , onBlur =
                     if settings.onBlur then
                         Just (UpdateValue "Neener neener Blur happened")

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -73,8 +73,7 @@ example =
                 toExampleCode name =
                     [ moduleName ++ "." ++ name
                     , Code.record
-                        [ ( "value", Code.string state.value )
-                        , ( "autofocus", Code.bool False )
+                        [ ( "autofocus", Code.bool False )
                         , ( "onInput", "identity" )
                         , ( "onBlur"
                           , Code.maybe <|
@@ -89,7 +88,9 @@ example =
                         , ( "height", Tuple.first settings.height )
                         , ( "placeholder", Code.string settings.placeholder )
                         ]
-                    , Code.list <| List.map Tuple.first attributes
+                    , Code.list <|
+                        ("TextArea.value " ++ Code.string state.value)
+                            :: List.map Tuple.first attributes
                     ]
                         |> String.join ""
             in
@@ -111,8 +112,7 @@ example =
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
             , TextArea.view
-                { value = state.value
-                , autofocus = False
+                { autofocus = False
                 , onInput = UpdateValue
                 , onBlur =
                     if settings.onBlur then
@@ -125,7 +125,9 @@ example =
                 , height = Tuple.second settings.height
                 , placeholder = settings.placeholder
                 }
-                (List.map Tuple.second attributes)
+                (TextArea.value state.value
+                    :: List.map Tuple.second attributes
+                )
             ]
     }
 

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -10,6 +10,7 @@ import Accessibility.Styled exposing (..)
 import Accessibility.Styled.Key as Key
 import Category exposing (Category(..))
 import Code
+import CommonControls
 import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
@@ -385,24 +386,12 @@ controlAttributes =
             )
         |> ControlExtra.optionalBoolListItem "hiddenLabel"
             ( "TextInput.hiddenLabel", TextInput.hiddenLabel )
-        |> ControlExtra.optionalListItem "errorMessage"
-            (Control.map
-                (\str ->
-                    ( "TextInput.errorMessage " ++ Code.withParens (Code.maybeString (Just str))
-                    , TextInput.errorMessage (Just str)
-                    )
-                )
-                (Control.string "The statement must be true.")
-            )
-        |> ControlExtra.optionalListItem "guidance"
-            (Control.string "The statement must be true."
-                |> Control.map
-                    (\str ->
-                        ( "TextInput.guidance " ++ Code.string str
-                        , TextInput.guidance str
-                        )
-                    )
-            )
+        |> CommonControls.guidanceAndErrorMessage
+            { moduleName = moduleName
+            , guidance = TextInput.guidance
+            , errorMessage = TextInput.errorMessage
+            , message = "The statement must be true."
+            }
         |> ControlExtra.optionalBoolListItem "disabled"
             ( "TextInput.disabled", TextInput.disabled )
         |> ControlExtra.optionalBoolListItem "loading"

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -36,6 +36,7 @@
         "Nri.Ui.Html.Attributes.V2",
         "Nri.Ui.Html.V3",
         "Nri.Ui.InputStyles.V3",
+        "Nri.Ui.InputStyles.V4",
         "Nri.Ui.Loading.V1",
         "Nri.Ui.Logo.V1",
         "Nri.Ui.MasteryIcon.V1",

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -45,6 +45,7 @@
         "Nri.Ui.Modal.V11",
         "Nri.Ui.Page.V3",
         "Nri.Ui.Palette.V1",
+        "Nri.Ui.Panel.V1",
         "Nri.Ui.Pennant.V2",
         "Nri.Ui.PremiumCheckbox.V8",
         "Nri.Ui.RadioButton.V4",
@@ -64,6 +65,7 @@
         "Nri.Ui.Text.V6",
         "Nri.Ui.Text.Writing.V1",
         "Nri.Ui.TextArea.V4",
+        "Nri.Ui.TextArea.V5",
         "Nri.Ui.TextInput.V7",
         "Nri.Ui.Tooltip.V3",
         "Nri.Ui.UiIcon.V1"


### PR DESCRIPTION
Fixes https://github.com/NoRedInk/noredink-ui/issues/1098
Fixes A11-1714

## Guidance & Error messages

### Showing guidance
<img width="491" alt="Screen Shot 2022-10-10 at 12 13 29 PM" src="https://user-images.githubusercontent.com/8811312/194928862-2a48728e-8c15-4626-8e1c-305ca705c992.png">

### Showing error message
<img width="481" alt="Screen Shot 2022-10-10 at 12 13 20 PM" src="https://user-images.githubusercontent.com/8811312/194928863-cf7a2386-a384-433f-87c3-450bb61ecff2.png">


## Disabled styles

### Writing
<img width="479" alt="Screen Shot 2022-10-10 at 12 12 55 PM" src="https://user-images.githubusercontent.com/8811312/194928901-fa23a51a-334d-4d07-8197-f5866b5abf95.png">
<img width="478" alt="Screen Shot 2022-10-10 at 12 12 45 PM" src="https://user-images.githubusercontent.com/8811312/194928904-0e72e83d-32b4-42c2-bb39-993cc659c533.png">

### Standard
<img width="490" alt="Screen Shot 2022-10-10 at 12 12 27 PM" src="https://user-images.githubusercontent.com/8811312/194928908-f1d42026-13f5-44ac-9ecf-ad274619e9a1.png">
<img width="490" alt="Screen Shot 2022-10-10 at 12 12 35 PM" src="https://user-images.githubusercontent.com/8811312/194928906-9c8d3d95-773b-4125-8bae-0e7acc1cf352.png">

cc @NoRedInk/design 