### PR TITLE
Bat/stretched balloons

### DIFF
--- a/src/Nri/Ui/Balloon/V2.elm
+++ b/src/Nri/Ui/Balloon/V2.elm
@@ -555,6 +555,10 @@ arrowPosition ({ position, arrowAlignment, theme } as config) =
         color =
             theme.backgroundColor
 
+        highContrastColor =
+            Maybe.withDefault "CanvasText"
+                (Maybe.map .backgroundColor config.highContrastModeTheme)
+
         offset =
             String.fromFloat (borderRounding + 8) ++ "px"
 
@@ -580,13 +584,22 @@ arrowPosition ({ position, arrowAlignment, theme } as config) =
                 [ translate "X"
                 , Css.property "transform-origin" "center"
                 , Css.borderTop (Css.px arrowHeight_)
-                , Css.borderTopColor color
                 , Css.borderRight (Css.px arrowWidth)
-                , Css.borderRightColor transparent
                 , Css.borderBottom Css.zero
-                , Css.borderBottomColor transparent
                 , Css.borderLeft (Css.px arrowWidth)
+
+                -- Colors:
+                , Css.borderTopColor color
+                , Css.borderRightColor transparent
+                , Css.borderBottomColor transparent
                 , Css.borderLeftColor transparent
+                , MediaQuery.highContrastMode
+                    [ Css.property "forced-color-adjust" "none"
+                    , Css.property "border-top-color" highContrastColor
+                    , Css.property "border-right-color" "Canvas"
+                    , Css.property "border-bottom-color" "Canvas"
+                    , Css.property "border-left-color" "Canvas"
+                    ]
                 ]
 
         OnBottom ->
@@ -594,13 +607,22 @@ arrowPosition ({ position, arrowAlignment, theme } as config) =
                 [ translate "X"
                 , Css.property "transform-origin" "center"
                 , Css.borderTop Css.zero
-                , Css.borderTopColor transparent
                 , Css.borderRight (Css.px arrowWidth)
-                , Css.borderRightColor transparent
                 , Css.borderBottom (Css.px arrowHeight_)
-                , Css.borderBottomColor color
                 , Css.borderLeft (Css.px arrowWidth)
+
+                -- Colors:
+                , Css.borderTopColor transparent
+                , Css.borderRightColor transparent
+                , Css.borderBottomColor color
                 , Css.borderLeftColor transparent
+                , MediaQuery.highContrastMode
+                    [ Css.property "forced-color-adjust" "none"
+                    , Css.property "border-top-color" "Canvas"
+                    , Css.property "border-right-color" "Canvas"
+                    , Css.property "border-bottom-color" highContrastColor
+                    , Css.property "border-left-color" "Canvas"
+                    ]
                 ]
 
         OnLeft ->
@@ -608,13 +630,22 @@ arrowPosition ({ position, arrowAlignment, theme } as config) =
                 [ translate "Y"
                 , Css.property "transform-origin" "center"
                 , Css.borderTop (Css.px arrowWidth)
-                , Css.borderTopColor transparent
                 , Css.borderRight Css.zero
-                , Css.borderRightColor transparent
                 , Css.borderBottom (Css.px arrowWidth)
-                , Css.borderBottomColor transparent
                 , Css.borderLeft (Css.px arrowHeight_)
+
+                -- Colors:
+                , Css.borderTopColor transparent
+                , Css.borderRightColor transparent
+                , Css.borderBottomColor transparent
                 , Css.borderLeftColor color
+                , MediaQuery.highContrastMode
+                    [ Css.property "forced-color-adjust" "none"
+                    , Css.property "border-top-color" "Canvas"
+                    , Css.property "border-right-color" "Canvas"
+                    , Css.property "border-bottom-color" "Canvas"
+                    , Css.property "border-left-color" highContrastColor
+                    ]
                 ]
 
         OnRight ->
@@ -622,13 +653,22 @@ arrowPosition ({ position, arrowAlignment, theme } as config) =
                 [ translate "Y"
                 , Css.property "transform-origin" "center"
                 , Css.borderTop (Css.px arrowWidth)
-                , Css.borderTopColor transparent
                 , Css.borderRight (Css.px arrowHeight_)
-                , Css.borderRightColor color
                 , Css.borderBottom (Css.px arrowWidth)
-                , Css.borderBottomColor transparent
                 , Css.borderLeft Css.zero
+
+                -- Colors:
+                , Css.borderTopColor transparent
+                , Css.borderRightColor color
+                , Css.borderBottomColor transparent
                 , Css.borderLeftColor transparent
+                , MediaQuery.highContrastMode
+                    [ Css.property "forced-color-adjust" "none"
+                    , Css.property "border-top-color" "Canvas"
+                    , Css.property "border-right-color" highContrastColor
+                    , Css.property "border-bottom-color" "Canvas"
+                    , Css.property "border-left-color" "Canvas"
+                    ]
                 ]
 
         NoArrow ->

