### PR TITLE
Adds submit button attributes and opensModal attributes

### DIFF
--- a/src/ClickableAttributes.elm
+++ b/src/ClickableAttributes.elm
@@ -1,6 +1,6 @@
 module ClickableAttributes exposing
     ( ClickableAttributes, init
-    , onClick, submit
+    , onClick, submit, opensModal
     , toButtonAttributes
     , href, linkWithMethod, linkWithTracking
     , linkSpa
@@ -15,7 +15,7 @@ module ClickableAttributes exposing
 
 # For buttons
 
-@docs onClick, submit
+@docs onClick, submit, opensModal
 @docs toButtonAttributes
 
 
@@ -45,6 +45,7 @@ type alias ClickableAttributes route msg =
     , url : Maybe route
     , urlString : Maybe String
     , onClick : Maybe msg
+    , opensModal : Bool
     }
 
 
@@ -65,6 +66,7 @@ init =
     , url = Nothing
     , urlString = Nothing
     , onClick = Nothing
+    , opensModal = False
     }
 
 
@@ -78,6 +80,12 @@ onClick msg clickableAttributes =
 submit : ClickableAttributes route msg -> ClickableAttributes route msg
 submit clickableAttributes =
     { clickableAttributes | buttonType = "submit" }
+
+
+{-| -}
+opensModal : ClickableAttributes route msg -> ClickableAttributes route msg
+opensModal clickableAttributes =
+    { clickableAttributes | opensModal = True }
 
 
 {-| -}
@@ -129,6 +137,12 @@ toButtonAttributes : ClickableAttributes route msg -> List (Attribute msg)
 toButtonAttributes clickableAttributes =
     [ AttributesExtra.maybe Events.onClick clickableAttributes.onClick
     , Attributes.type_ clickableAttributes.buttonType
+    , -- why "aria-haspopup=true" instead of "aria-haspopup=dialog"?
+      -- AT support for aria-haspopup=dialog is currently (Nov 2022) limited.
+      -- See https://html5accessibility.com/stuff/2021/02/02/haspopup-haspoop/
+      -- If time has passed, feel free to revisit and see if dialog support has improved!
+      AttributesExtra.includeIf clickableAttributes.opensModal
+        (Attributes.attribute "aria-haspopup" "true")
     ]
 
 

