### PR TITLE
Adds Checkbox.V7

### DIFF
--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -1,5 +1,6 @@
 Nri.Ui.BreadCrumbs.V1,upgrade to V2
-Nri.Ui.Checkbox.V5,upgrade to V6
+Nri.Ui.Checkbox.V5,upgrade to V7
+Nri.Ui.Checkbox.V6,upgrade to V7
 Nri.Ui.InputStyles.V3,upgrade to V4
 Nri.Ui.Tabs.V6,upgrade to V7
 Nri.Ui.TextArea.V4,upgrade to V5

--- a/elm.json
+++ b/elm.json
@@ -17,6 +17,7 @@
         "Nri.Ui.Carousel.V1",
         "Nri.Ui.Checkbox.V5",
         "Nri.Ui.Checkbox.V6",
+        "Nri.Ui.Checkbox.V7",
         "Nri.Ui.ClickableSvg.V2",
         "Nri.Ui.ClickableText.V3",
         "Nri.Ui.Container.V2",

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -46,7 +46,10 @@ hint = 'upgrade to V10'
 usages = ['styleguide-app/../src/Nri/Ui/SlideModal/V2.elm']
 
 [forbidden."Nri.Ui.Checkbox.V5"]
-hint = 'upgrade to V6'
+hint = 'upgrade to V7'
+
+[forbidden."Nri.Ui.Checkbox.V6"]
+hint = 'upgrade to V7'
 
 [forbidden."Nri.Ui.ClickableSvg.V1"]
 hint = 'upgrade to V2'

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -140,7 +140,7 @@ describe("UI tests", function () {
 
     // visible icon names snapshot
     await page.click("label");
-    await page.waitForSelector(".checkbox-V5__Checked");
+    await page.waitForSelector(".checkbox-V7__Checked");
     await percySnapshot(page, `${name} - display icon names`);
 
     const results = await new AxePuppeteer(page)

--- a/src/InputErrorAndGuidanceInternal.elm
+++ b/src/InputErrorAndGuidanceInternal.elm
@@ -2,7 +2,7 @@ module InputErrorAndGuidanceInternal exposing
     ( ErrorState, noError, setErrorIf, setErrorMessage
     , Guidance, noGuidance, setGuidance
     , getIsInError, getErrorMessage
-    , describedBy, view
+    , describedBy, view, smallMargin
     )
 
 {-|
@@ -10,7 +10,7 @@ module InputErrorAndGuidanceInternal exposing
 @docs ErrorState, noError, setErrorIf, setErrorMessage
 @docs Guidance, noGuidance, setGuidance
 @docs getIsInError, getErrorMessage
-@docs describedBy, view
+@docs describedBy, view, smallMargin
 
 -}
 
@@ -121,8 +121,8 @@ describedBy idValue config =
             Nri.Ui.Html.Attributes.V2.none
 
 
-view : String -> { config | guidance : Guidance, error : ErrorState } -> Html msg
-view idValue config =
+view : String -> Css.Style -> { config | guidance : Guidance, error : ErrorState } -> Html msg
+view idValue marginTop config =
     case ( getErrorMessage config.error, config.guidance ) of
         ( Just m, _ ) ->
             Message.view
@@ -135,7 +135,7 @@ view idValue config =
                 , Message.css
                     [ Css.important (Css.paddingTop Css.zero)
                     , Css.important (Css.paddingBottom Css.zero)
-                    , Css.marginTop (Css.px 5)
+                    , marginTop
                     ]
                 ]
 
@@ -146,13 +146,18 @@ view idValue config =
                 , Text.css
                     [ Css.important (Css.paddingTop Css.zero)
                     , Css.important (Css.paddingBottom Css.zero)
-                    , Css.important (Css.marginTop (Css.px 5))
+                    , Css.important marginTop
                     , Css.lineHeight (Css.int 1)
                     ]
                 ]
 
         _ ->
             Html.text ""
