### PR TITLE
Fix highlighter styles

### DIFF
--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -339,16 +339,7 @@ viewMark palette markContent =
                 ]
                 (List.map renderContent content_)
         )
-        [ markContent ]
-        |> span
-            [ css
-                (if Tuple.first markContent == [ Blank ] then
-                    [ Css.display Css.inlineFlex, Css.alignSelf Css.stretch ]
-
-                 else
-                    [ Css.display Css.inlineFlex ]
-                )
-            ]
+        markContent
 
 
 viewBlank : Html msg

--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -29,7 +29,6 @@ module Nri.Ui.Block.V1 exposing
 -}
 
 import Accessibility.Styled exposing (..)
-import Accessibility.Styled.Style exposing (invisibleStyle)
 import Css exposing (Color)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors

--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -333,12 +333,7 @@ viewMark palette markContent =
         (\content_ markStyles ->
             span
                 [ css
-                    (Css.display Css.inlineFlex
-                        :: Css.whiteSpace Css.preWrap
-                        :: -- empty spaces get collapsed away despite the preWrap setting
-                           -- to ensure there's still visible whitespace between emphasis blocks,
-                           -- set a minimum width for the container.
-                           Css.minWidth (Css.px 4)
+                    (Css.whiteSpace Css.preWrap
                         :: markStyles
                     )
                 ]

--- a/src/Nri/Ui/Highlighter/V1.elm
+++ b/src/Nri/Ui/Highlighter/V1.elm
@@ -621,12 +621,6 @@ view_ groupConfig viewSegment { id, highlightables } =
     p
         [ Html.Styled.Attributes.id id
         , class "highlighter-container"
-        , css
-            [ Css.display Css.inlineFlex
-            , Css.flexWrap Css.wrap
-            , Css.alignItems Css.center
-            , Css.whiteSpace Css.preWrap
-            ]
         ]
         (viewSegments groupConfig viewSegment highlightables)
 

--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -106,8 +106,7 @@ view_ tagStyle viewSegment highlightables =
                             |> Maybe.map (\name -> Aria.roleDescription (name ++ " highlight"))
                             |> Maybe.withDefault AttributesExtra.none
                         , css
-                            [ Css.display Css.inlineFlex
-                            , Css.backgroundColor Css.transparent
+                            [ Css.backgroundColor Css.transparent
                             , case tagStyle of
                                 BalloonTags _ ->
                                     Css.position Css.relative

--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -63,21 +63,24 @@ Show the label for the mark, if present, in a balloon centered above the emphasi
 
 -}
 viewWithBalloonTags :
-    Color
-    -> (content -> List Style -> Html msg)
-    -> ( content, Maybe Mark )
-    -> Html msg
-viewWithBalloonTags backgroundColor viewSegment ( content, marked ) =
+    (c -> List Style -> Html msg)
+    -> Color
+    -> Maybe Mark
+    -> List c
+    -> List (Html msg)
+viewWithBalloonTags viewSegment backgroundColor marked contents =
     let
-        segment =
-            viewSegment content (markStyles 0 marked)
+        segments =
+            List.indexedMap
+                (\index content -> viewSegment content (markStyles index marked))
+                contents
     in
     case marked of
         Just markedWith ->
-            viewMarked (BalloonTags backgroundColor) markedWith [ segment ]
+            [ viewMarked (BalloonTags backgroundColor) markedWith segments ]
 
         Nothing ->
-            segment
+            segments
 
 
 type TagStyle
@@ -235,7 +238,7 @@ viewBalloon backgroundColor label =
         [ Balloon.onTop
         , Balloon.containerCss
             [ Css.position Css.absolute
-            , Css.bottom (Css.pct 100)
+            , Css.bottom (Css.calc (Css.pct 100) Css.plus (Css.px 4))
             , -- using position, 50% is wrt the parent container
               -- using transform & translate, 50% is wrt to the element itself
               -- combining these two properties, we can center the tag against the parent container

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -143,17 +143,7 @@ example =
                     }
                 , Table.custom
                     { header = text "Example"
-                    , view =
-                        .example
-                            >> p
-                                [ css
-                                    [ Css.displayFlex
-                                    , Css.justifyContent Css.center
-                                    , Css.flexWrap Css.wrap
-                                    , Css.alignItems Css.center
-                                    , Css.margin2 (Css.px 30) Css.zero
-                                    ]
-                                ]
+                    , view = .example >> p [ css [ Css.margin2 (Css.px 30) Css.zero ] ]
                     , width = Css.px 200
                     , cellStyles = always [ Css.textAlign Css.center ]
                     , sort = Nothing

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -45,40 +45,33 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , preview =
-        [ p
-            [ css
-                [ Fonts.baseFont
-                , Css.fontSize (Css.px 12)
-                , Css.displayFlex
-                , Css.flexWrap Css.wrap
-                , Css.alignItems Css.center
-                ]
-            ]
-            [ Block.view
+        [ [ Block.view
                 [ Block.plaintext "Dave"
                 , Block.label "subject"
                 , Block.yellow
                 ]
-            , Block.view [ Block.plaintext " " ]
-            , Block.view
+          , Block.view [ Block.plaintext " " ]
+          , Block.view
                 [ Block.plaintext "broke"
                 , Block.label "verb"
                 , Block.cyan
                 ]
-            , Block.view [ Block.plaintext " his french fry so " ]
-            , Block.view
+          , Block.view [ Block.plaintext " his french fry so " ]
+          , Block.view
                 [ Block.plaintext "he"
                 , Block.label "subject"
                 , Block.yellow
                 ]
-            , Block.view [ Block.plaintext " " ]
-            , Block.view
+          , Block.view [ Block.plaintext " " ]
+          , Block.view
                 [ Block.plaintext "glued"
                 , Block.label "verb"
                 , Block.cyan
                 ]
-            , Block.view [ Block.plaintext " it with ketchup." ]
-            ]
+          , Block.view [ Block.plaintext " it with ketchup." ]
+          ]
+            |> List.concat
+            |> p [ css [ Fonts.baseFont, Css.fontSize (Css.px 12) ] ]
         ]
     , view =
         \ellieLinkConfig state ->
@@ -108,20 +101,18 @@ example =
                 [ Heading.plaintext "Interactive example"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
-            , p
-                [ css
-                    [ Fonts.quizFont
-                    , Css.fontSize (Css.px 30)
-                    , Css.displayFlex
-                    , Css.justifyContent Css.center
-                    , Css.flexWrap Css.wrap
-                    , Css.alignItems Css.center
+            , [ Block.view [ Block.plaintext "I like " ]
+              , Block.view (List.map Tuple.second attributes)
+              , Block.view [ Block.plaintext " a lot!" ]
+              ]
+                |> List.concat
+                |> p
+                    [ css
+                        [ Fonts.quizFont
+                        , Css.fontSize (Css.px 30)
+                        , Css.textAlign Css.center
+                        ]
                     ]
-                ]
-                [ Block.view [ Block.plaintext "I like " ]
-                , Block.view (List.map Tuple.second attributes)
-                , Block.view [ Block.plaintext " a lot!" ]
-                ]
             , Heading.h2
                 [ Heading.plaintext "Non-interactive examples"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
@@ -143,7 +134,7 @@ example =
                     }
                 , Table.custom
                     { header = text "Example"
-                    , view = .example >> p [ css [ Css.margin2 (Css.px 30) Css.zero ] ]
+                    , view = .example >> List.concat >> p [ css [ Css.margin2 (Css.px 30) Css.zero ] ]
                     , width = Css.px 200
                     , cellStyles = always [ Css.textAlign Css.center ]
                     , sort = Nothing

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -19,23 +19,28 @@ contentSpec : List Test
 contentSpec =
     [ test "blank" <|
         \() ->
-            Block.view []
-                |> Html.Styled.toUnstyled
-                |> Query.fromHtml
+            []
+                |> toQuery
                 |> Query.has [ Selector.text "blank" ]
     , test "plaintext" <|
         \() ->
-            Block.view [ Block.plaintext "Yo" ]
-                |> Html.Styled.toUnstyled
-                |> Query.fromHtml
+            [ Block.plaintext "Yo" ]
+                |> toQuery
                 |> Expect.all
                     [ Query.hasNot [ Selector.text "blank" ]
                     , Query.has [ Selector.text "Yo" ]
                     ]
     , test "content with string and blank" <|
         \() ->
-            Block.view [ Block.content [ Block.string "Yo", Block.blank ] ]
-                |> Html.Styled.toUnstyled
-                |> Query.fromHtml
+            [ Block.content [ Block.string "Yo", Block.blank ] ]
+                |> toQuery
                 |> Query.has [ Selector.text "Yo", Selector.text "blank" ]
     ]
+
+
+toQuery : List Block.Attribute -> Query.Single a
+toQuery block =
+    Block.view block
+        |> Html.Styled.p []
+        |> Html.Styled.toUnstyled
+        |> Query.fromHtml


### PR DESCRIPTION
Using inline-flex for Mark styles breaks the Highlighter styles. This PR refactors to avoid using inline-flex in favor of inline. So now, Highlighter and Block should both have working styles! 

### Before

<img width="1480" alt="image" src="https://user-images.githubusercontent.com/8811312/202033313-4c5f5e98-219d-4e5a-820a-7b20c6b7f494.png">


### After

<img width="1468" alt="Screen Shot 2022-11-15 at 2 54 26 PM" src="https://user-images.githubusercontent.com/8811312/202033328-b084be1f-3057-45b9-a5a8-bec6cf7a264d.png">
