### PR TITLE
Keep outline around transparently for high contrast os modes

### DIFF
--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -610,7 +610,9 @@ renderButton ((ButtonOrLink config) as button_) =
         (styledName "customButton")
         [ buttonStyles config.size config.width buttonStyle_ config.customStyles
         , Css.pseudoClass "focus-visible"
-            [ Css.outline Css.none, FocusRing.boxShadows [] ]
+            [ Css.outline3 (Css.px 2) Css.solid Css.transparent
+            , FocusRing.boxShadows []
+            ]
         ]
         (ClickableAttributes.toButtonAttributes config.clickableAttributes
             ++ Attributes.disabled (isDisabled config.state)
@@ -637,7 +639,7 @@ renderLink ((ButtonOrLink config) as link_) =
         (styledName linkFunctionName)
         [ buttonStyles config.size config.width colorPalette config.customStyles
         , Css.pseudoClass "focus-visible"
-            [ Css.outline Css.none, FocusRing.boxShadows [] ]
+            [ Css.outline3 (Css.px 2) Css.solid Css.transparent, FocusRing.boxShadows [] ]
         ]
         (Attributes.class FocusRing.customClass
             :: attributes
@@ -715,7 +717,7 @@ toggleButton config =
                     , Css.backgroundColor Colors.glacier
                     , Css.boxShadow5 Css.inset Css.zero (Css.px 3) Css.zero pressedShadowColor
                     , Css.pseudoClass "focus-visible"
-                        [ Css.outline Css.none
+                        [ Css.outline3 (Css.px 2) Css.solid Css.transparent
                         , FocusRing.boxShadows [ toggledBoxShadow ]
                         ]
                     , Css.border3 (Css.px 1) Css.solid Colors.azure
@@ -725,7 +727,7 @@ toggleButton config =
             else
                 Css.batch
                     [ Css.pseudoClass "focus-visible"
-                        [ Css.outline Css.none
+                        [ Css.outline3 (Css.px 2) Css.solid Css.transparent
                         , FocusRing.boxShadows []
                         ]
                     ]

--- a/src/Nri/Ui/Checkbox/V6.elm
+++ b/src/Nri/Ui/Checkbox/V6.elm
@@ -261,7 +261,7 @@ viewDisabledLabel model labelView icon =
         , css
             [ positioning
             , textStyle
-            , outline none
+            , Css.outline3 (Css.px 2) Css.solid Css.transparent
             , cursor auto
             , color Colors.gray45
             , Css.batch model.disabledLabelCss

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -402,7 +402,7 @@ viewDisabledLabel config icon =
         , css
             [ display inlineBlock
             , textStyle
-            , outline none
+            , Css.outline3 (Css.px 2) Css.solid Css.transparent
             , cursor auto
             , color Colors.gray45
             , Css.batch config.labelCss

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -777,7 +777,7 @@ buttonOrLinkStyles config { main_, mainHovered, background, backgroundHovered, b
     -- Focus
     , Css.pseudoClass "focus-visible"
         (if config.hasBorder then
-            [ Css.outline Css.none, FocusRing.boxShadows [] ]
+            [ Css.outline3 (Css.px 2) Css.solid Css.transparent, FocusRing.boxShadows [] ]
 
          else
             FocusRing.styles

--- a/src/Nri/Ui/FocusRing/V1.elm
+++ b/src/Nri/Ui/FocusRing/V1.elm
@@ -30,7 +30,7 @@ Hides default focus ring from elements that are tagged as having a custom focus 
 -}
 forKeyboardUsers : List Css.Global.Snippet
 forKeyboardUsers =
-    [ Css.Global.class customClass [ Css.outline Css.none ]
+    [ Css.Global.class customClass [ Css.outlineColor Css.transparent ]
     , Css.Global.selector (":not(." ++ customClass ++ "):focus-visible") styles
     , Css.Global.selector "p a:focus-visible" [ Css.important (Css.batch tightStyles) ]
     , Css.Global.class InputStyles.inputClass
@@ -90,7 +90,7 @@ NOTE: use `boxShadows` instead if your focusable element:
 styles : List Css.Style
 styles =
     [ boxShadows []
-    , Css.outline Css.none
+    , Css.outline3 (Css.px 2) Css.solid Css.transparent
     , Css.borderRadius (Css.px 4)
     ]
 
@@ -99,7 +99,7 @@ styles =
 
     focus
         [ FocusRing.boxShadows [ "inset 0 3px 0 0 " ++ ColorsExtra.toCssString glacier ]
-        , outline none
+        , Css.outline3 (Css.px 2) Css.solid Css.transparent
         ]
 
 -}
@@ -116,7 +116,7 @@ boxShadows existingBoxShadows =
 
     focus
         [ FocusRing.insetBoxShadows [ "inset 0 3px 0 0 " ++ ColorsExtra.toCssString glacier ]
-        , outline none
+        , Css.outline3 (Css.px 2) Css.solid Css.transparent
         ]
 
 -}
@@ -133,7 +133,7 @@ insetBoxShadows existingBoxShadows =
 -}
 tightStyles : List Css.Style
 tightStyles =
-    [ Css.outline Css.none
+    [ Css.outline3 (Css.px 2) Css.solid Css.transparent
     , applyBoxShadows
         [ "inset 0 0 0 2px " ++ innerColorString
         , "0 0 0 2px " ++ outerColorString

--- a/src/Nri/Ui/InputStyles/V4.elm
+++ b/src/Nri/Ui/InputStyles/V4.elm
@@ -166,7 +166,7 @@ input theme =
                 , boxSizing borderBox
                 , focus
                     [ borderColor azure
-                    , outline none
+                    , Css.outline3 (Css.px 2) Css.solid Css.transparent
                     , property "box-shadow" focusedInputBoxShadow
                     ]
                 , Css.Global.withClass errorClass

--- a/src/Nri/Ui/Menu/V3.elm
+++ b/src/Nri/Ui/Menu/V3.elm
@@ -358,7 +358,7 @@ button attributes title =
                     , fontWeight (int 600)
                     , cursor pointer
                     , pseudoClass "focus-visible"
-                        [ outline none
+                        [ Css.outline3 (Css.px 2) Css.solid Css.transparent
                         , FocusRing.boxShadows []
                         ]
                     , if menuConfig.isDisabled then

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -298,7 +298,7 @@ viewLockedButton { idValue, label, containerCss, onLockedMsg } =
                     , fontSize (px 15)
                     , fontWeight (int 600)
                     , color Colors.navy
-                    , outline none
+                    , Css.outline3 (Css.px 2) Css.solid Css.transparent
                     ]
                 ]
                 [ Checkbox.viewIcon [] (CheckboxIcons.lockOnInside idValue)

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -350,7 +350,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
                     , ( "Nri-RadioButton-RadioButtonChecked", isChecked )
                     ]
                 , css
-                    [ outline Css.none
+                    [ Css.outline3 (Css.px 2) Css.solid Css.transparent
                     , Fonts.baseFont
                     , Css.batch
                         (if config.isDisabled then

--- a/src/Nri/Ui/SegmentedControl/V14.elm
+++ b/src/Nri/Ui/SegmentedControl/V14.elm
@@ -272,7 +272,9 @@ styles focusSelector positioning numEntries index isSelected =
     , -- ensure that the focus state is visible & looks nice
       Css.pseudoClass focusSelector
         [ FocusRing.boxShadows [ focusedSegmentBoxShadowValue ]
-        , outline none
+        , Css.outline3 (Css.px 2) Css.solid Css.transparent
+        , outlineStyle solid
+        , outlineWidth (Css.px 1)
         , zIndex (int 1)
         ]
     ]

--- a/src/Nri/Ui/SideNav/V4.elm
+++ b/src/Nri/Ui/SideNav/V4.elm
@@ -342,7 +342,7 @@ viewSkipLink onSkip =
                 [ Style.invisibleStyle
                 ]
             , Css.pseudoClass "focus-visible"
-                [ outline none
+                [ Css.outline3 (Css.px 2) Css.solid Css.transparent
                 , FocusRing.outerBoxShadow
                 ]
             , Css.padding (Css.px 2)
@@ -478,7 +478,10 @@ viewLockedEntry extraStyles entryConfig =
 sharedEntryStyles : List Style
 sharedEntryStyles =
     [ padding2 (px 13) (px 20)
-    , Css.pseudoClass "focus-visible" [ outline none, FocusRing.insetBoxShadow ]
+    , Css.pseudoClass "focus-visible"
+        [ Css.outline3 (Css.px 2) Css.solid Css.transparent
+        , FocusRing.insetBoxShadow
+        ]
     , Css.property "word-break" "normal"
     , Css.property "overflow-wrap" "anywhere"
     , displayFlex

--- a/src/Nri/Ui/Tabs/V7.elm
+++ b/src/Nri/Ui/Tabs/V7.elm
@@ -288,7 +288,7 @@ tabStyles customSpacing index isSelected =
                 ]
             , pseudoClass "focus-visible"
                 [ FocusRing.outerBoxShadow
-                , outline none
+                , Css.outline3 (Css.px 2) Css.solid Css.transparent
                 ]
             ]
 

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -1149,7 +1149,7 @@ viewTooltip tooltipId config =
                         , Css.visited [ Css.color Colors.white ]
                         , Css.hover [ Css.color Colors.white ]
                         , Css.pseudoClass "focus-visible"
-                            [ Css.outline Css.none
+                            [ Css.outline3 (Css.px 2) Css.solid Css.transparent
                             , Css.property "box-shadow" "0 0 0 2px #FFF"
                             ]
                         ]


### PR DESCRIPTION
One of the [technique examples for a two-toned focus ring](https://www.w3.org/WAI/WCAG21/Techniques/css/C40) shows the outline as transparent instead of `none`, which actually causes the outline to become visible in high contrast mode! (A transparent border is why our checkboxes look kinda funky in high contrast mode -- transparent borders and such get coerced to be visible in high contrast mode).


https://user-images.githubusercontent.com/8811312/204913293-d6eac024-0796-4bea-a370-66bde80eb49f.mov

cc @NoRedInk/design 

Fixes A11-1929