+
+
+smallMargin : Css.Style
+smallMargin =
+    Css.marginTop (Css.px 5)
 
 
 errorId : String -> String

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -6,6 +6,7 @@ module Nri.Ui.Checkbox.V7 exposing
     , selectedFromBool
     , containerCss, labelCss, custom, nriDescription, id, testId
     , disabled, enabled, guidance
+    , viewIcon
     )
 
 {-|
@@ -34,6 +35,11 @@ module Nri.Ui.Checkbox.V7 exposing
 @docs selectedFromBool
 @docs containerCss, labelCss, custom, nriDescription, id, testId
 @docs disabled, enabled, guidance
+
+
+### Internal
+
+@docs viewIcon
 
 -}
 

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -383,7 +383,7 @@ viewEnabledLabel config icon =
         ]
         [ viewIcon [] icon
         , labelView config
-        , InputErrorAndGuidanceInternal.view config.identifier config
+        , InputErrorAndGuidanceInternal.view config.identifier (Css.marginTop Css.zero) config
         ]
 
 
@@ -414,7 +414,7 @@ viewDisabledLabel config icon =
         ]
         [ viewIcon [] icon
         , labelView config
-        , InputErrorAndGuidanceInternal.view config.identifier config
+        , InputErrorAndGuidanceInternal.view config.identifier (Css.marginTop Css.zero) config
         ]
 
 

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -1,0 +1,480 @@
+module Nri.Ui.Checkbox.V7 exposing
+    ( view
+    , onCheck
+    , Attribute, IsSelected(..)
+    , hiddenLabel, visibleLabel
+    , selectedFromBool
+    , containerCss, labelCss, custom, nriDescription, id, testId
+    , disabled, enabled, guidance
+    )
+
+{-|
+
+
+# Changes from V6:
+
+  - Reworked api similar to other components based on Attributes
+  - Add support for guidance
+  - Dropped checkboxLockOnInside functionality
+  - Dropped disabledLabelCss functionality. Use labelCss instead in case when the checbox is disabled.
+  - (breacking-change) By default the label is visible (ie: V6.viewWithLabel), use hiddenLabel to migrate from V6.view.
+
+@docs view
+
+
+### Event handlers
+
+@docs onCheck
+
+
+### Attributes
+
+@docs Attribute, IsSelected
+@docs hiddenLabel, visibleLabel
+@docs selectedFromBool
+@docs containerCss, labelCss, custom, nriDescription, id, testId
+@docs disabled, enabled, guidance
+
+-}
+
+import Accessibility.Styled exposing (..)
+import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Style
+import CheckboxIcons
+import Css exposing (..)
+import Css.Global
+import Html.Styled as Html
+import Html.Styled.Attributes as Attributes exposing (css)
+import Html.Styled.Events as Events
+import InputErrorAndGuidanceInternal exposing (Guidance)
+import Json.Decode
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.FocusRing.V1 as FocusRing
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Html.Attributes.V2 as Extra
+import Nri.Ui.Svg.V1 exposing (Svg)
+import String exposing (toLower)
+import String.Extra exposing (dasherize)
+
+
+{-| This disables the input
+-}
+disabled : Attribute msg
+disabled =
+    Attribute <| \config -> { config | isDisabled = True }
+
+
+{-| This enables the input, this is the default behavior
+-}
+enabled : Attribute msg
+enabled =
+    Attribute <| \config -> { config | isDisabled = False }
+
+
+{-| A guidance message shows below the input, unless an error message is showing instead.
+-}
+guidance : String -> Attribute msg
+guidance =
+    Attribute << InputErrorAndGuidanceInternal.setGuidance
+
+
+{-| Fire a message when toggling the checkbox.
+-}
+onCheck : (Bool -> msg) -> Attribute msg
+onCheck onCheck_ =
+    Attribute <| \config -> { config | onCheck = Just onCheck_ }
+
+
+{-| Adds CSS to the element containing the input.
+-}
+containerCss : List Css.Style -> Attribute msg
+containerCss styles =
+    Attribute <| \config -> { config | containerCss = config.containerCss ++ styles }
+
+
+{-| Adds CSS to the element containing the label text.
+
+Note that these styles don't apply to the literal HTML label element, since it contains the icon SVG as well.
+
+-}
+labelCss : List Css.Style -> Attribute msg
+labelCss styles =
+    Attribute <| \config -> { config | labelCss = config.labelCss ++ styles }
+
+
+{-| Hides the visible label. (There will still be an invisible label for screen readers.)
+-}
+hiddenLabel : Attribute msg
+hiddenLabel =
+    Attribute <| \config -> { config | hideLabel = True }
+
+
+{-| Shows the visible label. This is the default behavior
+-}
+visibleLabel : Attribute msg
+visibleLabel =
+    Attribute <| \config -> { config | hideLabel = False }
+
+
+{-| Set a custom ID for this checkbox input and label. If you don't set this,
+we'll automatically generate one from the label you pass in, but this can
+cause problems if you have more than one checkbox input with the same label on
+the page. You might also use this helper if you're manually managing focus.
+-}
+id : String -> Attribute msg
+id id_ =
+    Attribute <| \config -> { config | id = Just id_ }
+
+
+{-| Use this helper to add custom attributes.
+
+Do NOT use this helper to add css styles, as they may not be applied the way
+you want/expect if underlying styles change.
+Instead, please use the `css` helper.
+
+-}
+custom : List (Html.Attribute Never) -> Attribute msg
+custom attributes =
+    Attribute <| \config -> { config | custom = config.custom ++ attributes }
+
+
+{-| -}
+nriDescription : String -> Attribute msg
+nriDescription description =
+    custom [ Extra.nriDescription description ]
+
+
+{-| -}
+testId : String -> Attribute msg
+testId id_ =
+    custom [ Extra.testId id_ ]
+
+
+{-| Customizations for the Checkbox.
+-}
+type Attribute msg
+    = Attribute (Config msg -> Config msg)
+
+
+{-| This is private. The public API only exposes `Attribute`.
+-}
+type alias Config msg =
+    { id : Maybe String
+    , hideLabel : Bool
+    , onCheck : Maybe (Bool -> msg)
+    , isDisabled : Bool
+    , guidance : Guidance
+    , custom : List (Html.Attribute Never)
+    , containerCss : List Css.Style
+    , labelCss : List Css.Style
+    }
+
+
+{-|
+
+    = Selected --  Checked (rendered with a checkmark)
+    | NotSelected -- Not Checked (rendered blank)
+    | PartiallySelected -- Indeterminate (rendered dash)
+
+-}
+type IsSelected
+    = Selected
+    | NotSelected
+    | PartiallySelected
+
+
+emptyConfig : Config msg
+emptyConfig =
+    { id = Nothing
+    , hideLabel = False
+    , onCheck = Nothing
+    , isDisabled = False
+    , guidance = InputErrorAndGuidanceInternal.noGuidance
+    , custom = []
+    , containerCss = []
+    , labelCss = []
+    }
+
+
+applyConfig : List (Attribute msg) -> Config msg -> Config msg
+applyConfig attributes beginningConfig =
+    List.foldl (\(Attribute update) config -> update config)
+        beginningConfig
+        attributes
+
+
+{-| View a checkbox (the label is only used for accessibility hints unless visibleLabel attribute is applied)
+-}
+view :
+    { label : String
+    , selected : IsSelected
+    }
+    -> List (Attribute msg)
+    -> Html msg
+view { label, selected } attributes =
+    let
+        config =
+            applyConfig attributes emptyConfig
+
+        idValue =
+            case config.id of
+                Just specificId ->
+                    specificId
+
+                Nothing ->
+                    "checkbox-v7-" ++ dasherize (toLower label)
+
+        config_ =
+            { identifier = idValue
+            , containerCss = config.containerCss
+            , label = label
+            , hideLabel = config.hideLabel
+            , labelCss = config.labelCss
+            , onCheck = config.onCheck
+            , selected = selected
+            , disabled = config.isDisabled
+            }
+    in
+    checkboxContainer config_
+        [ viewCheckbox config_
+        , let
+            ( icon, disabledIcon ) =
+                case selected of
+                    Selected ->
+                        ( CheckboxIcons.checked idValue
+                        , CheckboxIcons.checkedDisabled
+                        )
+
+                    NotSelected ->
+                        ( CheckboxIcons.unchecked idValue
+                        , CheckboxIcons.uncheckedDisabled
+                        )
+
+                    PartiallySelected ->
+                        ( CheckboxIcons.checkedPartially idValue
+                        , CheckboxIcons.checkedPartiallyDisabled
+                        )
+          in
+          if config.isDisabled then
+            viewDisabledLabel config_ disabledIcon
+
+          else
+            viewEnabledLabel config_ icon
+        ]
+
+
+{-| If your selectedness is always selected or not selected,
+you will likely store that state as a `Bool` in your model.
+`selectedFromBool` lets you easily convert that into an `IsSelected` value
+for use with `Nri.Ui.Checkbox`.
+-}
+selectedFromBool : Bool -> IsSelected
+selectedFromBool isSelected =
+    if isSelected then
+        Selected
+
+    else
+        NotSelected
+
+
+selectedToMaybe : IsSelected -> Maybe Bool
+selectedToMaybe selected =
+    case selected of
+        Selected ->
+            Just True
+
+        NotSelected ->
+            Just False
+
+        PartiallySelected ->
+            Nothing
+
+
+checkboxContainer : { a | identifier : String, containerCss : List Style } -> List (Html msg) -> Html msg
+checkboxContainer model =
+    Html.span
+        [ css
+            [ display block
+            , height inherit
+            , position relative
+            , marginLeft (px -4)
+            , pseudoClass "focus-within"
+                [ Css.Global.descendants
+                    [ Css.Global.class "checkbox-icon-container" FocusRing.tightStyles
+                    ]
+                ]
+            , Css.Global.descendants
+                [ Css.Global.input
+                    [ position absolute
+                    , top (calc (pct 50) minus (px 10))
+                    , left (px 10)
+                    , boxShadow none |> Css.important
+                    ]
+                ]
+            , Css.batch model.containerCss
+            ]
+        , Attributes.id (model.identifier ++ "-container")
+        , Events.stopPropagationOn "click" (Json.Decode.fail "stop click propagation")
+        ]
+
+
+viewCheckbox :
+    { a
+        | identifier : String
+        , onCheck : Maybe (Bool -> msg)
+        , selected : IsSelected
+        , disabled : Bool
+    }
+    -> Html.Html msg
+viewCheckbox config =
+    checkbox config.identifier
+        (selectedToMaybe config.selected)
+        (List.filterMap identity <|
+            [ Just <| Attributes.id config.identifier
+            , if config.disabled then
+                Just <| Aria.disabled True
+
+              else
+                config.onCheck
+                    |> Maybe.map (onCheckMsg config.selected)
+                    |> Maybe.map (\msg -> Events.onCheck (\_ -> msg))
+            ]
+        )
+
+
+onCheckMsg : IsSelected -> (Bool -> msg) -> msg
+onCheckMsg selected msg =
+    selectedToMaybe selected
+        |> Maybe.withDefault False
+        |> not
+        |> msg
+
+
+viewEnabledLabel :
+    { a
+        | identifier : String
+        , selected : IsSelected
+        , label : String
+        , hideLabel : Bool
+        , labelCss : List Style
+    }
+    -> Svg
+    -> Html.Html msg
+viewEnabledLabel config icon =
+    Html.label
+        [ Attributes.for config.identifier
+        , labelClass config.selected
+        , css
+            [ positioning
+            , textStyle
+            , cursor pointer
+            , Css.batch config.labelCss
+            ]
+        ]
+        [ viewIcon [] icon
+        , labelView config
+        ]
+
+
+viewDisabledLabel :
+    { a
+        | identifier : String
+        , selected : IsSelected
+        , label : String
+        , hideLabel : Bool
+        , labelCss : List Style
+    }
+    -> Svg
+    -> Html.Html msg
+viewDisabledLabel config icon =
+    Html.label
+        [ Attributes.for config.identifier
+        , labelClass config.selected
+        , css
+            [ positioning
+            , textStyle
+            , outline none
+            , cursor auto
+            , color Colors.gray45
+            , Css.batch config.labelCss
+            ]
+        ]
+        [ viewIcon [] icon
+        , labelView config
+        ]
+
+
+labelClass : IsSelected -> Html.Attribute msg
+labelClass isSelected =
+    case isSelected of
+        Selected ->
+            toClassList [ "Label", "Checked" ]
+
+        NotSelected ->
+            toClassList [ "Label", "Unchecked" ]
+
+        PartiallySelected ->
+            toClassList [ "Label", "Indeterminate" ]
+
+
+toClassList : List String -> Html.Attribute msg
+toClassList =
+    List.map (\a -> ( "checkbox-V7__" ++ a, True )) >> Attributes.classList
+
+
+positioning : Style
+positioning =
+    batch
+        [ display inlineBlock
+        , padding4 (px 13) zero (px 13) (px 40)
+        , position relative
+        ]
+
+
+textStyle : Style
+textStyle =
+    batch
+        [ Fonts.baseFont
+        , fontSize (px 15)
+        , fontWeight (int 600)
+        , color Colors.navy
+        ]
+
+
+{-| -}
+viewIcon : List Style -> Svg -> Html msg
+viewIcon styles icon =
+    Html.div
+        [ css
+            [ position absolute
+            , left zero
+            , top (calc (pct 50) minus (px 18))
+            , border3 (px 2) solid transparent
+            , padding (px 2)
+            , borderRadius (px 3)
+            , height (Css.px 27)
+            , boxSizing contentBox
+            ]
+        , Attributes.class "checkbox-icon-container"
+        ]
+        [ Html.div
+            [ css
+                [ display inlineBlock
+                , backgroundColor Colors.white
+                , height (Css.px 27)
+                , borderRadius (px 4)
+                ]
+            ]
+            [ Nri.Ui.Svg.V1.toHtml (Nri.Ui.Svg.V1.withCss styles icon)
+            ]
+        ]
+
+
+labelView : { a | hideLabel : Bool, label : String } -> Html msg
+labelView config =
+    if config.hideLabel then
+        Html.span Accessibility.Styled.Style.invisible
+            [ Html.text config.label ]
+
+    else
+        Html.span [] [ Html.text config.label ]

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -16,8 +16,8 @@ module Nri.Ui.Checkbox.V7 exposing
   - Reworked api similar to other components based on Attributes
   - Add support for guidance
   - Dropped checkboxLockOnInside functionality
