### PR TITLE
Fix overlapping block labels

### DIFF
--- a/src/Nri/Ui/Balloon/V2.elm
+++ b/src/Nri/Ui/Balloon/V2.elm
@@ -6,7 +6,7 @@ module Nri.Ui.Balloon.V2 exposing
     , onBottom, onLeft, onRight, onTop
     , alignArrowStart, alignArrowMiddle, alignArrowEnd
     , arrowHeight
-    , custom, id, nriDescription, testId
+    , custom, id, contentId, nriDescription, testId
     , containerCss
     , css, notMobileCss, mobileCss, quizEngineMobileCss
     )
@@ -55,7 +55,7 @@ Changes from V1:
 @docs onBottom, onLeft, onRight, onTop
 @docs alignArrowStart, alignArrowMiddle, alignArrowEnd
 @docs arrowHeight
-@docs custom, id, nriDescription, testId
+@docs custom, id, contentId, nriDescription, testId
 
 
 ### CSS
@@ -348,6 +348,12 @@ id id_ =
     custom [ Attributes.id id_ ]
 
 
+{-| -}
+contentId : String -> Attribute msg
+contentId id_ =
+    Attribute (\config -> { config | contentId = Just id_ })
+
+
 {-| Provide a plain-text string.
 -}
 plaintext : String -> Attribute msg
@@ -387,6 +393,7 @@ type alias Config msg =
     , theme : Theme
     , highContrastModeTheme : Maybe HighContrastModeTheme
     , containerCss : List Css.Style
+    , contentId : Maybe String
     , css : List Css.Style
     , customAttributes : List (Html.Attribute msg)
     , content : List (Html msg)
@@ -403,6 +410,7 @@ defaultConfig =
     , theme = defaultGreenTheme
     , highContrastModeTheme = Nothing
     , containerCss = []
+    , contentId = Nothing
     , css = [ Css.padding (Css.px 20) ]
     , customAttributes = []
     , content = []
@@ -457,7 +465,7 @@ view_ : Config msg -> Html msg
 view_ config =
     container config.position
         (Attributes.css config.containerCss :: config.customAttributes)
