### PR TITLE
Fix issues with z-index on switch

### DIFF
--- a/src/Nri/Ui/Switch/V2.elm
+++ b/src/Nri/Ui/Switch/V2.elm
@@ -396,7 +396,6 @@ viewSwitch config =
         ]
         |> Nri.Ui.Svg.V1.withWidth (Css.px 43)
         |> Nri.Ui.Svg.V1.withHeight (Css.px 32)
-        |> Nri.Ui.Svg.V1.withCss [ Css.zIndex (Css.int 1) ]
         |> Nri.Ui.Svg.V1.withCustom [ SvgAttributes.class "switch-track" ]
 
 


### PR DESCRIPTION
This PR removes the z-index from the switch component, and resolves issues where the the part of the switch on which that z-index is set is _painted_ on modals and other elements which should usually cover and hide the entire switch.

__Before:__

https://user-images.githubusercontent.com/50708034/205177743-5d941e64-e7ad-4e35-89e6-1a62119159eb.mov

__After:__

https://user-images.githubusercontent.com/50708034/205179021-43ad8f4f-c5eb-438c-98cd-825d66c26c2c.mov

Resolves [ZEN-713](https://linear.app/noredink/issue/ZEN-713/weird-button-overlap-on-integrations-page)