### PR TITLE
A11-2039 remove brackets from pseudo-elements

### DIFF
--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -136,7 +136,7 @@ viewMarked tagStyle markedWith segments =
             , Css.Global.children
                 [ Css.Global.selector ":last-child"
                     (Css.after
-                        [ Css.property "content" ("\" [end " ++ (Maybe.map (\name -> name) markedWith.name |> Maybe.withDefault "highlight") ++ "] \"")
+                        [ Css.property "content" ("\" end " ++ (Maybe.map (\name -> name) markedWith.name |> Maybe.withDefault "highlight") ++ " \"")
                         , invisibleStyle
                         ]
                         :: markedWith.endStyles
@@ -175,14 +175,14 @@ tagBeforeContent markedWith =
         Just name ->
             Css.before
                 [ MediaQuery.notHighContrastMode
-                    [ Css.property "content" ("\" [start " ++ name ++ " highlight] \"")
+                    [ Css.property "content" ("\" start " ++ name ++ " highlight \"")
                     , invisibleStyle
                     ]
                 ]
 
         Nothing ->
             Css.before
-                [ Css.property "content" "\" [start highlight] \""
+                [ Css.property "content" "\" start highlight \""
                 , invisibleStyle
                 ]
 

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -294,7 +294,7 @@ hasStartHighlightBeforeContent startHighlightMarker relevantHighlightableText vi
 
         startHighlightClassRegex : Maybe Regex
         startHighlightClassRegex =
-            "\\.(\\_[a-zA-Z0-9]+)::before\\{content:\\\\\"\\s*\\[\\s*"
+            "\\.(\\_[a-zA-Z0-9]+)::before\\{content:\\\\\"\\s*\\s*"
                 ++ startHighlightMarker
                 |> Regex.fromString
 


### PR DESCRIPTION
This removes the square brackets from the highlighter pseudo-elements because NVDA reads them.