### PR TITLE
Adjust tooltip bridge

### DIFF
--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -1010,6 +1010,7 @@ hoverBridge { isOpen, direction } =
             [ Css.boxSizing Css.borderBox
             , Css.padding (Css.px tailSize)
             , Css.position Css.absolute
+            , Css.backgroundColor Colors.red
             , Css.batch <|
                 case direction of
                     OnTop ->

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -1120,7 +1120,6 @@ viewTooltip tooltipId config =
                         [ ExtraAttributes.nriDescription "tooltip-hover-bridge"
                         , Attributes.css
                             [ Css.position Css.absolute
-                            , Css.backgroundColor Colors.green
                             , MediaQuery.withViewport (Just mobileBreakpoint) Nothing <|
                                 hoverAreaForDirection config.direction
                             , MediaQuery.withViewport (Just quizEngineBreakpoint) (Just mobileBreakpoint) <|

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -77,7 +77,7 @@ These tooltips aim to follow the accessibility recommendations from:
 
 -}
 
-import Accessibility.Styled as Html exposing (Attribute, Html, text)
+import Accessibility.Styled as Html exposing (Attribute, Html)
 import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Key as Key
 import Accessibility.Styled.Role as Role
@@ -990,62 +990,9 @@ viewTooltip_ { trigger, id } tooltip =
                     ++ buttonEvents
                     ++ tooltip.triggerAttributes
                 )
-            , hoverBridge tooltip
             ]
         , viewTooltip id tooltip
         ]
-
-
-{-| This is a "bridge" for the cursor to move from trigger content to tooltip, so the user can click on links, etc.
--}
-hoverBridge : Tooltip msg -> Html msg
-hoverBridge { isOpen, direction } =
-    let
-        bridgeLength =
-            tailSize + 5
-    in
-    if isOpen then
-        Nri.Ui.styled Html.div
-            "tooltip-hover-bridge"
-            [ Css.boxSizing Css.borderBox
-            , Css.padding (Css.px tailSize)
-            , Css.position Css.absolute
-            , Css.backgroundColor Colors.red
-            , Css.batch <|
-                case direction of
-                    OnTop ->
-                        [ Css.top (Css.px -bridgeLength)
-                        , Css.left Css.zero
-                        , Css.width (Css.pct 100)
-                        , Css.height (Css.px tailSize)
-                        ]
-
-                    OnRight ->
-                        [ Css.right (Css.px -bridgeLength)
-                        , Css.top Css.zero
-                        , Css.width (Css.px tailSize)
-                        , Css.height (Css.pct 100)
-                        ]
-
-                    OnBottom ->
-                        [ Css.bottom (Css.px -bridgeLength)
-                        , Css.left Css.zero
-                        , Css.width (Css.pct 100)
-                        , Css.height (Css.px tailSize)
-                        ]
-
-                    OnLeft ->
-                        [ Css.left (Css.px -bridgeLength)
-                        , Css.top Css.zero
-                        , Css.width (Css.px tailSize)
-                        , Css.height (Css.pct 100)
-                        ]
-            ]
-            []
-            []
-
-    else
-        text ""
 
 
 viewTooltip : String -> Tooltip msg -> Html msg