-  - Dropped disabledLabelCss functionality. Use labelCss instead in case when the checbox is disabled.
-  - (breacking-change) By default the label is visible (ie: V6.viewWithLabel), use hiddenLabel to migrate from V6.view.
+  - Dropped disabledLabelCss functionality. Use labelCss instead in case when the checkbox is disabled.
+  - (breaking-change) By default the label is visible (ie: V6.viewWithLabel), use hiddenLabel to migrate from V6.view.
 
 @docs view
 

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -46,7 +46,7 @@ import Css.Global
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes exposing (css)
 import Html.Styled.Events as Events
-import InputErrorAndGuidanceInternal exposing (Guidance)
+import InputErrorAndGuidanceInternal exposing (ErrorState, Guidance)
 import Json.Decode
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.FocusRing.V1 as FocusRing
@@ -233,6 +233,8 @@ view { label, selected } attributes =
             , onCheck = config.onCheck
             , selected = selected
             , disabled = config.isDisabled
+            , guidance = config.guidance
+            , error = InputErrorAndGuidanceInternal.noError
             }
     in
     checkboxContainer config_
@@ -357,6 +359,8 @@ viewEnabledLabel :
         , label : String
         , hideLabel : Bool
         , labelCss : List Style
+        , guidance : Guidance
+        , error : ErrorState
     }
     -> Svg
     -> Html.Html msg
