### PR TITLE
Allow setting Message codeDetails [QUE-475]

### DIFF
--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -9,6 +9,7 @@ module Nri.Ui.Message.V3 exposing
     , tip, error, alert, success, customTheme
     , alertRole, alertDialogRole
     , onDismiss
+    , codeDetails
     )
 
 {-| Patch changes:

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -5,11 +5,10 @@ module Nri.Ui.Message.V3 exposing
     , hideIconForMobile, hideIconFor
     , css, notMobileCss, mobileCss, quizEngineMobileCss
     , tiny, large, banner
-    , plaintext, markdown, html, httpError
+    , plaintext, markdown, html, httpError, codeDetails
     , tip, error, alert, success, customTheme
     , alertRole, alertDialogRole
     , onDismiss
-    , codeDetails
     )
 
 {-| Patch changes:
@@ -43,7 +42,7 @@ Changes from V2:
 
 ## Content
 
-@docs plaintext, markdown, html, httpError
+@docs plaintext, markdown, html, httpError, codeDetails
 
 
 ## Theme
@@ -454,6 +453,11 @@ httpError error_ =
     Attribute <| \config -> { config | content = content, codeDetails = codeDetails_ }
 
 
+{-| Details for Engineers
+
+Will be rendered in a closed details box
+
+-}
 codeDetails : String -> Attribute msg
 codeDetails code =
     Attribute <| \config -> { config | codeDetails = Just code }

--- a/styleguide-app/Code.elm
+++ b/styleguide-app/Code.elm
@@ -1,5 +1,5 @@
 module Code exposing
-    ( string, maybeString
+    ( string, stringMultiline, maybeString
     , maybe
     , maybeFloat
     , bool
@@ -18,7 +18,7 @@ module Code exposing
 
 {-|
 
-@docs string, maybeString
+@docs string, stringMultiline, maybeString
 @docs maybe
 @docs maybeFloat
 @docs bool
@@ -42,6 +42,16 @@ module Code exposing
 string : String -> String
 string s =
     "\"" ++ s ++ "\""
+
+
+{-| -}
+stringMultiline : String -> String
+stringMultiline s =
+    newlineWithIndent 1
+        ++ "\"\"\""
+        ++ String.replace "\n" (newlineWithIndent 1) s
+        ++ newlineWithIndent 1
+        ++ "\"\"\""
 
 
 {-| -}

--- a/styleguide-app/CommonControls.elm
+++ b/styleguide-app/CommonControls.elm
@@ -6,7 +6,7 @@ module CommonControls exposing
     , customIcon
     , specificColor
     , content, exampleHtml
-    , httpError
+    , httpError, badBodyString
     , romeoAndJulietQuotation
     , guidanceAndErrorMessage
     , disabledListItem, premiumDisplay
@@ -25,7 +25,7 @@ module CommonControls exposing
 ### Content
 
 @docs content, exampleHtml
-@docs httpError
+@docs httpError, badBodyString
 @docs romeoAndJulietQuotation
 @docs guidanceAndErrorMessage
 
@@ -74,30 +74,32 @@ httpError =
         , ( "Bad Status: 404", Control.value (Http.BadStatus 404) )
         , ( "Bad Status: ???", Control.value (Http.BadStatus 500) )
         , ( "Bad Body (often, a JSON decoding problem)"
-          , Control.value
-                (Http.BadBody
-                    """
-                        The Json.Decode.oneOf at json.draft failed in the following 2 ways:
-
-
-
-                        (1) Problem with the given value:
-
-                            null
-
-                            Expecting an OBJECT with a field named `content`
-
-
-
-                        (2) Problem with the given value:
-
-                            null
-
-                            Expecting an OBJECT with a field named `code`
-                        """
-                )
+          , Control.value (Http.BadBody badBodyString)
           )
         ]
+
+
+badBodyString : String
+badBodyString =
+    """
+    The Json.Decode.oneOf at json.draft failed in the following 2 ways:
+
+
+
+    (1) Problem with the given value:
+
+        null
+
+        Expecting an OBJECT with a field named `content`
+
+
+
+    (2) Problem with the given value:
+
+        null
+
+        Expecting an OBJECT with a field named `code`
+    """
 
 
 content :

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -42,6 +42,10 @@ init =
                     }
                 )
             |> ControlExtra.optionalListItem "role" controlRole
+            |> ControlExtra.optionalListItem "codeDetails"
+                (Control.map (\str -> ( "Message.codeDetails " ++ Code.stringMultiline str, Message.codeDetails str ))
+                    (Control.stringTextarea CommonControls.badBodyString)
+                )
             |> ControlExtra.optionalBoolListItem "dismissable"
                 ( "Message.onDismiss Dismiss", Message.onDismiss Dismiss )
             |> CommonControls.iconNotCheckedByDefault "Message" Message.icon


### PR DESCRIPTION
Right now our choice is either a generic error message and helpful context for engineers, or a nicer error message and no helpful context for engineers.

With this PR we can do `[Message.markdown "Some helpful error message that reassures the user, tells them how to work around stuff and perhaps even where to look for help", Message.codeDetails "Fluctuations in the bi-neural electroplasma subinterlink."]`