-        [ viewBalloon config.theme config.highContrastModeTheme config.css config.content
+        [ viewBalloon config
         , case config.position of
             NoArrow ->
                 Html.text ""
@@ -501,8 +509,16 @@ container position attributes =
         attributes
 
 
-viewBalloon : Theme -> Maybe HighContrastModeTheme -> List Css.Style -> List (Html msg) -> Html msg
-viewBalloon palette maybeHighContrastModeTheme styles contents =
+viewBalloon :
+    { config
+        | theme : Theme
+        , highContrastModeTheme : Maybe HighContrastModeTheme
+        , contentId : Maybe String
+        , css : List Css.Style
+        , content : List (Html msg)
+    }
+    -> Html msg
+viewBalloon config =
     styled div
         [ display inlineBlock
         , lineHeight (num 1.4)
@@ -510,16 +526,22 @@ viewBalloon palette maybeHighContrastModeTheme styles contents =
         , position relative
         , Css.borderRadius (px borderRounding)
         , Shadows.high
-        , backgroundColor palette.backgroundColor
-        , border3 (px 1) solid palette.backgroundColor
-        , color palette.color
+        , backgroundColor config.theme.backgroundColor
+        , border3 (px 1) solid config.theme.backgroundColor
+        , color config.theme.color
         , Fonts.baseFont
         , fontSize (px 15)
-        , applyHighContrastModeTheme maybeHighContrastModeTheme
-        , Css.batch styles
+        , applyHighContrastModeTheme config.highContrastModeTheme
+        , Css.batch config.css
         ]
-        []
-        contents
+        (case config.contentId of
+            Nothing ->
+                []
+
+            Just id_ ->
+                [ Attributes.id id_ ]
+        )
+        config.content
 
 
 borderRounding : Float

--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -217,38 +217,20 @@ toMark : Maybe String -> Maybe Palette -> Maybe Mark
 toMark label_ palette =
     case ( label_, palette ) of
         ( _, Just { backgroundColor, borderColor } ) ->
-            let
-                borderWidth =
-                    Css.px 1
-
-                borderStyles =
-                    [ Css.borderStyle Css.dashed
-                    , Css.borderColor borderColor
-                    ]
-            in
             Just
                 { name = label_
-                , startStyles =
-                    [ Css.paddingLeft (Css.px 2)
-                    , Css.batch borderStyles
-                    , Css.borderWidth4 borderWidth Css.zero borderWidth borderWidth
-                    ]
+                , startStyles = []
                 , styles =
-                    [ Css.padding2 (Css.px 4) Css.zero
+                    [ Css.padding2 (Css.px 4) (Css.px 2)
                     , Css.backgroundColor backgroundColor
-                    , Css.batch borderStyles
-                    , Css.borderWidth2 borderWidth Css.zero
+                    , Css.border3 (Css.px 1) Css.dashed borderColor
                     , MediaQuery.highContrastMode
                         [ Css.property "background-color" "Mark"
                         , Css.property "color" "MarkText"
                         , Css.property "forced-color-adjust" "none"
                         ]
                     ]
-                , endStyles =
-                    [ Css.paddingRight (Css.px 2)
-                    , Css.batch borderStyles
-                    , Css.borderWidth4 borderWidth borderWidth borderWidth Css.zero
-                    ]
+                , endStyles = []
                 }
 
         ( Just l, Nothing ) ->

--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -2,7 +2,7 @@ module Nri.Ui.Block.V1 exposing
     ( view, Attribute
     , plaintext, content
     , Content, string, blank
-    , emphasize, label
+    , emphasize, label, labelOffset
     , yellow, cyan, magenta, green, blue, purple, brown
     , class
     )
@@ -20,7 +20,7 @@ module Nri.Ui.Block.V1 exposing
 
 ## Content customization
 
-@docs emphasize, label
+@docs emphasize, label, labelOffset
 
 
 ### Visual customization
@@ -90,6 +90,12 @@ emphasize =
 label : String -> Attribute
 label label_ =
     Attribute <| \config -> { config | label = Just label_ }
+
+
+{-| -}
+labelOffset : Maybe Float -> Attribute
+labelOffset offset =
+    Attribute <| \config -> { config | labelOffset = offset }
 
 
 
@@ -312,6 +318,7 @@ defaultConfig : Config
 defaultConfig =
     { content = []
     , label = Nothing
+    , labelOffset = Nothing
     , theme = Nothing
     , class = Nothing
     }
@@ -320,6 +327,7 @@ defaultConfig =
 type alias Config =
     { content : List Content
     , label : Maybe String
+    , labelOffset : Maybe Float
     , theme : Maybe Theme
     , class : Maybe String
     }
@@ -343,7 +351,7 @@ render config =
                         config.class
                         ( [ Blank ]
                         , Just mark
-                        , Nothing
+                        , config.labelOffset
                         )
 
                 Nothing ->
@@ -352,7 +360,7 @@ render config =
         _ ->
             viewMark (Maybe.withDefault defaultPalette maybePalette)
                 config.class
-                ( config.content, maybeMark, Nothing )
+                ( config.content, maybeMark, config.labelOffset )
 
 
 viewMark : Palette -> Maybe String -> ( List Content, Maybe Mark, Maybe Float ) -> List (Html msg)

--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -338,9 +338,13 @@ render config =
         [] ->
             case maybeMark of
                 Just mark ->
-                    viewMark (Maybe.withDefault defaultPalette maybePalette)
+                    viewMark
+                        (Maybe.withDefault defaultPalette maybePalette)
                         config.class
-                        ( [ Blank ], Just mark )
+                        ( [ Blank ]
+                        , Just mark
+                        , Nothing
+                        )
 
                 Nothing ->
                     [ viewBlank config.class ]
@@ -348,14 +352,17 @@ render config =
         _ ->
             viewMark (Maybe.withDefault defaultPalette maybePalette)
                 config.class
-                ( config.content, maybeMark )
+                ( config.content, maybeMark, Nothing )
 
 
-viewMark : Palette -> Maybe String -> ( List Content, Maybe Mark ) -> List (Html msg)
-viewMark palette class_ ( content_, mark ) =
-    Mark.viewWithBalloonTags (renderContent class_)
-        palette.backgroundColor
-        mark
+viewMark : Palette -> Maybe String -> ( List Content, Maybe Mark, Maybe Float ) -> List (Html msg)
+viewMark palette class_ ( content_, mark, offset ) =
+    Mark.viewWithOffsetBalloonTags
+        { renderSegment = renderContent class_
+        , backgroundColor = palette.backgroundColor
+        , maybeMarker = mark
+        , offset = offset
+        }
         content_
 
 

--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -2,7 +2,7 @@ module Nri.Ui.Block.V1 exposing
     ( view, Attribute
     , plaintext, content
     , Content, string, blank
-    , emphasize, label, labelId, labelOffset
+    , emphasize, label, labelId, labelHeight
     , yellow, cyan, magenta, green, blue, purple, brown
     , class
     )
@@ -20,7 +20,7 @@ module Nri.Ui.Block.V1 exposing
 
 ## Content customization
 
-@docs emphasize, label, labelId, labelOffset
+@docs emphasize, label, labelId, labelHeight
 
 
 ### Visual customization
@@ -99,9 +99,9 @@ labelId labelId_ =
 
 
 {-| -}
-labelOffset : Maybe Float -> Attribute
-labelOffset offset =
-    Attribute <| \config -> { config | labelOffset = offset }
+labelHeight : Maybe { totalHeight : Float, arrowHeight : Float } -> Attribute
+labelHeight offset =
+    Attribute <| \config -> { config | labelHeight = offset }
 
 
 
@@ -307,7 +307,7 @@ defaultConfig =
     { content = []
     , label = Nothing
     , labelId = Nothing
-    , labelOffset = Nothing
+    , labelHeight = Nothing
     , theme = Nothing
     , class = Nothing
     }
@@ -317,7 +317,7 @@ type alias Config =
     { content : List Content
     , label : Maybe String
     , labelId : Maybe String
-    , labelOffset : Maybe Float
+    , labelHeight : Maybe { totalHeight : Float, arrowHeight : Float }
     , theme : Maybe Theme
     , class : Maybe String
     }
@@ -343,7 +343,7 @@ render config =
                         { renderSegment = renderContent config.class
                         , backgroundColor = palette.backgroundColor
                         , maybeMarker = Just mark
-                        , offset = config.labelOffset
+                        , labelHeight = config.labelHeight
                         , labelId = config.labelId
                         }
                         [ Blank ]
@@ -356,7 +356,7 @@ render config =
                 { renderSegment = renderContent config.class
                 , backgroundColor = palette.backgroundColor
                 , maybeMarker = maybeMark
-                , offset = config.labelOffset
+                , labelHeight = config.labelHeight
                 , labelId = config.labelId
                 }
                 config.content

--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -97,12 +97,12 @@ viewWithOffsetBalloonTags :
     { renderSegment : c -> List Style -> Html msg
     , backgroundColor : Color
     , maybeMarker : Maybe Mark
-    , offset : Maybe Float
+    , labelHeight : Maybe { totalHeight : Float, arrowHeight : Float }
     , labelId : Maybe String
     }
     -> List c
     -> List (Html msg)
-viewWithOffsetBalloonTags { renderSegment, backgroundColor, maybeMarker, labelId, offset } contents =
+viewWithOffsetBalloonTags { renderSegment, backgroundColor, maybeMarker, labelId, labelHeight } contents =
     let
         segments =
             List.indexedMap
@@ -114,7 +114,7 @@ viewWithOffsetBalloonTags { renderSegment, backgroundColor, maybeMarker, labelId
     in
     case maybeMarker of
         Just markedWith ->
-            [ viewMarkedByBalloon backgroundColor labelId offset markedWith segments ]
+            [ viewMarkedByBalloon backgroundColor labelId labelHeight markedWith segments ]
 
         Nothing ->
             segments
@@ -155,7 +155,7 @@ view_ tagStyle viewSegment highlightables =
                     segments
 
 
-viewMarkedByBalloon : Color -> Maybe String -> Maybe Float -> Mark -> List (Html msg) -> Html msg
+viewMarkedByBalloon : Color -> Maybe String -> Maybe { totalHeight : Float, arrowHeight : Float } -> Mark -> List (Html msg) -> Html msg
 viewMarkedByBalloon backgroundColor id offset markedWith segments =
     Html.mark
         [ markedWith.name
@@ -183,7 +183,7 @@ viewMarkedByBalloon backgroundColor id offset markedWith segments =
             [ css
                 [ Css.display Css.inlineBlock
                 , offset
-                    |> Maybe.map (\offset_ -> Css.property "padding-top" ("calc(20px + " ++ String.fromFloat offset_ ++ "px)"))
+                    |> Maybe.map (\{ totalHeight } -> Css.paddingTop (Css.px totalHeight))
                     |> Maybe.withDefault (Css.batch [])
                 , Css.border3 (Css.px 2) Css.solid Colors.red
                 ]
@@ -294,7 +294,7 @@ viewInlineTag customizations name =
         [ Html.text name ]
 
 
-viewBalloon : Color -> Maybe String -> Maybe Float -> String -> Html msg
+viewBalloon : Color -> Maybe String -> Maybe { totalHeight : Float, arrowHeight : Float } -> String -> Html msg
 viewBalloon backgroundColor maybeId maybeOffset label =
     Balloon.view
         [ Balloon.onTop
@@ -333,8 +333,8 @@ viewBalloon backgroundColor maybeId maybeOffset label =
                 [ Html.text label ]
             ]
         , case maybeOffset of
-            Just offset ->
-                Balloon.arrowHeight offset
+            Just { arrowHeight } ->
+                Balloon.arrowHeight arrowHeight
 
             Nothing ->
                 Balloon.css []

--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -168,6 +168,8 @@ viewMarkedByBalloon backgroundColor id offset markedWith segments =
             , Css.batch markedWith.startStyles
             , Css.batch markedWith.styles
             , Css.batch markedWith.endStyles
+            , Maybe.map (Css.px >> Css.marginTop) offset
+                |> Maybe.withDefault (Css.batch [])
             , Css.Global.children
                 [ Css.Global.selector ":last-child"
                     [ Css.after

--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -201,7 +201,10 @@ viewMarkedByBalloon config markedWith segments =
             [ css
                 [ Css.display Css.inlineBlock
                 , config.labelHeight
-                    |> Maybe.map (\{ totalHeight } -> Css.paddingTop (Css.px totalHeight))
+                    |> Maybe.map
+                        (\{ totalHeight } ->
+                            Css.paddingTop (Css.px totalHeight)
+                        )
                     |> Maybe.withDefault (Css.batch [])
                 , Css.border3 (Css.px 2) Css.solid Colors.red
                 ]
@@ -326,13 +329,14 @@ viewBalloon config label =
         [ Balloon.onTop
         , Balloon.containerCss
             [ Css.position Css.absolute
-            , Css.bottom (Css.calc (Css.pct 100) Css.plus (Css.px 6))
+            , Css.top (Css.px -4)
+            , Css.border3 (Css.px 1) Css.dashed Colors.green
             , -- using position, 50% is wrt the parent container
               -- using transform & translate, 50% is wrt to the element itself
               -- combining these two properties, we can center the tag against the parent container
               -- for any arbitrary width element
               Css.left (Css.pct 50)
-            , Css.property "transform" "translateX(-50%)"
+            , Css.property "transform" "translateX(-50%) translateY(-100%)"
             ]
         , Balloon.css
             [ Css.padding3 Css.zero (Css.px 6) (Css.px 1)
@@ -351,13 +355,13 @@ viewBalloon config label =
             { backgroundColor = "Mark"
             , color = "MarkText"
             }
-        , Balloon.html
-            [ Html.p
-                [ css [ Css.margin Css.zero ]
-                , AttributesExtra.maybe Attributes.id config.labelContentId
-                ]
-                [ Html.text label ]
-            ]
+        , case config.labelContentId of
+            Just id_ ->
+                Balloon.contentId id_
+
+            Nothing ->
+                Balloon.css []
+        , Balloon.plaintext label
         , case config.labelId of
             Just id_ ->
                 Balloon.id id_

--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -15,7 +15,7 @@ import Accessibility.Styled.Style exposing (invisibleStyle)
 import Css exposing (Color, Style)
 import Css.Global
 import Html.Styled as Html exposing (Html, span)
-import Html.Styled.Attributes exposing (class, css)
+import Html.Styled.Attributes as Attributes exposing (class, css)
 import Nri.Ui.Balloon.V2 as Balloon
 import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
@@ -77,7 +77,7 @@ viewWithBalloonTags viewSegment backgroundColor marked contents =
     in
     case marked of
         Just markedWith ->
-            [ viewMarked (BalloonTags backgroundColor Nothing) markedWith segments ]
+            [ viewMarked (BalloonTags backgroundColor Nothing Nothing) markedWith segments ]
 
         Nothing ->
             segments
@@ -95,10 +95,11 @@ viewWithOffsetBalloonTags :
     , backgroundColor : Color
     , maybeMarker : Maybe Mark
     , offset : Maybe Float
+    , labelId : Maybe String
     }
     -> List c
     -> List (Html msg)
-viewWithOffsetBalloonTags { renderSegment, backgroundColor, maybeMarker, offset } contents =
+viewWithOffsetBalloonTags { renderSegment, backgroundColor, maybeMarker, labelId, offset } contents =
     let
         segments =
             List.indexedMap
@@ -107,7 +108,7 @@ viewWithOffsetBalloonTags { renderSegment, backgroundColor, maybeMarker, offset 
     in
     case maybeMarker of
         Just markedWith ->
-            [ viewMarked (BalloonTags backgroundColor offset) markedWith segments ]
+            [ viewMarked (BalloonTags backgroundColor labelId offset) markedWith segments ]
 
         Nothing ->
             segments
@@ -116,7 +117,7 @@ viewWithOffsetBalloonTags { renderSegment, backgroundColor, maybeMarker, offset 
 type TagStyle
     = HiddenTags
     | InlineTags
-    | BalloonTags Color (Maybe Float)
+    | BalloonTags Color (Maybe String) (Maybe Float)
 
 
 {-| When elements are marked, wrap them in a single `mark` html node.
@@ -158,7 +159,7 @@ viewMarked tagStyle markedWith segments =
         , css
             [ Css.backgroundColor Css.transparent
             , case tagStyle of
-                BalloonTags _ _ ->
+                BalloonTags _ _ _ ->
                     Css.position Css.relative
 
                 _ ->
@@ -238,8 +239,8 @@ viewTag tagStyle =
                     ]
                 ]
 
-        BalloonTags backgroundColor offset ->
-            viewBalloon backgroundColor offset
+        BalloonTags backgroundColor id offset ->
+            viewBalloon backgroundColor id offset
 
 
 viewInlineTag : List Css.Style -> String -> Html msg
@@ -262,8 +263,8 @@ viewInlineTag customizations name =
         [ Html.text name ]
 
 
-viewBalloon : Color -> Maybe Float -> String -> Html msg
-viewBalloon backgroundColor maybeOffset label =
+viewBalloon : Color -> Maybe String -> Maybe Float -> String -> Html msg
+viewBalloon backgroundColor maybeId maybeOffset label =
     Balloon.view
         [ Balloon.onTop
         , Balloon.containerCss
@@ -293,7 +294,13 @@ viewBalloon backgroundColor maybeOffset label =
             { backgroundColor = "Mark"
             , color = "MarkText"
             }
-        , Balloon.plaintext label
+        , Balloon.html
+            [ Html.p
+                [ css [ Css.margin Css.zero ]
+                , AttributesExtra.maybe Attributes.id maybeId
+                ]
+                [ Html.text label ]
+            ]
         , case maybeOffset of
             Just offset ->
                 Balloon.arrowHeight offset

--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -238,7 +238,7 @@ viewBalloon backgroundColor label =
         [ Balloon.onTop
         , Balloon.containerCss
             [ Css.position Css.absolute
-            , Css.bottom (Css.calc (Css.pct 100) Css.plus (Css.px 4))
+            , Css.bottom (Css.calc (Css.pct 100) Css.plus (Css.px 6))
             , -- using position, 50% is wrt the parent container
               -- using transform & translate, 50% is wrt to the element itself
               -- combining these two properties, we can center the tag against the parent container

--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -15,7 +15,7 @@ import Accessibility.Styled.Style exposing (invisibleStyle)
 import Css exposing (Color, Style)
 import Css.Global
 import Html.Styled as Html exposing (Html, span)
-import Html.Styled.Attributes as Attributes exposing (class, css)
+import Html.Styled.Attributes exposing (class, css)
 import Nri.Ui.Balloon.V2 as Balloon
 import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors

--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -164,12 +164,9 @@ viewMarkedByBalloon backgroundColor id offset markedWith segments =
         , css
             [ Css.backgroundColor Css.transparent
             , Css.position Css.relative
-            , Css.display Css.inlineFlex
             , Css.batch markedWith.startStyles
             , Css.batch markedWith.styles
             , Css.batch markedWith.endStyles
-            , Maybe.map (Css.px >> Css.marginTop) offset
-                |> Maybe.withDefault (Css.batch [])
             , Css.Global.children
                 [ Css.Global.selector ":last-child"
                     [ Css.after
@@ -181,6 +178,16 @@ viewMarkedByBalloon backgroundColor id offset markedWith segments =
             ]
         ]
         (viewJust (viewBalloon backgroundColor id offset) markedWith.name :: segments)
+        |> List.singleton
+        |> span
+            [ css
+                [ Css.display Css.inlineBlock
+                , offset
+                    |> Maybe.map (\offset_ -> Css.property "padding-top" ("calc(20px + " ++ String.fromFloat offset_ ++ "px)"))
+                    |> Maybe.withDefault (Css.batch [])
+                , Css.border3 (Css.px 2) Css.solid Colors.red
+                ]
+            ]
 
 
 viewMarked : TagStyle -> Mark -> List (Html msg) -> Html msg

--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -206,7 +206,6 @@ viewMarkedByBalloon config markedWith segments =
                             Css.paddingTop (Css.px totalHeight)
                         )
                     |> Maybe.withDefault (Css.batch [])
-                , Css.border3 (Css.px 2) Css.solid Colors.red
                 ]
             ]
 
@@ -330,7 +329,6 @@ viewBalloon config label =
         , Balloon.containerCss
             [ Css.position Css.absolute
             , Css.top (Css.px -4)
-            , Css.border3 (Css.px 1) Css.dashed Colors.green
             , -- using position, 50% is wrt the parent container
               -- using transform & translate, 50% is wrt to the element itself
               -- combining these two properties, we can center the tag against the parent container

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -169,6 +169,9 @@ example =
                   , description = "Help students understand the function different words and phrases are playing in a sentence"
                   , example =
                         let
+                            startingArrowHeight =
+                                8
+
                             offsets =
                                 [ ageId, purposeId, colorId ]
                                     |> List.filterMap
@@ -189,21 +192,18 @@ example =
                                     |> List.concatMap
                                         (\( first, rem ) ->
                                             (first :: rem)
+                                                -- Put the widest elements higher visually to avoid overlaps
                                                 |> List.sortBy (Tuple.second >> .labelContent >> .element >> .width)
                                                 |> List.foldl
-                                                    (\( id, { label, labelContent } ) ( previousHeight, acc ) ->
-                                                        case previousHeight of
-                                                            Nothing ->
-                                                                ( Just
-                                                                    -- Start off considering the entire label height, including the arrow
-                                                                    (label.element.height + 8)
-                                                                , acc
-                                                                )
-
-                                                            Just height ->
-                                                                ( Just (height + labelContent.element.height), ( id, height ) :: acc )
+                                                    (\( id, { label, labelContent } ) ( height, acc ) ->
+                                                        ( height + labelContent.element.height
+                                                        , ( id
+                                                          , { totalHeight = height + labelContent.element.height + 8, arrowHeight = height }
+                                                          )
+                                                            :: acc
+                                                        )
                                                     )
-                                                    ( Nothing, [] )
+                                                    ( startingArrowHeight, [] )
                                                 |> Tuple.second
                                         )
                                     |> Dict.fromList
@@ -215,7 +215,7 @@ example =
                                     [ Block.plaintext "new"
                                     , Block.label "age"
                                     , Block.id ageId
-                                    , Block.labelHeight (Maybe.map (\v -> { totalHeight = v + 20, arrowHeight = v }) (Dict.get ageId offsets))
+                                    , Block.labelHeight (Dict.get ageId offsets)
                                     , Block.yellow
                                     ]
                                 , Block.view [ Block.plaintext " " ]
@@ -223,7 +223,7 @@ example =
                                     [ Block.plaintext "bowling"
                                     , Block.label "purpose"
                                     , Block.id purposeId
-                                    , Block.labelHeight (Maybe.map (\v -> { totalHeight = v + 20, arrowHeight = v }) (Dict.get purposeId offsets))
+                                    , Block.labelHeight (Dict.get purposeId offsets)
                                     , Block.cyan
                                     ]
                                 , Block.view [ Block.plaintext " " ]
@@ -231,7 +231,7 @@ example =
                                     [ Block.plaintext "yellow"
                                     , Block.label "color"
                                     , Block.id colorId
-                                    , Block.labelHeight (Maybe.map (\v -> { totalHeight = v + 20, arrowHeight = v }) (Dict.get colorId offsets))
+                                    , Block.labelHeight (Dict.get colorId offsets)
                                     , Block.magenta
                                     ]
                                 , Block.view [ Block.plaintext " shoes." ]

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -226,6 +226,8 @@ initControl =
         |> ControlExtra.optionalBoolListItem "emphasize" ( Code.fromModule moduleName "emphasize", Block.emphasize )
         |> ControlExtra.optionalListItem "label"
             (CommonControls.string ( Code.fromModule moduleName "label", Block.label ) "Fruit")
+        |> ControlExtra.optionalListItem "labelId"
+            (CommonControls.string ( Code.fromModule moduleName "labelId", Block.labelId ) "fruit-label")
         |> ControlExtra.optionalListItem "labelOffset"
             (Control.map
                 (\i ->

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -25,6 +25,7 @@ import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V6 as Table
+import Nri.Ui.Text.V6 as Text
 import Task
 
 
@@ -210,7 +211,14 @@ example =
                                 [ Button.onClick GetBlockLabelMeasurements
                                 , Button.small
                                 , Button.secondary
-                                , Button.css [ Css.marginBottom Spacing.verticalSpacerPx ]
+                                ]
+                            , Text.caption
+                                [ Text.plaintext "Click \"Measure & render\" to reposition this example's labels to avoid overlaps given the current viewport."
+                                , Text.css
+                                    [ Css.textAlign Css.center
+                                    , Css.maxWidth (Css.px 200)
+                                    , Css.margin3 Css.zero Css.auto Spacing.verticalSpacerPx |> Css.important
+                                    ]
                                 ]
                             ]
                   }

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -183,9 +183,8 @@ example =
                                     |> List.Extra.groupWhile (\( _, a ) ( _, b ) -> a.element.y == b.element.y)
                                     |> List.concatMap
                                         (\( first, rem ) ->
-                                            first
-                                                :: rem
-                                                |> List.reverse
+                                            (first :: rem)
+                                                |> List.sortBy (Tuple.second >> .element >> .width)
                                                 |> List.foldl
                                                     (\( id, { element } ) ( previousHeight, acc ) ->
                                                         case previousHeight of

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -205,7 +205,7 @@ example =
                                     |> Dict.fromList
                         in
                         div []
-                            [ (List.concat >> p [ css [ Css.marginTop (Css.px 60) ] ])
+                            [ inParagraph
                                 [ Block.view [ Block.plaintext "Taylor Swift bought " ]
                                 , Block.view
                                     [ Block.plaintext "new"

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -211,7 +211,7 @@ example =
                                     [ Block.plaintext "new"
                                     , Block.label "age"
                                     , Block.labelId ageId
-                                    , Block.labelOffset (Dict.get ageId offsets)
+                                    , Block.labelHeight (Maybe.map (\v -> { totalHeight = v + 20, arrowHeight = v }) (Dict.get ageId offsets))
                                     , Block.yellow
                                     ]
                                 , Block.view [ Block.plaintext " " ]
@@ -219,7 +219,7 @@ example =
                                     [ Block.plaintext "bowling"
                                     , Block.label "purpose"
                                     , Block.labelId purposeId
-                                    , Block.labelOffset (Dict.get purposeId offsets)
+                                    , Block.labelHeight (Maybe.map (\v -> { totalHeight = v + 20, arrowHeight = v }) (Dict.get purposeId offsets))
                                     , Block.cyan
                                     ]
                                 , Block.view [ Block.plaintext " " ]
@@ -227,7 +227,7 @@ example =
                                     [ Block.plaintext "yellow"
                                     , Block.label "color"
                                     , Block.labelId colorId
-                                    , Block.labelOffset (Dict.get colorId offsets)
+                                    , Block.labelHeight (Maybe.map (\v -> { totalHeight = v + 20, arrowHeight = v }) (Dict.get colorId offsets))
                                     , Block.magenta
                                     ]
                                 , Block.view [ Block.plaintext " shoes." ]
@@ -304,14 +304,22 @@ initControl =
             (CommonControls.string ( Code.fromModule moduleName "label", Block.label ) "Fruit")
         |> ControlExtra.optionalListItem "labelId"
             (CommonControls.string ( Code.fromModule moduleName "labelId", Block.labelId ) "fruit-label")
-        |> ControlExtra.optionalListItem "labelOffset"
+        |> ControlExtra.optionalListItem "labelHeight"
             (Control.map
-                (\i ->
-                    ( Code.fromModule moduleName "labelOffset (Just" ++ String.fromFloat i ++ ")"
-                    , Block.labelOffset (Just i)
+                (\( code, v ) ->
+                    ( Code.fromModule moduleName "labelHeight (Just" ++ code ++ ")"
+                    , Block.labelHeight (Just v)
                     )
                 )
-                (ControlExtra.float 40)
+                (Control.record
+                    (\a b ->
+                        ( Code.record [ ( "arrowHeight", String.fromFloat a ), ( "totalHeight", String.fromFloat b ) ]
+                        , { arrowHeight = a, totalHeight = b }
+                        )
+                    )
+                    |> Control.field "arrowHeight" (ControlExtra.float 40)
+                    |> Control.field "totalHeight" (ControlExtra.float 80)
+                )
             )
         |> ControlExtra.optionalListItem "theme"
             (CommonControls.choice moduleName

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -6,6 +6,7 @@ module Examples.Block exposing (Msg, State, example)
 
 -}
 
+import Browser.Dom as Dom
 import Category exposing (Category(..))
 import Code
 import CommonControls
@@ -225,6 +226,15 @@ initControl =
         |> ControlExtra.optionalBoolListItem "emphasize" ( Code.fromModule moduleName "emphasize", Block.emphasize )
         |> ControlExtra.optionalListItem "label"
             (CommonControls.string ( Code.fromModule moduleName "label", Block.label ) "Fruit")
+        |> ControlExtra.optionalListItem "labelOffset"
+            (Control.map
+                (\i ->
+                    ( Code.fromModule moduleName "labelOffset (Just" ++ String.fromFloat i ++ ")"
+                    , Block.labelOffset (Just i)
+                    )
+                )
+                (ControlExtra.float 40)
+            )
         |> ControlExtra.optionalListItem "theme"
             (CommonControls.choice moduleName
                 [ ( "yellow", Block.yellow )

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -190,7 +190,12 @@ example =
                                                     (\( id, { element } ) ( previousHeight, acc ) ->
                                                         case previousHeight of
                                                             Nothing ->
-                                                                ( Just element.height, acc )
+                                                                ( Just
+                                                                    -- Include a starting offset of 8, which is the height
+                                                                    -- of the balloon arrow by default
+                                                                    (element.height + 8)
+                                                                , acc
+                                                                )
 
                                                             Just height ->
                                                                 ( Just (height + element.height), ( id, height ) :: acc )

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -18,7 +18,6 @@ import Dict exposing (Dict)
 import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
-import List.Extra
 import Markdown
 import Nri.Ui.Block.V1 as Block
 import Nri.Ui.Button.V10 as Button
@@ -176,44 +175,8 @@ example =
                   , description = "Help students understand the function different words and phrases are playing in a sentence"
                   , example =
                         let
-                            startingArrowHeight =
-                                8
-
                             offsets =
-                                [ ageId, purposeId, colorId ]
-                                    |> List.filterMap
-                                        (\id ->
-                                            case Dict.get id state.labelMeasurementsById of
-                                                Just measurement ->
-                                                    Just ( id, measurement )
-
-                                                Nothing ->
-                                                    Nothing
-                                        )
-                                    -- Group the elements whose bottom edges are at the same height
-                                    -- this ensures that we only offset labels against other labels in the same line of content
-                                    |> List.Extra.groupWhile
-                                        (\( _, a ) ( _, b ) ->
-                                            (a.label.element.y + a.label.element.height) == (b.label.element.y + b.label.element.height)
-                                        )
-                                    |> List.concatMap
-                                        (\( first, rem ) ->
-                                            (first :: rem)
-                                                -- Put the widest elements higher visually to avoid overlaps
-                                                |> List.sortBy (Tuple.second >> .labelContent >> .element >> .width)
-                                                |> List.foldl
-                                                    (\( id, { label, labelContent } ) ( height, acc ) ->
-                                                        ( height + labelContent.element.height
-                                                        , ( id
-                                                          , { totalHeight = height + labelContent.element.height + 8, arrowHeight = height }
-                                                          )
-                                                            :: acc
-                                                        )
-                                                    )
-                                                    ( startingArrowHeight, [] )
-                                                |> Tuple.second
-                                        )
-                                    |> Dict.fromList
+                                Block.getLabelHeights [ ageId, purposeId, colorId ] state.labelMeasurementsById
                         in
                         div []
                             [ inParagraph

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -205,7 +205,7 @@ example =
                                     |> Dict.fromList
                         in
                         div []
-                            [ inParagraph
+                            [ (List.concat >> p [ css [ Css.marginTop (Css.px 60) ] ])
                                 [ Block.view [ Block.plaintext "Taylor Swift bought " ]
                                 , Block.view
                                     [ Block.plaintext "new"

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -52,16 +52,12 @@ example =
     , preview =
         [ [ Block.view
                 [ Block.plaintext "Dave"
-                , Block.label "subject"
                 , Block.yellow
-                , Block.labelHeight (Just { totalHeight = 58, arrowHeight = 34 })
                 ]
           , Block.view [ Block.plaintext " " ]
           , Block.view
                 [ Block.plaintext "broke"
-                , Block.label "verb"
                 , Block.cyan
-                , Block.labelHeight (Just { totalHeight = 34, arrowHeight = 8 })
                 ]
           , Block.view [ Block.plaintext " his french fry so " ]
           , Block.view

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -54,17 +54,29 @@ example =
                 [ Block.plaintext "Dave"
                 , Block.label "subject"
                 , Block.yellow
+                , Block.labelHeight (Just { totalHeight = 58, arrowHeight = 34 })
                 ]
           , Block.view [ Block.plaintext " " ]
           , Block.view
                 [ Block.plaintext "broke"
                 , Block.label "verb"
                 , Block.cyan
+                , Block.labelHeight (Just { totalHeight = 34, arrowHeight = 8 })
                 ]
           , Block.view [ Block.plaintext " his french fry so " ]
-          , Block.view [ Block.plaintext "he", Block.yellow ]
+          , Block.view
+                [ Block.plaintext "he"
+                , Block.label "subject"
+                , Block.yellow
+                , Block.labelHeight (Just { totalHeight = 58, arrowHeight = 34 })
+                ]
           , Block.view [ Block.plaintext " " ]
-          , Block.view [ Block.plaintext "glued", Block.cyan ]
+          , Block.view
+                [ Block.plaintext "glued"
+                , Block.label "verb"
+                , Block.cyan
+                , Block.labelHeight (Just { totalHeight = 34, arrowHeight = 8 })
+                ]
           , Block.view [ Block.plaintext " it with ketchup." ]
           ]
             |> List.concat
@@ -72,7 +84,6 @@ example =
                 [ css
                     [ Fonts.baseFont
                     , Css.fontSize (Css.px 12)
-                    , Css.marginTop (Css.px 40)
                     , Css.lineHeight (Css.num 2.5)
                     ]
                 ]

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -77,7 +77,7 @@ getLabelHeightsSpec =
             Block.getLabelHeights [ "a" ]
                 (Dict.singleton "a"
                     { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
-                    , labelContent = dummyElement { x = 0, y = 0, width = 100, height = 20 }
+                    , labelContent = dummyElement { x = 0, y = 0, width = 100, height = startingHeight }
                     }
                 )
                 |> Expect.equal
@@ -85,6 +85,45 @@ getLabelHeightsSpec =
                         { totalHeight = startingHeight + defaultArrowHeight + balloonOffset
                         , arrowHeight = defaultArrowHeight
                         }
+                    )
+    , test "with different height measurements, prevents overlaps" <|
+        \() ->
+            let
+                aStartingHeight =
+                    40
+
+                bStartingHeight =
+                    30
+            in
+            Block.getLabelHeights [ "a", "b", "c" ]
+                ([ --  A has taller content
+                   ( "a"
+                   , { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = aStartingHeight }
+                     }
+                   )
+                 , -- B has shorter content
+                   ( "b"
+                   , { label = dummyElement { x = 0, y = 0, width = 200, height = 100 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = bStartingHeight }
+                     }
+                   )
+                 ]
+                    |> Dict.fromList
+                )
+                |> Expect.equal
+                    ([ ( "a"
+                       , { totalHeight = aStartingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight = defaultArrowHeight
+                         }
+                       )
+                     , ( "b"
+                       , { totalHeight = aStartingHeight + bStartingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight = aStartingHeight + defaultArrowHeight
+                         }
+                       )
+                     ]
+                        |> Dict.fromList
                     )
     , test "with multiple ids and measurements, positions wider elements above narrower elements" <|
         \() ->
@@ -96,19 +135,19 @@ getLabelHeightsSpec =
                 ([ --  A is the second-widest element
                    ( "a"
                    , { label = dummyElement { x = 0, y = 0, width = 200, height = 100 }
-                     , labelContent = dummyElement { x = 0, y = 0, width = 200, height = 20 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 200, height = startingHeight }
                      }
                    )
                  , -- B is the narrowest element
                    ( "b"
                    , { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
-                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = 20 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = startingHeight }
                      }
                    )
                  , -- C is the widest element
                    ( "c"
                    , { label = dummyElement { x = 0, y = 0, width = 300, height = 100 }
-                     , labelContent = dummyElement { x = 0, y = 0, width = 300, height = 20 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 300, height = startingHeight }
                      }
                    )
                  ]
@@ -148,12 +187,12 @@ getLabelHeightsSpec =
             Block.getLabelHeights [ "a", "b" ]
                 ([ ( "a"
                    , { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
-                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = 20 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = startingHeight }
                      }
                    )
                  , ( "b"
                    , { label = dummyElement { x = 0, y = 20, width = 100, height = 100 }
-                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = 20 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = startingHeight }
                      }
                    )
                  ]
@@ -183,19 +222,19 @@ getLabelHeightsSpec =
                 ([ --  A is the second-widest element
                    ( "a"
                    , { label = dummyElement { x = 0, y = 0, width = 200, height = 100 }
-                     , labelContent = dummyElement { x = 0, y = 0, width = 200, height = 20 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 200, height = startingHeight }
                      }
                    )
                  , -- B is the narrowest element
                    ( "b"
                    , { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
-                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = 20 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = startingHeight }
                      }
                    )
                  , -- C is the widest element and it is also on a new line by itself
                    ( "c"
                    , { label = dummyElement { x = 0, y = 20, width = 300, height = 100 }
-                     , labelContent = dummyElement { x = 0, y = 0, width = 300, height = 20 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 300, height = startingHeight }
                      }
                    )
                  ]

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -139,6 +139,92 @@ getLabelHeightsSpec =
                      ]
                         |> Dict.fromList
                     )
+    , test "with labels on different lines, specifies the default heights" <|
+        \() ->
+            let
+                startingHeight =
+                    20
+            in
+            Block.getLabelHeights [ "a", "b" ]
+                ([ ( "a"
+                   , { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = 20 }
+                     }
+                   )
+                 , ( "b"
+                   , { label = dummyElement { x = 0, y = 20, width = 100, height = 100 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = 20 }
+                     }
+                   )
+                 ]
+                    |> Dict.fromList
+                )
+                |> Expect.equal
+                    ([ ( "a"
+                       , { totalHeight = startingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight = defaultArrowHeight
+                         }
+                       )
+                     , ( "b"
+                       , { totalHeight = startingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight = defaultArrowHeight
+                         }
+                       )
+                     ]
+                        |> Dict.fromList
+                    )
+    , test "with multiple ids and measurements on different lines, positions elements correctly" <|
+        \() ->
+            let
+                startingHeight =
+                    20
+            in
+            Block.getLabelHeights [ "a", "b", "c" ]
+                ([ --  A is the second-widest element
+                   ( "a"
+                   , { label = dummyElement { x = 0, y = 0, width = 200, height = 100 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 200, height = 20 }
+                     }
+                   )
+                 , -- B is the narrowest element
+                   ( "b"
+                   , { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = 20 }
+                     }
+                   )
+                 , -- C is the widest element and it is also on a new line by itself
+                   ( "c"
+                   , { label = dummyElement { x = 0, y = 20, width = 300, height = 100 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 300, height = 20 }
+                     }
+                   )
+                 ]
+                    |> Dict.fromList
+                )
+                |> Expect.equal
+                    ([ ( "a"
+                       , { totalHeight = 2 * startingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight =
+                            -- A is positioned on top of B.
+                            -- So its arrow height is the total height of b minus the positioning offset
+                            startingHeight + defaultArrowHeight
+                         }
+                       )
+                     , ( "b"
+                       , { totalHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight = defaultArrowHeight
+                         }
+                       )
+                     , ( "c"
+                       , { totalHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight =
+                            -- C is on a new line, so it goes back to default positioning.
+                            defaultArrowHeight
+                         }
+                       )
+                     ]
+                        |> Dict.fromList
+                    )
     ]
 
 

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -1,5 +1,7 @@
 module Spec.Nri.Ui.Block exposing (spec)
 
+import Browser.Dom exposing (Element)
+import Dict
 import Expect
 import Html.Styled
 import Nri.Ui.Block.V1 as Block
@@ -12,6 +14,7 @@ spec : Test
 spec =
     describe "Nri.Ui.Block.V1"
         [ describe "content" contentSpec
+        , describe "getLabelHeights" getLabelHeightsSpec
         ]
 
 
@@ -44,3 +47,61 @@ toQuery block =
         |> Html.Styled.p []
         |> Html.Styled.toUnstyled
         |> Query.fromHtml
+
+
+getLabelHeightsSpec : List Test
+getLabelHeightsSpec =
+    [ test "without any ids or measurements, does not specify heights" <|
+        \() ->
+            Block.getLabelHeights [] Dict.empty
+                |> Expect.equal Dict.empty
+    , test "without any measurements, does not specify heights" <|
+        \() ->
+            Block.getLabelHeights [ "a" ] Dict.empty
+                |> Expect.equal Dict.empty
+    , test "without any ids, does not specify heights" <|
+        \() ->
+            Block.getLabelHeights []
+                (Dict.singleton "a"
+                    { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
+                    , labelContent = dummyElement { x = 0, y = 0, width = 100, height = 20 }
+                    }
+                )
+                |> Expect.equal Dict.empty
+    , test "with 1 id and 1 measurement, specifies the default heights" <|
+        \() ->
+            let
+                startingHeight =
+                    20
+            in
+            Block.getLabelHeights [ "a" ]
+                (Dict.singleton "a"
+                    { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
+                    , labelContent = dummyElement { x = 0, y = 0, width = 100, height = 20 }
+                    }
+                )
+                |> Expect.equal
+                    (Dict.singleton "a"
+                        { totalHeight = startingHeight + defaultArrowHeight + balloonOffset
+                        , arrowHeight = defaultArrowHeight
+                        }
+                    )
+    ]
+
+
+balloonOffset : Float
+balloonOffset =
+    8
+
+
+defaultArrowHeight : Float
+defaultArrowHeight =
+    8
+
+
+dummyElement : { x : Float, y : Float, width : Float, height : Float } -> Element
+dummyElement element =
+    { scene = { width = 1000, height = 1000 }
+    , viewport = { x = 0, y = 0, width = 1000, height = 500 }
+    , element = element
+    }

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -86,6 +86,59 @@ getLabelHeightsSpec =
                         , arrowHeight = defaultArrowHeight
                         }
                     )
+    , test "with multiple ids and measurements, positions wider elements above narrower elements" <|
+        \() ->
+            let
+                startingHeight =
+                    20
+            in
+            Block.getLabelHeights [ "a", "b", "c" ]
+                ([ --  A is the second-widest element
+                   ( "a"
+                   , { label = dummyElement { x = 0, y = 0, width = 200, height = 100 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 200, height = 20 }
+                     }
+                   )
+                 , -- B is the narrowest element
+                   ( "b"
+                   , { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = 20 }
+                     }
+                   )
+                 , -- C is the widest element
+                   ( "c"
+                   , { label = dummyElement { x = 0, y = 0, width = 300, height = 100 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 300, height = 20 }
+                     }
+                   )
+                 ]
+                    |> Dict.fromList
+                )
+                |> Expect.equal
+                    ([ ( "a"
+                       , { totalHeight = 2 * startingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight =
+                            -- A is positioned on top of B.
+                            -- So its arrow height is the total height of b minus the positioning offset
+                            startingHeight + defaultArrowHeight
+                         }
+                       )
+                     , ( "b"
+                       , { totalHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight = defaultArrowHeight
+                         }
+                       )
+                     , ( "c"
+                       , { totalHeight = 3 * startingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight =
+                            -- C is positioned on top of A.
+                            -- So its arrow height is the total height of A minus the positioning offset
+                            2 * startingHeight + defaultArrowHeight
+                         }
+                       )
+                     ]
+                        |> Dict.fromList
+                    )
     ]
 
 


### PR DESCRIPTION
Fixes A11-1804

To prevent overlapping labels on Blocks, we need to measure the content in the balloon and then adjust the arrow height accordingly. This requires some tasks to run to measure the page content. In the example page, I've wired the tasks to run on-click, rather than on load or window resize events.

Note that the current solution is not maximally vertically "compact." If it needs to be, I can keep working on this. I don't want to assume the MVP target, so pausing here for feedback. (See video if this is confusing)

<img width="342" alt="Screen Shot 2022-12-15 at 10 55 23 AM" src="https://user-images.githubusercontent.com/8811312/207933259-356402df-6b2f-4b62-aeb8-83862bf5e369.png">


<img width="193" alt="Screen Shot 2022-12-15 at 10 55 33 AM" src="https://user-images.githubusercontent.com/8811312/207933258-6cdad6f1-e684-4c34-88a0-28654894e872.png">


https://user-images.githubusercontent.com/8811312/207933198-cacac5d8-7a57-4aaf-ad85-57b0490825b0.mov

cc @NoRedInk/design 
