### PR TITLE
Use inset styles for tabpanel focus ring

### DIFF
--- a/src/TabsInternal/V2.elm
+++ b/src/TabsInternal/V2.elm
@@ -19,6 +19,7 @@ import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Html.Styled.Keyed as Keyed
+import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
 import Nri.Ui.Tooltip.V3 as Tooltip
 import Nri.Ui.Util exposing (dashify)
@@ -243,6 +244,10 @@ viewTabPanel tab selected =
          , Aria.labelledBy (tabToId tab.idString)
          , Attributes.id (tabToBodyId tab.idString)
          , Attributes.tabindex 0
+         , Attributes.class FocusRing.customClass
+         , Attributes.css
+            [ Css.pseudoClass "focus-visible" [ FocusRing.insetBoxShadow ]
+            ]
          ]
             ++ (if selected then
                     [ -- Used as selector for test queries


### PR DESCRIPTION
Fixes A11-2049

Quick writes and guided drafts side panels include tabs whose tabpanels hide overflow. This causes the focus ring to disappear.

Changing the focus indicator for tabpanel to be inset (and therefore no longer overflowing) should resolve this issue.

Note that this change will also impact SegmentedControls (the tab-based view) and Carousel.

## Before

<img width="1385" alt="Screen Shot 2022-12-13 at 10 06 57 AM" src="https://user-images.githubusercontent.com/8811312/207398611-0d83d542-1b30-45c7-b217-32c033076534.png">

## After

<img width="1362" alt="Screen Shot 2022-12-13 at 10 06 41 AM" src="https://user-images.githubusercontent.com/8811312/207398607-8ba68134-1862-4f86-8bec-268023f743c3.png">
