### PR TITLE
A11-1786 Add missing highlightable and highlighted classes

### DIFF
--- a/src/Nri/Ui/Highlighter/V1.elm
+++ b/src/Nri/Ui/Highlighter/V1.elm
@@ -723,6 +723,13 @@ viewInlineTag { showTagsInline, isInteractive, maybeTool } highlightable =
              )
                 ++ highlightableStyle maybeTool highlightable isInteractive
             )
+        , class "highlighter-highlightable"
+        , case highlightable.marked of
+            Just markedWith ->
+                class "highlighter-highlighted"
+
+            _ ->
+                AttributesExtra.none
         ]
         [ viewJust
             (\name ->
@@ -876,6 +883,12 @@ viewHighlightableSegment { isInteractive, focusIndex, highlighterId, eventListen
                            )
                     )
                , class "highlighter-highlightable"
+               , case highlightable.marked of
+                    Just markedWith ->
+                        class "highlighter-highlighted"
+
+                    _ ->
+                        AttributesExtra.none
                , if isInteractive then
                     Key.tabbable
                         (case focusIndex of

--- a/src/Nri/Ui/Highlighter/V1.elm
+++ b/src/Nri/Ui/Highlighter/V1.elm
@@ -723,10 +723,10 @@ viewInlineTag { showTagsInline, isInteractive, maybeTool } highlightable =
              )
                 ++ highlightableStyle maybeTool highlightable isInteractive
             )
-        , class "highlighter-highlightable"
+        , class "highlighter-inline-tag"
         , case highlightable.marked of
             Just markedWith ->
-                class "highlighter-highlighted"
+                class "highlighter-inline-tag-highlighted"
 
             _ ->
                 AttributesExtra.none


### PR DESCRIPTION
Adds `"highlighter-inline-tag"` and `"highlighter-inline-tag-highlighted"` classes to inline tags, and `"highlighter-highlighted"` class to segments. Necessary to match the current monolith highlighter styles. In the monolith, some styles are applied when segments or inline tags are highlighted.