### PR TITLE
Bat/block class

### DIFF
--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -4,6 +4,7 @@ module Nri.Ui.Block.V1 exposing
     , Content, string, blank
     , emphasize, label
     , yellow, cyan, magenta, green, blue, purple, brown
+    , class
     )
 
 {-|
@@ -26,13 +27,18 @@ module Nri.Ui.Block.V1 exposing
 
 @docs yellow, cyan, magenta, green, blue, purple, brown
 
+
+### General attributes
+
+@docs class
+
 -}
 
 import Accessibility.Styled exposing (..)
 import Css exposing (Color)
-import Html.Styled.Attributes exposing (css)
+import Html.Styled.Attributes as Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.Html.Attributes.V2 exposing (nriDescription)
+import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (nriDescription)
 import Nri.Ui.Mark.V1 as Mark exposing (Mark)
 import Nri.Ui.MediaQuery.V1 as MediaQuery
 
@@ -108,7 +114,7 @@ renderContent content_ markStyles =
                 [ text str ]
 
             Blank ->
-                [ viewBlank ]
+                [ viewBlank Nothing ]
 
 
 {-| You will only need to use this helper if you're also using `content` to construct a more complex Block. Maybe you want `plaintext` instead?
@@ -286,6 +292,12 @@ brown =
     Attribute (\config -> { config | theme = Just Brown })
 
 
+{-| -}
+class : String -> Attribute
+class class_ =
+    Attribute (\config -> { config | class = Just class_ })
+
+
 
 -- Internals
 
@@ -300,6 +312,7 @@ defaultConfig =
     { content = []
     , label = Nothing
     , theme = Nothing
+    , class = Nothing
     }
 
 
@@ -307,6 +320,7 @@ type alias Config =
     { content : List Content
     , label : Maybe String
     , theme : Maybe Theme
+    , class : Maybe String
     }
 
 
@@ -324,26 +338,28 @@ render config =
             case maybeMark of
                 Just mark ->
                     viewMark (Maybe.withDefault defaultPalette maybePalette)
+                        config.class
                         ( [ Blank ], Just mark )
 
                 Nothing ->
-                    [ viewBlank ]
+                    [ viewBlank config.class ]
 
         _ ->
             viewMark (Maybe.withDefault defaultPalette maybePalette)
+                config.class
                 ( config.content, maybeMark )
 
 
-viewMark : Palette -> ( List Content, Maybe Mark ) -> List (Html msg)
-viewMark palette ( content_, mark ) =
+viewMark : Palette -> Maybe String -> ( List Content, Maybe Mark ) -> List (Html msg)
+viewMark palette class_ ( content_, mark ) =
     Mark.viewWithBalloonTags renderContent
         palette.backgroundColor
         mark
         content_
 
 
-viewBlank : Html msg
-viewBlank =
+viewBlank : Maybe String -> Html msg
+viewBlank class_ =
     span
         [ css
             [ Css.border3 (Css.px 2) Css.dashed Colors.navy
@@ -356,6 +372,7 @@ viewBlank =
             , Css.display Css.inlineBlock
             , Css.borderRadius (Css.px 4)
             ]
+        , AttributesExtra.maybe Attributes.class class_
         ]
         [ span
             [ css

--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -102,19 +102,20 @@ type Content
     | Blank
 
 
-renderContent : Content -> List Css.Style -> Html msg
-renderContent content_ markStyles =
+renderContent : Maybe String -> Content -> List Css.Style -> Html msg
+renderContent class_ content_ markStyles =
     span
         [ css (Css.whiteSpace Css.preWrap :: markStyles)
         , nriDescription "block-segment-container"
+        , AttributesExtra.maybe Attributes.class class_
         ]
-    <|
-        case content_ of
+        (case content_ of
             String_ str ->
                 [ text str ]
 
             Blank ->
-                [ viewBlank Nothing ]
+                [ viewBlank class_ ]
+        )
 
 
 {-| You will only need to use this helper if you're also using `content` to construct a more complex Block. Maybe you want `plaintext` instead?
@@ -352,7 +353,7 @@ render config =
 
 viewMark : Palette -> Maybe String -> ( List Content, Maybe Mark ) -> List (Html msg)
 viewMark palette class_ ( content_, mark ) =
-    Mark.viewWithBalloonTags renderContent
+    Mark.viewWithBalloonTags (renderContent class_)
         palette.backgroundColor
         mark
         content_

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -236,6 +236,8 @@ initControl =
                 , ( "brown", Block.brown )
                 ]
             )
+        |> ControlExtra.optionalListItem "class"
+            (CommonControls.string ( "class", Block.class ) "kiwis-are-good")
 
 
 controlContent : Control ( String, Block.Attribute )


### PR DESCRIPTION
Support adding an arbitrary class to the block.

Note that when emphasis is added, the segment/s is/are wrapped in a mark element. I kept the class on the segment -- I did not add it to the mark.

## Blank

<img width="391" alt="Screen Shot 2022-12-13 at 9 36 35 AM" src="https://user-images.githubusercontent.com/8811312/207392392-84e731d6-68e6-4c5d-ad6a-8f1f471a25cd.png">

<img width="686" alt="Screen Shot 2022-12-13 at 9 36 58 AM" src="https://user-images.githubusercontent.com/8811312/207392388-ff9932ee-f149-441a-81a9-d69188229a1d.png">


## Plain

<img width="404" alt="Screen Shot 2022-12-13 at 9 38 05 AM" src="https://user-images.githubusercontent.com/8811312/207392204-37baf47b-4f22-4856-9df9-aaeab78bd8a3.png">
<img width="715" alt="Screen Shot 2022-12-13 at 9 37 59 AM" src="https://user-images.githubusercontent.com/8811312/207392248-a24698db-f6cc-4fc0-b8d0-4f9b6f4bef3a.png">


## Emphasis

<img width="404" alt="Screen Shot 2022-12-13 at 9 37 44 AM" src="https://user-images.githubusercontent.com/8811312/207392291-1370174a-cdb8-4a58-85b8-92f6567d16a2.png">
<img width="703" alt="Screen Shot 2022-12-13 at 9 37 30 AM" src="https://user-images.githubusercontent.com/8811312/207392312-b74a4028-d997-42c7-836a-fb33ef0a1ee3.png">


## Emphasis -- mixed content

<img width="647" alt="Screen Shot 2022-12-13 at 9 44 59 AM" src="https://user-images.githubusercontent.com/8811312/207393150-85bfe26d-d030-4175-a670-d8707e4e729e.png">


<img width="682" alt="Screen Shot 2022-12-13 at 9 38 29 AM" src="https://user-images.githubusercontent.com/8811312/207391944-22eccdc5-17ae-4587-a416-9a6ba41c372f.png">