@@ -373,6 +377,7 @@ viewEnabledLabel config icon =
         ]
         [ viewIcon [] icon
         , labelView config
+        , InputErrorAndGuidanceInternal.view config.identifier config
         ]
 
 
@@ -383,6 +388,8 @@ viewDisabledLabel :
         , label : String
         , hideLabel : Bool
         , labelCss : List Style
+        , guidance : Guidance
+        , error : ErrorState
     }
     -> Svg
     -> Html.Html msg
@@ -401,6 +408,7 @@ viewDisabledLabel config icon =
         ]
         [ viewIcon [] icon
         , labelView config
+        , InputErrorAndGuidanceInternal.view config.identifier config
         ]
 
 

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -43,10 +43,11 @@ module Nri.Ui.PremiumCheckbox.V8 exposing
 -}
 
 import Accessibility.Styled as Html exposing (Html)
+import CheckboxIcons
 import Css exposing (..)
 import Html.Styled.Attributes as Attributes exposing (class, css)
 import Html.Styled.Events as Events
-import Nri.Ui.Checkbox.V6 as Checkbox
+import Nri.Ui.Checkbox.V7 as Checkbox
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Data.PremiumDisplay as PremiumDisplay exposing (PremiumDisplay)
 import Nri.Ui.Fonts.V1 as Fonts
