### PR TITLE
Adds paragraph helpers to components

### DIFF
--- a/src/Content.elm
+++ b/src/Content.elm
@@ -2,7 +2,9 @@ module Content exposing (..)
 
 {-| -}
 
+import Css
 import Html.Styled exposing (..)
+import Html.Styled.Attributes exposing (css)
 import Markdown
 
 
@@ -14,6 +16,16 @@ plaintext :
     -> { config | content : List (Html msg) }
 plaintext content config =
     { config | content = [ text content ] }
+
+
+{-| Provide a plain-text string that will be put into a paragraph tag, with the default margin removed.
+-}
+paragraphPlaintext :
+    String
+    -> { config | content : List (Html msg) }
+    -> { config | content : List (Html msg) }
+paragraphPlaintext content config =
+    { config | content = [ p [ css [ Css.margin Css.zero ] ] [ text content ] ] }
 
 
 {-| Provide a string that will be rendered as markdown.

--- a/src/Content.elm
+++ b/src/Content.elm
@@ -20,11 +20,11 @@ plaintext content config =
 
 {-| Provide a plain-text string that will be put into a paragraph tag, with the default margin removed.
 -}
-paragraphPlaintext :
+paragraph :
     String
     -> { config | content : List (Html msg) }
     -> { config | content : List (Html msg) }
-paragraphPlaintext content config =
+paragraph content config =
     { config | content = [ p [ css [ Css.margin Css.zero ] ] [ text content ] ] }
 
 

--- a/src/Nri/Ui/Balloon/V2.elm
+++ b/src/Nri/Ui/Balloon/V2.elm
@@ -7,19 +7,24 @@ module Nri.Ui.Balloon.V2 exposing
     , custom, id, nriDescription, testId
     , containerCss
     , css, notMobileCss, mobileCss, quizEngineMobileCss
+    , paragraph
     )
 
 {-| Adding a tooltip? Use `Nri.Ui.Tooltip`, not Balloon.
 Balloon is really just a container: it is non-interactive and isn't semantically meaningful.
 
     Balloon.view
-        [ Balloon.plaintext "Hello!"
+        [ Balloon.paragraph "Hello, world! I'm a balloon!"
         , Balloon.onTop
         , Balloon.navy
         ]
 
 
 ## Changelog
+
+Patch changes:
+
+  - adds paragraph
 
 Changes from V1:
 
@@ -285,6 +290,13 @@ id id_ =
 plaintext : String -> Attribute msg
 plaintext =
     Attribute << Content.plaintext
+
+
+{-| Provide a plain-text string that will be put into a paragraph tag, with the default margin removed.
+-}
+paragraph : String -> Attribute msg
+paragraph =
+    Attribute << Content.paragraph
 
 
 {-| Provide a string that will be rendered as markdown.

--- a/src/Nri/Ui/Balloon/V2.elm
+++ b/src/Nri/Ui/Balloon/V2.elm
@@ -1,13 +1,12 @@
 module Nri.Ui.Balloon.V2 exposing
     ( view, Attribute
-    , plaintext, markdown, html
+    , paragraph, plaintext, markdown, html
     , green, purple, orange, white, navy, customTheme
     , highContrastModeTheme
     , onBottom, onLeft, onRight, onTop
     , custom, id, nriDescription, testId
     , containerCss
     , css, notMobileCss, mobileCss, quizEngineMobileCss
-    , paragraph
     )
 
 {-| Adding a tooltip? Use `Nri.Ui.Tooltip`, not Balloon.
@@ -44,7 +43,7 @@ Changes from V1:
 
 ### Content
 
-@docs plaintext, markdown, html
+@docs paragraph, plaintext, markdown, html
 
 
 ### Customizations for Balloon

--- a/src/Nri/Ui/Container/V2.elm
+++ b/src/Nri/Ui/Container/V2.elm
@@ -3,7 +3,7 @@ module Nri.Ui.Container.V2 exposing
     , custom, testId, id
     , css, notMobileCss, mobileCss, quizEngineMobileCss
     , paddingPx
-    , plaintext, markdown, html
+    , paragraph, plaintext, markdown, html
     , gray, default, disabled, invalid, pillow, buttony
     )
 
@@ -23,6 +23,7 @@ module Nri.Ui.Container.V2 exposing
   - use `Shadows`
   - add notMobileCss, mobileCss, quizEngineMobileCss
   - use internal `Content` module
+  - adds paragraph
 
 
 ## Changes from V1
@@ -53,7 +54,7 @@ module Nri.Ui.Container.V2 exposing
 
 ## Content
 
-@docs plaintext, markdown, html
+@docs paragraph, plaintext, markdown, html
 
 
 ## Themes
@@ -339,6 +340,13 @@ html =
 plaintext : String -> Attribute msg
 plaintext =
     Attribute << Content.plaintext
+
+
+{-| Provide a plain-text string that will be put into a paragraph tag, with the default margin removed.
+-}
+paragraph : String -> Attribute msg
+paragraph =
+    Attribute << Content.paragraph
 
 
 {-| Provide a string that will be rendered as markdown.

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -5,7 +5,7 @@ module Nri.Ui.Message.V3 exposing
     , hideIconForMobile, hideIconFor
     , css, notMobileCss, mobileCss, quizEngineMobileCss
     , tiny, large, banner
-    , plaintext, markdown, html, httpError, codeDetails
+    , paragraph, plaintext, markdown, html, httpError, codeDetails
     , tip, error, alert, success, customTheme
     , alertRole, alertDialogRole
     , onDismiss
@@ -43,7 +43,7 @@ Changes from V2:
 
 ## Content
 
-@docs plaintext, markdown, html, httpError, codeDetails
+@docs paragraph, plaintext, markdown, html, httpError, codeDetails
 
 
 ## Theme
@@ -387,6 +387,13 @@ banner =
 plaintext : String -> Attribute msg
 plaintext =
     Attribute << Content.plaintext
+
+
+{-| Provide a plain-text string that will be put into a paragraph tag, with the default margin removed.
+-}
+paragraph : String -> Attribute msg
+paragraph =
+    Attribute << Content.paragraph
 
 
 {-| Provide a string that will be rendered as markdown.

--- a/src/Nri/Ui/Panel/V1.elm
+++ b/src/Nri/Ui/Panel/V1.elm
@@ -1,7 +1,7 @@
 module Nri.Ui.Panel.V1 exposing
     ( view, Attribute
     , header
-    , plaintext, markdown, html
+    , paragraph, plaintext, markdown, html
     , containerCss, headerCss, css
     , primary, secondary
     )
@@ -15,6 +15,7 @@ module Nri.Ui.Panel.V1 exposing
 ### Patch changes
 
   - use internal `Content` module
+  - adds paragraph
 
 @docs view, Attribute
 
@@ -22,7 +23,7 @@ module Nri.Ui.Panel.V1 exposing
 ## Content
 
 @docs header
-@docs plaintext, markdown, html
+@docs paragraph, plaintext, markdown, html
 @docs containerCss, headerCss, css
 
 
@@ -104,6 +105,13 @@ html =
 plaintext : String -> Attribute msg
 plaintext =
     Attribute << Content.plaintext
+
+
+{-| Provide a plain-text string that will be put into a paragraph tag, with the default margin removed.
+-}
+paragraph : String -> Attribute msg
+paragraph =
+    Attribute << Content.paragraph
 
 
 {-| Use a markdown string for the panel content.

--- a/src/Nri/Ui/Text/V6.elm
+++ b/src/Nri/Ui/Text/V6.elm
@@ -2,7 +2,7 @@ module Nri.Ui.Text.V6 exposing
     ( caption, mediumBody, mediumBodyGray, smallBody, smallBodyGray
     , footnote
     , ugMediumBody, ugSmallBody
-    , paragraph, plaintext, markdown, html
+    , plaintext, markdown, html
     , Attribute, noBreak, css, id, custom
     , nriDescription, testId
     )
@@ -10,7 +10,6 @@ module Nri.Ui.Text.V6 exposing
 {-| Patch changes:
 
   - use internal `Content` module
-  - adds paragraph
 
 Changes from V5:
 
@@ -49,7 +48,7 @@ You're in the wrong place! Headings live in Nri.Ui.Heading.V3.
 
 # Content
 
-@docs paragraph, plaintext, markdown, html
+@docs plaintext, markdown, html
 
 
 ## Customizations
@@ -351,13 +350,6 @@ footnote attributes =
 plaintext : String -> Attribute msg
 plaintext =
     Attribute << Content.plaintext
-
-
-{-| Provide a plain-text string that will be put into a paragraph tag, with the default margin removed.
--}
-paragraph : String -> Attribute msg
-paragraph =
-    Attribute << Content.paragraph
 
 
 {-| Provide a string that will be rendered as markdown.

--- a/src/Nri/Ui/Text/V6.elm
+++ b/src/Nri/Ui/Text/V6.elm
@@ -2,7 +2,7 @@ module Nri.Ui.Text.V6 exposing
     ( caption, mediumBody, mediumBodyGray, smallBody, smallBodyGray
     , footnote
     , ugMediumBody, ugSmallBody
-    , plaintext, markdown, html
+    , paragraph, plaintext, markdown, html
     , Attribute, noBreak, css, id, custom
     , nriDescription, testId
     )
@@ -10,6 +10,7 @@ module Nri.Ui.Text.V6 exposing
 {-| Patch changes:
 
   - use internal `Content` module
+  - adds paragraph
 
 Changes from V5:
 
@@ -48,7 +49,7 @@ You're in the wrong place! Headings live in Nri.Ui.Heading.V3.
 
 # Content
 
-@docs plaintext, markdown, html
+@docs paragraph, plaintext, markdown, html
 
 
 ## Customizations
@@ -350,6 +351,13 @@ footnote attributes =
 plaintext : String -> Attribute msg
 plaintext =
     Attribute << Content.plaintext
+
+
+{-| Provide a plain-text string that will be put into a paragraph tag, with the default margin removed.
+-}
+paragraph : String -> Attribute msg
+paragraph =
+    Attribute << Content.paragraph
 
 
 {-| Provide a string that will be rendered as markdown.

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -1,7 +1,7 @@
 module Nri.Ui.Tooltip.V3 exposing
     ( view, viewToggleTip
     , Attribute
-    , plaintext, html
+    , paragraph, plaintext, markdown, html
     , withoutTail
     , onTop, onBottom, onLeft, onRight
     , onTopForQuizEngineMobile, onBottomForQuizEngineMobile, onLeftForQuizEngineMobile, onRightForQuizEngineMobile
@@ -30,6 +30,7 @@ module Nri.Ui.Tooltip.V3 exposing
   - adds alignStartForNarrowMobile, alignMiddleForNarrowMobile, alignEndForNarrowMobile
   - adds narrowMobileCss
   - use internal `Content` module
+  - adds `paragraph` and `markdown` support
 
 Changes from V2:
 
@@ -52,7 +53,7 @@ These tooltips aim to follow the accessibility recommendations from:
 
 @docs view, viewToggleTip
 @docs Attribute
-@docs plaintext, html
+@docs paragraph, plaintext, markdown, html
 @docs withoutTail
 
 @docs onTop, onBottom, onLeft, onRight
@@ -161,13 +162,29 @@ buildAttributes =
     List.foldl (\(Attribute applyAttr) acc -> applyAttr acc) defaultTooltip
 
 
-{-| -}
+{-| Provide a plain-text string.
+-}
 plaintext : String -> Attribute msg
 plaintext =
     Attribute << Content.plaintext
 
 
-{-| -}
+{-| Provide a plain-text string that will be put into a paragraph tag, with the default margin removed.
+-}
+paragraph : String -> Attribute msg
+paragraph =
+    Attribute << Content.paragraph
+
+
+{-| Provide a string that will be rendered as markdown.
+-}
+markdown : String -> Attribute msg
+markdown =
+    Attribute << Content.markdown
+
+
+{-| Provide a list of custom HTML.
+-}
 html : List (Html msg) -> Attribute msg
 html =
     Attribute << Content.html

--- a/styleguide-app/Examples/Balloon.elm
+++ b/styleguide-app/Examples/Balloon.elm
@@ -72,6 +72,7 @@ controlSettings =
         |> ControlExtra.listItem "content"
             (CommonControls.content
                 { moduleName = moduleName
+                , paragraph = Just Balloon.paragraph
                 , plaintext = Balloon.plaintext
                 , markdown = Just Balloon.markdown
                 , html = Balloon.html

--- a/styleguide-app/Examples/Container.elm
+++ b/styleguide-app/Examples/Container.elm
@@ -170,6 +170,7 @@ controlContent : Control ( String, Container.Attribute msg )
 controlContent =
     CommonControls.content
         { moduleName = "Container"
+        , paragraph = Just Container.paragraph
         , plaintext = Container.plaintext
         , markdown = Just Container.markdown
         , html = Container.html

--- a/styleguide-app/Examples/Heading.elm
+++ b/styleguide-app/Examples/Heading.elm
@@ -109,6 +109,7 @@ controlContent : Control ( String, Heading.Attribute msg )
 controlContent =
     CommonControls.content
         { moduleName = moduleName
+        , paragraph = Nothing
         , plaintext = Heading.plaintext
         , markdown = Just Heading.markdown
         , html = Heading.html

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -35,6 +35,7 @@ init =
             |> ControlExtra.listItem "content"
                 (CommonControls.content
                     { moduleName = moduleName
+                    , paragraph = Just Message.paragraph
                     , plaintext = Message.plaintext
                     , markdown = Just Message.markdown
                     , html = Message.html

--- a/styleguide-app/Examples/Panel.elm
+++ b/styleguide-app/Examples/Panel.elm
@@ -107,6 +107,7 @@ init =
             |> ControlExtra.listItem "content"
                 (CommonControls.content
                     { moduleName = moduleName
+                    , paragraph = Just Panel.paragraph
                     , plaintext = Panel.plaintext
                     , markdown = Just Panel.markdown
                     , html = Panel.html

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -142,6 +142,7 @@ controlContent : Control ( String, Text.Attribute msg )
 controlContent =
     CommonControls.content
         { moduleName = "Text"
+        , paragraph = Just Text.paragraph
         , plaintext = Text.plaintext
         , markdown = Just Text.markdown
         , html = Text.html

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -142,7 +142,7 @@ controlContent : Control ( String, Text.Attribute msg )
 controlContent =
     CommonControls.content
         { moduleName = "Text"
-        , paragraph = Just Text.paragraph
+        , paragraph = Nothing
         , plaintext = Text.plaintext
         , markdown = Just Text.markdown
         , html = Text.html

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -360,9 +360,9 @@ controlContent : Control ( String, Tooltip.Attribute Never )
 controlContent =
     CommonControls.content
         { moduleName = "Tooltip"
-        , paragraph = Nothing
+        , paragraph = Just Tooltip.paragraph
         , plaintext = Tooltip.plaintext
-        , markdown = Nothing
+        , markdown = Just Tooltip.markdown
         , html = Tooltip.html
         , httpError = Nothing
         }

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -360,6 +360,7 @@ controlContent : Control ( String, Tooltip.Attribute Never )
 controlContent =
     CommonControls.content
         { moduleName = "Tooltip"
+        , paragraph = Nothing
         , plaintext = Tooltip.plaintext
         , markdown = Nothing
         , html = Tooltip.html


### PR DESCRIPTION
Visually, there should be no difference between using `paragraph` and `plaintext`, but the new helper should help making using semantic HTML easier.

Inspiration is coming from https://github.com/NoRedInk/NoRedInk/pull/41434, where I noticed we always want a Balloon containing a paragraph without default margin.

```
This is a MINOR change.

---- Nri.Ui.Balloon.V2 - MINOR ----

    Added:
        paragraph : String.String -> Nri.Ui.Balloon.V2.Attribute msg


---- Nri.Ui.Container.V2 - MINOR ----

    Added:
        paragraph : String.String -> Nri.Ui.Container.V2.Attribute msg


---- Nri.Ui.Message.V3 - MINOR ----

    Added:
        paragraph : String.String -> Nri.Ui.Message.V3.Attribute msg


---- Nri.Ui.Panel.V1 - MINOR ----

    Added:
        paragraph : String.String -> Nri.Ui.Panel.V1.Attribute msg


---- Nri.Ui.Tooltip.V3 - MINOR ----

    Added:
        markdown : String.String -> Nri.Ui.Tooltip.V3.Attribute msg
        paragraph : String.String -> Nri.Ui.Tooltip.V3.Attribute msg

```