@@ -1170,8 +1117,10 @@ viewTooltip tooltipId config =
             )
             (config.content
                 ++ [ Html.div
-                        [ Attributes.css
+                        [ ExtraAttributes.nriDescription "tooltip-hover-bridge"
+                        , Attributes.css
                             [ Css.position Css.absolute
+                            , Css.backgroundColor Colors.green
                             , MediaQuery.withViewport (Just mobileBreakpoint) Nothing <|
                                 hoverAreaForDirection config.direction
                             , MediaQuery.withViewport (Just quizEngineBreakpoint) (Just mobileBreakpoint) <|

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -1305,7 +1305,7 @@ topHoverArea =
     [ Css.bottom (Css.pct 100)
     , Css.left Css.zero
     , Css.right Css.zero
-    , Css.height (Css.px (tailSize * 2))
+    , Css.height (Css.px (tailSize + 3))
     ]
 
 
@@ -1314,7 +1314,7 @@ bottomHoverArea =
     [ Css.top (Css.pct 100)
     , Css.left Css.zero
     , Css.right Css.zero
-    , Css.height (Css.px (tailSize * 2))
+    , Css.height (Css.px (tailSize + 3))
     ]
 
 
@@ -1323,7 +1323,7 @@ leftHoverArea =
     [ Css.right (Css.pct 100)
     , Css.top Css.zero
     , Css.bottom Css.zero
-    , Css.width (Css.px (tailSize * 2))
+    , Css.width (Css.px (tailSize + 3))
     ]
 
 
@@ -1332,7 +1332,7 @@ rightHoverArea =
     [ Css.left (Css.pct 100)
     , Css.top Css.zero
     , Css.bottom Css.zero
-    , Css.width (Css.px (tailSize * 2))
+    , Css.width (Css.px (tailSize + 3))
     ]
 
 

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -546,6 +546,7 @@ viewCustomizableExample ellieLinkConfig controlSettings =
                         ClickableSvg.button "Up"
                             UiIcon.arrowTop
                             [ ClickableSvg.custom eventHandlers
+                            , ClickableSvg.withBorder
                             ]
                 , id = "an-id-for-the-tooltip"
                 }


### PR DESCRIPTION
Fixes A11-1904

Relevant to KRA-610

## Before this PR

It turns out that the tooltip component actually had 2 hover bridges!

The rectangle highlighted in mustard had an nri description claiming it to be the hover bridge.
<img width="354" alt="Screen Shot 2022-12-08 at 11 06 20 AM" src="https://user-images.githubusercontent.com/8811312/206531811-a6bd7848-7536-4bb3-800b-847a0f20695e.png">

But it was actually _underneath_ another element that was functioning as the hover bridge, highlighted in green:
<img width="372" alt="Screen Shot 2022-12-08 at 11 06 51 AM" src="https://user-images.githubusercontent.com/8811312/206531805-87d6f2f1-5fed-4962-ad06-b75b5e4d00b5.png">

Note that both hover bridges are actually rendering on top of the tooltip trigger, which was causing the covered portion of the element to not be clickable.

You might be thinking "I know! Pointer events none will allow the clicks to travel through to the trigger!" Totally! But this will also make the hover bridge not actually keep the tooltip open when the user hovers it.

![hover bridge](https://user-images.githubusercontent.com/8811312/206533124-3230aa7e-3fb5-458b-a631-5b8d3afbac63.gif)

---

## After this PR

I've removed the extraneous hover bridge.

I've removed the overlap from the remaining hover bridge. I think that when there's a triggering element with rounded edges, we may lose some of the bridge behavior where the trigger has a cut-out. However, I think this is a reasonable tradeoff (and if the user mouses to the tooltip area quickly, it won't matter).

<img width="379" alt="Screen Shot 2022-12-08 at 11 03 41 AM" src="https://user-images.githubusercontent.com/8811312/206531817-5558c7b6-6f93-4310-bcc5-0ef2ae607c0d.png">

<img width="384" alt="Screen Shot 2022-12-08 at 11 03 53 AM" src="https://user-images.githubusercontent.com/8811312/206531813-c6e501bb-338b-4ecc-b2ef-6fdb84206faa.png">

<img width="418" alt="Screen Shot 2022-12-08 at 11 04 00 AM" src="https://user-images.githubusercontent.com/8811312/206531812-2837e09e-b56d-4bc5-a0d1-fc81d9287845.png">

<img width="416" alt="Screen Shot 2022-12-08 at 11 03 48 AM" src="https://user-images.githubusercontent.com/8811312/206531815-a5632795-fc3f-4d4f-9939-39657613b3f0.png">

Another option is to mess with a negative z-index to get the bridge behind the trigger. However, I think this would be a mistake to do because it will require adding non-static positioning to all tooltip triggering elements -- a risky move! Also, this non-static positioning would be challenging to override (we wouldn't want to use `css`, because of potential class name re-ordering surprises, and inline styles are high precedence).

Note that the green background is for demo purposes. It is not present in the actual PR.