@@ -229,22 +230,24 @@ view { label, onChange } attributes =
               else
                 -- left-align the checkbox with checkboxes that _do_ have the premium pennant
                 Html.div [ css [ Css.width (Css.px (iconWidth + iconRightMargin)), Css.flexShrink Css.zero ] ] []
-            , Checkbox.viewWithLabel
-                { identifier = idValue
-                , label = label
-                , setterMsg = onChange
+            , Checkbox.view
+                { label = label
                 , selected = config.selected
-                , disabled = config.isDisabled
-                , theme =
-                    if isLocked then
-                        Checkbox.Locked
-
-                    else
-                        Checkbox.Square
-                , containerCss = config.checkboxContainerCss
-                , enabledLabelCss = config.checkboxEnabledLabelCss
-                , disabledLabelCss = config.checkboxDisabledLabelCss
                 }
+                [ Checkbox.id idValue
+                , Checkbox.onCheck onChange
+                , if config.isDisabled then
+                    Checkbox.disabled
+
+                  else
+                    Checkbox.enabled
+                , Checkbox.containerCss config.checkboxContainerCss
+                , if config.isDisabled then
+                    Checkbox.labelCss config.checkboxDisabledLabelCss
+
+                  else
+                    Checkbox.labelCss config.checkboxEnabledLabelCss
+                ]
             ]
 
 
