### PR TITLE
Fix modal focus trap when the last id changes on the fly

### DIFF
--- a/src/Nri/Ui/FocusTrap/V1.elm
+++ b/src/Nri/Ui/FocusTrap/V1.elm
@@ -7,7 +7,8 @@ module Nri.Ui.FocusTrap.V1 exposing (FocusTrap, toAttribute)
 -}
 
 import Accessibility.Styled as Html
-import Accessibility.Styled.Key as Key
+import Html.Styled.Events exposing (preventDefaultOn)
+import Json.Decode
 import Nri.Ui.WhenFocusLeaves.V1 as WhenFocusLeaves
 
 
@@ -28,15 +29,17 @@ type alias FocusTrap msg =
 -}
 toAttribute : FocusTrap msg -> Html.Attribute msg
 toAttribute { firstId, lastId, focus } =
-    Key.onKeyDownPreventDefault
-        [ WhenFocusLeaves.toDecoder
-            { firstId = firstId
-            , lastId = lastId
-            , -- if the user tabs back while on the first id,
-              -- we want to wrap around to the last id.
-              tabBackAction = focus lastId
-            , -- if the user tabs forward while on the last id,
-              -- we want to wrap around to the first id.
-              tabForwardAction = focus firstId
-            }
-        ]
+    preventDefaultOn "keydown"
+        (Json.Decode.map (\e -> ( e, True ))
+            (WhenFocusLeaves.toDecoder
+                { firstId = firstId
+                , lastId = lastId
+                , -- if the user tabs back while on the first id,
+                  -- we want to wrap around to the last id.
+                  tabBackAction = focus lastId
+                , -- if the user tabs forward while on the last id,
+                  -- we want to wrap around to the first id.
+                  tabForwardAction = focus firstId
+                }
+            )
+        )


### PR DESCRIPTION
See [Slack](https://noredink.slack.com/archives/C02NVG4M45U/p1666815109380059) for original context.

It seems that having the key event listener using Json.Decode.oneOf to decode events is causing the decoder to not get updated. Investigation steps:

- [using focus trap Ellie](https://ellie-app.com/jZJX3fkRnc3a1)
- [using when focus leaves decoder directly Ellie](https://ellie-app.com/jZK3Qzfj3D3a1)
- [moving the decoder code from when focus leaves into the view Ellie](https://ellie-app.com/jZK8xJbn66Va1)
- [removing the Decode.oneOf wrapping from the decoder Ellie](https://ellie-app.com/jZK9kMg7FCva1)

Underlying problem is already issued against elm/json here: https://github.com/elm/json/issues/15