### PR TITLE
Fix arrow connection to speech bubble for short content

### DIFF
--- a/src/Nri/Ui/QuestionBox/V1.elm
+++ b/src/Nri/Ui/QuestionBox/V1.elm
@@ -449,6 +449,7 @@ viewGuidance withCharacter markdown_ =
                     [ Balloon.markdown markdown_
                     , Balloon.onLeft
                     , Balloon.alignArrowEnd
+                    , Balloon.css [ Css.minHeight (Css.px 46) ]
                     ]
                 ]
 


### PR DESCRIPTION
Fixes A11-2068

### Before 

<img width="382" alt="Screen Shot 2022-12-15 at 4 27 42 PM" src="https://user-images.githubusercontent.com/8811312/207988284-66919e9e-33d8-4f4a-9c9e-ebea79c89b49.png">


### After

<img width="389" alt="Screen Shot 2022-12-15 at 4 27 06 PM" src="https://user-images.githubusercontent.com/8811312/207988282-a2a56678-4c2d-4b90-ae15-2e29c1a436c0.png">

cc @NoRedInk/design 