### PR TITLE
Bat/add theme

### DIFF
--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -215,6 +215,7 @@ toMark label_ palette =
                     , MediaQuery.highContrastMode
                         [ Css.property "background-color" "Mark"
                         , Css.property "color" "MarkText"
+                        , Css.property "forced-color-adjust" "none"
                         ]
                     ]
                 , endStyles =
@@ -360,7 +361,10 @@ viewBlank =
     span
         [ css
             [ Css.border3 (Css.px 2) Css.dashed Colors.navy
-            , MediaQuery.highContrastMode [ Css.property "border-color" "CanvasText" ]
+            , MediaQuery.highContrastMode
+                [ Css.property "border-color" "CanvasText"
+                , Css.property "background-color" "Canvas"
+                ]
             , Css.backgroundColor Colors.white
             , Css.display Css.inlineBlock
             , Css.minWidth (Css.px 80)

--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -140,32 +140,53 @@ themeToPalette : Theme -> Palette
 themeToPalette theme =
     case theme of
         Emphasis ->
-            { backgroundColor = Colors.highlightYellow, borderColor = Colors.highlightYellowDark }
+            defaultPalette
 
         Yellow ->
-            { backgroundColor = Colors.highlightYellow, borderColor = Colors.highlightYellowDark }
+            { backgroundColor = Colors.highlightYellow
+            , borderColor = Colors.highlightYellowDark
+            }
 
         Cyan ->
-            { backgroundColor = Colors.highlightCyan, borderColor = Colors.highlightCyanDark }
+            { backgroundColor = Colors.highlightCyan
+            , borderColor = Colors.highlightCyanDark
+            }
 
         Magenta ->
-            { backgroundColor = Colors.highlightMagenta, borderColor = Colors.highlightMagentaDark }
+            { backgroundColor = Colors.highlightMagenta
+            , borderColor = Colors.highlightMagentaDark
+            }
 
         Green ->
-            { backgroundColor = Colors.highlightGreen, borderColor = Colors.highlightGreenDark }
+            { backgroundColor = Colors.highlightGreen
+            , borderColor = Colors.highlightGreenDark
+            }
 
         Blue ->
-            { backgroundColor = Colors.highlightBlue, borderColor = Colors.highlightBlueDark }
+            { backgroundColor = Colors.highlightBlue
+            , borderColor = Colors.highlightBlueDark
+            }
 
         Purple ->
-            { backgroundColor = Colors.highlightPurple, borderColor = Colors.highlightPurpleDark }
+            { backgroundColor = Colors.highlightPurple
+            , borderColor = Colors.highlightPurpleDark
+            }
 
         Brown ->
-            { backgroundColor = Colors.highlightBrown, borderColor = Colors.highlightBrownDark }
+            { backgroundColor = Colors.highlightBrown
+            , borderColor = Colors.highlightBrownDark
+            }
 
 
 type alias Palette =
     { backgroundColor : Color, borderColor : Color }
+
+
+defaultPalette : Palette
+defaultPalette =
+    { backgroundColor = Colors.highlightYellow
+    , borderColor = Colors.highlightYellowDark
+    }
 
 
 toMark : Maybe String -> Maybe Palette -> Maybe Mark

--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -302,25 +302,30 @@ type alias Config =
 render : Config -> Html msg
 render config =
     let
+        maybePalette =
+            Maybe.map themeToPalette config.theme
+
         maybeMark =
-            toMark config.label (Maybe.map themeToPalette config.theme)
+            toMark config.label maybePalette
     in
     case config.content of
         [] ->
             case maybeMark of
                 Just mark ->
-                    viewMark ( [ Blank ], Just mark )
+                    viewMark (Maybe.withDefault defaultPalette maybePalette)
+                        ( [ Blank ], Just mark )
 
                 Nothing ->
                     viewBlank
 
         _ ->
-            viewMark ( config.content, maybeMark )
+            viewMark (Maybe.withDefault defaultPalette maybePalette)
+                ( config.content, maybeMark )
 
 
-viewMark : ( List Content, Maybe Mark ) -> Html msg
-viewMark markContent =
-    Mark.viewWithBalloonTags
+viewMark : Palette -> ( List Content, Maybe Mark ) -> Html msg
+viewMark palette markContent =
+    Mark.viewWithBalloonTags palette.backgroundColor
         (\content_ markStyles ->
             span
                 [ css

--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -212,7 +212,10 @@ toMark label_ palette =
                 , styles =
                     [ Css.padding2 (Css.px 4) Css.zero
                     , Css.backgroundColor backgroundColor
-                    , MediaQuery.highContrastMode [ Css.property "background-color" "Mark" ]
+                    , MediaQuery.highContrastMode
+                        [ Css.property "background-color" "Mark"
+                        , Css.property "color" "MarkText"
+                        ]
                     ]
                 , endStyles =
                     [ Css.paddingRight (Css.px 2)
@@ -357,6 +360,7 @@ viewBlank =
     span
         [ css
             [ Css.border3 (Css.px 2) Css.dashed Colors.navy
+            , MediaQuery.highContrastMode [ Css.property "border-color" "CanvasText" ]
             , Css.backgroundColor Colors.white
             , Css.display Css.inlineBlock
             , Css.minWidth (Css.px 80)

--- a/src/Nri/Ui/HighlighterTool/V1.elm
+++ b/src/Nri/Ui/HighlighterTool/V1.elm
@@ -91,7 +91,10 @@ highlightStyles color =
         sharedStyles
         [ Css.backgroundColor color
         , Css.boxShadow5 Css.zero (Css.px 1) Css.zero Css.zero Colors.gray75
-        , MediaQuery.highContrastMode [ Css.property "background-color" "Mark" ]
+        , MediaQuery.highContrastMode
+            [ Css.property "background-color" "Mark"
+            , Css.property "forced-color-adjust" "none"
+            ]
         ]
 
 
@@ -110,6 +113,7 @@ hoverStyles color =
         , MediaQuery.highContrastMode
             [ Css.property "background-color" "Highlight" |> Css.important
             , Css.property "color" "HighlightText"
+            , Css.property "forced-color-adjust" "none"
             ]
 
         -- The Highlighter applies both these styles and the startGroup and

--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -231,7 +231,7 @@ viewBalloon backgroundColor label =
               Css.left (Css.pct 50)
             , Css.property "transform" "translateX(-50%)"
             ]
-        , Balloon.css [ Css.padding2 Css.zero (Css.px 6) ]
+        , Balloon.css [ Css.padding3 Css.zero (Css.px 6) (Css.px 1) ]
         , Balloon.custom
             [ -- we use the :before element to convey details about the start of the
               -- highlighter to screenreaders, so the visual label is redundant

--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -234,6 +234,10 @@ viewBalloon backgroundColor label =
         , Balloon.css
             [ Css.padding3 Css.zero (Css.px 6) (Css.px 1)
             , Css.property "box-shadow" "none"
+            , MediaQuery.highContrastMode
+                [ Css.property "background-color" "Mark"
+                , Css.property "color" "MarkText"
+                ]
             ]
         , Balloon.custom
             [ -- we use the :before element to convey details about the start of the

--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -234,10 +234,6 @@ viewBalloon backgroundColor label =
         , Balloon.css
             [ Css.padding3 Css.zero (Css.px 6) (Css.px 1)
             , Css.property "box-shadow" "none"
-            , MediaQuery.highContrastMode
-                [ Css.property "background-color" "Mark"
-                , Css.property "color" "MarkText"
-                ]
             ]
         , Balloon.custom
             [ -- we use the :before element to convey details about the start of the
@@ -247,6 +243,10 @@ viewBalloon backgroundColor label =
         , Balloon.customTheme
             { backgroundColor = backgroundColor
             , color = Nri.Ui.Colors.Extra.highContrastColor backgroundColor
+            }
+        , Balloon.highContrastModeTheme
+            { backgroundColor = "Mark"
+            , color = "MarkText"
             }
 
         -- TODO: ensure the balloon is legible for users in high-contrast mode

--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -12,11 +12,12 @@ module Nri.Ui.Mark.V1 exposing
 
 import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Style exposing (invisibleStyle)
-import Css exposing (Style)
+import Css exposing (Color, Style)
 import Css.Global
 import Html.Styled as Html exposing (Html, span)
 import Html.Styled.Attributes exposing (class, css)
 import Nri.Ui.Balloon.V2 as Balloon
+import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
@@ -62,17 +63,18 @@ Show the label for the mark, if present, in a balloon centered above the emphasi
 
 -}
 viewWithBalloonTags :
-    (content -> List Style -> Html msg)
+    Color
+    -> (content -> List Style -> Html msg)
     -> List ( content, Maybe Mark )
     -> List (Html msg)
-viewWithBalloonTags =
-    view_ BalloonTags
+viewWithBalloonTags backgroundColor =
+    view_ (BalloonTags backgroundColor)
 
 
 type TagStyle
     = HiddenTags
     | InlineTags
-    | BalloonTags
+    | BalloonTags Color
 
 
 {-| When elements are marked, wrap them in a single `mark` html node.
@@ -107,7 +109,7 @@ view_ tagStyle viewSegment highlightables =
                             [ Css.display Css.inlineFlex
                             , Css.backgroundColor Css.transparent
                             , case tagStyle of
-                                BalloonTags ->
+                                BalloonTags _ ->
                                     Css.position Css.relative
 
                                 _ ->
@@ -191,8 +193,8 @@ viewTag tagStyle =
                     ]
                 ]
 
-        BalloonTags ->
-            viewBalloon
+        BalloonTags color ->
+            viewBalloon color
 
 
 viewInlineTag : List Css.Style -> String -> Html msg
@@ -215,8 +217,8 @@ viewInlineTag customizations name =
         [ Html.text name ]
 
 
-viewBalloon : String -> Html msg
-viewBalloon label =
+viewBalloon : Color -> String -> Html msg
+viewBalloon backgroundColor label =
     Balloon.view
         [ Balloon.onTop
         , Balloon.containerCss
@@ -235,8 +237,11 @@ viewBalloon label =
               -- highlighter to screenreaders, so the visual label is redundant
               Aria.hidden True
             ]
+        , Balloon.customTheme
+            { backgroundColor = backgroundColor
+            , color = Nri.Ui.Colors.Extra.highContrastColor backgroundColor
+            }
 
-        -- TODO: customize the balloon color
         -- TODO: ensure the balloon is legible for users in high-contrast mode
         , Balloon.plaintext label
         ]

--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -231,7 +231,10 @@ viewBalloon backgroundColor label =
               Css.left (Css.pct 50)
             , Css.property "transform" "translateX(-50%)"
             ]
-        , Balloon.css [ Css.padding3 Css.zero (Css.px 6) (Css.px 1) ]
+        , Balloon.css
+            [ Css.padding3 Css.zero (Css.px 6) (Css.px 1)
+            , Css.property "box-shadow" "none"
+            ]
         , Balloon.custom
             [ -- we use the :before element to convey details about the start of the
               -- highlighter to screenreaders, so the visual label is redundant

--- a/styleguide-app/Examples/Balloon.elm
+++ b/styleguide-app/Examples/Balloon.elm
@@ -15,6 +15,7 @@ import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import EllieLink
 import Example exposing (Example)
+import Examples.Colors
 import Html.Styled exposing (Html)
 import Nri.Ui.Balloon.V2 as Balloon
 import Nri.Ui.Colors.V1 as Colors
@@ -96,7 +97,23 @@ themeOptions =
         , ( "orange", Control.value ( "Balloon.orange", Balloon.orange ) )
         , ( "white", Control.value ( "Balloon.white", Balloon.white ) )
         , ( "navy", Control.value ( "Balloon.navy", Balloon.navy ) )
+        , ( "customTheme", controlCustomTheme )
         ]
+
+
+controlCustomTheme : Control ( String, Balloon.Attribute msg )
+controlCustomTheme =
+    Examples.Colors.backgroundHighlightColors
+        |> List.map
+            (\( name, value, _ ) ->
+                ( name
+                , Control.value
+                    ( "Balloon.customTheme { backgroundColor = Colors." ++ name ++ ", color = Colors.gray20 }"
+                    , Balloon.customTheme { backgroundColor = value, color = Colors.gray20 }
+                    )
+                )
+            )
+        |> ControlExtra.rotatedChoice 0
 
 
 positionOptions : Control ( String, Balloon.Attribute msg )
@@ -142,7 +159,7 @@ view ellieLinkConfig state =
             \_ ->
                 [ { sectionName = "Balloon"
                   , code =
-                        Code.fromModule moduleName "view"
+                        Code.fromModule moduleName "view "
                             ++ Code.list (List.map Tuple.first attributes)
                   }
                 ]


### PR DESCRIPTION
Fixes A11-1803 and fixes A11-1790

### All supported color themes

**Brown**
<img width="343" alt="Screen Shot - brown theme" src="https://user-images.githubusercontent.com/8811312/201996251-33d6c96d-eeb9-4437-b66a-8308d79dc39b.png">

**Purple**
<img width="330" alt="Screen Shot - purple theme" src="https://user-images.githubusercontent.com/8811312/201996253-2c028036-4e7a-4fe2-8d9d-222ca5178995.png">

**Blue**
<img width="362" alt="Screen Shot - purple theme" src="https://user-images.githubusercontent.com/8811312/201996256-374a4890-7781-4765-aa39-7deaa284100e.png">

**Green**
<img width="351" alt="Screen Shot - green theme" src="https://user-images.githubusercontent.com/8811312/201996257-a62ac55b-a00d-43a1-b5c3-95c752aaa5a9.png">

**Magenta**
<img width="345" alt="Screen Shot - magenta theme" src="https://user-images.githubusercontent.com/8811312/201996259-10136bf7-8d9f-4247-8aa3-de5c6b343506.png">

**Cyan**
<img width="355" alt="Screen Shot - cyan theme" src="https://user-images.githubusercontent.com/8811312/201996260-d7de5c92-5fa6-4d2b-ac90-1481b4227030.png">

**Yellow/default**
<img width="336" alt="Screen Shot - yellow theme" src="https://user-images.githubusercontent.com/8811312/201996261-608ba97b-2591-4eb2-aef1-1b80aff69a2d.png">


### High contrast mode
<img width="610" alt="Screen Shot - high contrast mode examples" src="https://user-images.githubusercontent.com/8811312/201995972-13a1480e-8307-4ddc-b0ae-c76d8be484f2.png">


cc @NoRedInk/design 