### PR TITLE
A11-1838 NVDA and JAWS: fixes focus loss when pressing space on a highlightable with marker or eraser

### DIFF
--- a/src/Nri/Ui/Highlighter/V1.elm
+++ b/src/Nri/Ui/Highlighter/V1.elm
@@ -475,7 +475,7 @@ pointerEventToActions msg model =
                     case ( model.mouseOverIndex, model.mouseDownIndex ) of
                         ( Just overIndex, Just downIndex ) ->
                             if overIndex == downIndex then
-                                [ Toggle downIndex marker ]
+                                [ Toggle downIndex marker, Focus downIndex ]
 
                             else
                                 [ Save marker ]
@@ -485,13 +485,28 @@ pointerEventToActions msg model =
 
                         _ ->
                             []
+
+                focus =
+                    case ( model.mouseOverIndex, model.mouseDownIndex ) of
+                        ( Just overIndex, Just downIndex ) ->
+                            if overIndex == downIndex then
+                                [ Focus downIndex ]
+
+                            else
+                                []
+
+                        ( Nothing, Just downIndex ) ->
+                            []
+
+                        _ ->
+                            []
             in
             case model.marker of
                 Tool.Marker marker ->
                     MouseUp :: save marker
 
                 Tool.Eraser _ ->
-                    [ MouseUp, Remove ]
+                    MouseUp :: Remove :: focus
 
         Out eventIndex ->
             [ Blur eventIndex ]


### PR DESCRIPTION
This keeps the current highlightable focused when pressing space to toggle or erase a highlight.