--- a/src/ClickableAttributes.elm
+++ b/src/ClickableAttributes.elm
@@ -41,6 +41,7 @@ import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (targetBlank)
 {-| -}
 type alias ClickableAttributes route msg =
     { linkType : Link
+    , buttonType : String
     , url : Maybe route
     , urlString : Maybe String
     , onClick : Maybe msg
@@ -60,6 +61,7 @@ type Link
 init : ClickableAttributes route msg
 init =
     { linkType = Default
+    , buttonType = "button"
     , url = Nothing
     , urlString = Nothing
     , onClick = Nothing
@@ -120,6 +122,7 @@ linkExternalWithTracking { track, url } clickableAttributes =
 toButtonAttributes : ClickableAttributes route msg -> List (Attribute msg)
 toButtonAttributes clickableAttributes =
     [ AttributesExtra.maybe Events.onClick clickableAttributes.onClick
+    , Attributes.type_ clickableAttributes.buttonType
     ]
 
 

--- a/src/ClickableAttributes.elm
+++ b/src/ClickableAttributes.elm
@@ -1,6 +1,6 @@
 module ClickableAttributes exposing
     ( ClickableAttributes, init
-    , onClick
+    , onClick, submit
     , toButtonAttributes
     , href, linkWithMethod, linkWithTracking
     , linkSpa
@@ -15,7 +15,7 @@ module ClickableAttributes exposing
 
 # For buttons
 
-@docs onClick
+@docs onClick, submit
 @docs toButtonAttributes
 
 
@@ -72,6 +72,12 @@ init =
 onClick : msg -> ClickableAttributes route msg -> ClickableAttributes route msg
 onClick msg clickableAttributes =
     { clickableAttributes | onClick = Just msg }
+
+
+{-| -}
+submit : ClickableAttributes route msg -> ClickableAttributes route msg
+submit clickableAttributes =
+    { clickableAttributes | buttonType = "submit" }
 
 
 {-| -}

--- a/src/ClickableAttributes.elm
+++ b/src/ClickableAttributes.elm
@@ -35,7 +35,7 @@ import Html.Styled exposing (Attribute)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Json.Decode
-import Nri.Ui.Html.Attributes.V2 exposing (targetBlank)
+import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (targetBlank)
 
 
 {-| -}
@@ -119,12 +119,8 @@ linkExternalWithTracking { track, url } clickableAttributes =
 {-| -}
 toButtonAttributes : ClickableAttributes route msg -> List (Attribute msg)
 toButtonAttributes clickableAttributes =
-    case clickableAttributes.onClick of
-        Just handler ->
-            [ Events.onClick handler ]
-
-        Nothing ->
-            []
+    [ AttributesExtra.maybe Events.onClick clickableAttributes.onClick
+    ]
 
 
 {-| -}

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -1,7 +1,7 @@
 module Nri.Ui.Button.V10 exposing
     ( button, link
     , Attribute
-    , onClick, submit
+    , onClick, submit, opensModal
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     , small, medium, large, modal
     , exactWidth, boundedWidth, unboundedWidth, fillContainerWidth
@@ -30,6 +30,7 @@ adding a span around the text could potentially lead to regressions.
   - adds `hideIconForMobile` and `hideIconFor`
   - support 'disabled' links according to [Scott O'Hara's disabled links](https://www.scottohara.me/blog/2021/05/28/disabled-links.html) article
   - adds `tertiary` style
+  - adds `submit` and `opensModal`
 
 
 # Changes from V9:
@@ -46,7 +47,7 @@ adding a span around the text could potentially lead to regressions.
 
 ## Behavior
 
-@docs onClick, submit
+@docs onClick, submit, opensModal
 @docs href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
 
 
@@ -286,6 +287,13 @@ Note: this attribute is not supported by links.
 submit : Attribute msg
 submit =
     setClickableAttributes ClickableAttributes.submit
+
+
+{-| Use this attribute when interacting with the button will launch a modal.
+-}
+opensModal : Attribute msg
+opensModal =
+    setClickableAttributes ClickableAttributes.opensModal
 
 
 {-| -}

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -1,7 +1,7 @@
 module Nri.Ui.Button.V10 exposing
     ( button, link
     , Attribute
-    , onClick
+    , onClick, submit
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     , small, medium, large, modal
     , exactWidth, boundedWidth, unboundedWidth, fillContainerWidth
@@ -46,7 +46,7 @@ adding a span around the text could potentially lead to regressions.
 
 ## Behavior
 
-@docs onClick
+@docs onClick, submit
 @docs href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
 
 
@@ -276,6 +276,16 @@ setClickableAttributes apply =
 onClick : msg -> Attribute msg
 onClick msg =
     setClickableAttributes (ClickableAttributes.onClick msg)
+
+
+{-| By default, buttons have type "button". Use this attribute to change the button type to "submit".
+
+Note: this attribute is not supported by links.
+
+-}
+submit : Attribute msg
+submit =
+    setClickableAttributes ClickableAttributes.submit
 
 
 {-| -}

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -596,7 +596,6 @@ renderButton ((ButtonOrLink config) as button_) =
         ]
         (ClickableAttributes.toButtonAttributes config.clickableAttributes
             ++ Attributes.disabled (isDisabled config.state)
-            :: Attributes.type_ "button"
             :: Attributes.class FocusRing.customClass
             :: config.customAttributes
         )

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -539,7 +539,6 @@ renderButton ((ButtonOrLink config) as button_) =
     Html.button
         ([ Attributes.class "Nri-Ui-Clickable-Svg-V1__button"
          , Attributes.class FocusRing.customClass
-         , Attributes.type_ "button"
          , Attributes.css (buttonOrLinkStyles config theme ++ config.customStyles)
          , Attributes.disabled config.disabled
          , Aria.label config.label

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -1,7 +1,7 @@
 module Nri.Ui.ClickableSvg.V2 exposing
     ( button, link
     , Attribute
-    , onClick
+    , onClick, submit
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     , exactSize, exactWidth, exactHeight
     , disabled
@@ -30,7 +30,7 @@ module Nri.Ui.ClickableSvg.V2 exposing
 
 ## Behavior
 
-@docs onClick
+@docs onClick, submit
 @docs href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
 
 
@@ -118,6 +118,16 @@ setClickableAttributes apply =
 onClick : msg -> Attribute msg
 onClick msg =
     setClickableAttributes (ClickableAttributes.onClick msg)
+
+
+{-| By default, buttons have type "button". Use this attribute to change the button type to "submit".
+
+Note: this attribute is not supported by links.
+
+-}
+submit : Attribute msg
+submit =
+    setClickableAttributes ClickableAttributes.submit
 
 
 {-| -}

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -1,7 +1,7 @@
 module Nri.Ui.ClickableSvg.V2 exposing
     ( button, link
     , Attribute
-    , onClick, submit
+    , onClick, submit, opensModal
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     , exactSize, exactWidth, exactHeight
     , disabled
@@ -20,6 +20,7 @@ module Nri.Ui.ClickableSvg.V2 exposing
 
     - adds `nriDescription`, `testId`, and `id` helpers
     - adds `iconForMobile`, `iconForQuizEngineMobile`, `iconForNarrowMobile`
+    - adds `submit` and `opensModal`
 
 
 # Create a button or link
@@ -30,7 +31,7 @@ module Nri.Ui.ClickableSvg.V2 exposing
 
 ## Behavior
 
-@docs onClick, submit
+@docs onClick, submit, opensModal
 @docs href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
 
 
@@ -128,6 +129,13 @@ Note: this attribute is not supported by links.
 submit : Attribute msg
 submit =
     setClickableAttributes ClickableAttributes.submit
+
+
+{-| Use this attribute when interacting with the button will launch a modal.
+-}
+opensModal : Attribute msg
+opensModal =
+    setClickableAttributes ClickableAttributes.opensModal
 
 
 {-| -}

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -3,7 +3,7 @@ module Nri.Ui.ClickableText.V3 exposing
     , link
     , Attribute
     , small, medium, large, modal
-    , onClick
+    , onClick, submit
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     , icon
     , custom, nriDescription, testId, id
@@ -69,7 +69,7 @@ HTML `<a>` elements and are created here with `*Link` functions.
 
 ## Behavior
 
-@docs onClick
+@docs onClick, submit
 @docs href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
 
 
@@ -288,6 +288,16 @@ setClickableAttributes apply =
 onClick : msg -> Attribute msg
 onClick msg =
     setClickableAttributes (ClickableAttributes.onClick msg)
+
+
+{-| By default, buttons have type "button". Use this attribute to change the button type to "submit".
+
+Note: this attribute is not supported by links.
+
+-}
+submit : Attribute msg
+submit =
+    setClickableAttributes ClickableAttributes.submit
 
 
 {-| -}

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -3,7 +3,7 @@ module Nri.Ui.ClickableText.V3 exposing
     , link
     , Attribute
     , small, medium, large, modal
-    , onClick, submit
+    , onClick, submit, opensModal
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     , icon
     , custom, nriDescription, testId, id
@@ -29,6 +29,7 @@ module Nri.Ui.ClickableText.V3 exposing
   - adds `notMobileCss`, `mobileCss`, `quizEngineMobileCss`
   - adds `hideIconForMobile` and `hideIconAt`
   - adds `hideTextForMobile` and `hideTextAt`
+  - adds `submit` and `opensModal`
 
 
 # Changes from V2
@@ -69,7 +70,7 @@ HTML `<a>` elements and are created here with `*Link` functions.
 
 ## Behavior
 
-@docs onClick, submit
+@docs onClick, submit, opensModal
 @docs href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
 
 
@@ -298,6 +299,13 @@ Note: this attribute is not supported by links.
 submit : Attribute msg
 submit =
     setClickableAttributes ClickableAttributes.submit
+
+
+{-| Use this attribute when interacting with the button will launch a modal.
+-}
+opensModal : Attribute msg
+opensModal =
+    setClickableAttributes ClickableAttributes.opensModal
 
 
 {-| -}

--- a/src/Nri/Ui/Html/Attributes/V2.elm
+++ b/src/Nri/Ui/Html/Attributes/V2.elm
@@ -1,4 +1,9 @@
-module Nri.Ui.Html.Attributes.V2 exposing (none, includeIf, targetBlank, nriDescription, nriDescriptionSelector, testId)
+module Nri.Ui.Html.Attributes.V2 exposing
+    ( none, includeIf, maybe
+    , targetBlank
+    , nriDescription, nriDescriptionSelector
+    , testId
+    )
 
 {-|
 
@@ -6,12 +11,16 @@ module Nri.Ui.Html.Attributes.V2 exposing (none, includeIf, targetBlank, nriDesc
 # Patch changes:
 
     - adds `nriDescription` and `testId` helpers
+    - adds `maybe` helper
 
 Extras for working with Html.Attributes.
 
 This is the new version of Nri.Ui.Html.Attributes.Extra.
 
-@docs none, includeIf, targetBlank, nriDescription, nriDescriptionSelector, testId
+@docs none, includeIf, maybe
+@docs targetBlank
+@docs nriDescription, nriDescriptionSelector
+@docs testId
 
 -}
 
@@ -36,6 +45,13 @@ It's totally safe and lets us clean up conditional and maybe attributes
 none : Attribute msg
 none =
     Attributes.property "Html.Attributes.Extra.none" Encode.null
+
+
+{-| Transform a maybe value to an attribute or attach `none`
+-}
+maybe : (v -> Attribute msg) -> Maybe v -> Attribute msg
+maybe toAttr =
+    Maybe.map toAttr >> Maybe.withDefault none
 
 
 {-| conditionally include an attribute. Useful for CSS classes generated with

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -791,11 +791,6 @@ view label attributes =
                 _ ->
                     []
 
-        maybeAttr attr maybeValue =
-            maybeValue
-                |> Maybe.map attr
-                |> Maybe.withDefault Extra.none
-
         stringValue =
             eventsAndValues.currentValue
                 |> Maybe.map2 identity eventsAndValues.toString
@@ -856,18 +851,18 @@ view label attributes =
                                 []
                             )
                         ]
-                   , maybeAttr Attributes.placeholder config.placeholder
+                   , Extra.maybe Attributes.placeholder config.placeholder
                    , Attributes.value stringValue
                    , Attributes.disabled disabled_
                    , Attributes.readonly config.readOnly
-                   , maybeAttr Events.onInput eventsAndValues.onInput
-                   , maybeAttr Events.onFocus eventsAndValues.onFocus
-                   , maybeAttr Events.onBlur eventsAndValues.onBlur
+                   , Extra.maybe Events.onInput eventsAndValues.onInput
+                   , Extra.maybe Events.onFocus eventsAndValues.onFocus
+                   , Extra.maybe Events.onBlur eventsAndValues.onBlur
                    , Attributes.autofocus config.autofocus
-                   , maybeAttr type_ config.fieldType
-                   , maybeAttr (attribute "inputmode") config.inputMode
-                   , maybeAttr (attribute "autocomplete") config.autocomplete
-                   , maybeAttr onEnter_ eventsAndValues.onEnter
+                   , Extra.maybe type_ config.fieldType
+                   , Extra.maybe (attribute "inputmode") config.inputMode
+                   , Extra.maybe (attribute "autocomplete") config.autocomplete
+                   , Extra.maybe onEnter_ eventsAndValues.onEnter
                    , class "nri-ui-textinput override-sass-styles custom-focus-ring"
                    , classList
                         [ ( InputStyles.inputClass, True )

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -176,6 +176,8 @@ initDebugControls =
                         , ( "success", Button.success )
                         ]
                     )
+                |> ControlExtra.optionalBoolListItem "submit (button only)"
+                    ( "Button.submit", Button.submit )
                 |> ControlExtra.optionalBoolListItem "hideIconForMobile"
                     ( "Button.hideIconForMobile", Button.hideIconForMobile )
                 |> CommonControls.css

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -178,6 +178,8 @@ initDebugControls =
                     )
                 |> ControlExtra.optionalBoolListItem "submit (button only)"
                     ( "Button.submit", Button.submit )
+                |> ControlExtra.optionalBoolListItem "opensModal (button only)"
+                    ( "Button.opensModal", Button.opensModal )
                 |> ControlExtra.optionalBoolListItem "hideIconForMobile"
                     ( "Button.hideIconForMobile", Button.hideIconForMobile )
                 |> CommonControls.css

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -325,4 +325,6 @@ initSettings =
                         )
                         (CommonControls.rotatedUiIcon 3)
                     )
+                |> ControlExtra.optionalBoolListItem "submit (button only)"
+                    ( "ClickableSvg.submit", ClickableSvg.submit )
             )

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -327,4 +327,6 @@ initSettings =
                     )
                 |> ControlExtra.optionalBoolListItem "submit (button only)"
                     ( "ClickableSvg.submit", ClickableSvg.submit )
+                |> ControlExtra.optionalBoolListItem "opensModal (button only)"
+                    ( "ClickableSvg.opensModal", ClickableSvg.opensModal )
             )

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -97,6 +97,8 @@ init =
                     { moduleName = moduleName
                     , use = ClickableText.notMobileCss
                     }
+                |> ControlExtra.optionalBoolListItem "submit (button only)"
+                    ( "ClickableText.submit", ClickableText.submit )
             )
         |> State
 

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -99,6 +99,8 @@ init =
                     }
                 |> ControlExtra.optionalBoolListItem "submit (button only)"
                     ( "ClickableText.submit", ClickableText.submit )
