### PR TITLE
A11-2065 Add username autocomplete to TextInput

### DIFF
--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -1,6 +1,6 @@
 module Nri.Ui.TextInput.V7 exposing
     ( view, generateId
-    , number, float, text, newPassword, currentPassword, email, search, addressLevel2, addressLine1, countryName, familyName, givenName, organization, organizationTitle, postalCode, sex, tel
+    , number, float, text, newPassword, currentPassword, email, search, addressLevel2, addressLine1, countryName, familyName, givenName, username, organization, organizationTitle, postalCode, sex, tel
     , readOnlyText
     , value, map
     , onFocus, onBlur, onEnter
@@ -9,7 +9,6 @@ module Nri.Ui.TextInput.V7 exposing
     , css, custom, nriDescription, id, testId, noMargin
     , disabled, loading, errorIf, errorMessage, guidance
     , writing
-    , username
     )
 
 {-|
@@ -33,7 +32,7 @@ module Nri.Ui.TextInput.V7 exposing
 
 ### Input types
 
-@docs number, float, text, newPassword, currentPassword, email, search, addressLevel2, addressLine1, countryName, familyName, givenName, organization, organizationTitle, postalCode, sex, tel
+@docs number, float, text, newPassword, currentPassword, email, search, addressLevel2, addressLine1, countryName, familyName, givenName, username, organization, organizationTitle, postalCode, sex, tel
 @docs readOnlyText
 
 

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -9,6 +9,7 @@ module Nri.Ui.TextInput.V7 exposing
     , css, custom, nriDescription, id, testId, noMargin
     , disabled, loading, errorIf, errorMessage, guidance
     , writing
+    , username
     )
 
 {-|

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -312,6 +312,25 @@ familyName onInput_ =
         )
 
 
+{-| An input that allows username entry
+-}
+username : (String -> msg) -> Attribute String msg
+username onInput_ =
+    Attribute
+        { emptyEventsAndValues
+            | toString = Just identity
+            , fromString = Just identity
+            , onInput = Just (identity >> onInput_)
+        }
+        (\config ->
+            { config
+                | fieldType = Just "text"
+                , inputMode = Nothing
+                , autocomplete = Just "username"
+            }
+        )
+
+
 {-| An input that allows organization entry
 -}
 organization : (String -> msg) -> Attribute String msg


### PR DESCRIPTION
Adds "username" autocomplete value to TextInput to fix [A11-2046 : \[A11yAud-0385\] Account settings page needs more autocomplete attributes](https://linear.app/noredink/issue/A11-2046/[a11yaud-0385]-account-settings-page-needs-more-autocomplete).