### PR TITLE
"use strict" is fine

### DIFF
--- a/lib/CustomElement.js
+++ b/lib/CustomElement.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /**
  * @module CustomElement
  */

--- a/lib/TextArea/V5.js
+++ b/lib/TextArea/V5.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var CustomElement = require("../CustomElement");
 
 CustomElement.create({

--- a/lib/TextArea/V5.js
+++ b/lib/TextArea/V5.js
@@ -1,4 +1,4 @@
-CustomElement = require("../CustomElement");
+var CustomElement = require("../CustomElement");
 
 CustomElement.create({
   tagName: "nri-textarea-v5",

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 require("./TextArea/V5");
 
 exports.CustomElement = require("./CustomElement");


### PR DESCRIPTION
I'm changing some stuff up in the monolith builds, and the new setup adds "use strict" at the top of the exported file. Turns out we can't allow that! (we do `CustomElement = …` which is not allowed in strict mode, as it refers to the name without defining it.)

Anyway, this makes all our JS use "use strict" so this stops happening, and defines `CustomElement` instead of just assigning it. 👍 