@@ -298,7 +301,7 @@ viewLockedButton { idValue, label, containerCss, onLockedMsg } =
                     , outline none
                     ]
                 ]
-                [ Checkbox.viewIcon [] (Checkbox.checkboxLockOnInside idValue)
+                [ Checkbox.viewIcon [] (CheckboxIcons.lockOnInside idValue)
                 , Html.span [] [ Html.text label ]
                 ]
             ]

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -404,7 +404,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
                         text ""
                     ]
                 ]
-             , InputErrorAndGuidanceInternal.view idValue config
+             , InputErrorAndGuidanceInternal.view idValue (Css.marginTop Css.zero) config
              ]
                 ++ (if isChecked then
                         disclosedElements
@@ -483,7 +483,7 @@ viewLockedButton { idValue, label } config =
                 , premiumPennant
                 ]
             ]
-        , InputErrorAndGuidanceInternal.view idValue config
+        , InputErrorAndGuidanceInternal.view idValue (Css.marginTop Css.zero) config
         ]
 
 

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -160,7 +160,7 @@ visibleLabel =
     Attribute <| \config -> { config | hideLabel = False }
 
 
-{-| Set a custom ID for this text input and label. If you don't set this,
+{-| Set a custom ID for this radio input and label. If you don't set this,
 we'll automatically generate one from the label you pass in, but this can
 cause problems if you have more than one radio input with the same label on
 the page. You might also use this helper if you're manually managing focus.

--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -310,7 +310,7 @@ view label attributes =
             , theme = InputStyles.Standard
             }
             config
-        , InputErrorAndGuidanceInternal.view id_ config
+        , InputErrorAndGuidanceInternal.view id_ InputErrorAndGuidanceInternal.smallMargin config
         ]
 
 

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -397,7 +397,7 @@ view_ label config =
             , theme = config.theme
             }
             config