+                |> ControlExtra.optionalBoolListItem "opensModal (button only)"
+                    ( "ClickableText.opensModal", ClickableText.opensModal )
             )
         |> State
 


### PR DESCRIPTION
Fixes A11-1988
Fixes https://github.com/NoRedInk/noredink-ui/issues/868
Fixes https://github.com/NoRedInk/noredink-ui/issues/809


```
This is a MINOR change.

---- Nri.Ui.Button.V10 - MINOR ----

    Added:
        opensModal : Nri.Ui.Button.V10.Attribute msg
        submit : Nri.Ui.Button.V10.Attribute msg


---- Nri.Ui.ClickableSvg.V2 - MINOR ----

    Added:
        opensModal : Nri.Ui.ClickableSvg.V2.Attribute msg
        submit : Nri.Ui.ClickableSvg.V2.Attribute msg


---- Nri.Ui.ClickableText.V3 - MINOR ----

    Added:
        opensModal : Nri.Ui.ClickableText.V3.Attribute msg
        submit : Nri.Ui.ClickableText.V3.Attribute msg


---- Nri.Ui.Html.Attributes.V2 - MINOR ----

    Added:
        maybe :
            (v -> Html.Styled.Attribute msg)
            -> Maybe.Maybe v
            -> Html.Styled.Attribute msg
```