### PR TITLE
Adds another utility for creating safe Id strings

### DIFF
--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -59,8 +59,7 @@ import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.Svg.V1 exposing (Svg)
-import String exposing (toLower)
-import String.Extra exposing (dasherize)
+import Nri.Ui.Util as Util
 
 
 {-| This disables the input
@@ -228,7 +227,7 @@ view { label, selected } attributes =
                     specificId
 
                 Nothing ->
-                    "checkbox-v7-" ++ dasherize (toLower label)
+                    "checkbox-v7-" ++ Util.safeIdString label
 
         config_ =
             { identifier = idValue

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -54,8 +54,7 @@ import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.Pennant.V2 as Pennant
 import Nri.Ui.Svg.V1 exposing (Svg)
-import String exposing (toLower)
-import String.Extra exposing (dasherize)
+import Nri.Ui.Util as Util
 import Svg.Styled as Svg
 import Svg.Styled.Attributes as SvgAttributes
 
@@ -269,7 +268,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
                     specificId
 
                 Nothing ->
-                    name ++ "-" ++ dasherize (toLower stringValue)
+                    name ++ "-" ++ Util.safeIdString stringValue
 
         isChecked =
             selectedValue == Just value

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -93,8 +93,8 @@ import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
 import Nri.Ui.MediaQuery.V1 as MediaQuery exposing (mobileBreakpoint, narrowMobileBreakpoint, quizEngineBreakpoint)
 import Nri.Ui.Shadows.V1 as Shadows
 import Nri.Ui.UiIcon.V1 as UiIcon
+import Nri.Ui.Util as Util
 import Nri.Ui.WhenFocusLeaves.V1 as WhenFocusLeaves
-import String.Extra
 
 
 {-| -}
@@ -864,7 +864,7 @@ viewToggleTip : { label : String, lastId : Maybe String } -> List (Attribute msg
 viewToggleTip { label, lastId } attributes_ =
     let
         id =
-            String.Extra.dasherize label
+            Util.safeIdString label
 
         triggerId =
             "tooltip-trigger__" ++ id

--- a/src/Nri/Ui/Util.elm
+++ b/src/Nri/Ui/Util.elm
@@ -29,6 +29,7 @@ removePunctuation =
 
 
 {-| Creates a lowercased string that is safe to use for HTML IDs.
+Ensures that nonletter characters are cut from the front and replaces bad characters with a dash
 -}
 safeIdString : String -> String
 safeIdString =

--- a/src/Nri/Ui/Util.elm
+++ b/src/Nri/Ui/Util.elm
@@ -1,4 +1,4 @@
-module Nri.Ui.Util exposing (dashify, removePunctuation)
+module Nri.Ui.Util exposing (dashify, removePunctuation, safeIdString)
 
 import Regex
 
@@ -26,3 +26,22 @@ removePunctuation =
                 |> Maybe.withDefault Regex.never
     in
     Regex.replace regex (always "")
+
+
+{-| Creates a lowercased string that is safe to use for HTML IDs.
+-}
+safeIdString : String -> String
+safeIdString =
+    let
+        unsafeChar =
+            Regex.fromString "(^[^a-zA-Z]+|[^a-zA-Z0-9_-]+)" |> Maybe.withDefault Regex.never
+    in
+    Regex.replace unsafeChar
+        (\{ index } ->
+            if index == 0 then
+                ""
+
+            else
+                "-"
+        )
+        >> String.toLower

--- a/src/Nri/Ui/Util.elm
+++ b/src/Nri/Ui/Util.elm
@@ -16,13 +16,13 @@ dashify =
 
 
 {-| Convenience method for removing punctuation
-(removes everything that isn't whitespace or alphanumeric).
+(removes everything that isn't whitespace, alphanumeric, or an underscore).
 -}
 removePunctuation : String -> String
 removePunctuation =
     let
         regex =
-            Regex.fromString "[^A-z0-9\\w\\s]"
+            Regex.fromString "[^A-Za-z0-9\\w\\s]"
                 |> Maybe.withDefault Regex.never
     in
     Regex.replace regex (always "")

--- a/src/Nri/Ui/Util.elm
+++ b/src/Nri/Ui/Util.elm
@@ -1,6 +1,6 @@
 module Nri.Ui.Util exposing (dashify, removePunctuation, safeIdString)
 
-import Regex
+import Regex exposing (Regex)
 
 
 {-| Convenience method for going from a string with spaces to a string with dashes.
@@ -35,7 +35,10 @@ safeIdString : String -> String
 safeIdString =
     let
         unsafeChar =
-            Regex.fromString "(^[^a-zA-Z]+|[^a-zA-Z0-9_-]+)" |> Maybe.withDefault Regex.never
+            regexFromString "(^[^a-zA-Z]+|[^a-zA-Z0-9_-]+)"
+
+        collapse =
+            regexFromString "[_-\\s]+"
     in
     Regex.replace unsafeChar
         (\{ index } ->
@@ -45,4 +48,10 @@ safeIdString =
             else
                 "-"
         )
+        >> Regex.replace collapse (always "-")
         >> String.toLower
+
+
+regexFromString : String -> Regex
+regexFromString =
+    Regex.fromString >> Maybe.withDefault Regex.never

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -113,7 +113,7 @@ row i ( name, selectionStatus ) =
     { state = name
     , enabled =
         Checkbox.view
-            { label = "Settings"
+            { label = "Setting"
             , selected = selectionStatus
             }
             [ Checkbox.id <| "enabled-" ++ String.fromInt i

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -113,7 +113,7 @@ row i ( name, selectionStatus ) =
     { state = name
     , enabled =
         Checkbox.view
-            { label = "Setting"
+            { label = "Settings"
             , selected = selectionStatus
             }
             [ Checkbox.id <| "enabled-" ++ String.fromInt i

--- a/tests/Spec/Nri/Ui/Util.elm
+++ b/tests/Spec/Nri/Ui/Util.elm
@@ -34,4 +34,11 @@ spec =
                     Util.safeIdString "--__--hellO----_______---HOw----___---____--ArE------___You___--__--__Today"
                         |> Expect.equal "hello-how-are-you-today"
             ]
+        , describe "removePunctuation"
+            [ test "A string with some punctuation" <|
+                \() ->
+                    Util.removePunctuation
+                        "To sleep? Perchance: to dream? “Alas poor ‘Yorick’” but he's not `in` _this_ \"[play]\"."
+                        |> Expect.equal "To sleep Perchance to dream Alas poor Yorick but hes not in _this_ play"
+            ]
         ]

--- a/tests/Spec/Nri/Ui/Util.elm
+++ b/tests/Spec/Nri/Ui/Util.elm
@@ -1,0 +1,33 @@
+module Spec.Nri.Ui.Util exposing (spec)
+
+import Expect
+import Nri.Ui.Util as Util
+import Test exposing (..)
+
+
+spec : Test
+spec =
+    describe "Nri.Ui.Util"
+        [ describe "safeIdString transforms strings as expected"
+            [ test "with a comma" <|
+                \() ->
+                    Util.safeIdString "Enable text-to-speech for Angela's account"
+                        |> Expect.equal "enable-text-to-speech-for-angela-s-account"
+            , test "removes leading non alpha characters" <|
+                \() ->
+                    Util.safeIdString "#@!!232now we are in business"
+                        |> Expect.equal "now-we-are-in-business"
+            , test "hard mode" <|
+                \() ->
+                    Util.safeIdString "!@#21something else interesting321$ ... hi"
+                        |> Expect.equal "something-else-interesting321-hi"
+            , test "with capitol letters" <|
+                \() ->
+                    Util.safeIdString "1232!@#%#@JFEKLfds-----SFJK3@#@jj23FDS........''''\"\"***"
+                        |> Expect.equal "jfeklfds-sfjk3-jj23fds-"
+            , test "lotsa hyphens and dashes" <|
+                \() ->
+                    Util.safeIdString "hellO----_______---HOw----___---____--ArE------___You___--__--__Today"
+                        |> Expect.equal "hello-how-are-you-today"
+            ]
+        ]

--- a/tests/Spec/Nri/Ui/Util.elm
+++ b/tests/Spec/Nri/Ui/Util.elm
@@ -15,19 +15,23 @@ spec =
                         |> Expect.equal "enable-text-to-speech-for-angela-s-account"
             , test "removes leading non alpha characters" <|
                 \() ->
-                    Util.safeIdString "#@!!232now we are in business"
+                    Util.safeIdString "#@!!232now we are in business__--__"
                         |> Expect.equal "now-we-are-in-business"
+            , test "removes trailing non alphanum characters" <|
+                \() ->
+                    Util.safeIdString "#@!!232now we are in business__--__123!!@&*%^ @"
+                        |> Expect.equal "now-we-are-in-business-123"
             , test "hard mode" <|
                 \() ->
                     Util.safeIdString "!@#21something else interesting321$ ... hi"
                         |> Expect.equal "something-else-interesting321-hi"
-            , test "with capitol letters" <|
+            , test "with capital letters" <|
                 \() ->
                     Util.safeIdString "1232!@#%#@JFEKLfds-----SFJK3@#@jj23FDS........''''\"\"***"
-                        |> Expect.equal "jfeklfds-sfjk3-jj23fds-"
+                        |> Expect.equal "jfeklfds-sfjk3-jj23fds"
             , test "lotsa hyphens and dashes" <|
                 \() ->
-                    Util.safeIdString "hellO----_______---HOw----___---____--ArE------___You___--__--__Today"
+                    Util.safeIdString "--__--hellO----_______---HOw----___---____--ArE------___You___--__--__Today"
                         |> Expect.equal "hello-how-are-you-today"
             ]
         ]


### PR DESCRIPTION
While implementing something with Checkboxv7 we noticed an issue where when the id was being created from the label it would break the filter on the svg causing the fill to be black. In this case it was due to the label having something like "Angela's account" in it which broke the id on the comma.