-        , InputErrorAndGuidanceInternal.view idValue config
+        , InputErrorAndGuidanceInternal.view idValue InputErrorAndGuidanceInternal.smallMargin config
         ]
 
 

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -900,7 +900,7 @@ view label attributes =
             eventsAndValues.floatingContent
             eventsAndValues.onInput
             |> Maybe.withDefault (Html.text "")
-        , InputErrorAndGuidanceInternal.view idValue config
+        , InputErrorAndGuidanceInternal.view idValue InputErrorAndGuidanceInternal.smallMargin config
         ]
 
 

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -9,8 +9,10 @@ module Examples.Checkbox exposing (Msg, State, example)
 import Category exposing (Category(..))
 import CheckboxIcons
 import Code
+import CommonControls
 import Css exposing (Style)
 import Debug.Control as Control exposing (Control)
+import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled exposing (..)
@@ -181,6 +183,7 @@ type alias Settings =
     , hiddenLabel : Bool
     , containerCss : ( String, List Style )
     , labelCss : ( String, List Style )
+    , guidance : Maybe String
     }
 
 
@@ -212,6 +215,8 @@ controlSettings =
                   )
                 ]
             )
+        |> Control.field "guidance"
+            (Control.maybe False (Control.string "There is something you need to be aware of."))
 
 
 viewExampleWithCode : State -> Settings -> ( String, Html Msg )
@@ -227,41 +232,47 @@ viewExampleWithCode state settings =
             ]
             1
       , Code.list
-            [ "Checkbox.onCheck identity"
-            , if settings.disabled then
-                "Checkbox.disabled"
+            (List.filterMap identity
+                [ Just <| "Checkbox.onCheck identity"
+                , if settings.disabled then
+                    Just <| "Checkbox.disabled"
 
-              else
-                "Checkbox.enabled"
-            , if settings.hiddenLabel then
-                "Checkbox.hiddenLabel"
+                  else
+                    Just <| "Checkbox.enabled"
+                , if settings.hiddenLabel then
+                    Just <| "Checkbox.hiddenLabel"
 
-              else
-                "Checkbox.visibleLabel"
-            , "Checkbox.containerCss " ++ Tuple.first settings.containerCss
-            , "Checkbox.labelCss " ++ Tuple.first settings.labelCss
-            ]
+                  else
+                    Just <| "Checkbox.visibleLabel"
+                , Just <| "Checkbox.containerCss " ++ Tuple.first settings.containerCss
+                , Just <| "Checkbox.labelCss " ++ Tuple.first settings.labelCss
+                , settings.guidance |> Maybe.map (\v -> "Checkbox.guidance " ++ Code.string v)
+                ]
+            )
       ]
         |> String.join ""
     , Checkbox.view
         { label = settings.label
         , selected = state.isChecked
         }