--- a/src/Nri/Ui/Balloon/V2.elm
+++ b/src/Nri/Ui/Balloon/V2.elm
@@ -5,6 +5,7 @@ module Nri.Ui.Balloon.V2 exposing
     , highContrastModeTheme
     , onBottom, onLeft, onRight, onTop
     , alignArrowStart, alignArrowMiddle, alignArrowEnd
+    , arrowHeight
     , custom, id, nriDescription, testId
     , containerCss
     , css, notMobileCss, mobileCss, quizEngineMobileCss
@@ -53,6 +54,7 @@ Changes from V1:
 @docs highContrastModeTheme
 @docs onBottom, onLeft, onRight, onTop
 @docs alignArrowStart, alignArrowMiddle, alignArrowEnd
+@docs arrowHeight
 @docs custom, id, nriDescription, testId
 
 
@@ -209,6 +211,13 @@ For onLeft & onRight ballon, this means "bottom".
 alignArrowEnd : Attribute msg
 alignArrowEnd =
     withArrowAlignment End
+
+
+{-| Set how tall you want the arrow to be. The default is 8px.
+-}
+arrowHeight : Float -> Attribute msg
+arrowHeight height =
+    Attribute (\config -> { config | arrowHeight = height })
 
 
 {-| Green theme (This is the default theme.)
@@ -374,6 +383,7 @@ html =
 type alias Config msg =
     { position : Position
     , arrowAlignment : ArrowAlignment
+    , arrowHeight : Float
     , theme : Theme
     , highContrastModeTheme : Maybe HighContrastModeTheme
     , containerCss : List Css.Style
@@ -389,6 +399,7 @@ defaultConfig : Config msg
 defaultConfig =
     { position = NoArrow
     , arrowAlignment = Middle
+    , arrowHeight = 8
     , theme = defaultGreenTheme
     , highContrastModeTheme = Nothing
     , containerCss = []
@@ -452,7 +463,7 @@ view_ config =
                 Html.text ""
 
             _ ->
-                viewArrow config 16
+                viewArrow config
         ]
 
 
@@ -516,11 +527,16 @@ borderRounding =
     8
 
 
-viewArrow : Config msg -> Float -> Html msg
-viewArrow config diagonal =
+arrowWidth : Float
+arrowWidth =
+    8
+
+
+viewArrow : Config msg -> Html msg
+viewArrow config =
     let
         arrowSideWidth =
-            sqrt ((diagonal ^ 2) / 2)
+            sqrt ((config.arrowHeight ^ 2 + arrowWidth ^ 2) / 2)
     in
     styled div
         [ arrowPosition config.position config.arrowAlignment

--- a/src/Nri/Ui/Balloon/V2.elm
+++ b/src/Nri/Ui/Balloon/V2.elm
@@ -534,96 +534,101 @@ arrowWidth =
 
 viewArrow : Config msg -> Html msg
 viewArrow config =
-    let
-        arrowSideWidth =
-            sqrt ((config.arrowHeight ^ 2 + arrowWidth ^ 2) / 2)
-    in
     styled div
-        [ arrowPosition config.position config.arrowAlignment
-        , backgroundColor config.theme.backgroundColor
-        , border3 (px 1) solid config.theme.backgroundColor
+        [ arrowPosition config
+        , borderStyle solid
         , applyHighContrastModeTheme config.highContrastModeTheme
-        , Css.height (px arrowSideWidth)
-        , Css.width (px arrowSideWidth)
+        , Css.height zero
+        , Css.width zero
         , Css.flexShrink (Css.num 0)
         ]
         []
         []
 
 
-arrowPosition : Position -> ArrowAlignment -> Css.Style
-arrowPosition position arrowAlignment =
+arrowPosition : Config msg -> Css.Style
+arrowPosition ({ position, arrowAlignment, theme } as config) =
     let
+        arrowHeight_ =
+            config.arrowHeight
+
+        color =
+            theme.backgroundColor
+
         offset =
             String.fromFloat (borderRounding + 8) ++ "px"
 
-        translateYBy y =
+        translate direction =
             Css.batch <|
                 case arrowAlignment of
                     Start ->
                         [ Css.alignSelf Css.flexStart
-                        , Css.property "transform" ("translate(" ++ offset ++ "," ++ y ++ ") rotate(45deg)")
+                        , Css.property "transform" ("translate" ++ direction ++ "(" ++ offset ++ ")")
                         ]
 
                     Middle ->
-                        [ Css.property "transform" ("translateY(" ++ y ++ ") rotate(45deg)") ]
+                        [ Css.property "transform" "scale(1)" ]
 
                     End ->
                         [ Css.alignSelf Css.flexEnd
-                        , Css.property "transform" ("translate(-" ++ offset ++ "," ++ y ++ ") rotate(45deg)")
-                        ]
-
-        translateXBy x =
-            Css.batch <|
-                case arrowAlignment of
-                    Start ->
-                        [ Css.alignSelf Css.flexStart
-                        , Css.property "transform" ("translate(" ++ x ++ "," ++ offset ++ ") rotate(45deg)")
-                        ]
-
-                    Middle ->
-                        [ Css.property "transform" ("translateX(" ++ x ++ ") rotate(45deg)") ]
-
-                    End ->
-                        [ Css.alignSelf Css.flexEnd
-                        , Css.property "transform" ("translate(" ++ x ++ ",-" ++ offset ++ ") rotate(45deg)")
+                        , Css.property "transform" ("translate" ++ direction ++ "(-" ++ offset ++ ")")
                         ]
     in
     case position of
         OnTop ->
             batch
-                [ translateYBy "-50%"
+                [ translate "X"
                 , Css.property "transform-origin" "center"
-                , Css.borderTop Css.zero
-                , Css.borderLeft Css.zero
-                , Css.borderTopLeftRadius (pct 100)
+                , Css.borderTop (Css.px arrowHeight_)
+                , Css.borderTopColor color
+                , Css.borderRight (Css.px arrowWidth)
+                , Css.borderRightColor transparent
+                , Css.borderBottom Css.zero
+                , Css.borderBottomColor transparent
+                , Css.borderLeft (Css.px arrowWidth)
+                , Css.borderLeftColor transparent
                 ]
 
         OnBottom ->
             batch
-                [ translateYBy "50%"
+                [ translate "X"
                 , Css.property "transform-origin" "center"
-                , Css.borderRight Css.zero
-                , Css.borderBottom Css.zero
-                , Css.borderBottomRightRadius (pct 100)
+                , Css.borderTop Css.zero
+                , Css.borderTopColor transparent
+                , Css.borderRight (Css.px arrowWidth)
+                , Css.borderRightColor transparent
+                , Css.borderBottom (Css.px arrowHeight_)
+                , Css.borderBottomColor color
+                , Css.borderLeft (Css.px arrowWidth)
+                , Css.borderLeftColor transparent
                 ]
 
         OnLeft ->
             batch
-                [ translateXBy "-50%"
+                [ translate "Y"
                 , Css.property "transform-origin" "center"
-                , Css.borderBottom Css.zero
-                , Css.borderLeft Css.zero
-                , Css.borderBottomLeftRadius (pct 100)
+                , Css.borderTop (Css.px arrowWidth)
+                , Css.borderTopColor transparent
+                , Css.borderRight Css.zero
+                , Css.borderRightColor transparent
+                , Css.borderBottom (Css.px arrowWidth)
+                , Css.borderBottomColor transparent
+                , Css.borderLeft (Css.px arrowHeight_)
+                , Css.borderLeftColor color
                 ]
 
         OnRight ->
             batch
-                [ translateXBy "50%"
+                [ translate "Y"
                 , Css.property "transform-origin" "center"
-                , Css.borderRight Css.zero
-                , Css.borderTop Css.zero
-                , Css.borderTopRightRadius (pct 100)
+                , Css.borderTop (Css.px arrowWidth)
+                , Css.borderTopColor transparent
+                , Css.borderRight (Css.px arrowHeight_)
+                , Css.borderRightColor color
+                , Css.borderBottom (Css.px arrowWidth)
+                , Css.borderBottomColor transparent
+                , Css.borderLeft Css.zero
+                , Css.borderLeftColor transparent
                 ]
 
         NoArrow ->

--- a/styleguide-app/Examples/Balloon.elm
+++ b/styleguide-app/Examples/Balloon.elm
@@ -80,7 +80,7 @@ controlSettings =
                 }
             )
         |> ControlExtra.optionalListItem "theme" themeOptions
-        |> ControlExtra.optionalListItem "position" positionOptions
+        |> ControlExtra.optionalListItemDefaultChecked "position" positionOptions
         |> CommonControls.css_ "containerCss"
             ( "[ Css.backgroundColor Colors.magenta ]", [ Css.backgroundColor Colors.magenta ] )
             { moduleName = moduleName, use = Balloon.containerCss }
@@ -120,10 +120,10 @@ controlCustomTheme =
 positionOptions : Control ( String, Balloon.Attribute msg )
 positionOptions =
     Control.choice
-        [ ( "onBottom", Control.value ( "Balloon.onBottom", Balloon.onBottom ) )
-        , ( "onLeft", Control.value ( "Balloon.onLeft", Balloon.onLeft ) )
+        [ ( "onTop", Control.value ( "Balloon.onTop", Balloon.onTop ) )
         , ( "onRight", Control.value ( "Balloon.onRight", Balloon.onRight ) )
-        , ( "onTop", Control.value ( "Balloon.onTop", Balloon.onTop ) )
+        , ( "onBottom", Control.value ( "Balloon.onBottom", Balloon.onBottom ) )
+        , ( "onLeft", Control.value ( "Balloon.onLeft", Balloon.onLeft ) )
         ]
 
 

--- a/styleguide-app/Examples/Balloon.elm
+++ b/styleguide-app/Examples/Balloon.elm
@@ -81,6 +81,7 @@ controlSettings =
             )
         |> ControlExtra.optionalListItem "theme" themeOptions
         |> ControlExtra.optionalListItemDefaultChecked "position" positionOptions
+        |> ControlExtra.optionalListItem "arrowAlignment" arrowAlignmentOptions
         |> CommonControls.css_ "containerCss"
             ( "[ Css.backgroundColor Colors.magenta ]", [ Css.backgroundColor Colors.magenta ] )
             { moduleName = moduleName, use = Balloon.containerCss }
@@ -124,6 +125,15 @@ positionOptions =
         , ( "onRight", Control.value ( "Balloon.onRight", Balloon.onRight ) )
         , ( "onBottom", Control.value ( "Balloon.onBottom", Balloon.onBottom ) )
         , ( "onLeft", Control.value ( "Balloon.onLeft", Balloon.onLeft ) )
+        ]
+
+
+arrowAlignmentOptions : Control ( String, Balloon.Attribute msg )
+arrowAlignmentOptions =
+    Control.choice
+        [ ( "alignArrowStart", Control.value ( "Balloon.alignArrowStart", Balloon.alignArrowStart ) )
+        , ( "alignArrowMiddle", Control.value ( "Balloon.alignArrowMiddle", Balloon.alignArrowMiddle ) )
+        , ( "alignArrowEnd", Control.value ( "Balloon.alignArrowEnd", Balloon.alignArrowEnd ) )
         ]
 
 

--- a/styleguide-app/Examples/Balloon.elm
+++ b/styleguide-app/Examples/Balloon.elm
@@ -82,6 +82,15 @@ controlSettings =
         |> ControlExtra.optionalListItem "theme" themeOptions
         |> ControlExtra.optionalListItemDefaultChecked "position" positionOptions
         |> ControlExtra.optionalListItem "arrowAlignment" arrowAlignmentOptions
+        |> ControlExtra.optionalListItem "arrowHeight"
+            (Control.map
+                (\v ->
+                    ( "Balloon.arrowHeight " ++ String.fromFloat v ++ ""
+                    , Balloon.arrowHeight v
+                    )
+                )
+                (ControlExtra.float 20)
+            )
         |> CommonControls.css_ "containerCss"
             ( "[ Css.backgroundColor Colors.magenta ]", [ Css.backgroundColor Colors.magenta ] )
             { moduleName = moduleName, use = Balloon.containerCss }


### PR DESCRIPTION
Blocks need balloons that can have extra-tall arrows in order to position them against each other nicely (See https://linear.app/noredink/issue/A11-1804/overlapping-tagged-labels)

This PR only adds support for arbitrarily-tall balloon arrows.

<img width="373" alt="Screen Shot 2022-12-12 at 3 55 28 PM" src="https://user-images.githubusercontent.com/8811312/207172696-9261f9ad-4dbc-4f5f-b6a1-6b46bcf73526.png">


## High Contrast Note:
This PR also changes the appearance of balloon arrows in high-contrast mode (because I had to change approach from a rotated square to the border-trick in order to get the arrow to extend).

## Before

<img width="381" alt="Screen Shot 2022-12-12 at 4 54 09 PM" src="https://user-images.githubusercontent.com/8811312/207184800-4501254e-0783-441c-8a65-1be051015747.png">


## After

<img width="380" alt="Screen Shot 2022-12-12 at 4 51 05 PM" src="https://user-images.githubusercontent.com/8811312/207184639-00e159ac-549f-4a91-9e2b-a1c46747b399.png">

cc @NoRedInk/design 