### PR TITLE
Standardize Highlighter Tool styles and fix high contrast mode focus ring

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "21.3.0",
+    "version": "21.4.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Ui",


### PR DESCRIPTION
- https://github.com/NoRedInk/noredink-ui/pull/1175
- https://github.com/NoRedInk/noredink-ui/pull/1177

```
This is a MINOR change.

---- Nri.Ui.HighlighterTool.V1 - MINOR ----

    Added:
        buildEraser : Nri.Ui.HighlighterTool.V1.EraserModel
        buildMarkerWithBorder :
            { highlightColor : Css.Color
            , kind : kind
            , name : Maybe.Maybe String.String
            }
            -> Nri.Ui.HighlighterTool.V1.MarkerModel kind
```