-        [ Checkbox.id id
-        , Checkbox.onCheck (ToggleCheck id)
-        , if settings.hiddenLabel then
-            Checkbox.hiddenLabel
+        (List.filterMap identity
+            [ Just <| Checkbox.id id
+            , Just <| Checkbox.onCheck (ToggleCheck id)
+            , if settings.hiddenLabel then
+                Just <| Checkbox.hiddenLabel
 
-          else
-            Checkbox.visibleLabel
-        , if settings.disabled then
-            Checkbox.disabled
+              else
+                Just <| Checkbox.visibleLabel
+            , if settings.disabled then
+                Just <| Checkbox.disabled
 
-          else
-            Checkbox.enabled
-        , Checkbox.containerCss (Tuple.second settings.containerCss)
-        , Checkbox.labelCss (Tuple.second settings.labelCss)
-        ]
+              else
+                Just <| Checkbox.enabled
+            , Just <| Checkbox.containerCss (Tuple.second settings.containerCss)
+            , Just <| Checkbox.labelCss (Tuple.second settings.labelCss)
+            , settings.guidance |> Maybe.map Checkbox.guidance
+            ]
+        )
     )
 
 

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -9,10 +9,8 @@ module Examples.Checkbox exposing (Msg, State, example)
 import Category exposing (Category(..))
 import CheckboxIcons
 import Code
-import CommonControls
 import Css exposing (Style)
 import Debug.Control as Control exposing (Control)
-import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled exposing (..)

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -33,7 +33,7 @@ moduleName =
 
 version : Int
 version =
-    6
+    7
 
 
 {-| -}

--- a/styleguide-app/Examples/IconExamples.elm
+++ b/styleguide-app/Examples/IconExamples.elm
@@ -21,7 +21,7 @@ import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes exposing (css)
 import Html.Styled.Events as Events
-import Nri.Ui.Checkbox.V6 as Checkbox
+import Nri.Ui.Checkbox.V7 as Checkbox
 import Nri.Ui.Colors.Extra exposing (fromCssColor, toCssColor)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
@@ -160,17 +160,13 @@ update msg state =
 {-| -}
 viewSettings : Settings -> Html Msg
 viewSettings { showIconName } =
-    Checkbox.viewWithLabel
-        { identifier = "show-icon-name-checkbox"
-        , label = "Show names"
-        , setterMsg = ShowNames
+    Checkbox.view
+        { label = "Show names"
         , selected = Checkbox.selectedFromBool showIconName
-        , disabled = False
-        , theme = Checkbox.Square
-        , containerCss = []
-        , enabledLabelCss = []
-        , disabledLabelCss = []
         }
+        [ Checkbox.id "show-icon-name-checkbox"
+        , Checkbox.onCheck ShowNames
+        ]
 
 
 type alias Group =
@@ -302,17 +298,13 @@ viewSingularExampleSettings groups state =
             , Select.value (Just state.icon)
             ]
             |> Html.map SetIcon
-        , Checkbox.viewWithLabel
-            { identifier = "show-border"
-            , label = "Show border"
-            , setterMsg = SetBorder
+        , Checkbox.view
+            { label = "Show border"
             , selected = Checkbox.selectedFromBool state.showBorder
-            , disabled = False
-            , theme = Checkbox.Square
-            , containerCss = []
-            , enabledLabelCss = []
-            , disabledLabelCss = []
             }
+            [ Checkbox.id "show-border"
+            , Checkbox.onCheck SetBorder
+            ]
         , Html.label []
             [ Html.text "Color: "
             , Html.input

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -13,6 +13,7 @@
         "Nri.Ui.Carousel.V1",
         "Nri.Ui.Checkbox.V5",
         "Nri.Ui.Checkbox.V6",
+        "Nri.Ui.Checkbox.V7",
         "Nri.Ui.ClickableSvg.V2",
         "Nri.Ui.ClickableText.V3",
         "Nri.Ui.Container.V2",


### PR DESCRIPTION
A shinny new checkbox has appeared.

- Reworked api similar to other components based on Attributes
- Add support for guidance
- Dropped checkboxLockOnInside / Themes functionality. [*].
- Dropped disabledLabelCss functionality. Use labelCss instead in case when the checkbox is disabled. [*]
- (breaking-change) By default the label is visible (ie: V6.viewWithLabel), use hiddenLabel to migrate from V6.view.

[*] It seems to no longer be needed in monolith

- Maybe the examples should be migrated to use a similar structure as others.
- Maybe we could include `errorIf`, `errorMessage` for completeness, but there is no use case so far.