### PR TITLE
Marker and eraser styles

### DIFF
--- a/src/Nri/Ui/HighlighterTool/V1.elm
+++ b/src/Nri/Ui/HighlighterTool/V1.elm
@@ -110,7 +110,8 @@ hoverStyles : Css.Color -> List Css.Style
 hoverStyles color =
     List.append
         sharedStyles
-        [ Css.important (Css.backgroundColor color)
+        [ Css.boxShadow5 Css.zero Css.zero (Css.px 10) (Css.px 2) color
+        , Css.important (Css.backgroundColor color)
         , MediaQuery.highContrastMode
             [ Css.property "background-color" "Highlight" |> Css.important
             , Css.property "color" "HighlightText"

--- a/src/Nri/Ui/HighlighterTool/V1.elm
+++ b/src/Nri/Ui/HighlighterTool/V1.elm
@@ -158,6 +158,10 @@ buildMarkerWithBorder { highlightColor, kind, name } =
             Css.batch
                 [ Css.padding2 (Css.px 6) Css.zero
                 , Css.lineHeight (Css.em 2.5)
+                , MediaQuery.highContrastMode
+                    [ Css.property "background-color" "Mark" |> Css.important
+                    , Css.property "forced-color-adjust" "none"
+                    ]
                 ]
     in
     { hoverClass = []

--- a/src/Nri/Ui/HighlighterTool/V1.elm
+++ b/src/Nri/Ui/HighlighterTool/V1.elm
@@ -1,14 +1,14 @@
 module Nri.Ui.HighlighterTool.V1 exposing
     ( Tool(..)
     , EraserModel, buildEraser
-    , MarkerModel, buildMarker
+    , MarkerModel, buildMarker, buildMarkerWithBorder
     )
 
 {-|
 
 @docs Tool
 @docs EraserModel, buildEraser
-@docs MarkerModel, buildMarker
+@docs MarkerModel, buildMarker, buildMarkerWithBorder
 
 -}
 
@@ -82,6 +82,42 @@ buildMarker { highlightColor, hoverColor, hoverHighlightColor, kind, name } =
     , endGroupClass = endGroupStyles
     , highlightClass = highlightStyles highlightColor
     , hoverHighlightClass = highlightStyles hoverHighlightColor
+    , kind = kind
+    , name = name
+    }
+
+
+{-| Typically, this marker is only used for static highlighters.
+-}
+buildMarkerWithBorder :
+    { highlightColor : Css.Color
+    , kind : kind
+    , name : Maybe String
+    }
+    -> MarkerModel kind
+buildMarkerWithBorder { highlightColor, kind, name } =
+    { hoverClass = []
+    , hintClass = []
+    , startGroupClass =
+        [ Css.borderBottomLeftRadius (Css.px 8)
+        , Css.borderTopLeftRadius (Css.px 8)
+        , Css.borderTop3 (Css.px 1) Css.solid Colors.gray45
+        , Css.borderBottom3 (Css.px 1) Css.solid Colors.gray45
+        , Css.borderLeft3 (Css.px 1) Css.solid Colors.gray45
+        ]
+    , endGroupClass =
+        [ Css.borderBottomRightRadius (Css.px 8)
+        , Css.borderTopRightRadius (Css.px 8)
+        , Css.borderTop3 (Css.px 1) Css.solid Colors.gray45
+        , Css.borderBottom3 (Css.px 1) Css.solid Colors.gray45
+        , Css.borderRight3 (Css.px 1) Css.solid Colors.gray45
+        ]
+    , highlightClass =
+        [ Css.backgroundColor highlightColor
+        , Css.borderTop3 (Css.px 1) Css.solid Colors.gray45
+        , Css.borderBottom3 (Css.px 1) Css.solid Colors.gray45
+        ]
+    , hoverHighlightClass = []
     , kind = kind
     , name = name
     }

--- a/src/Nri/Ui/HighlighterTool/V1.elm
+++ b/src/Nri/Ui/HighlighterTool/V1.elm
@@ -1,12 +1,14 @@
 module Nri.Ui.HighlighterTool.V1 exposing
-    ( Tool(..), EraserModel, MarkerModel
-    , buildMarker
+    ( Tool(..)
+    , EraserModel, buildEraser
+    , MarkerModel, buildMarker
     )
 
 {-|
 
-@docs Tool, EraserModel, MarkerModel
-@docs buildMarker
+@docs Tool
+@docs EraserModel, buildEraser
+@docs MarkerModel, buildMarker
 
 -}
 
@@ -29,6 +31,22 @@ type alias EraserModel =
     , hintClass : List Css.Style
     , startGroupClass : List Css.Style
     , endGroupClass : List Css.Style
+    }
+
+
+{-| The default eraser.
+-}
+buildEraser : EraserModel
+buildEraser =
+    let
+        eraserStyles : List Css.Style
+        eraserStyles =
+            [ Css.opacity (Css.num 0.4) ]
+    in
+    { hoverClass = eraserStyles
+    , hintClass = eraserStyles
+    , startGroupClass = eraserStyles
+    , endGroupClass = eraserStyles
     }
 
 

--- a/src/Nri/Ui/HighlighterTool/V1.elm
+++ b/src/Nri/Ui/HighlighterTool/V1.elm
@@ -87,42 +87,6 @@ buildMarker { highlightColor, hoverColor, hoverHighlightColor, kind, name } =
     }
 
 
-{-| Typically, this marker is only used for static highlighters.
--}
-buildMarkerWithBorder :
-    { highlightColor : Css.Color
-    , kind : kind
-    , name : Maybe String
-    }
-    -> MarkerModel kind
-buildMarkerWithBorder { highlightColor, kind, name } =
-    { hoverClass = []
-    , hintClass = []
-    , startGroupClass =
-        [ Css.borderBottomLeftRadius (Css.px 8)
-        , Css.borderTopLeftRadius (Css.px 8)
-        , Css.borderTop3 (Css.px 1) Css.solid Colors.gray45
-        , Css.borderBottom3 (Css.px 1) Css.solid Colors.gray45
-        , Css.borderLeft3 (Css.px 1) Css.solid Colors.gray45
-        ]
-    , endGroupClass =
-        [ Css.borderBottomRightRadius (Css.px 8)
-        , Css.borderTopRightRadius (Css.px 8)
-        , Css.borderTop3 (Css.px 1) Css.solid Colors.gray45
-        , Css.borderBottom3 (Css.px 1) Css.solid Colors.gray45
-        , Css.borderRight3 (Css.px 1) Css.solid Colors.gray45
-        ]
-    , highlightClass =
-        [ Css.backgroundColor highlightColor
-        , Css.borderTop3 (Css.px 1) Css.solid Colors.gray45
-        , Css.borderBottom3 (Css.px 1) Css.solid Colors.gray45
-        ]
-    , hoverHighlightClass = []
-    , kind = kind
-    , name = name
-    }
-
-
 startGroupStyles : List Css.Style
 startGroupStyles =
     [ Css.paddingLeft (Css.px 4)
@@ -178,3 +142,49 @@ hoverStyles color =
         , Css.important (Css.paddingLeft Css.zero)
         , Css.important (Css.paddingRight Css.zero)
         ]
+
+
+{-| Typically, this marker is only used for static highlighters.
+-}
+buildMarkerWithBorder :
+    { highlightColor : Css.Color
+    , kind : kind
+    , name : Maybe String
+    }
+    -> MarkerModel kind
+buildMarkerWithBorder { highlightColor, kind, name } =
+    let
+        sharedStylesWithBorder =
+            Css.batch
+                [ Css.padding2 (Css.px 6) Css.zero
+                , Css.lineHeight (Css.em 2.5)
+                ]
+    in
+    { hoverClass = []
+    , hintClass = []
+    , startGroupClass =
+        [ sharedStylesWithBorder
+        , Css.borderBottomLeftRadius (Css.px 8)
+        , Css.borderTopLeftRadius (Css.px 8)
+        , Css.borderTop3 (Css.px 1) Css.solid Colors.gray45
+        , Css.borderBottom3 (Css.px 1) Css.solid Colors.gray45
+        , Css.borderLeft3 (Css.px 1) Css.solid Colors.gray45
+        ]
+    , endGroupClass =
+        [ sharedStylesWithBorder
+        , Css.borderBottomRightRadius (Css.px 8)
+        , Css.borderTopRightRadius (Css.px 8)
+        , Css.borderTop3 (Css.px 1) Css.solid Colors.gray45
+        , Css.borderBottom3 (Css.px 1) Css.solid Colors.gray45
+        , Css.borderRight3 (Css.px 1) Css.solid Colors.gray45
+        ]
+    , highlightClass =
+        [ sharedStylesWithBorder
+        , Css.backgroundColor highlightColor
+        , Css.borderTop3 (Css.px 1) Css.solid Colors.gray45
+        , Css.borderBottom3 (Css.px 1) Css.solid Colors.gray45
+        ]
+    , hoverHighlightClass = []
+    , kind = kind
+    , name = name
+    }

--- a/src/Nri/Ui/HighlighterTool/V1.elm
+++ b/src/Nri/Ui/HighlighterTool/V1.elm
@@ -102,6 +102,7 @@ sharedStyles : List Css.Style
 sharedStyles =
     [ Css.paddingTop (Css.px 4)
     , Css.paddingBottom (Css.px 3)
+    , Css.property "transition" "background-color 0.4s, box-shadow 0.4s"
     ]
 
 

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -85,10 +85,23 @@ example =
             , Heading.h2 [ Heading.plaintext "Non-interactive examples" ]
             , Heading.h3 [ Heading.plaintext "These are examples of some different ways the highlighter can appear to users." ]
             , Table.view
-                [ Table.string
-                    { header = "View"
-                    , value = .viewName
+                [ Table.rowHeader
+                    { header = text "Highlighter."
+                    , view = .viewName >> text
                     , width = Css.zero
+                    , cellStyles =
+                        always
+                            [ Css.padding2 (Css.px 14) (Css.px 7)
+                            , Css.verticalAlign Css.middle
+                            , Css.textAlign Css.left
+                            , Css.fontWeight Css.normal
+                            ]
+                    , sort = Nothing
+                    }
+                , Table.string
+                    { header = "HighlighterTool."
+                    , value = .tool
+                    , width = Css.pct 10
                     , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
                     , sort = Nothing
                     }
@@ -112,7 +125,8 @@ example =
                     , sort = Nothing
                     }
                 ]
-                [ { viewName = "Highlighter.static"
+                [ { viewName = "static"
+                  , tool = "buildMarker"
                   , description = "One word highlighted"
                   , example =
                         Highlighter.static
@@ -130,7 +144,8 @@ example =
                                     |> List.indexedMap (\i ( word, marker ) -> Highlightable.init Highlightable.Static marker i ( [], word ))
                             }
                   }
-                , { viewName = "Highlighter.static"
+                , { viewName = "static"
+                  , tool = "buildMarker"
                   , description = "Multiple words highlighted separately"
                   , example =
                         Highlighter.static
@@ -148,7 +163,8 @@ example =
                                     |> List.indexedMap (\i ( word, marker ) -> Highlightable.init Highlightable.Static marker i ( [], word ))
                             }
                   }
-                , { viewName = "Highlighter.static"
+                , { viewName = "static"
+                  , tool = "buildMarker"
                   , description = "Multiple words highlighted & joined"
                   , example =
                         Highlighter.static
@@ -165,19 +181,23 @@ example =
                                     |> List.indexedMap (\i ( word, marker ) -> Highlightable.init Highlightable.Static marker i ( [], word ))
                             }
                   }
-                , { viewName = "Highlighter.static"
+                , { viewName = "static"
+                  , tool = "buildMarker"
                   , description = "Multiple kinds of highlights without overlaps"
                   , example = Highlighter.static { id = "example-3a", highlightables = multipleHighlightsHighlightables }
                   }
-                , { viewName = "Highlighter.staticMarkdown"
+                , { viewName = "staticMarkdown"
+                  , tool = "buildMarker"
                   , description = "Multiple kinds of highlights without overlaps and with interpreted Markdown"
                   , example = Highlighter.staticMarkdown { id = "example-3b", highlightables = multipleHighlightsHighlightables }
                   }
-                , { viewName = "Highlighter.staticWithTags"
+                , { viewName = "staticWithTags"
+                  , tool = "buildMarker"
                   , description = "Multiple kinds of highlights without overlaps"
                   , example = Highlighter.staticWithTags { id = "example-4a", highlightables = multipleHighlightsHighlightables }
                   }
-                , { viewName = "Highlighter.staticMarkdownWithTags"
+                , { viewName = "staticMarkdownWithTags"
+                  , tool = "buildMarker"
                   , description = "Multiple kinds of highlights without overlaps and with interpreted Markdown"
                   , example = Highlighter.staticMarkdownWithTags { id = "example-4b", highlightables = multipleHighlightsHighlightables }
                   }

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -192,14 +192,14 @@ example =
                   , example = Highlighter.staticMarkdown { id = "example-3b", highlightables = multipleHighlightsHighlightables }
                   }
                 , { viewName = "staticWithTags"
-                  , tool = "buildMarker"
+                  , tool = "buildMarkerWithBorder"
                   , description = "Multiple kinds of highlights without overlaps"
-                  , example = Highlighter.staticWithTags { id = "example-4a", highlightables = multipleHighlightsHighlightables }
+                  , example = Highlighter.staticWithTags { id = "example-4a", highlightables = multipleHighlightsHighlightablesWithBorder }
                   }
                 , { viewName = "staticMarkdownWithTags"
-                  , tool = "buildMarker"
+                  , tool = "buildMarkerWithBorder"
                   , description = "Multiple kinds of highlights without overlaps and with interpreted Markdown"
-                  , example = Highlighter.staticMarkdownWithTags { id = "example-4b", highlightables = multipleHighlightsHighlightables }
+                  , example = Highlighter.staticMarkdownWithTags { id = "example-4b", highlightables = multipleHighlightsHighlightablesWithBorder }
                   }
                 ]
             ]
@@ -258,6 +258,44 @@ reasoningMarker =
         { highlightColor = Colors.highlightPurple
         , hoverColor = Colors.highlightMagenta
         , hoverHighlightColor = Colors.highlightPurpleDark
+        , kind = ()
+        , name = Just "Reasoning"
+        }
+
+
+multipleHighlightsHighlightablesWithBorder : List (Highlightable ())
+multipleHighlightsHighlightablesWithBorder =
+    [ ( "Waltz, bad nymph, for quick jigs vex.", Just claimMarkerWithBorder )
+    , ( "Glib jocks quiz nymph to vex dwarf.", Just evidenceMarkerWithBorder )
+    , ( "Sphinx of _black_ quartz, judge my vow.", Just reasoningMarkerWithBorder )
+    , ( "How *vexingly* quick daft zebras jump!", Nothing )
+    ]
+        |> List.intersperse ( " ", Nothing )
+        |> List.indexedMap (\i ( word, marker ) -> Highlightable.init Highlightable.Static marker i ( [], word ))
+
+
+claimMarkerWithBorder : Tool.MarkerModel ()
+claimMarkerWithBorder =
+    Tool.buildMarkerWithBorder
+        { highlightColor = Colors.highlightYellow
+        , kind = ()
+        , name = Just "Claim"
+        }
+
+
+evidenceMarkerWithBorder : Tool.MarkerModel ()
+evidenceMarkerWithBorder =
+    Tool.buildMarkerWithBorder
+        { highlightColor = Colors.highlightCyan
+        , kind = ()
+        , name = Just "Evidence"
+        }
+
+
+reasoningMarkerWithBorder : Tool.MarkerModel ()
+reasoningMarkerWithBorder =
+    Tool.buildMarkerWithBorder
+        { highlightColor = Colors.highlightPurple
         , kind = ()
         , name = Just "Reasoning"
         }

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -311,9 +311,7 @@ controlSettings =
         |> Control.field "tool"
             (Control.choice
                 [ ( "Marker", Control.map Tool.Marker controlMarker )
-                , ( "Eraser"
-                  , Control.map Tool.Eraser controlEraser
-                  )
+                , ( "Eraser", Control.value (Tool.Eraser Tool.buildEraser) )
                 ]
             )
 
@@ -334,19 +332,6 @@ controlMarker =
         |> Control.field "hoverColor" (backgroundHighlightColors 2)
         |> Control.field "hoverHighlightColor" (backgroundHighlightColors 4)
         |> Control.field "name" (Control.maybe True (Control.string "Claim"))
-
-
-controlEraser : Control Tool.EraserModel
-controlEraser =
-    Control.record Tool.EraserModel
-        |> Control.field "hoverClass"
-            (Control.choice [ ( "[ Css.border3 (Css.px 4) Css.dashed Colors.red ]", Control.value [ Css.border3 (Css.px 4) Css.dashed Colors.red ] ) ])
-        |> Control.field "hintClass"
-            (Control.choice [ ( "[ Css.border3 (Css.px 4) Css.dotted Colors.orange ]", Control.value [ Css.border3 (Css.px 4) Css.dotted Colors.orange ] ) ])
-        |> Control.field "startGroupClass"
-            (Control.choice [ ( "[ Css.opacity (Css.num 0.4) ]", Control.value [ Css.opacity (Css.num 0.4) ] ) ])
-        |> Control.field "endGroupClass"
-            (Control.choice [ ( "[ Css.opacity (Css.num 0.4) ]", Control.value [ Css.opacity (Css.num 0.4) ] ) ])
 
 
 backgroundHighlightColors : Int -> Control Color


### PR DESCRIPTION
Fixes A11-1993

1. Adds transitions to highlighter styles so that it's less flash-y to hover over multiple lines
2. Adds "bright" hover styles to default highligher
3. Adds default eraser tool styles
4. Adds marker with border, and fixes the high contrast styles for it

### "bright" hover styles
<img width="1364" alt="Screen Shot 2022-11-29 at 12 52 32 PM" src="https://user-images.githubusercontent.com/8811312/204634563-4b5bec7e-ca3f-49d1-a58c-151536e7e47e.png">

### with-border styles
<img width="1376" alt="Screen Shot 2022-11-29 at 12 52 11 PM" src="https://user-images.githubusercontent.com/8811312/204634564-6039d7d9-2d9c-4d96-a7f6-b91c9073752d.png">

### High-contrast with-border styles
<img width="1355" alt="Screen Shot 2022-11-29 at 12 49 43 PM" src="https://user-images.githubusercontent.com/8811312/204634561-c4bd38d0-ed79-4d30-961f-9988d31f0a16.png">

cc @NoRedInk/design nothing big to review here, I don't think. Just pinging to keep you in the loop!