### PR TITLE
Bat/compact labels

### DIFF
--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -1,4 +1,5 @@
 Nri.Ui.Balloon.V1,upgrade to V2
+Nri.Ui.Block.V1,upgrade to V2
 Nri.Ui.Checkbox.V6,upgrade to V7
 Nri.Ui.Mark.V1,upgrade to V2
 Nri.Ui.Tabs.V6,upgrade to V7

--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -1,3 +1,4 @@
 Nri.Ui.Balloon.V1,upgrade to V2
 Nri.Ui.Checkbox.V6,upgrade to V7
+Nri.Ui.Mark.V1,upgrade to V2
 Nri.Ui.Tabs.V6,upgrade to V7

--- a/elm.json
+++ b/elm.json
@@ -47,6 +47,7 @@
         "Nri.Ui.Loading.V1",
         "Nri.Ui.Logo.V1",
         "Nri.Ui.Mark.V1",
+        "Nri.Ui.Mark.V2",
         "Nri.Ui.MasteryIcon.V1",
         "Nri.Ui.MediaQuery.V1",
         "Nri.Ui.Menu.V3",

--- a/elm.json
+++ b/elm.json
@@ -14,6 +14,7 @@
         "Nri.Ui.Balloon.V1",
         "Nri.Ui.Balloon.V2",
         "Nri.Ui.Block.V1",
+        "Nri.Ui.Block.V2",
         "Nri.Ui.BreadCrumbs.V2",
         "Nri.Ui.Button.V10",
         "Nri.Ui.Carousel.V1",

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -78,6 +78,9 @@ hint = 'upgrade to V3'
 hint = 'upgrade to V4'
 usages = ['styleguide/../src/Nri/Ui/TextArea/V4.elm']
 
+[forbidden."Nri.Ui.Mark.V1"]
+hint = 'upgrade to V2'
+
 [forbidden."Nri.Ui.Menu.V1"]
 hint = 'upgrade to V3'
 

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -41,6 +41,9 @@ hint = 'upgrade to V3'
 [forbidden."Nri.Ui.Balloon.V1"]
 hint = 'upgrade to V2'
 
+[forbidden."Nri.Ui.Block.V1"]
+hint = 'upgrade to V2'
+
 [forbidden."Nri.Ui.BreadCrumbs.V1"]
 hint = 'upgrade to V2'
 

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -83,6 +83,7 @@ usages = ['styleguide/../src/Nri/Ui/TextArea/V4.elm']
 
 [forbidden."Nri.Ui.Mark.V1"]
 hint = 'upgrade to V2'
+usages = ['styleguide/../src/Nri/Ui/Block/V1.elm']
 
 [forbidden."Nri.Ui.Menu.V1"]
 hint = 'upgrade to V3'

--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -187,21 +187,23 @@ Then, for elements in the same row, group elements with horizontal overlaps .
 splitByOverlaps : List ( id, { a | label : Dom.Element } ) -> List (List ( id, { a | label : Dom.Element } ))
 splitByOverlaps =
     -- consider the elements from top to bottom
-    List.sortBy (\( _, a ) -> a.label.element.y + a.label.element.height)
-        >> List.Extra.groupWhile
-            (\( _, a ) ( _, b ) ->
-                (a.label.element.y + a.label.element.height) == (b.label.element.y + b.label.element.height)
-            )
+    groupWithSort (\( _, a ) -> a.label.element.y + a.label.element.height)
+        (\( _, a ) ( _, b ) ->
+            (a.label.element.y + a.label.element.height) == (b.label.element.y + b.label.element.height)
+        )
         >> List.concatMap
-            (\( first, rem ) ->
-                (first :: rem)
-                    |> -- consider the elements from left to right
-                       List.sortBy (\( _, a ) -> a.label.element.x)
-                    |> List.Extra.groupWhile
-                        (\( _, a ) ( _, b ) ->
-                            (a.label.element.x + a.label.element.width) >= b.label.element.x
-                        )
+            -- consider the elements from left to right
+            (groupWithSort (\( _, a ) -> a.label.element.x)
+                (\( _, a ) ( _, b ) ->
+                    (a.label.element.x + a.label.element.width) >= b.label.element.x
+                )
             )
+
+
+groupWithSort : (a -> comparable) -> (a -> a -> Bool) -> List a -> List (List a)
+groupWithSort sortBy groupBy =
+    List.sortBy sortBy
+        >> List.Extra.groupWhile groupBy
         >> List.map (\( first, rem ) -> first :: rem)
 
 

--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -158,11 +158,15 @@ getLabelHeights ids labelMeasurementsById =
                     Nothing ->
                         Nothing
             )
+        -- consider the elements from left to right
+        |> List.sortBy (Tuple.second >> .label >> .element >> .x)
         -- Group the elements whose bottom edges are at the same height
-        -- this ensures that we only offset labels against other labels in the same line of content
+        -- (this ensures that we only offset labels against other labels in the same line of content)
+        -- and whose edges overlap
         |> List.Extra.groupWhile
             (\( _, a ) ( _, b ) ->
-                (a.label.element.y + a.label.element.height) == (b.label.element.y + b.label.element.height)
+                ((a.label.element.y + a.label.element.height) == (b.label.element.y + b.label.element.height))
+                    && ((a.label.element.x + a.label.element.width) >= b.label.element.x)
             )
         |> List.concatMap
             (\( first, rem ) ->

--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -58,7 +58,7 @@ import Html.Styled.Attributes as Attributes exposing (css)
 import List.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (nriDescription)
-import Nri.Ui.Mark.V1 as Mark exposing (Mark)
+import Nri.Ui.Mark.V2 as Mark exposing (Mark)
 import Nri.Ui.MediaQuery.V1 as MediaQuery
 
 
@@ -484,7 +484,7 @@ render config =
         [] ->
             case maybeMark of
                 Just mark ->
-                    Mark.viewWithOffsetBalloonTags
+                    Mark.viewWithBalloonTags
                         { renderSegment = renderContent config
                         , backgroundColor = palette.backgroundColor
                         , maybeMarker = Just mark
@@ -503,7 +503,7 @@ render config =
                     ]
 
         _ ->
-            Mark.viewWithOffsetBalloonTags
+            Mark.viewWithBalloonTags
                 { renderSegment = renderContent config
                 , backgroundColor = palette.backgroundColor
                 , maybeMarker = maybeMark

--- a/src/Nri/Ui/Block/V1.elm
+++ b/src/Nri/Ui/Block/V1.elm
@@ -58,7 +58,7 @@ import Html.Styled.Attributes as Attributes exposing (css)
 import List.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (nriDescription)
-import Nri.Ui.Mark.V2 as Mark exposing (Mark)
+import Nri.Ui.Mark.V1 as Mark exposing (Mark)
 import Nri.Ui.MediaQuery.V1 as MediaQuery
 
 
@@ -484,7 +484,7 @@ render config =
         [] ->
             case maybeMark of
                 Just mark ->
-                    Mark.viewWithBalloonTags
+                    Mark.viewWithOffsetBalloonTags
                         { renderSegment = renderContent config
                         , backgroundColor = palette.backgroundColor
                         , maybeMarker = Just mark
@@ -503,7 +503,7 @@ render config =
                     ]
 
         _ ->
-            Mark.viewWithBalloonTags
+            Mark.viewWithOffsetBalloonTags
                 { renderSegment = renderContent config
                 , backgroundColor = palette.backgroundColor
                 , maybeMarker = maybeMark

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -1,0 +1,545 @@
+module Nri.Ui.Block.V2 exposing
+    ( view, Attribute
+    , plaintext, content
+    , Content, phrase, blank
+    , string
+    , emphasize, label, labelHeight
+    , yellow, cyan, magenta, green, blue, purple, brown
+    , class, id
+    , labelId, labelContentId
+    , getLabelHeights
+    )
+
+{-|
+
+@docs view, Attribute
+
+
+## Content
+
+@docs plaintext, content
+@docs Content, phrase, blank
+
+
+### Deprecated
+
+@docs string
+
+
+## Content customization
+
+@docs emphasize, label, labelHeight
+
+
+### Visual customization
+
+@docs yellow, cyan, magenta, green, blue, purple, brown
+
+
+### General attributes
+
+@docs class, id
+
+
+## Accessors
+
+You will need these helpers if you want to prevent label overlaps. (Which is to say -- anytime you have labels!)
+
+@docs labelId, labelContentId
+@docs getLabelHeights
+
+-}
+
+import Accessibility.Styled exposing (..)
+import Browser.Dom as Dom
+import Css exposing (Color)
+import Dict exposing (Dict)
+import Html.Styled.Attributes as Attributes exposing (css)
+import List.Extra
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (nriDescription)
+import Nri.Ui.Mark.V2 as Mark exposing (Mark)
+import Nri.Ui.MediaQuery.V1 as MediaQuery
+
+
+{-|
+
+    Block.view [ Block.plaintext "Hello, world!" ]
+
+-}
+view : List Attribute -> List (Html msg)
+view attributes =
+    attributes
+        |> List.foldl (\(Attribute attribute) b -> attribute b) defaultConfig
+        |> render
+
+
+
+-- Attributes
+
+
+{-| Provide the main content of the block as a plain-text string. You can also use `content` for more complex cases, including a blank appearing within an emphasis.
+-}
+plaintext : String -> Attribute
+plaintext content_ =
+    Attribute <| \config -> { config | content = parseString content_ }
+
+
+{-| Use `content` for more complex block views, for instance when a blank appears within an emphasis block. Prefer to use `plaintext` when possible for better readability.
+
+    Block.view
+        [ Block.emphasize
+        , Block.content [ Block.string "Hello, ", Block.blank, Block.string "!" ]
+        ]
+
+-}
+content : List Content -> Attribute
+content content_ =
+    Attribute <| \config -> { config | content = content_ }
+
+
+{-| Mark content as emphasized.
+-}
+emphasize : Attribute
+emphasize =
+    Attribute <| \config -> { config | theme = Just Emphasis }
+
+
+{-| -}
+label : String -> Attribute
+label label_ =
+    Attribute <| \config -> { config | label = Just label_ }
+
+
+{-| Use `getLabelHeights` to calculate what these values should be.
+-}
+labelHeight : Maybe { totalHeight : Float, arrowHeight : Float } -> Attribute
+labelHeight offset =
+    Attribute <| \config -> { config | labelHeight = offset }
+
+
+{-| -}
+labelId : String -> String
+labelId labelId_ =
+    labelId_ ++ "-label"
+
+
+{-| -}
+labelContentId : String -> String
+labelContentId labelId_ =
+    labelId_ ++ "-label-content"
+
+
+{-|
+
+    Pass in a list of the Block ids that you care about (use `Block.id` to attach these ids).
+
+    - First, we add ids to block with labels with `Block.id`.
+    - Say we added `Block.id "example-id"`, then we will use `Browser.Dom.getElement (Block.labelId "example-id")` and `Browser.Dom.getElement (Block.labelContentId "example-id")` to construct a record in the shape { label : Dom.Element, labelContent : Dom.Element }. We store this record in a dictionary keyed by ids (e.g., "example-id") with measurements for all other labels.
+    - Pass a list of all the block ids and the dictionary of measurements to `getLabelHeights`. `getLabelHeights` will return a dictionary of values (keyed by ids) that we will then pass directly to `labelHeight` for positioning.
+
+-}
+getLabelHeights :
+    List String
+    -> Dict String { label : Dom.Element, labelContent : Dom.Element }
+    -> Dict String { totalHeight : Float, arrowHeight : Float }
+getLabelHeights ids labelMeasurementsById =
+    let
+        startingArrowHeight =
+            8
+    in
+    ids
+        |> List.filterMap
+            (\idString ->
+                case Dict.get idString labelMeasurementsById of
+                    Just measurement ->
+                        Just ( idString, measurement )
+
+                    Nothing ->
+                        Nothing
+            )
+        |> splitByOverlaps
+        |> List.concatMap
+            (\row ->
+                row
+                    -- Put the widest elements higher visually to avoid overlaps
+                    |> List.sortBy (Tuple.second >> .labelContent >> .element >> .width)
+                    |> List.foldl
+                        (\( idString, e ) ( height, acc ) ->
+                            ( height + e.labelContent.element.height
+                            , ( idString
+                              , { totalHeight = height + e.labelContent.element.height + 8, arrowHeight = height }
+                              )
+                                :: acc
+                            )
+                        )
+                        ( startingArrowHeight, [] )
+                    |> Tuple.second
+            )
+        |> Dict.fromList
+
+
+{-| Group the elements whose bottom edges are at the same height. This ensures that we only offset labels against other labels in the same visual line of content.
+
+Then, for elements in the same row, group elements with horizontal overlaps .
+
+-}
+splitByOverlaps : List ( id, { a | label : Dom.Element } ) -> List (List ( id, { a | label : Dom.Element } ))
+splitByOverlaps =
+    -- consider the elements from top to bottom
+    groupWithSort (\( _, a ) -> a.label.element.y + a.label.element.height)
+        (\( _, a ) ( _, b ) ->
+            (a.label.element.y + a.label.element.height) == (b.label.element.y + b.label.element.height)
+        )
+        >> List.concatMap
+            -- consider the elements from left to right
+            (groupWithSort (\( _, a ) -> a.label.element.x)
+                (\( _, a ) ( _, b ) ->
+                    (a.label.element.x + a.label.element.width) >= b.label.element.x
+                )
+            )
+
+
+groupWithSort : (a -> comparable) -> (a -> a -> Bool) -> List a -> List (List a)
+groupWithSort sortBy groupBy =
+    List.sortBy sortBy
+        >> List.Extra.groupWhile groupBy
+        >> List.map (\( first, rem ) -> first :: rem)
+
+
+
+-- Content
+
+
+{-| -}
+type Content
+    = String_ String
+    | Blank
+
+
+parseString : String -> List Content
+parseString =
+    String.split " "
+        >> List.intersperse " "
+        >> List.map String_
+
+
+renderContent : { config | class : Maybe String, id : Maybe String } -> Content -> List Css.Style -> Html msg
+renderContent config content_ markStyles =
+    span
+        [ css (Css.whiteSpace Css.preWrap :: markStyles)
+        , nriDescription "block-segment-container"
+        , AttributesExtra.maybe Attributes.class config.class
+        , AttributesExtra.maybe Attributes.id config.id
+        ]
+        (case content_ of
+            String_ str ->
+                [ text str ]
+
+            Blank ->
+                [ viewBlank [] { class = Nothing, id = Nothing } ]
+        )
+
+
+{-| DEPRECATED -- prefer `phrase`.
+-}
+string : String -> Content
+string =
+    String_
+
+
+{-| -}
+phrase : String -> List Content
+phrase =
+    parseString
+
+
+{-| You will only need to use this helper if you're also using `content` to construct a more complex Block. For a less complex blank Block, don't include content or plaintext in the list of attributes.
+-}
+blank : Content
+blank =
+    Blank
+
+
+
+-- Color themes
+
+
+{-| -}
+type Theme
+    = Emphasis
+    | Yellow
+    | Cyan
+    | Magenta
+    | Green
+    | Blue
+    | Purple
+    | Brown
+
+
+themeToPalette : Theme -> Palette
+themeToPalette theme =
+    case theme of
+        Emphasis ->
+            defaultPalette
+
+        Yellow ->
+            { backgroundColor = Colors.highlightYellow
+            , borderColor = Colors.highlightYellowDark
+            }
+
+        Cyan ->
+            { backgroundColor = Colors.highlightCyan
+            , borderColor = Colors.highlightCyanDark
+            }
+
+        Magenta ->
+            { backgroundColor = Colors.highlightMagenta
+            , borderColor = Colors.highlightMagentaDark
+            }
+
+        Green ->
+            { backgroundColor = Colors.highlightGreen
+            , borderColor = Colors.highlightGreenDark
+            }
+
+        Blue ->
+            { backgroundColor = Colors.highlightBlue
+            , borderColor = Colors.highlightBlueDark
+            }
+
+        Purple ->
+            { backgroundColor = Colors.highlightPurple
+            , borderColor = Colors.highlightPurpleDark
+            }
+
+        Brown ->
+            { backgroundColor = Colors.highlightBrown
+            , borderColor = Colors.highlightBrownDark
+            }
+
+
+type alias Palette =
+    { backgroundColor : Color, borderColor : Color }
+
+
+defaultPalette : Palette
+defaultPalette =
+    { backgroundColor = Colors.highlightYellow
+    , borderColor = Colors.highlightYellowDark
+    }
+
+
+toMark : Maybe String -> Maybe Palette -> Maybe Mark
+toMark label_ palette =
+    case ( label_, palette ) of
+        ( _, Just { backgroundColor, borderColor } ) ->
+            let
+                borderWidth =
+                    Css.px 1
+
+                borderStyle =
+                    Css.dashed
+            in
+            Just
+                { name = label_
+                , startStyles =
+                    [ Css.borderLeft3 borderWidth borderStyle borderColor
+                    , Css.paddingLeft (Css.px 2)
+                    ]
+                , styles =
+                    [ Css.paddingTop topBottomSpace
+                    , Css.paddingBottom topBottomSpace
+                    , Css.backgroundColor backgroundColor
+                    , Css.borderTop3 borderWidth borderStyle borderColor
+                    , Css.borderBottom3 borderWidth borderStyle borderColor
+                    , MediaQuery.highContrastMode
+                        [ Css.property "background-color" "Mark"
+                        , Css.property "color" "MarkText"
+                        , Css.property "forced-color-adjust" "none"
+                        ]
+                    ]
+                , endStyles =
+                    [ Css.borderRight3 borderWidth borderStyle borderColor
+                    , Css.paddingRight (Css.px 2)
+                    ]
+                }
+
+        ( Just l, Nothing ) ->
+            Just
+                { name = Just l
+                , startStyles = []
+                , styles = []
+                , endStyles = []
+                }
+
+        ( Nothing, Nothing ) ->
+            Nothing
+
+
+topBottomSpace : Css.Px
+topBottomSpace =
+    Css.px 4
+
+
+{-| -}
+yellow : Attribute
+yellow =
+    Attribute (\config -> { config | theme = Just Yellow })
+
+
+{-| -}
+cyan : Attribute
+cyan =
+    Attribute (\config -> { config | theme = Just Cyan })
+
+
+{-| -}
+magenta : Attribute
+magenta =
+    Attribute (\config -> { config | theme = Just Magenta })
+
+
+{-| -}
+green : Attribute
+green =
+    Attribute (\config -> { config | theme = Just Green })
+
+
+{-| -}
+blue : Attribute
+blue =
+    Attribute (\config -> { config | theme = Just Blue })
+
+
+{-| -}
+purple : Attribute
+purple =
+    Attribute (\config -> { config | theme = Just Purple })
+
+
+{-| -}
+brown : Attribute
+brown =
+    Attribute (\config -> { config | theme = Just Brown })
+
+
+{-| -}
+class : String -> Attribute
+class class_ =
+    Attribute (\config -> { config | class = Just class_ })
+
+
+{-| -}
+id : String -> Attribute
+id id_ =
+    Attribute (\config -> { config | id = Just id_ })
+
+
+
+-- Internals
+
+
+{-| -}
+type Attribute
+    = Attribute (Config -> Config)
+
+
+defaultConfig : Config
+defaultConfig =
+    { content = []
+    , label = Nothing
+    , labelId = Nothing
+    , labelHeight = Nothing
+    , theme = Nothing
+    , class = Nothing
+    , id = Nothing
+    }
+
+
+type alias Config =
+    { content : List Content
+    , label : Maybe String
+    , labelId : Maybe String
+    , labelHeight : Maybe { totalHeight : Float, arrowHeight : Float }
+    , theme : Maybe Theme
+    , class : Maybe String
+    , id : Maybe String
+    }
+
+
+render : Config -> List (Html msg)
+render config =
+    let
+        maybePalette =
+            Maybe.map themeToPalette config.theme
+
+        palette =
+            Maybe.withDefault defaultPalette maybePalette
+
+        maybeMark =
+            toMark config.label maybePalette
+    in
+    case config.content of
+        [] ->
+            case maybeMark of
+                Just mark ->
+                    Mark.viewWithBalloonTags
+                        { renderSegment = renderContent config
+                        , backgroundColor = palette.backgroundColor
+                        , maybeMarker = Just mark
+                        , labelHeight = config.labelHeight
+                        , labelId = Maybe.map labelId config.id
+                        , labelContentId = Maybe.map labelContentId config.id
+                        }
+                        [ Blank ]
+
+                Nothing ->
+                    [ viewBlank
+                        [ Css.paddingTop topBottomSpace
+                        , Css.paddingBottom topBottomSpace
+                        ]
+                        config
+                    ]
+
+        _ ->
+            Mark.viewWithBalloonTags
+                { renderSegment = renderContent config
+                , backgroundColor = palette.backgroundColor
+                , maybeMarker = maybeMark
+                , labelHeight = config.labelHeight
+                , labelId = Maybe.map labelId config.id
+                , labelContentId = Maybe.map labelContentId config.id
+                }
+                config.content
+
+
+viewBlank : List Css.Style -> { config | class : Maybe String, id : Maybe String } -> Html msg
+viewBlank styles config =
+    span
+        [ css
+            [ Css.border3 (Css.px 2) Css.dashed Colors.navy
+            , MediaQuery.highContrastMode
+                [ Css.property "border-color" "CanvasText"
+                , Css.property "background-color" "Canvas"
+                ]
+            , Css.backgroundColor Colors.white
+            , Css.minWidth (Css.px 80)
+            , Css.display Css.inlineBlock
+            , Css.borderRadius (Css.px 4)
+            , Css.lineHeight (Css.int 1)
+            , Css.batch styles
+            ]
+        , AttributesExtra.maybe Attributes.class config.class
+        , AttributesExtra.maybe Attributes.id config.id
+        ]
+        [ span
+            [ css
+                [ Css.overflowX Css.hidden
+                , Css.width (Css.px 0)
+                , Css.display Css.inlineBlock
+                , Css.verticalAlign Css.bottom
+                ]
+            ]
+            [ text "blank" ]
+        ]

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -166,7 +166,7 @@ getLabelPositions labelMeasurementsById =
                               , { totalHeight = height + e.labelContent.element.height
                                 , arrowHeight = height
                                 , zIndex = maxRowIndex - index
-                                , xOffset = 0
+                                , xOffset = xOffset e.label
                                 }
                               )
                                 :: acc
@@ -194,7 +194,7 @@ splitByOverlaps =
             -- consider the elements from left to right
             (groupWithSort (\( _, a ) -> a.label.element.x)
                 (\( _, a ) ( _, b ) ->
-                    (a.label.element.x + a.label.element.width) >= b.label.element.x
+                    (a.label.element.x + xOffset a.label + a.label.element.width) >= (b.label.element.x + xOffset b.label)
                 )
             )
 
@@ -204,6 +204,29 @@ groupWithSort sortBy groupBy =
     List.sortBy sortBy
         >> List.Extra.groupWhile groupBy
         >> List.map (\( first, rem ) -> first :: rem)
+
+
+xOffset : Dom.Element -> Float
+xOffset { element, viewport } =
+    let
+        xMax =
+            viewport.x + viewport.width
+    in
+    -- if the element is cut off by the viewport on the left side,
+    -- we need to adjust rightward by the cut-off amount
+    if element.x < viewport.x then
+        viewport.x - element.x
+
+    else
+    -- if the element is cut off by the viewport on the right side,
+    -- we need to adjust leftward by the cut-off amount
+    if
+        xMax < (element.x + element.width)
+    then
+        xMax - (element.x + element.width)
+
+    else
+        0
 
 
 

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -121,34 +121,23 @@ labelContentId labelId_ =
     labelId_ ++ "-label-content"
 
 
-{-|
+{-| Determine where to position labels in order to dynamically avoid overlapping content.
 
-    Pass in a list of the Block ids that you care about (use `Block.id` to attach these ids).
+    - First, we add ids to block with labels with `Block.labelId`.
+    - Say we added `Block.labelId "example-id"`, then we will use `Browser.Dom.getElement "example-id"` and `Browser.Dom.getElement (Block.labelContentId "example-id")` to construct a record in the shape { label : Dom.Element, labelContent : Dom.Element }. We store this record in a dictionary keyed by ids (e.g., "example-id") with measurements for all other labels.
 
-    - First, we add ids to block with labels with `Block.id`.
-    - Say we added `Block.id "example-id"`, then we will use `Browser.Dom.getElement (Block.labelId "example-id")` and `Browser.Dom.getElement (Block.labelContentId "example-id")` to construct a record in the shape { label : Dom.Element, labelContent : Dom.Element }. We store this record in a dictionary keyed by ids (e.g., "example-id") with measurements for all other labels.
-    - Pass a list of all the block ids and the dictionary of measurements to `getLabelPositions`. `getLabelPositions` will return a dictionary of values (keyed by ids) that we will then pass directly to `labelPosition` for positioning.
+`getLabelPositions` will return a dictionary of values (keyed by label ids) whose values can be passed directly to `labelPosition` for positioning.
 
 -}
 getLabelPositions :
-    List String
-    -> Dict String { label : Dom.Element, labelContent : Dom.Element }
+    Dict String { label : Dom.Element, labelContent : Dom.Element }
     -> Dict String { totalHeight : Float, arrowHeight : Float }
-getLabelPositions ids labelMeasurementsById =
+getLabelPositions labelMeasurementsById =
     let
         startingArrowHeight =
             8
     in
-    ids
-        |> List.filterMap
-            (\idString ->
-                case Dict.get idString labelMeasurementsById of
-                    Just measurement ->
-                        Just ( idString, measurement )
-
-                    Nothing ->
-                        Nothing
-            )
+    Dict.toList labelMeasurementsById
         |> splitByOverlaps
         |> List.concatMap
             (\row ->

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -114,6 +114,7 @@ type alias LabelPosition =
     { totalHeight : Float
     , arrowHeight : Float
     , zIndex : Int
+    , xOffset : Float
     }
 
 
@@ -165,6 +166,7 @@ getLabelPositions labelMeasurementsById =
                               , { totalHeight = height + e.labelContent.element.height
                                 , arrowHeight = height
                                 , zIndex = maxRowIndex - index
+                                , xOffset = 0
                                 }
                               )
                                 :: acc

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -2,7 +2,6 @@ module Nri.Ui.Block.V2 exposing
     ( view, Attribute
     , plaintext, content
     , Content, phrase, blank
-    , string
     , emphasize, label, labelHeight
     , yellow, cyan, magenta, green, blue, purple, brown
     , class, id
@@ -19,11 +18,6 @@ module Nri.Ui.Block.V2 exposing
 
 @docs plaintext, content
 @docs Content, phrase, blank
-
-
-### Deprecated
-
-@docs string
 
 
 ## Content customization
@@ -89,7 +83,7 @@ plaintext content_ =
 
     Block.view
         [ Block.emphasize
-        , Block.content [ Block.string "Hello, ", Block.blank, Block.string "!" ]
+        , Block.content (Block.phrase "Hello, " ++  Block.blank :: Block.phrase "!" ) ]
         ]
 
 -}
@@ -239,13 +233,6 @@ renderContent config content_ markStyles =
             Blank ->
                 [ viewBlank [] { class = Nothing, id = Nothing } ]
         )
-
-
-{-| DEPRECATED -- prefer `phrase`.
--}
-string : String -> Content
-string =
-    String_
 
 
 {-| -}

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -2,11 +2,12 @@ module Nri.Ui.Block.V2 exposing
     ( view, Attribute
     , plaintext, content
     , Content, phrase, blank
-    , emphasize, label, labelHeight
-    , yellow, cyan, magenta, green, blue, purple, brown
-    , class, id
+    , emphasize
+    , label
     , labelId, labelContentId
-    , getLabelHeights
+    , getLabelHeights, labelHeight
+    , yellow, cyan, magenta, green, blue, purple, brown
+    , class
     )
 
 {-|
@@ -22,7 +23,17 @@ module Nri.Ui.Block.V2 exposing
 
 ## Content customization
 
-@docs emphasize, label, labelHeight
+@docs emphasize
+
+
+## Labels
+
+@docs label
+
+You will need these helpers if you want to prevent label overlaps. (Which is to say -- anytime you have labels!)
+
+@docs labelId, labelContentId
+@docs getLabelHeights, labelHeight
 
 
 ### Visual customization
@@ -32,15 +43,7 @@ module Nri.Ui.Block.V2 exposing
 
 ### General attributes
 
-@docs class, id
-
-
-## Accessors
-
-You will need these helpers if you want to prevent label overlaps. (Which is to say -- anytime you have labels!)
-
-@docs labelId, labelContentId
-@docs getLabelHeights
+@docs class
 
 -}
 
@@ -110,12 +113,6 @@ label label_ =
 labelHeight : Maybe { totalHeight : Float, arrowHeight : Float } -> Attribute
 labelHeight offset =
     Attribute <| \config -> { config | labelHeight = offset }
-
-
-{-| -}
-labelId : String -> String
-labelId labelId_ =
-    labelId_ ++ "-label"
 
 
 {-| -}
@@ -218,20 +215,19 @@ parseString =
         >> List.map String_
 
 
-renderContent : { config | class : Maybe String, id : Maybe String } -> Content -> List Css.Style -> Html msg
+renderContent : { config | class : Maybe String } -> Content -> List Css.Style -> Html msg
 renderContent config content_ markStyles =
     span
         [ css (Css.whiteSpace Css.preWrap :: markStyles)
         , nriDescription "block-segment-container"
         , AttributesExtra.maybe Attributes.class config.class
-        , AttributesExtra.maybe Attributes.id config.id
         ]
         (case content_ of
             String_ str ->
                 [ text str ]
 
             Blank ->
-                [ viewBlank [] { class = Nothing, id = Nothing } ]
+                [ viewBlank [] { class = Nothing } ]
         )
 
 
@@ -418,9 +414,9 @@ class class_ =
 
 
 {-| -}
-id : String -> Attribute
-id id_ =
-    Attribute (\config -> { config | id = Just id_ })
+labelId : String -> Attribute
+labelId id_ =
+    Attribute (\config -> { config | labelId = Just id_ })
 
 
 
@@ -440,7 +436,6 @@ defaultConfig =
     , labelHeight = Nothing
     , theme = Nothing
     , class = Nothing
-    , id = Nothing
     }
 
 
@@ -451,7 +446,6 @@ type alias Config =
     , labelHeight : Maybe { totalHeight : Float, arrowHeight : Float }
     , theme : Maybe Theme
     , class : Maybe String
-    , id : Maybe String
     }
 
 
@@ -476,8 +470,8 @@ render config =
                         , backgroundColor = palette.backgroundColor
                         , maybeMarker = Just mark
                         , labelHeight = config.labelHeight
-                        , labelId = Maybe.map labelId config.id
-                        , labelContentId = Maybe.map labelContentId config.id
+                        , labelId = config.labelId
+                        , labelContentId = Maybe.map labelContentId config.labelId
                         }
                         [ Blank ]
 
@@ -495,13 +489,13 @@ render config =
                 , backgroundColor = palette.backgroundColor
                 , maybeMarker = maybeMark
                 , labelHeight = config.labelHeight
-                , labelId = Maybe.map labelId config.id
-                , labelContentId = Maybe.map labelContentId config.id
+                , labelId = config.labelId
+                , labelContentId = Maybe.map labelContentId config.labelId
                 }
                 config.content
 
 
-viewBlank : List Css.Style -> { config | class : Maybe String, id : Maybe String } -> Html msg
+viewBlank : List Css.Style -> { config | class : Maybe String } -> Html msg
 viewBlank styles config =
     span
         [ css
@@ -518,7 +512,6 @@ viewBlank styles config =
             , Css.batch styles
             ]
         , AttributesExtra.maybe Attributes.class config.class
-        , AttributesExtra.maybe Attributes.id config.id
         ]
         [ span
             [ css

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -5,7 +5,7 @@ module Nri.Ui.Block.V2 exposing
     , emphasize
     , label
     , labelId, labelContentId
-    , getLabelHeights, labelHeight
+    , getLabelPositions, labelPosition
     , yellow, cyan, magenta, green, blue, purple, brown
     , class
     )
@@ -33,7 +33,7 @@ module Nri.Ui.Block.V2 exposing
 You will need these helpers if you want to prevent label overlaps. (Which is to say -- anytime you have labels!)
 
 @docs labelId, labelContentId
-@docs getLabelHeights, labelHeight
+@docs getLabelPositions, labelPosition
 
 
 ### Visual customization
@@ -108,11 +108,11 @@ label label_ =
     Attribute <| \config -> { config | label = Just label_ }
 
 
-{-| Use `getLabelHeights` to calculate what these values should be.
+{-| Use `getLabelPositions` to calculate what these values should be.
 -}
-labelHeight : Maybe { totalHeight : Float, arrowHeight : Float } -> Attribute
-labelHeight offset =
-    Attribute <| \config -> { config | labelHeight = offset }
+labelPosition : Maybe { totalHeight : Float, arrowHeight : Float } -> Attribute
+labelPosition offset =
+    Attribute <| \config -> { config | labelPosition = offset }
 
 
 {-| -}
@@ -127,14 +127,14 @@ labelContentId labelId_ =
 
     - First, we add ids to block with labels with `Block.id`.
     - Say we added `Block.id "example-id"`, then we will use `Browser.Dom.getElement (Block.labelId "example-id")` and `Browser.Dom.getElement (Block.labelContentId "example-id")` to construct a record in the shape { label : Dom.Element, labelContent : Dom.Element }. We store this record in a dictionary keyed by ids (e.g., "example-id") with measurements for all other labels.
-    - Pass a list of all the block ids and the dictionary of measurements to `getLabelHeights`. `getLabelHeights` will return a dictionary of values (keyed by ids) that we will then pass directly to `labelHeight` for positioning.
+    - Pass a list of all the block ids and the dictionary of measurements to `getLabelPositions`. `getLabelPositions` will return a dictionary of values (keyed by ids) that we will then pass directly to `labelPosition` for positioning.
 
 -}
-getLabelHeights :
+getLabelPositions :
     List String
     -> Dict String { label : Dom.Element, labelContent : Dom.Element }
     -> Dict String { totalHeight : Float, arrowHeight : Float }
-getLabelHeights ids labelMeasurementsById =
+getLabelPositions ids labelMeasurementsById =
     let
         startingArrowHeight =
             8
@@ -433,7 +433,7 @@ defaultConfig =
     { content = []
     , label = Nothing
     , labelId = Nothing
-    , labelHeight = Nothing
+    , labelPosition = Nothing
     , theme = Nothing
     , class = Nothing
     }
@@ -443,7 +443,7 @@ type alias Config =
     { content : List Content
     , label : Maybe String
     , labelId : Maybe String
-    , labelHeight : Maybe { totalHeight : Float, arrowHeight : Float }
+    , labelPosition : Maybe { totalHeight : Float, arrowHeight : Float }
     , theme : Maybe Theme
     , class : Maybe String
     }
@@ -469,7 +469,7 @@ render config =
                         { renderSegment = renderContent config
                         , backgroundColor = palette.backgroundColor
                         , maybeMarker = Just mark
-                        , labelHeight = config.labelHeight
+                        , labelPosition = config.labelPosition
                         , labelId = config.labelId
                         , labelContentId = Maybe.map labelContentId config.labelId
                         }
@@ -488,7 +488,7 @@ render config =
                 { renderSegment = renderContent config
                 , backgroundColor = palette.backgroundColor
                 , maybeMarker = maybeMark
-                , labelHeight = config.labelHeight
+                , labelPosition = config.labelPosition
                 , labelId = config.labelId
                 , labelContentId = Maybe.map labelContentId config.labelId
                 }

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -157,9 +157,11 @@ getLabelPositions ids labelMeasurementsById =
                     |> List.sortBy (Tuple.second >> .labelContent >> .element >> .width)
                     |> List.foldl
                         (\( idString, e ) ( height, acc ) ->
-                            ( height + e.labelContent.element.height
+                            ( height + e.labelContent.element.height + 4
                             , ( idString
-                              , { totalHeight = height + e.labelContent.element.height + 8, arrowHeight = height }
+                              , { totalHeight = height + e.labelContent.element.height
+                                , arrowHeight = height
+                                }
                               )
                                 :: acc
                             )

--- a/src/Nri/Ui/Highlighter/V1.elm
+++ b/src/Nri/Ui/Highlighter/V1.elm
@@ -77,7 +77,7 @@ import Markdown.Inline
 import Nri.Ui.Highlightable.V1 as Highlightable exposing (Highlightable)
 import Nri.Ui.HighlighterTool.V1 as Tool
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
-import Nri.Ui.Mark.V1 as Mark
+import Nri.Ui.Mark.V2 as Mark
 import Sort exposing (Sorter)
 import Sort.Set
 import String.Extra

--- a/src/Nri/Ui/Mark/V1.elm
+++ b/src/Nri/Ui/Mark/V1.elm
@@ -359,6 +359,9 @@ viewBalloon config label =
         , Balloon.css
             [ Css.padding3 Css.zero (Css.px 6) (Css.px 1)
             , Css.property "box-shadow" "none"
+            , Css.property "width" "max-content"
+            , Css.maxWidth (Css.px 150)
+            , Css.property "word-break" "break-word"
             ]
         , Balloon.custom
             [ -- we use the :before element to convey details about the start of the

--- a/src/Nri/Ui/Mark/V2.elm
+++ b/src/Nri/Ui/Mark/V2.elm
@@ -103,7 +103,17 @@ markedWithBalloonStyles marked lastIndex index =
             []
         , marked.styles
         , if index == lastIndex then
-            marked.endStyles
+            Css.after
+                [ Css.property "content"
+                    ("\" end "
+                        ++ (Maybe.map (\name -> name) marked.name
+                                |> Maybe.withDefault "highlight"
+                           )
+                        ++ " \""
+                    )
+                , invisibleStyle
+                ]
+                :: marked.endStyles
 
           else
             []
@@ -166,18 +176,7 @@ viewMarkedByBalloon config markedWith segments =
         [ markedWith.name
             |> Maybe.map (\name -> Aria.roleDescription (name ++ " highlight"))
             |> Maybe.withDefault AttributesExtra.none
-        , css
-            [ Css.backgroundColor Css.transparent
-            , Css.position Css.relative
-            , Css.Global.children
-                [ Css.Global.selector ":last-child"
-                    [ Css.after
-                        [ Css.property "content" ("\" end " ++ (Maybe.map (\name -> name) markedWith.name |> Maybe.withDefault "highlight") ++ " \"")
-                        , invisibleStyle
-                        ]
-                    ]
-                ]
-            ]
+        , css [ Css.backgroundColor Css.transparent, Css.position Css.relative ]
         ]
         -- the balloon should never end up on a line by itself, so we put it in the DOM
         -- after the first segment.

--- a/src/Nri/Ui/Mark/V2.elm
+++ b/src/Nri/Ui/Mark/V2.elm
@@ -323,14 +323,7 @@ viewBalloon config label =
               -- using transform & translate, 50% is wrt to the element itself
               -- combining these two properties, we can center the tag against the parent container
               -- for any arbitrary width element
-              Css.left
-                (Css.calc (Css.pct 50)
-                    Css.plus
-                    (Maybe.map .xOffset config.labelPosition
-                        |> Maybe.withDefault 0
-                        |> Css.px
-                    )
-                )
+              Css.left (Css.pct 50)
             , Css.property "transform" "translateX(-50%) translateY(-100%)"
             , case Maybe.map .zIndex config.labelPosition of
                 Just zIndex ->
@@ -339,25 +332,23 @@ viewBalloon config label =
                 Nothing ->
                     Css.batch []
             ]
-        , case config.labelPosition of
-            Just { xOffset } ->
-                if xOffset > 0 then
-                    Balloon.alignArrowStart
-
-                else if xOffset < 0 then
-                    Balloon.alignArrowEnd
-
-                else
-                    Balloon.alignArrowMiddle
-
-            Nothing ->
-                Balloon.css []
         , Balloon.css
             [ Css.padding3 Css.zero (Css.px 6) (Css.px 1)
             , Css.property "box-shadow" "none"
             , Css.property "width" "max-content"
             , Css.maxWidth (Css.px 150)
             , Css.property "word-break" "break-word"
+            , Css.batch <|
+                case config.labelPosition of
+                    Just { xOffset } ->
+                        if xOffset /= 0 then
+                            [ Css.property "transform" ("translateX(" ++ String.fromFloat xOffset ++ "px)") ]
+
+                        else
+                            []
+
+                    Nothing ->
+                        []
             ]
         , Balloon.custom
             [ -- we use the :before element to convey details about the start of the

--- a/src/Nri/Ui/Mark/V2.elm
+++ b/src/Nri/Ui/Mark/V2.elm
@@ -57,6 +57,13 @@ viewWithInlineTags =
     view_ InlineTags
 
 
+type alias LabelPosition =
+    { totalHeight : Float
+    , arrowHeight : Float
+    , zIndex : Int
+    }
+
+
 {-| When elements are marked, wrap them in a single `mark` html node.
 
 Show the label for the mark, if present, in a balloon centered above the emphasized content.
@@ -66,7 +73,7 @@ viewWithBalloonTags :
     { renderSegment : c -> List Style -> Html msg
     , backgroundColor : Color
     , maybeMarker : Maybe Mark
-    , labelPosition : Maybe { totalHeight : Float, arrowHeight : Float }
+    , labelPosition : Maybe LabelPosition
     , labelId : Maybe String
     , labelContentId : Maybe String
     }
@@ -164,7 +171,7 @@ view_ tagStyle viewSegment highlightables =
 viewMarkedByBalloon :
     { config
         | backgroundColor : Color
-        , labelPosition : Maybe { totalHeight : Float, arrowHeight : Float }
+        , labelPosition : Maybe LabelPosition
         , labelId : Maybe String
         , labelContentId : Maybe String
     }
@@ -299,7 +306,7 @@ viewInlineTag customizations name =
 viewBalloon :
     { config
         | backgroundColor : Color
-        , labelPosition : Maybe { totalHeight : Float, arrowHeight : Float }
+        , labelPosition : Maybe LabelPosition
         , labelId : Maybe String
         , labelContentId : Maybe String
     }
@@ -317,6 +324,12 @@ viewBalloon config label =
               -- for any arbitrary width element
               Css.left (Css.pct 50)
             , Css.property "transform" "translateX(-50%) translateY(-100%)"
+            , case Maybe.map .zIndex config.labelPosition of
+                Just zIndex ->
+                    Css.zIndex (Css.int zIndex)
+
+                Nothing ->
+                    Css.batch []
             ]
         , Balloon.css
             [ Css.padding3 Css.zero (Css.px 6) (Css.px 1)

--- a/src/Nri/Ui/Mark/V2.elm
+++ b/src/Nri/Ui/Mark/V2.elm
@@ -66,7 +66,7 @@ viewWithBalloonTags :
     { renderSegment : c -> List Style -> Html msg
     , backgroundColor : Color
     , maybeMarker : Maybe Mark
-    , labelHeight : Maybe { totalHeight : Float, arrowHeight : Float }
+    , labelPosition : Maybe { totalHeight : Float, arrowHeight : Float }
     , labelId : Maybe String
     , labelContentId : Maybe String
     }
@@ -164,7 +164,7 @@ view_ tagStyle viewSegment highlightables =
 viewMarkedByBalloon :
     { config
         | backgroundColor : Color
-        , labelHeight : Maybe { totalHeight : Float, arrowHeight : Float }
+        , labelPosition : Maybe { totalHeight : Float, arrowHeight : Float }
         , labelId : Maybe String
         , labelContentId : Maybe String
     }
@@ -299,7 +299,7 @@ viewInlineTag customizations name =
 viewBalloon :
     { config
         | backgroundColor : Color
-        , labelHeight : Maybe { totalHeight : Float, arrowHeight : Float }
+        , labelPosition : Maybe { totalHeight : Float, arrowHeight : Float }
         , labelId : Maybe String
         , labelContentId : Maybe String
     }
@@ -351,7 +351,7 @@ viewBalloon config label =
 
             Nothing ->
                 Balloon.css []
-        , case config.labelHeight of
+        , case config.labelPosition of
             Just { arrowHeight } ->
                 Balloon.arrowHeight arrowHeight
 
@@ -360,12 +360,12 @@ viewBalloon config label =
         ]
 
 
-viewBalloonSpacer : { config | labelHeight : Maybe { b | totalHeight : Float } } -> Html msg
+viewBalloonSpacer : { config | labelPosition : Maybe { b | totalHeight : Float } } -> Html msg
 viewBalloonSpacer config =
     span
         [ css
             [ Css.display Css.inlineBlock
-            , config.labelHeight
+            , config.labelPosition
                 |> Maybe.map
                     (\{ totalHeight } ->
                         Css.paddingTop (Css.px totalHeight)

--- a/src/Nri/Ui/Mark/V2.elm
+++ b/src/Nri/Ui/Mark/V2.elm
@@ -1,0 +1,389 @@
+module Nri.Ui.Mark.V2 exposing
+    ( Mark
+    , view, viewWithInlineTags, viewWithBalloonTags
+    )
+
+{-|
+
+@docs Mark
+@docs view, viewWithInlineTags, viewWithBalloonTags
+
+-}
+
+import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Style exposing (invisibleStyle)
+import Css exposing (Color, Style)
+import Css.Global
+import Html.Styled as Html exposing (Html, span)
+import Html.Styled.Attributes exposing (class, css)
+import Nri.Ui.Balloon.V2 as Balloon
+import Nri.Ui.Colors.Extra
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Html.Attributes.V2 as AttributesExtra
+import Nri.Ui.Html.V3 exposing (viewJust)
+import Nri.Ui.MediaQuery.V1 as MediaQuery
+
+
+{-| -}
+type alias Mark =
+    { name : Maybe String
+    , startStyles : List Css.Style
+    , styles : List Css.Style
+    , endStyles : List Css.Style
+    }
+
+
+{-| When elements are marked, wrap them in a single `mark` html node.
+-}
+view :
+    (content -> List Style -> Html msg)
+    -> List ( content, Maybe Mark )
+    -> List (Html msg)
+view =
+    view_ HiddenTags
+
+
+{-| When elements are marked, wrap them in a single `mark` html node.
+
+Show the label for the mark, if present, in-line with the emphasized content.
+
+-}
+viewWithInlineTags :
+    (content -> List Style -> Html msg)
+    -> List ( content, Maybe Mark )
+    -> List (Html msg)
+viewWithInlineTags =
+    view_ InlineTags
+
+
+{-| When elements are marked, wrap them in a single `mark` html node.
+
+Show the label for the mark, if present, in a balloon centered above the emphasized content.
+
+-}
+viewWithBalloonTags :
+    { renderSegment : c -> List Style -> Html msg
+    , backgroundColor : Color
+    , maybeMarker : Maybe Mark
+    , labelHeight : Maybe { totalHeight : Float, arrowHeight : Float }
+    , labelId : Maybe String
+    , labelContentId : Maybe String
+    }
+    -> List c
+    -> List (Html msg)
+viewWithBalloonTags ({ renderSegment, maybeMarker } as config) contents =
+    case maybeMarker of
+        Just markedWith ->
+            let
+                lastIndex =
+                    List.length contents - 1
+            in
+            [ viewMarkedByBalloon config
+                markedWith
+                (List.indexedMap
+                    (\index content -> renderSegment content (markedWithBalloonStyles markedWith lastIndex index))
+                    contents
+                )
+            ]
+
+        Nothing ->
+            List.map (\content -> renderSegment content []) contents
+
+
+markedWithBalloonStyles : Mark -> Int -> Int -> List Css.Style
+markedWithBalloonStyles marked lastIndex index =
+    List.concat
+        [ if index == 0 then
+            -- if we're on the first highlighted element, we add
+            -- a `before` content saying what kind of highlight we're starting
+            tagBeforeContent marked :: marked.startStyles
+
+          else
+            []
+        , marked.styles
+        , if index == lastIndex then
+            marked.endStyles
+
+          else
+            []
+        , -- display:inline-block is necessary for the balloon-spacer to actually
+          -- take up vertical space.
+          [ Css.display Css.inlineBlock
+          , Css.lineHeight (Css.num 1.2)
+          , Css.margin2 (Css.px 2) Css.zero
+          ]
+        ]
+
+
+type TagStyle
+    = HiddenTags
+    | InlineTags
+
+
+{-| When elements are marked, wrap them in a single `mark` html node.
+
+Show the label for the mark, if present, in-line with the emphasized content when `showTagsInline` is True.
+
+-}
+view_ :
+    TagStyle
+    -> (content -> List Style -> Html msg)
+    -> List ( content, Maybe Mark )
+    -> List (Html msg)
+view_ tagStyle viewSegment highlightables =
+    case highlightables of
+        [] ->
+            []
+
+        ( _, marked ) :: _ ->
+            let
+                segments =
+                    List.indexedMap
+                        (\index ( content, mark ) -> viewSegment content (markStyles index mark))
+                        highlightables
+            in
+            case marked of
+                Just markedWith ->
+                    [ viewMarked tagStyle markedWith segments ]
+
+                Nothing ->
+                    segments
+
+
+viewMarkedByBalloon :
+    { config
+        | backgroundColor : Color
+        , labelHeight : Maybe { totalHeight : Float, arrowHeight : Float }
+        , labelId : Maybe String
+        , labelContentId : Maybe String
+    }
+    -> Mark
+    -> List (Html msg)
+    -> Html msg
+viewMarkedByBalloon config markedWith segments =
+    Html.mark
+        [ markedWith.name
+            |> Maybe.map (\name -> Aria.roleDescription (name ++ " highlight"))
+            |> Maybe.withDefault AttributesExtra.none
+        , css
+            [ Css.backgroundColor Css.transparent
+            , Css.position Css.relative
+            , Css.Global.children
+                [ Css.Global.selector ":last-child"
+                    [ Css.after
+                        [ Css.property "content" ("\" end " ++ (Maybe.map (\name -> name) markedWith.name |> Maybe.withDefault "highlight") ++ " \"")
+                        , invisibleStyle
+                        ]
+                    ]
+                ]
+            ]
+        ]
+        -- the balloon should never end up on a line by itself, so we put it in the DOM
+        -- after the first segment.
+        (case segments of
+            first :: remainder ->
+                first
+                    :: viewJust (viewBalloon config) markedWith.name
+                    :: viewJust (\_ -> viewBalloonSpacer config) markedWith.name
+                    :: remainder
+
+            [] ->
+                []
+        )
+
+
+viewMarked : TagStyle -> Mark -> List (Html msg) -> Html msg
+viewMarked tagStyle markedWith segments =
+    Html.mark
+        [ markedWith.name
+            |> Maybe.map (\name -> Aria.roleDescription (name ++ " highlight"))
+            |> Maybe.withDefault AttributesExtra.none
+        , css
+            [ Css.backgroundColor Css.transparent
+            , Css.Global.children
+                [ Css.Global.selector ":last-child"
+                    (Css.after
+                        [ Css.property "content" ("\" end " ++ (Maybe.map (\name -> name) markedWith.name |> Maybe.withDefault "highlight") ++ " \"")
+                        , invisibleStyle
+                        ]
+                        :: markedWith.endStyles
+                    )
+                ]
+            ]
+        ]
+        (viewStartHighlight tagStyle markedWith :: segments)
+
+
+viewStartHighlight : TagStyle -> Mark -> Html msg
+viewStartHighlight tagStyle marked =
+    span
+        [ css (marked.styles ++ marked.startStyles)
+        , class "highlighter-inline-tag highlighter-inline-tag-highlighted"
+        ]
+        [ viewJust (viewTag tagStyle) marked.name ]
+
+
+markStyles : Int -> Maybe Mark -> List Css.Style
+markStyles index marked =
+    case ( index == 0, marked ) of
+        ( True, Just markedWith ) ->
+            -- if we're on the first highlighted element, we add
+            -- a `before` content saying what kind of highlight we're starting
+            tagBeforeContent markedWith :: markedWith.styles
+
+        _ ->
+            Maybe.map .styles marked
+                |> Maybe.withDefault []
+
+
+tagBeforeContent : Mark -> Css.Style
+tagBeforeContent markedWith =
+    case markedWith.name of
+        Just name ->
+            Css.before
+                [ MediaQuery.notHighContrastMode
+                    [ Css.property "content" ("\" start " ++ name ++ " highlight \"")
+                    , invisibleStyle
+                    ]
+                ]
+
+        Nothing ->
+            Css.before
+                [ Css.property "content" "\" start highlight \""
+                , invisibleStyle
+                ]
+
+
+viewTag : TagStyle -> String -> Html msg
+viewTag tagStyle =
+    case tagStyle of
+        InlineTags ->
+            viewInlineTag
+                [ MediaQuery.highContrastMode
+                    [ Css.property "forced-color-adjust" "none"
+                    , Css.property "color" "initial" |> Css.important
+                    ]
+                ]
+
+        HiddenTags ->
+            viewInlineTag
+                [ Css.display Css.none
+                , MediaQuery.highContrastMode
+                    [ Css.property "forced-color-adjust" "none"
+                    , Css.display Css.inline |> Css.important
+                    , Css.property "color" "initial" |> Css.important
+                    ]
+                ]
+
+
+viewInlineTag : List Css.Style -> String -> Html msg
+viewInlineTag customizations name =
+    span
+        [ css
+            [ Fonts.baseFont
+            , Css.backgroundColor Colors.white
+            , Css.color Colors.navy
+            , Css.padding2 (Css.px 2) (Css.px 4)
+            , Css.borderRadius (Css.px 3)
+            , Css.margin2 Css.zero (Css.px 5)
+            , Css.boxShadow5 Css.zero (Css.px 1) (Css.px 1) Css.zero Colors.gray75
+            , Css.batch customizations
+            ]
+        , -- we use the :before element to convey details about the start of the
+          -- highlighter to screenreaders, so the visual label is redundant
+          Aria.hidden True
+        ]
+        [ Html.text name ]
+
+
+viewBalloon :
+    { config
+        | backgroundColor : Color
+        , labelHeight : Maybe { totalHeight : Float, arrowHeight : Float }
+        , labelId : Maybe String
+        , labelContentId : Maybe String
+    }
+    -> String
+    -> Html msg
+viewBalloon config label =
+    Balloon.view
+        [ Balloon.onTop
+        , Balloon.containerCss
+            [ Css.position Css.absolute
+            , Css.top (Css.px -6)
+            , -- using position, 50% is wrt the parent container
+              -- using transform & translate, 50% is wrt to the element itself
+              -- combining these two properties, we can center the tag against the parent container
+              -- for any arbitrary width element
+              Css.left (Css.pct 50)
+            , Css.property "transform" "translateX(-50%) translateY(-100%)"
+            ]
+        , Balloon.css
+            [ Css.padding3 Css.zero (Css.px 6) (Css.px 1)
+            , Css.property "box-shadow" "none"
+            , Css.property "width" "max-content"
+            , Css.maxWidth (Css.px 150)
+            , Css.property "word-break" "break-word"
+            ]
+        , Balloon.custom
+            [ -- we use the :before element to convey details about the start of the
+              -- highlighter to screenreaders, so the visual label is redundant
+              Aria.hidden True
+            ]
+        , Balloon.customTheme
+            { backgroundColor = config.backgroundColor
+            , color = Nri.Ui.Colors.Extra.highContrastColor config.backgroundColor
+            }
+        , Balloon.highContrastModeTheme
+            { backgroundColor = "Mark"
+            , color = "MarkText"
+            }
+        , case config.labelContentId of
+            Just id_ ->
+                Balloon.contentId id_
+
+            Nothing ->
+                Balloon.css []
+        , Balloon.plaintext label
+        , case config.labelId of
+            Just id_ ->
+                Balloon.id id_
+
+            Nothing ->
+                Balloon.css []
+        , case config.labelHeight of
+            Just { arrowHeight } ->
+                Balloon.arrowHeight arrowHeight
+
+            Nothing ->
+                Balloon.css []
+        ]
+
+
+viewBalloonSpacer : { config | labelHeight : Maybe { b | totalHeight : Float } } -> Html msg
+viewBalloonSpacer config =
+    span
+        [ css
+            [ Css.display Css.inlineBlock
+            , config.labelHeight
+                |> Maybe.map
+                    (\{ totalHeight } ->
+                        Css.paddingTop (Css.px totalHeight)
+                    )
+                |> Maybe.withDefault (Css.batch [])
+            ]
+        , AttributesExtra.nriDescription "balloon-spacer"
+        ]
+        [ -- this element should never be displayed to anyone.
+          -- It's only present to take up vertical space in order to align the label.
+          span
+            [ css
+                [ Css.visibility Css.hidden
+                , Css.overflowX Css.hidden
+                , Css.width (Css.px 0)
+                , Css.display Css.inlineBlock
+                ]
+            ]
+            [ Html.text "()" ]
+        ]

--- a/src/Nri/Ui/Mark/V2.elm
+++ b/src/Nri/Ui/Mark/V2.elm
@@ -61,6 +61,7 @@ type alias LabelPosition =
     { totalHeight : Float
     , arrowHeight : Float
     , zIndex : Int
+    , xOffset : Float
     }
 
 
@@ -322,7 +323,14 @@ viewBalloon config label =
               -- using transform & translate, 50% is wrt to the element itself
               -- combining these two properties, we can center the tag against the parent container
               -- for any arbitrary width element
-              Css.left (Css.pct 50)
+              Css.left
+                (Css.calc (Css.pct 50)
+                    Css.plus
+                    (Maybe.map .xOffset config.labelPosition
+                        |> Maybe.withDefault 0
+                        |> Css.px
+                    )
+                )
             , Css.property "transform" "translateX(-50%) translateY(-100%)"
             , case Maybe.map .zIndex config.labelPosition of
                 Just zIndex ->
@@ -331,6 +339,19 @@ viewBalloon config label =
                 Nothing ->
                     Css.batch []
             ]
+        , case config.labelPosition of
+            Just { xOffset } ->
+                if xOffset > 0 then
+                    Balloon.alignArrowStart
+
+                else if xOffset < 0 then
+                    Balloon.alignArrowEnd
+
+                else
+                    Balloon.alignArrowMiddle
+
+            Nothing ->
+                Balloon.css []
         , Balloon.css
             [ Css.padding3 Css.zero (Css.px 6) (Css.px 1)
             , Css.property "box-shadow" "none"

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -95,7 +95,7 @@ example =
                             ]
 
                 offsets =
-                    Block.getLabelPositions blocksWithLabelsIds state.labelMeasurementsById
+                    Block.getLabelPositions state.labelMeasurementsById
             in
             [ ControlView.view
                 { ellieLinkConfig = ellieLinkConfig

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -64,14 +64,14 @@ example =
                 [ Block.plaintext "he"
                 , Block.label "subject"
                 , Block.yellow
-                , Block.labelHeight (Just { totalHeight = 66, arrowHeight = 34 })
+                , Block.labelPosition (Just { totalHeight = 66, arrowHeight = 34 })
                 ]
           , Block.view [ Block.plaintext " " ]
           , Block.view
                 [ Block.plaintext "glued"
                 , Block.label "verb"
                 , Block.cyan
-                , Block.labelHeight (Just { totalHeight = 34, arrowHeight = 8 })
+                , Block.labelPosition (Just { totalHeight = 34, arrowHeight = 8 })
                 ]
           , Block.view [ Block.plaintext " it with ketchup." ]
           ]
@@ -95,7 +95,7 @@ example =
                             ]
 
                 offsets =
-                    Block.getLabelHeights blocksWithLabelsIds state.labelMeasurementsById
+                    Block.getLabelPositions blocksWithLabelsIds state.labelMeasurementsById
             in
             [ ControlView.view
                 { ellieLinkConfig = ellieLinkConfig
@@ -157,7 +157,7 @@ example =
                     , Block.magenta
                     , Block.label "subject"
                     , Block.labelId subjectId
-                    , Block.labelHeight (Dict.get subjectId offsets)
+                    , Block.labelPosition (Dict.get subjectId offsets)
                     ]
                  , Block.view [ Block.plaintext " " ]
                  , Block.view []
@@ -167,14 +167,14 @@ example =
                     , Block.label "direct object"
                     , Block.yellow
                     , Block.labelId directObjectId
-                    , Block.labelHeight (Dict.get directObjectId offsets)
+                    , Block.labelPosition (Dict.get directObjectId offsets)
                     ]
                  , Block.view [ Block.plaintext " " ]
                  , Block.view
                     [ Block.label "preposition"
                     , Block.cyan
                     , Block.labelId prepositionId
-                    , Block.labelHeight (Dict.get prepositionId offsets)
+                    , Block.labelPosition (Dict.get prepositionId offsets)
                     ]
                  , Block.view [ Block.plaintext " comic book pages. " ]
                  , Block.view
@@ -186,7 +186,7 @@ example =
                     , Block.label "Editor's note"
                     , Block.brown
                     , Block.labelId editorsNoteId
-                    , Block.labelHeight (Dict.get editorsNoteId offsets)
+                    , Block.labelPosition (Dict.get editorsNoteId offsets)
                     ]
                  ]
                     |> List.concat
@@ -251,7 +251,7 @@ example =
                                     [ Block.plaintext "new"
                                     , Block.label "age"
                                     , Block.labelId ageId
-                                    , Block.labelHeight (Dict.get ageId offsets)
+                                    , Block.labelPosition (Dict.get ageId offsets)
                                     , Block.yellow
                                     ]
                                 , Block.view [ Block.plaintext " " ]
@@ -259,7 +259,7 @@ example =
                                     [ Block.plaintext "bowling"
                                     , Block.label "purpose"
                                     , Block.labelId purposeId
-                                    , Block.labelHeight (Dict.get purposeId offsets)
+                                    , Block.labelPosition (Dict.get purposeId offsets)
                                     , Block.cyan
                                     ]
                                 , Block.view [ Block.plaintext " " ]
@@ -267,7 +267,7 @@ example =
                                     [ Block.plaintext "yellow"
                                     , Block.label "color"
                                     , Block.labelId colorId
-                                    , Block.labelHeight (Dict.get colorId offsets)
+                                    , Block.labelPosition (Dict.get colorId offsets)
                                     , Block.magenta
                                     ]
                                 , Block.view [ Block.plaintext " shoes." ]
@@ -291,7 +291,7 @@ example =
                             , Block.view
                                 [ Block.label "pronoun"
                                 , Block.labelId pronounId
-                                , Block.labelHeight (Dict.get pronounId offsets)
+                                , Block.labelPosition (Dict.get pronounId offsets)
                                 ]
                             , Block.view [ Block.plaintext " will never erupt again." ]
                             ]
@@ -357,11 +357,11 @@ initControl =
         |> ControlExtra.optionalBoolListItem "emphasize" ( Code.fromModule moduleName "emphasize", Block.emphasize )
         |> ControlExtra.optionalListItem "label"
             (CommonControls.string ( Code.fromModule moduleName "label", Block.label ) "Fruit")
-        |> ControlExtra.optionalListItem "labelHeight"
+        |> ControlExtra.optionalListItem "labelPosition"
             (Control.map
                 (\( code, v ) ->
-                    ( Code.fromModule moduleName "labelHeight (Just" ++ code ++ ")"
-                    , Block.labelHeight (Just v)
+                    ( Code.fromModule moduleName "labelPosition (Just" ++ code ++ ")"
+                    , Block.labelPosition (Just v)
                     )
                 )
                 (Control.record

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -19,7 +19,7 @@ import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Markdown
-import Nri.Ui.Block.V1 as Block
+import Nri.Ui.Block.V2 as Block
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -191,6 +191,40 @@ example =
                  ]
                     |> List.concat
                 )
+            , p
+                [ css
+                    [ Fonts.quizFont
+                    , Css.fontSize (Css.px 30)
+                    , Css.marginTop (Css.px 60)
+                    ]
+                ]
+                ([ Block.view
+                    [ Block.plaintext "A"
+                    , Block.magenta
+                    , Block.label "this is an article. \"An\" is also an article."
+                    , Block.labelId articleId
+                    , Block.labelPosition (Dict.get articleId offsets)
+                    ]
+                 , Block.view [ Block.plaintext " " ]
+                 , Block.view
+                    [ Block.plaintext "tricky"
+                    , Block.label "this is an adjective"
+                    , Block.yellow
+                    , Block.labelId trickyId
+                    , Block.labelPosition (Dict.get trickyId offsets)
+                    ]
+                 , Block.view [ Block.plaintext " " ]
+                 , Block.view
+                    [ Block.plaintext "example"
+                    , Block.label "the goal of which is to demonstrate horizontal repositioning"
+                    , Block.cyan
+                    , Block.labelId goalId
+                    , Block.labelPosition (Dict.get goalId offsets)
+                    ]
+                 , Block.view [ Block.plaintext "." ]
+                 ]
+                    |> List.concat
+                )
             , Table.view
                 [ Table.custom
                     { header = text "Pattern name & description"
@@ -459,6 +493,21 @@ pronounId =
     "pronoun-label-id"
 
 
+articleId : String
+articleId =
+    "article-label-id"
+
+
+trickyId : String
+trickyId =
+    "tricky-label-id"
+
+
+goalId : String
+goalId =
+    "goal-label-id"
+
+
 blocksWithLabelsIds : List String
 blocksWithLabelsIds =
     [ ageId
@@ -469,6 +518,9 @@ blocksWithLabelsIds =
     , prepositionId
     , editorsNoteId
     , pronounId
+    , articleId
+    , trickyId
+    , goalId
     ]
 
 

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -95,7 +95,7 @@ example =
                             ]
 
                 offsets =
-                    Block.getLabelHeights [ ageId, purposeId, colorId ] state.labelMeasurementsById
+                    Block.getLabelHeights blocksWithLabelsIds state.labelMeasurementsById
             in
             [ ControlView.view
                 { ellieLinkConfig = ellieLinkConfig
@@ -157,8 +157,7 @@ example =
                     , Block.magenta
                     , Block.label "subject"
                     , Block.id subjectId
-                                    , Block.labelHeight (Dict.get subjectId offsets)
-
+                    , Block.labelHeight (Dict.get subjectId offsets)
                     ]
                  , Block.view [ Block.plaintext " " ]
                  , Block.view []
@@ -168,16 +167,14 @@ example =
                     , Block.label "direct object"
                     , Block.yellow
                     , Block.id directObjectId
-                                    , Block.labelHeight (Dict.get directObjectId offsets)
-
+                    , Block.labelHeight (Dict.get directObjectId offsets)
                     ]
                  , Block.view [ Block.plaintext " " ]
                  , Block.view
                     [ Block.label "preposition"
                     , Block.cyan
                     , Block.id prepositionId
-                                    , Block.labelHeight (Dict.get prepositionId offsets)
-
+                    , Block.labelHeight (Dict.get prepositionId offsets)
                     ]
                  , Block.view [ Block.plaintext " comic book pages. " ]
                  , Block.view
@@ -189,8 +186,7 @@ example =
                     , Block.label "Editor's note"
                     , Block.brown
                     , Block.id editorsNoteId
-                                    , Block.labelHeight (Dict.get editorsNoteId offsets)
-
+                    , Block.labelHeight (Dict.get editorsNoteId offsets)
                     ]
                  ]
                     |> List.concat
@@ -256,7 +252,6 @@ example =
                                     , Block.label "age"
                                     , Block.id ageId
                                     , Block.labelHeight (Dict.get ageId offsets)
-
                                     , Block.yellow
                                     ]
                                 , Block.view [ Block.plaintext " " ]
@@ -265,7 +260,6 @@ example =
                                     , Block.label "purpose"
                                     , Block.id purposeId
                                     , Block.labelHeight (Dict.get purposeId offsets)
-
                                     , Block.cyan
                                     ]
                                 , Block.view [ Block.plaintext " " ]
@@ -274,7 +268,6 @@ example =
                                     , Block.label "color"
                                     , Block.id colorId
                                     , Block.labelHeight (Dict.get colorId offsets)
-
                                     , Block.magenta
                                     ]
                                 , Block.view [ Block.plaintext " shoes." ]
@@ -298,8 +291,7 @@ example =
                             , Block.view
                                 [ Block.label "pronoun"
                                 , Block.id pronounId
-                                    , Block.labelHeight (Dict.get pronounId offsets)
-
+                                , Block.labelHeight (Dict.get pronounId offsets)
                                 ]
                             , Block.view [ Block.plaintext " will never erupt again." ]
                             ]

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -64,14 +64,14 @@ example =
                 [ Block.plaintext "he"
                 , Block.label "subject"
                 , Block.yellow
-                , Block.labelPosition (Just { totalHeight = 66, arrowHeight = 34, zIndex = 0 })
+                , Block.labelPosition (Just { totalHeight = 66, arrowHeight = 34, zIndex = 0, xOffset = 0 })
                 ]
           , Block.view [ Block.plaintext " " ]
           , Block.view
                 [ Block.plaintext "glued"
                 , Block.label "verb"
                 , Block.cyan
-                , Block.labelPosition (Just { totalHeight = 34, arrowHeight = 8, zIndex = 0 })
+                , Block.labelPosition (Just { totalHeight = 34, arrowHeight = 8, zIndex = 0, xOffset = 0 })
                 ]
           , Block.view [ Block.plaintext " it with ketchup." ]
           ]
@@ -413,17 +413,19 @@ initControl =
                     )
                 )
                 (Control.record
-                    (\a b ->
+                    (\a b c ->
                         ( Code.record
                             [ ( "arrowHeight", String.fromFloat a )
                             , ( "totalHeight", String.fromFloat b )
                             , ( "zIndex", "0" )
+                            , ( "xOffset", String.fromFloat c )
                             ]
-                        , { arrowHeight = a, totalHeight = b, zIndex = 0 }
+                        , { arrowHeight = a, totalHeight = b, zIndex = 0, xOffset = c }
                         )
                     )
                     |> Control.field "arrowHeight" (ControlExtra.float 40)
                     |> Control.field "totalHeight" (ControlExtra.float 80)
+                    |> Control.field "xOffset" (ControlExtra.float 0)
                 )
             )
         |> ControlExtra.optionalListItem "theme"

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -93,6 +93,9 @@ example =
                                 , Css.fontSize (Css.px 30)
                                 ]
                             ]
+
+                offsets =
+                    Block.getLabelHeights [ ageId, purposeId, colorId ] state.labelMeasurementsById
             in
             [ ControlView.view
                 { ellieLinkConfig = ellieLinkConfig
@@ -132,6 +135,16 @@ example =
                 [ Heading.plaintext "Non-interactive examples"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
+            , Button.button "Measure & render"
+                [ Button.onClick GetBlockLabelMeasurements
+                , Button.small
+                , Button.secondary
+                , Button.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
+            , Text.caption
+                [ Text.plaintext "Click \"Measure & render\" to reposition the noninteractive examples' labels to avoid overlaps given the current viewport."
+                , Text.css [ Css.marginBottom Spacing.verticalSpacerPx |> Css.important ]
+                ]
             , p
                 [ css
                     [ Fonts.quizFont
@@ -143,6 +156,9 @@ example =
                     [ Block.plaintext "Superman"
                     , Block.magenta
                     , Block.label "subject"
+                    , Block.id subjectId
+                                    , Block.labelHeight (Dict.get subjectId offsets)
+
                     ]
                  , Block.view [ Block.plaintext " " ]
                  , Block.view []
@@ -151,9 +167,18 @@ example =
                     [ Block.plaintext "gifts"
                     , Block.label "direct object"
                     , Block.yellow
+                    , Block.id directObjectId
+                                    , Block.labelHeight (Dict.get directObjectId offsets)
+
                     ]
                  , Block.view [ Block.plaintext " " ]
-                 , Block.view [ Block.label "preposition", Block.cyan ]
+                 , Block.view
+                    [ Block.label "preposition"
+                    , Block.cyan
+                    , Block.id prepositionId
+                                    , Block.labelHeight (Dict.get prepositionId offsets)
+
+                    ]
                  , Block.view [ Block.plaintext " comic book pages. " ]
                  , Block.view
                     [ (List.concat >> Block.content)
@@ -163,6 +188,9 @@ example =
                         ]
                     , Block.label "Editor's note"
                     , Block.brown
+                    , Block.id editorsNoteId
+                                    , Block.labelHeight (Dict.get editorsNoteId offsets)
+
                     ]
                  ]
                     |> List.concat
@@ -220,10 +248,6 @@ example =
                                 1
                   , description = "**Label block**\n\nHelp students understand the function different words and phrases are playing in a sentence"
                   , example =
-                        let
-                            offsets =
-                                Block.getLabelHeights [ ageId, purposeId, colorId ] state.labelMeasurementsById
-                        in
                         div []
                             [ inParagraph
                                 [ Block.view [ Block.plaintext "Taylor Swift bought " ]
@@ -232,6 +256,7 @@ example =
                                     , Block.label "age"
                                     , Block.id ageId
                                     , Block.labelHeight (Dict.get ageId offsets)
+
                                     , Block.yellow
                                     ]
                                 , Block.view [ Block.plaintext " " ]
@@ -240,6 +265,7 @@ example =
                                     , Block.label "purpose"
                                     , Block.id purposeId
                                     , Block.labelHeight (Dict.get purposeId offsets)
+
                                     , Block.cyan
                                     ]
                                 , Block.view [ Block.plaintext " " ]
@@ -248,22 +274,10 @@ example =
                                     , Block.label "color"
                                     , Block.id colorId
                                     , Block.labelHeight (Dict.get colorId offsets)
+
                                     , Block.magenta
                                     ]
                                 , Block.view [ Block.plaintext " shoes." ]
-                                ]
-                            , Button.button "Measure & render"
-                                [ Button.onClick GetBlockLabelMeasurements
-                                , Button.small
-                                , Button.secondary
-                                ]
-                            , Text.caption
-                                [ Text.plaintext "Click \"Measure & render\" to reposition this example's labels to avoid overlaps given the current viewport."
-                                , Text.css
-                                    [ Css.textAlign Css.center
-                                    , Css.maxWidth (Css.px 200)
-                                    , Css.margin3 Css.zero Css.auto Spacing.verticalSpacerPx |> Css.important
-                                    ]
                                 ]
                             ]
                   }
@@ -281,7 +295,12 @@ example =
                   , example =
                         inParagraph
                             [ Block.view [ Block.plaintext "If a volcano is extinct, " ]
-                            , Block.view [ Block.label "pronoun" ]
+                            , Block.view
+                                [ Block.label "pronoun"
+                                , Block.id pronounId
+                                    , Block.labelHeight (Dict.get pronounId offsets)
+
+                                ]
                             , Block.view [ Block.plaintext " will never erupt again." ]
                             ]
                   }
@@ -423,6 +442,44 @@ purposeId =
     "purpose-label-id"
 
 
+subjectId : String
+subjectId =
+    "subject-label-id"
+
+
+directObjectId : String
+directObjectId =
+    "direct-object-label-id"
+
+
+prepositionId : String
+prepositionId =
+    "preposition-label-id"
+
+
+editorsNoteId : String
+editorsNoteId =
+    "editors-note-label-id"
+
+
+pronounId : String
+pronounId =
+    "pronoun-label-id"
+
+
+blocksWithLabelsIds : List String
+blocksWithLabelsIds =
+    [ ageId
+    , colorId
+    , purposeId
+    , subjectId
+    , directObjectId
+    , prepositionId
+    , editorsNoteId
+    , pronounId
+    ]
+
+
 {-| -}
 type Msg
     = UpdateSettings (Control Settings)
@@ -448,11 +505,7 @@ update msg state =
 
         GetBlockLabelMeasurements ->
             ( state
-            , Cmd.batch
-                [ measure ageId
-                , measure purposeId
-                , measure colorId
-                ]
+            , Cmd.batch (List.map measure blocksWithLabelsIds)
             )
 
         GotBlockLabelMeasurements id (Ok measurement) ->

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -64,14 +64,14 @@ example =
                 [ Block.plaintext "he"
                 , Block.label "subject"
                 , Block.yellow
-                , Block.labelPosition (Just { totalHeight = 66, arrowHeight = 34 })
+                , Block.labelPosition (Just { totalHeight = 66, arrowHeight = 34, zIndex = 0 })
                 ]
           , Block.view [ Block.plaintext " " ]
           , Block.view
                 [ Block.plaintext "glued"
                 , Block.label "verb"
                 , Block.cyan
-                , Block.labelPosition (Just { totalHeight = 34, arrowHeight = 8 })
+                , Block.labelPosition (Just { totalHeight = 34, arrowHeight = 8, zIndex = 0 })
                 ]
           , Block.view [ Block.plaintext " it with ketchup." ]
           ]
@@ -414,8 +414,12 @@ initControl =
                 )
                 (Control.record
                     (\a b ->
-                        ( Code.record [ ( "arrowHeight", String.fromFloat a ), ( "totalHeight", String.fromFloat b ) ]
-                        , { arrowHeight = a, totalHeight = b }
+                        ( Code.record
+                            [ ( "arrowHeight", String.fromFloat a )
+                            , ( "totalHeight", String.fromFloat b )
+                            , ( "zIndex", "0" )
+                            ]
+                        , { arrowHeight = a, totalHeight = b, zIndex = 0 }
                         )
                     )
                     |> Control.field "arrowHeight" (ControlExtra.float 40)

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -221,7 +221,21 @@ example =
                     , Block.labelId goalId
                     , Block.labelPosition (Dict.get goalId offsets)
                     ]
-                 , Block.view [ Block.plaintext "." ]
+                 , Block.view [ Block.plaintext ". Be sure to be " ]
+                 , Block.view
+                    [ Block.plaintext "careful"
+                    , Block.label "Shortish content..."
+                    , Block.green
+                    , Block.labelId shortId
+                    , Block.labelPosition (Dict.get shortId offsets)
+                    ]
+                 , Block.view
+                    [ Block.plaintext "!"
+                    , Block.label "It's important that the 'lowest' content is rendered on top of all other content."
+                    , Block.blue
+                    , Block.labelId longId
+                    , Block.labelPosition (Dict.get longId offsets)
+                    ]
                  ]
                     |> List.concat
                 )
@@ -508,6 +522,16 @@ goalId =
     "goal-label-id"
 
 
+shortId : String
+shortId =
+    "short-label-id"
+
+
+longId : String
+longId =
+    "long-label-id"
+
+
 blocksWithLabelsIds : List String
 blocksWithLabelsIds =
     [ ageId
@@ -521,6 +545,8 @@ blocksWithLabelsIds =
     , articleId
     , trickyId
     , goalId
+    , shortId
+    , longId
     ]
 
 

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -156,7 +156,7 @@ example =
                     [ Block.plaintext "Superman"
                     , Block.magenta
                     , Block.label "subject"
-                    , Block.id subjectId
+                    , Block.labelId subjectId
                     , Block.labelHeight (Dict.get subjectId offsets)
                     ]
                  , Block.view [ Block.plaintext " " ]
@@ -166,14 +166,14 @@ example =
                     [ Block.plaintext "gifts"
                     , Block.label "direct object"
                     , Block.yellow
-                    , Block.id directObjectId
+                    , Block.labelId directObjectId
                     , Block.labelHeight (Dict.get directObjectId offsets)
                     ]
                  , Block.view [ Block.plaintext " " ]
                  , Block.view
                     [ Block.label "preposition"
                     , Block.cyan
-                    , Block.id prepositionId
+                    , Block.labelId prepositionId
                     , Block.labelHeight (Dict.get prepositionId offsets)
                     ]
                  , Block.view [ Block.plaintext " comic book pages. " ]
@@ -185,7 +185,7 @@ example =
                         ]
                     , Block.label "Editor's note"
                     , Block.brown
-                    , Block.id editorsNoteId
+                    , Block.labelId editorsNoteId
                     , Block.labelHeight (Dict.get editorsNoteId offsets)
                     ]
                  ]
@@ -250,7 +250,7 @@ example =
                                 , Block.view
                                     [ Block.plaintext "new"
                                     , Block.label "age"
-                                    , Block.id ageId
+                                    , Block.labelId ageId
                                     , Block.labelHeight (Dict.get ageId offsets)
                                     , Block.yellow
                                     ]
@@ -258,7 +258,7 @@ example =
                                 , Block.view
                                     [ Block.plaintext "bowling"
                                     , Block.label "purpose"
-                                    , Block.id purposeId
+                                    , Block.labelId purposeId
                                     , Block.labelHeight (Dict.get purposeId offsets)
                                     , Block.cyan
                                     ]
@@ -266,7 +266,7 @@ example =
                                 , Block.view
                                     [ Block.plaintext "yellow"
                                     , Block.label "color"
-                                    , Block.id colorId
+                                    , Block.labelId colorId
                                     , Block.labelHeight (Dict.get colorId offsets)
                                     , Block.magenta
                                     ]
@@ -290,7 +290,7 @@ example =
                             [ Block.view [ Block.plaintext "If a volcano is extinct, " ]
                             , Block.view
                                 [ Block.label "pronoun"
-                                , Block.id pronounId
+                                , Block.labelId pronounId
                                 , Block.labelHeight (Dict.get pronounId offsets)
                                 ]
                             , Block.view [ Block.plaintext " will never erupt again." ]
@@ -385,8 +385,8 @@ initControl =
                 , ( "brown", Block.brown )
                 ]
             )
-        |> ControlExtra.optionalListItem "id"
-            (CommonControls.string ( Code.fromModule moduleName "id", Block.id ) "fruit-block")
+        |> ControlExtra.optionalListItem "labelId"
+            (CommonControls.string ( Code.fromModule moduleName "labelId", Block.labelId ) "fruit-block")
         |> ControlExtra.optionalListItem "class"
             (CommonControls.string ( "class", Block.class ) "kiwis-are-good")
 
@@ -513,8 +513,8 @@ update msg state =
 
 
 measure : String -> Cmd Msg
-measure id =
+measure labelId =
     Task.map2 (\label labelContent -> { label = label, labelContent = labelContent })
-        (Dom.getElement (Block.labelId id))
-        (Dom.getElement (Block.labelContentId id))
-        |> Task.attempt (GotBlockLabelMeasurements id)
+        (Dom.getElement labelId)
+        (Dom.getElement (Block.labelContentId labelId))
+        |> Task.attempt (GotBlockLabelMeasurements labelId)

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -20,7 +20,7 @@ import Html.Styled.Attributes as Attributes exposing (css)
 import Json.Decode
 import Json.Encode as Encode
 import Markdown
-import Nri.Ui.Block.V1 as Block
+import Nri.Ui.Block.V2 as Block
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -84,30 +84,17 @@ toQuery block =
 
 getLabelPositionsSpec : List Test
 getLabelPositionsSpec =
-    [ test "without any ids or measurements, does not specify heights" <|
+    [ test "without any measurements, does not specify heights" <|
         \() ->
-            Block.getLabelPositions [] Dict.empty
+            Block.getLabelPositions Dict.empty
                 |> Expect.equal Dict.empty
-    , test "without any measurements, does not specify heights" <|
-        \() ->
-            Block.getLabelPositions [ "a" ] Dict.empty
-                |> Expect.equal Dict.empty
-    , test "without any ids, does not specify heights" <|
-        \() ->
-            Block.getLabelPositions []
-                (Dict.singleton "a"
-                    { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
-                    , labelContent = dummyElement { x = 0, y = 0, width = 100, height = 20 }
-                    }
-                )
-                |> Expect.equal Dict.empty
-    , test "with 1 id and 1 measurement, specifies the default heights" <|
+    , test "with a measured label, specifies the default heights" <|
         \() ->
             let
                 startingHeight =
                     20
             in
-            Block.getLabelPositions [ "a" ]
+            Block.getLabelPositions
                 (Dict.singleton "a"
                     { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = startingHeight }
@@ -128,7 +115,7 @@ getLabelPositionsSpec =
                 bStartingHeight =
                     30
             in
-            Block.getLabelPositions [ "a", "b", "c" ]
+            Block.getLabelPositions
                 ([ --  A has taller content
                    ( "a"
                    , { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
@@ -173,7 +160,7 @@ getLabelPositionsSpec =
                 bX =
                     aWidth + 1
             in
-            Block.getLabelPositions [ "a", "b", "c" ]
+            Block.getLabelPositions
                 ([ --  A has taller content
                    ( "a"
                    , { label = dummyElement { x = 0, y = 0, width = aWidth, height = 100 }
@@ -209,7 +196,7 @@ getLabelPositionsSpec =
                 startingHeight =
                     20
             in
-            Block.getLabelPositions [ "a", "b", "c" ]
+            Block.getLabelPositions
                 ([ --  A is the second-widest element
                    ( "a"
                    , { label = dummyElement { x = 0, y = 0, width = 200, height = 100 }
@@ -260,7 +247,7 @@ getLabelPositionsSpec =
                 startingHeight =
                     20
             in
-            Block.getLabelPositions [ "a", "b", "c" ]
+            Block.getLabelPositions
                 ([ --  A is the second-widest element, but doesn't overlap any other labels
                    ( "a"
                    , { label = dummyElement { x = 500, y = 0, width = 200, height = 100 }
@@ -313,7 +300,7 @@ getLabelPositionsSpec =
                     , element = element
                     }
             in
-            Block.getLabelPositions [ "subjectId", "directObjectId", "prepositionId", "editorsNoteId" ]
+            Block.getLabelPositions
                 ([ ( "subjectId"
                    , { label = withElement { x = 56.8828125, y = 883, width = 63.515625, height = 32 }
                      , labelContent = withElement { x = 56.8828125, y = 883, width = 63.515625, height = 24 }
@@ -351,7 +338,7 @@ getLabelPositionsSpec =
                 startingHeight =
                     20
             in
-            Block.getLabelPositions [ "a", "b" ]
+            Block.getLabelPositions
                 ([ ( "a"
                    , { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
                      , labelContent = dummyElement { x = 0, y = 0, width = 100, height = startingHeight }
@@ -385,7 +372,7 @@ getLabelPositionsSpec =
                 startingHeight =
                     20
             in
-            Block.getLabelPositions [ "a", "b", "c" ]
+            Block.getLabelPositions
                 ([ --  A is the second-widest element
                    ( "a"
                    , { label = dummyElement { x = 0, y = 0, width = 200, height = 100 }
@@ -437,7 +424,7 @@ getLabelPositionsSpec =
                 startingHeight =
                     20
             in
-            Block.getLabelPositions [ "a", "b", "c" ]
+            Block.getLabelPositions
                 ([ --  A is the second-widest element
                    ( "a"
                    , { label = dummyElement { x = 0, y = 0, width = 200, height = 100 }

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -105,6 +105,7 @@ getLabelPositionsSpec =
                         { totalHeight = startingHeight + defaultArrowHeight
                         , arrowHeight = defaultArrowHeight
                         , zIndex = 0
+                        , xOffset = 0
                         }
                     )
     , test "with different height measurements, prevents overlaps" <|
@@ -137,12 +138,14 @@ getLabelPositionsSpec =
                        , { totalHeight = aStartingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          , zIndex = 1
+                         , xOffset = 0
                          }
                        )
                      , ( "b"
                        , { totalHeight = aStartingHeight + bStartingHeight + defaultArrowHeight + balloonOffset
                          , arrowHeight = aStartingHeight + defaultArrowHeight + balloonOffset
                          , zIndex = 0
+                         , xOffset = 0
                          }
                        )
                      ]
@@ -184,12 +187,14 @@ getLabelPositionsSpec =
                        , { totalHeight = aStartingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          , zIndex = 0
+                         , xOffset = 0
                          }
                        )
                      , ( "b"
                        , { totalHeight = bStartingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          , zIndex = 0
+                         , xOffset = 0
                          }
                        )
                      ]
@@ -230,12 +235,14 @@ getLabelPositionsSpec =
                             -- A is positioned on top of B.
                             startingHeight + defaultArrowHeight + balloonOffset
                          , zIndex = 1
+                         , xOffset = 0
                          }
                        )
                      , ( "b"
                        , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          , zIndex = 2
+                         , xOffset = 0
                          }
                        )
                      , ( "c"
@@ -244,6 +251,7 @@ getLabelPositionsSpec =
                             -- C is positioned on top of A.
                             2 * startingHeight + defaultArrowHeight + 2 * balloonOffset
                          , zIndex = 0
+                         , xOffset = 0
                          }
                        )
                      ]
@@ -283,6 +291,7 @@ getLabelPositionsSpec =
                          { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          , zIndex = 0
+                         , xOffset = 0
                          }
                        )
                      , -- B is positioned under C
@@ -290,6 +299,7 @@ getLabelPositionsSpec =
                        , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          , zIndex = 1
+                         , xOffset = 0
                          }
                        )
                      , -- C is positioned over B
@@ -297,6 +307,7 @@ getLabelPositionsSpec =
                        , { totalHeight = 2 * startingHeight + defaultArrowHeight + balloonOffset
                          , arrowHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
                          , zIndex = 0
+                         , xOffset = 0
                          }
                        )
                      ]
@@ -336,10 +347,10 @@ getLabelPositionsSpec =
                     |> Dict.fromList
                 )
                 |> Expect.equal
-                    ([ ( "prepositionId", { arrowHeight = 8, totalHeight = 32, zIndex = 1 } )
-                     , ( "directObjectId", { arrowHeight = 36, totalHeight = 60, zIndex = 0 } )
-                     , ( "subjectId", { arrowHeight = 8, totalHeight = 32, zIndex = 0 } )
-                     , ( "editorsNoteId", { arrowHeight = 8, totalHeight = 32, zIndex = 0 } )
+                    ([ ( "prepositionId", { arrowHeight = 8, totalHeight = 32, zIndex = 1, xOffset = 0 } )
+                     , ( "directObjectId", { arrowHeight = 36, totalHeight = 60, zIndex = 0, xOffset = 0 } )
+                     , ( "subjectId", { arrowHeight = 8, totalHeight = 32, zIndex = 0, xOffset = 0 } )
+                     , ( "editorsNoteId", { arrowHeight = 8, totalHeight = 32, zIndex = 0, xOffset = 0 } )
                      ]
                         |> Dict.fromList
                     )
@@ -368,12 +379,14 @@ getLabelPositionsSpec =
                        , { totalHeight = startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          , zIndex = 0
+                         , xOffset = 0
                          }
                        )
                      , ( "b"
                        , { totalHeight = startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          , zIndex = 0
+                         , xOffset = 0
                          }
                        )
                      ]
@@ -415,12 +428,14 @@ getLabelPositionsSpec =
                             -- So its arrow height is the total height of b minus the positioning offset
                             startingHeight + defaultArrowHeight + balloonOffset
                          , zIndex = 0
+                         , xOffset = 0
                          }
                        )
                      , ( "b"
                        , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          , zIndex = 1
+                         , xOffset = 0
                          }
                        )
                      , ( "c"
@@ -429,6 +444,7 @@ getLabelPositionsSpec =
                             -- C is on a new line, so it goes back to default positioning.
                             defaultArrowHeight
                          , zIndex = 0
+                         , xOffset = 0
                          }
                        )
                      ]
@@ -467,18 +483,73 @@ getLabelPositionsSpec =
                        , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          , zIndex = 0
+                         , xOffset = 0
                          }
                        )
                      , ( "b"
                        , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          , zIndex = 0
+                         , xOffset = 0
                          }
                        )
                      , ( "c"
                        , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          , zIndex = 0
+                         , xOffset = 0
+                         }
+                       )
+                     ]
+                        |> Dict.fromList
+                    )
+    , test "when a label extends horizontally outside the viewport to the left" <|
+        \() ->
+            let
+                width =
+                    300
+
+                x =
+                    10
+            in
+            Block.getLabelPositions
+                (Dict.singleton "a"
+                    { label = dummyElement { x = x, y = 0, width = width, height = 100 }
+                    , labelContent = dummyElement { x = x, y = 0, width = width, height = 100 }
+                    }
+                )
+                |> Expect.equal
+                    ([ ( "a"
+                       , { arrowHeight = 8
+                         , totalHeight = 108
+                         , zIndex = 0
+                         , xOffset = width / 2 - x
+                         }
+                       )
+                     ]
+                        |> Dict.fromList
+                    )
+    , test "when a label extends horizontally outside the viewport to the right" <|
+        \() ->
+            let
+                width =
+                    300
+
+                x =
+                    viewportWidth
+            in
+            Block.getLabelPositions
+                (Dict.singleton "a"
+                    { label = dummyElement { x = x, y = 0, width = width, height = 100 }
+                    , labelContent = dummyElement { x = x, y = 0, width = width, height = 100 }
+                    }
+                )
+                |> Expect.equal
+                    ([ ( "a"
+                       , { arrowHeight = 8
+                         , totalHeight = 108
+                         , zIndex = 0
+                         , xOffset = -width / 2
                          }
                        )
                      ]
@@ -500,6 +571,11 @@ defaultArrowHeight =
 dummyElement : { x : Float, y : Float, width : Float, height : Float } -> Element
 dummyElement element =
     { scene = { width = 1000, height = 1000 }
-    , viewport = { x = 0, y = 0, width = 1000, height = 500 }
+    , viewport = { x = 0, y = 0, width = viewportWidth, height = 500 }
     , element = element
     }
+
+
+viewportWidth : Float
+viewportWidth =
+    1000

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -510,7 +510,7 @@ getLabelPositionsSpec =
                     300
 
                 x =
-                    10
+                    -150
             in
             Block.getLabelPositions
                 (Dict.singleton "a"
@@ -523,7 +523,7 @@ getLabelPositionsSpec =
                        , { arrowHeight = 8
                          , totalHeight = 108
                          , zIndex = 0
-                         , xOffset = width / 2 - x
+                         , xOffset = 150
                          }
                        )
                      ]
@@ -536,7 +536,7 @@ getLabelPositionsSpec =
                     300
 
                 x =
-                    viewportWidth
+                    viewportWidth - 10
             in
             Block.getLabelPositions
                 (Dict.singleton "a"
@@ -549,7 +549,7 @@ getLabelPositionsSpec =
                        , { arrowHeight = 8
                          , totalHeight = 108
                          , zIndex = 0
-                         , xOffset = -width / 2
+                         , xOffset = -290
                          }
                        )
                      ]

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -115,7 +115,7 @@ getLabelPositionsSpec =
                 )
                 |> Expect.equal
                     (Dict.singleton "a"
-                        { totalHeight = startingHeight + defaultArrowHeight + balloonOffset
+                        { totalHeight = startingHeight + defaultArrowHeight
                         , arrowHeight = defaultArrowHeight
                         }
                     )
@@ -146,13 +146,13 @@ getLabelPositionsSpec =
                 )
                 |> Expect.equal
                     ([ ( "a"
-                       , { totalHeight = aStartingHeight + defaultArrowHeight + balloonOffset
+                       , { totalHeight = aStartingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          }
                        )
                      , ( "b"
                        , { totalHeight = aStartingHeight + bStartingHeight + defaultArrowHeight + balloonOffset
-                         , arrowHeight = aStartingHeight + defaultArrowHeight
+                         , arrowHeight = aStartingHeight + defaultArrowHeight + balloonOffset
                          }
                        )
                      ]
@@ -191,12 +191,12 @@ getLabelPositionsSpec =
                 )
                 |> Expect.equal
                     ([ ( "a"
-                       , { totalHeight = aStartingHeight + defaultArrowHeight + balloonOffset
+                       , { totalHeight = aStartingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          }
                        )
                      , ( "b"
-                       , { totalHeight = bStartingHeight + defaultArrowHeight + balloonOffset
+                       , { totalHeight = bStartingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          }
                        )
@@ -236,21 +236,19 @@ getLabelPositionsSpec =
                        , { totalHeight = 2 * startingHeight + defaultArrowHeight + balloonOffset
                          , arrowHeight =
                             -- A is positioned on top of B.
-                            -- So its arrow height is the total height of b minus the positioning offset
-                            startingHeight + defaultArrowHeight
+                            startingHeight + defaultArrowHeight + balloonOffset
                          }
                        )
                      , ( "b"
-                       , { totalHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                       , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          }
                        )
                      , ( "c"
-                       , { totalHeight = 3 * startingHeight + defaultArrowHeight + balloonOffset
+                       , { totalHeight = 3 * startingHeight + defaultArrowHeight + 2 * balloonOffset
                          , arrowHeight =
                             -- C is positioned on top of A.
-                            -- So its arrow height is the total height of A minus the positioning offset
-                            2 * startingHeight + defaultArrowHeight
+                            2 * startingHeight + defaultArrowHeight + 2 * balloonOffset
                          }
                        )
                      ]
@@ -287,20 +285,20 @@ getLabelPositionsSpec =
                 |> Expect.equal
                     ([ ( "a"
                        , -- A is positioned in its default position.
-                         { totalHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                         { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          }
                        )
                      , -- B is positioned under C
                        ( "b"
-                       , { totalHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                       , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          }
                        )
                      , -- C is positioned over B
                        ( "c"
                        , { totalHeight = 2 * startingHeight + defaultArrowHeight + balloonOffset
-                         , arrowHeight = 1 * startingHeight + defaultArrowHeight
+                         , arrowHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
                          }
                        )
                      ]
@@ -340,10 +338,10 @@ getLabelPositionsSpec =
                     |> Dict.fromList
                 )
                 |> Expect.equal
-                    ([ ( "prepositionId", { arrowHeight = 8, totalHeight = 40 } )
-                     , ( "directObjectId", { arrowHeight = 32, totalHeight = 64 } )
-                     , ( "subjectId", { arrowHeight = 8, totalHeight = 40 } )
-                     , ( "editorsNoteId", { arrowHeight = 8, totalHeight = 40 } )
+                    ([ ( "prepositionId", { arrowHeight = 8, totalHeight = 32 } )
+                     , ( "directObjectId", { arrowHeight = 36, totalHeight = 60 } )
+                     , ( "subjectId", { arrowHeight = 8, totalHeight = 32 } )
+                     , ( "editorsNoteId", { arrowHeight = 8, totalHeight = 32 } )
                      ]
                         |> Dict.fromList
                     )
@@ -369,12 +367,12 @@ getLabelPositionsSpec =
                 )
                 |> Expect.equal
                     ([ ( "a"
-                       , { totalHeight = startingHeight + defaultArrowHeight + balloonOffset
+                       , { totalHeight = startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          }
                        )
                      , ( "b"
-                       , { totalHeight = startingHeight + defaultArrowHeight + balloonOffset
+                       , { totalHeight = startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          }
                        )
@@ -415,16 +413,16 @@ getLabelPositionsSpec =
                          , arrowHeight =
                             -- A is positioned on top of B.
                             -- So its arrow height is the total height of b minus the positioning offset
-                            startingHeight + defaultArrowHeight
+                            startingHeight + defaultArrowHeight + balloonOffset
                          }
                        )
                      , ( "b"
-                       , { totalHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                       , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          }
                        )
                      , ( "c"
-                       , { totalHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                       , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight =
                             -- C is on a new line, so it goes back to default positioning.
                             defaultArrowHeight
@@ -463,17 +461,17 @@ getLabelPositionsSpec =
                 )
                 |> Expect.equal
                     ([ ( "a"
-                       , { totalHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                       , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          }
                        )
                      , ( "b"
-                       , { totalHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                       , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          }
                        )
                      , ( "c"
-                       , { totalHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                       , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
                          }
                        )
@@ -485,7 +483,7 @@ getLabelPositionsSpec =
 
 balloonOffset : Float
 balloonOffset =
-    8
+    4
 
 
 defaultArrowHeight : Float

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -5,7 +5,7 @@ import Dict
 import Expect
 import Html.Attributes as Attributes
 import Html.Styled
-import Nri.Ui.Block.V1 as Block
+import Nri.Ui.Block.V2 as Block
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector
@@ -13,7 +13,7 @@ import Test.Html.Selector as Selector
 
 spec : Test
 spec =
-    describe "Nri.Ui.Block.V1"
+    describe "Nri.Ui.Block.V2"
         [ describe "content" contentSpec
         , describe "id" idSpec
         , describe "getLabelHeights" getLabelHeightsSpec

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -104,6 +104,7 @@ getLabelPositionsSpec =
                     (Dict.singleton "a"
                         { totalHeight = startingHeight + defaultArrowHeight
                         , arrowHeight = defaultArrowHeight
+                        , zIndex = 0
                         }
                     )
     , test "with different height measurements, prevents overlaps" <|
@@ -135,11 +136,13 @@ getLabelPositionsSpec =
                     ([ ( "a"
                        , { totalHeight = aStartingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
+                         , zIndex = 1
                          }
                        )
                      , ( "b"
                        , { totalHeight = aStartingHeight + bStartingHeight + defaultArrowHeight + balloonOffset
                          , arrowHeight = aStartingHeight + defaultArrowHeight + balloonOffset
+                         , zIndex = 0
                          }
                        )
                      ]
@@ -180,11 +183,13 @@ getLabelPositionsSpec =
                     ([ ( "a"
                        , { totalHeight = aStartingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
+                         , zIndex = 0
                          }
                        )
                      , ( "b"
                        , { totalHeight = bStartingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
+                         , zIndex = 0
                          }
                        )
                      ]
@@ -224,11 +229,13 @@ getLabelPositionsSpec =
                          , arrowHeight =
                             -- A is positioned on top of B.
                             startingHeight + defaultArrowHeight + balloonOffset
+                         , zIndex = 1
                          }
                        )
                      , ( "b"
                        , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
+                         , zIndex = 2
                          }
                        )
                      , ( "c"
@@ -236,6 +243,7 @@ getLabelPositionsSpec =
                          , arrowHeight =
                             -- C is positioned on top of A.
                             2 * startingHeight + defaultArrowHeight + 2 * balloonOffset
+                         , zIndex = 0
                          }
                        )
                      ]
@@ -274,18 +282,21 @@ getLabelPositionsSpec =
                        , -- A is positioned in its default position.
                          { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
+                         , zIndex = 0
                          }
                        )
                      , -- B is positioned under C
                        ( "b"
                        , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
+                         , zIndex = 1
                          }
                        )
                      , -- C is positioned over B
                        ( "c"
                        , { totalHeight = 2 * startingHeight + defaultArrowHeight + balloonOffset
                          , arrowHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                         , zIndex = 0
                          }
                        )
                      ]
@@ -325,10 +336,10 @@ getLabelPositionsSpec =
                     |> Dict.fromList
                 )
                 |> Expect.equal
-                    ([ ( "prepositionId", { arrowHeight = 8, totalHeight = 32 } )
-                     , ( "directObjectId", { arrowHeight = 36, totalHeight = 60 } )
-                     , ( "subjectId", { arrowHeight = 8, totalHeight = 32 } )
-                     , ( "editorsNoteId", { arrowHeight = 8, totalHeight = 32 } )
+                    ([ ( "prepositionId", { arrowHeight = 8, totalHeight = 32, zIndex = 1 } )
+                     , ( "directObjectId", { arrowHeight = 36, totalHeight = 60, zIndex = 0 } )
+                     , ( "subjectId", { arrowHeight = 8, totalHeight = 32, zIndex = 0 } )
+                     , ( "editorsNoteId", { arrowHeight = 8, totalHeight = 32, zIndex = 0 } )
                      ]
                         |> Dict.fromList
                     )
@@ -356,11 +367,13 @@ getLabelPositionsSpec =
                     ([ ( "a"
                        , { totalHeight = startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
+                         , zIndex = 0
                          }
                        )
                      , ( "b"
                        , { totalHeight = startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
+                         , zIndex = 0
                          }
                        )
                      ]
@@ -401,11 +414,13 @@ getLabelPositionsSpec =
                             -- A is positioned on top of B.
                             -- So its arrow height is the total height of b minus the positioning offset
                             startingHeight + defaultArrowHeight + balloonOffset
+                         , zIndex = 0
                          }
                        )
                      , ( "b"
                        , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
+                         , zIndex = 1
                          }
                        )
                      , ( "c"
@@ -413,6 +428,7 @@ getLabelPositionsSpec =
                          , arrowHeight =
                             -- C is on a new line, so it goes back to default positioning.
                             defaultArrowHeight
+                         , zIndex = 0
                          }
                        )
                      ]
@@ -450,16 +466,19 @@ getLabelPositionsSpec =
                     ([ ( "a"
                        , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
+                         , zIndex = 0
                          }
                        )
                      , ( "b"
                        , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
+                         , zIndex = 0
                          }
                        )
                      , ( "c"
                        , { totalHeight = 1 * startingHeight + defaultArrowHeight
                          , arrowHeight = defaultArrowHeight
+                         , zIndex = 0
                          }
                        )
                      ]

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -16,7 +16,7 @@ spec =
     describe "Nri.Ui.Block.V2"
         [ describe "content" contentSpec
         , describe "labelId" labelIdSpec
-        , describe "getLabelHeights" getLabelHeightsSpec
+        , describe "getLabelPositions" getLabelPositionsSpec
         ]
 
 
@@ -82,19 +82,19 @@ toQuery block =
         |> Query.fromHtml
 
 
-getLabelHeightsSpec : List Test
-getLabelHeightsSpec =
+getLabelPositionsSpec : List Test
+getLabelPositionsSpec =
     [ test "without any ids or measurements, does not specify heights" <|
         \() ->
-            Block.getLabelHeights [] Dict.empty
+            Block.getLabelPositions [] Dict.empty
                 |> Expect.equal Dict.empty
     , test "without any measurements, does not specify heights" <|
         \() ->
-            Block.getLabelHeights [ "a" ] Dict.empty
+            Block.getLabelPositions [ "a" ] Dict.empty
                 |> Expect.equal Dict.empty
     , test "without any ids, does not specify heights" <|
         \() ->
-            Block.getLabelHeights []
+            Block.getLabelPositions []
                 (Dict.singleton "a"
                     { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = 20 }
@@ -107,7 +107,7 @@ getLabelHeightsSpec =
                 startingHeight =
                     20
             in
-            Block.getLabelHeights [ "a" ]
+            Block.getLabelPositions [ "a" ]
                 (Dict.singleton "a"
                     { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
                     , labelContent = dummyElement { x = 0, y = 0, width = 100, height = startingHeight }
@@ -128,7 +128,7 @@ getLabelHeightsSpec =
                 bStartingHeight =
                     30
             in
-            Block.getLabelHeights [ "a", "b", "c" ]
+            Block.getLabelPositions [ "a", "b", "c" ]
                 ([ --  A has taller content
                    ( "a"
                    , { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
@@ -173,7 +173,7 @@ getLabelHeightsSpec =
                 bX =
                     aWidth + 1
             in
-            Block.getLabelHeights [ "a", "b", "c" ]
+            Block.getLabelPositions [ "a", "b", "c" ]
                 ([ --  A has taller content
                    ( "a"
                    , { label = dummyElement { x = 0, y = 0, width = aWidth, height = 100 }
@@ -209,7 +209,7 @@ getLabelHeightsSpec =
                 startingHeight =
                     20
             in
-            Block.getLabelHeights [ "a", "b", "c" ]
+            Block.getLabelPositions [ "a", "b", "c" ]
                 ([ --  A is the second-widest element
                    ( "a"
                    , { label = dummyElement { x = 0, y = 0, width = 200, height = 100 }
@@ -262,7 +262,7 @@ getLabelHeightsSpec =
                 startingHeight =
                     20
             in
-            Block.getLabelHeights [ "a", "b", "c" ]
+            Block.getLabelPositions [ "a", "b", "c" ]
                 ([ --  A is the second-widest element, but doesn't overlap any other labels
                    ( "a"
                    , { label = dummyElement { x = 500, y = 0, width = 200, height = 100 }
@@ -315,7 +315,7 @@ getLabelHeightsSpec =
                     , element = element
                     }
             in
-            Block.getLabelHeights [ "subjectId", "directObjectId", "prepositionId", "editorsNoteId" ]
+            Block.getLabelPositions [ "subjectId", "directObjectId", "prepositionId", "editorsNoteId" ]
                 ([ ( "subjectId"
                    , { label = withElement { x = 56.8828125, y = 883, width = 63.515625, height = 32 }
                      , labelContent = withElement { x = 56.8828125, y = 883, width = 63.515625, height = 24 }
@@ -353,7 +353,7 @@ getLabelHeightsSpec =
                 startingHeight =
                     20
             in
-            Block.getLabelHeights [ "a", "b" ]
+            Block.getLabelPositions [ "a", "b" ]
                 ([ ( "a"
                    , { label = dummyElement { x = 0, y = 0, width = 100, height = 100 }
                      , labelContent = dummyElement { x = 0, y = 0, width = 100, height = startingHeight }
@@ -387,7 +387,7 @@ getLabelHeightsSpec =
                 startingHeight =
                     20
             in
-            Block.getLabelHeights [ "a", "b", "c" ]
+            Block.getLabelPositions [ "a", "b", "c" ]
                 ([ --  A is the second-widest element
                    ( "a"
                    , { label = dummyElement { x = 0, y = 0, width = 200, height = 100 }
@@ -439,7 +439,7 @@ getLabelHeightsSpec =
                 startingHeight =
                     20
             in
-            Block.getLabelHeights [ "a", "b", "c" ]
+            Block.getLabelPositions [ "a", "b", "c" ]
                 ([ --  A is the second-widest element
                    ( "a"
                    , { label = dummyElement { x = 0, y = 0, width = 200, height = 100 }

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -35,9 +35,9 @@ contentSpec =
                     [ Query.hasNot [ Selector.text "blank" ]
                     , Query.has [ Selector.text "Yo" ]
                     ]
-    , test "content with string and blank" <|
+    , test "content with phrase and blank" <|
         \() ->
-            [ Block.content [ Block.string "Yo", Block.blank ] ]
+            [ Block.content (Block.phrase "Yo hello" ++ [ Block.blank ]) ]
                 |> toQuery
                 |> Query.has [ Selector.text "Yo", Selector.text "blank" ]
     ]

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -15,7 +15,7 @@ spec : Test
 spec =
     describe "Nri.Ui.Block.V2"
         [ describe "content" contentSpec
-        , describe "id" idSpec
+        , describe "labelId" labelIdSpec
         , describe "getLabelHeights" getLabelHeightsSpec
         ]
 
@@ -43,17 +43,31 @@ contentSpec =
     ]
 
 
-idSpec : List Test
-idSpec =
-    [ test "a single word with an id" <|
+labelIdSpec : List Test
+labelIdSpec =
+    [ test "an unemphasized word with a labelId" <|
         \() ->
-            [ Block.plaintext "Yo", Block.id "yo-id" ]
+            [ Block.plaintext "Yo"
+            , Block.labelId "yo-id"
+            ]
+                |> toQuery
+                |> Query.findAll [ Selector.attribute (Attributes.id "yo-id") ]
+                |> Query.count (Expect.equal 0)
+    , test "a single emphasized word with a labelId" <|
+        \() ->
+            [ Block.plaintext "Yo"
+            , Block.labelId "yo-id"
+            , Block.label "label content"
+            ]
                 |> toQuery
                 |> Query.findAll [ Selector.attribute (Attributes.id "yo-id") ]
                 |> Query.count (Expect.equal 1)
-    , test "multiple words with an id" <|
+    , test "emphasized phrase with an id" <|
         \() ->
-            [ Block.plaintext "Yo yo yo", Block.id "yo-id" ]
+            [ Block.plaintext "Yo yo yo"
+            , Block.labelId "yo-id"
+            , Block.label "label content"
+            ]
                 |> toQuery
                 |> Query.findAll [ Selector.attribute (Attributes.id "yo-id") ]
                 |> Query.count (Expect.equal 1)

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -3,6 +3,7 @@ module Spec.Nri.Ui.Block exposing (spec)
 import Browser.Dom exposing (Element)
 import Dict
 import Expect
+import Html.Attributes as Attributes
 import Html.Styled
 import Nri.Ui.Block.V1 as Block
 import Test exposing (..)
@@ -14,6 +15,7 @@ spec : Test
 spec =
     describe "Nri.Ui.Block.V1"
         [ describe "content" contentSpec
+        , describe "id" idSpec
         , describe "getLabelHeights" getLabelHeightsSpec
         ]
 
@@ -38,6 +40,23 @@ contentSpec =
             [ Block.content [ Block.string "Yo", Block.blank ] ]
                 |> toQuery
                 |> Query.has [ Selector.text "Yo", Selector.text "blank" ]
+    ]
+
+
+idSpec : List Test
+idSpec =
+    [ test "a single word with an id" <|
+        \() ->
+            [ Block.plaintext "Yo", Block.id "yo-id" ]
+                |> toQuery
+                |> Query.findAll [ Selector.attribute (Attributes.id "yo-id") ]
+                |> Query.count (Expect.equal 1)
+    , test "multiple words with an id" <|
+        \() ->
+            [ Block.plaintext "Yo yo yo", Block.id "yo-id" ]
+                |> toQuery
+                |> Query.findAll [ Selector.attribute (Attributes.id "yo-id") ]
+                |> Query.count (Expect.equal 1)
     ]
 
 

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -125,7 +125,52 @@ getLabelHeightsSpec =
                      ]
                         |> Dict.fromList
                     )
-    , test "with multiple ids and measurements, positions wider elements above narrower elements" <|
+    , test "with different height measurements but no overlaps, keeps labels in normal position" <|
+        \() ->
+            let
+                aStartingHeight =
+                    40
+
+                bStartingHeight =
+                    30
+
+                aWidth =
+                    100
+
+                bX =
+                    aWidth + 1
+            in
+            Block.getLabelHeights [ "a", "b", "c" ]
+                ([ --  A has taller content
+                   ( "a"
+                   , { label = dummyElement { x = 0, y = 0, width = aWidth, height = 100 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = aWidth, height = aStartingHeight }
+                     }
+                   )
+                 , -- B has shorter content
+                   ( "b"
+                   , { label = dummyElement { x = bX, y = 0, width = 200, height = 100 }
+                     , labelContent = dummyElement { x = bX, y = 0, width = 100, height = bStartingHeight }
+                     }
+                   )
+                 ]
+                    |> Dict.fromList
+                )
+                |> Expect.equal
+                    ([ ( "a"
+                       , { totalHeight = aStartingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight = defaultArrowHeight
+                         }
+                       )
+                     , ( "b"
+                       , { totalHeight = bStartingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight = defaultArrowHeight
+                         }
+                       )
+                     ]
+                        |> Dict.fromList
+                    )
+    , test "with multiple ids and measurements, positions overlapping wider elements above narrower elements" <|
         \() ->
             let
                 startingHeight =
@@ -178,7 +223,57 @@ getLabelHeightsSpec =
                      ]
                         |> Dict.fromList
                     )
-    , test "with labels on different lines, specifies the default heights" <|
+    , test "with multiple ids and measurements, positions non-overlapping elements in default positions" <|
+        \() ->
+            let
+                startingHeight =
+                    20
+            in
+            Block.getLabelHeights [ "a", "b", "c" ]
+                ([ --  A is the second-widest element, but doesn't overlap any other labels
+                   ( "a"
+                   , { label = dummyElement { x = 500, y = 0, width = 200, height = 100 }
+                     , labelContent = dummyElement { x = 500, y = 0, width = 200, height = startingHeight }
+                     }
+                   )
+                 , -- B is the narrowest element and it overlaps C
+                   ( "b"
+                   , { label = dummyElement { x = 10, y = 0, width = 100, height = 100 }
+                     , labelContent = dummyElement { x = 10, y = 0, width = 100, height = startingHeight }
+                     }
+                   )
+                 , -- C is the widest element and it overlaps B
+                   ( "c"
+                   , { label = dummyElement { x = 0, y = 0, width = 300, height = 100 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 300, height = startingHeight }
+                     }
+                   )
+                 ]
+                    |> Dict.fromList
+                )
+                |> Expect.equal
+                    ([ ( "a"
+                       , -- A is positioned in its default position.
+                         { totalHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight = defaultArrowHeight
+                         }
+                       )
+                     , -- B is positioned under C
+                       ( "b"
+                       , { totalHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight = defaultArrowHeight
+                         }
+                       )
+                     , -- C is positioned over B
+                       ( "c"
+                       , { totalHeight = 2 * startingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight = 1 * startingHeight + defaultArrowHeight
+                         }
+                       )
+                     ]
+                        |> Dict.fromList
+                    )
+    , test "with overlapping labels on different lines, specifies the default heights" <|
         \() ->
             let
                 startingHeight =
@@ -212,7 +307,7 @@ getLabelHeightsSpec =
                      ]
                         |> Dict.fromList
                     )
-    , test "with multiple ids and measurements on different lines, positions elements correctly" <|
+    , test "with multiple overlapping labels on different lines, positions elements correctly" <|
         \() ->
             let
                 startingHeight =
@@ -259,6 +354,53 @@ getLabelHeightsSpec =
                          , arrowHeight =
                             -- C is on a new line, so it goes back to default positioning.
                             defaultArrowHeight
+                         }
+                       )
+                     ]
+                        |> Dict.fromList
+                    )
+    , test "with multiple non-overlapping labels on different lines, positions elements correctly" <|
+        \() ->
+            let
+                startingHeight =
+                    20
+            in
+            Block.getLabelHeights [ "a", "b", "c" ]
+                ([ --  A is the second-widest element
+                   ( "a"
+                   , { label = dummyElement { x = 0, y = 0, width = 200, height = 100 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 200, height = startingHeight }
+                     }
+                   )
+                 , -- B is the narrowest element
+                   ( "b"
+                   , { label = dummyElement { x = 201, y = 0, width = 100, height = 100 }
+                     , labelContent = dummyElement { x = 201, y = 0, width = 100, height = startingHeight }
+                     }
+                   )
+                 , -- C is the widest element and it is also on a new line by itself
+                   ( "c"
+                   , { label = dummyElement { x = 0, y = 20, width = 300, height = 100 }
+                     , labelContent = dummyElement { x = 0, y = 0, width = 300, height = startingHeight }
+                     }
+                   )
+                 ]
+                    |> Dict.fromList
+                )
+                |> Expect.equal
+                    ([ ( "a"
+                       , { totalHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight = defaultArrowHeight
+                         }
+                       )
+                     , ( "b"
+                       , { totalHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight = defaultArrowHeight
+                         }
+                       )
+                     , ( "c"
+                       , { totalHeight = 1 * startingHeight + defaultArrowHeight + balloonOffset
+                         , arrowHeight = defaultArrowHeight
                          }
                        )
                      ]

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -273,6 +273,47 @@ getLabelHeightsSpec =
                      ]
                         |> Dict.fromList
                     )
+    , test "styleguide example regression test: 3 labels on 1 line, with 1 overlap to resolve" <|
+        \() ->
+            let
+                withElement element =
+                    { scene = { width = 497, height = 1974 }
+                    , viewport = { x = 0, y = 733, width = 497, height = 373 }
+                    , element = element
+                    }
+            in
+            Block.getLabelHeights [ "subjectId", "directObjectId", "prepositionId", "editorsNoteId" ]
+                ([ ( "subjectId"
+                   , { label = withElement { x = 56.8828125, y = 883, width = 63.515625, height = 32 }
+                     , labelContent = withElement { x = 56.8828125, y = 883, width = 63.515625, height = 24 }
+                     }
+                   )
+                 , ( "directObjectId"
+                   , { label = withElement { x = 241.03515625, y = 883, width = 98.6171875, height = 32 }
+                     , labelContent = withElement { x = 241.03515625, y = 883, width = 98.6171875, height = 24 }
+                     }
+                   )
+                 , ( "prepositionId"
+                   , { label = withElement { x = 330.55859375, y = 883, width = 91.2109375, height = 32 }
+                     , labelContent = withElement { x = 330.55859375, y = 883, width = 91.2109375, height = 24 }
+                     }
+                   )
+                 , ( "editorsNoteId"
+                   , { label = withElement { x = 269.20703125, y = 973.5, width = 100.0859375, height = 32 }
+                     , labelContent = withElement { x = 269.20703125, y = 973.5, width = 100.0859375, height = 24 }
+                     }
+                   )
+                 ]
+                    |> Dict.fromList
+                )
+                |> Expect.equal
+                    ([ ( "prepositionId", { arrowHeight = 8, totalHeight = 40 } )
+                     , ( "directObjectId", { arrowHeight = 32, totalHeight = 64 } )
+                     , ( "subjectId", { arrowHeight = 8, totalHeight = 40 } )
+                     , ( "editorsNoteId", { arrowHeight = 8, totalHeight = 40 } )
+                     ]
+                        |> Dict.fromList
+                    )
     , test "with overlapping labels on different lines, specifies the default heights" <|
         \() ->
             let

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -43,6 +43,7 @@
         "Nri.Ui.Loading.V1",
         "Nri.Ui.Logo.V1",
         "Nri.Ui.Mark.V1",
+        "Nri.Ui.Mark.V2",
         "Nri.Ui.MasteryIcon.V1",
         "Nri.Ui.MediaQuery.V1",
         "Nri.Ui.Menu.V3",

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -10,6 +10,7 @@
         "Nri.Ui.Balloon.V1",
         "Nri.Ui.Balloon.V2",
         "Nri.Ui.Block.V1",
+        "Nri.Ui.Block.V2",
         "Nri.Ui.BreadCrumbs.V2",
         "Nri.Ui.Button.V10",
         "Nri.Ui.Carousel.V1",


### PR DESCRIPTION
Fixes A11-2112

- ensures that the vertically-lower labels are always positioned on top of the higher labels
- ensures that labels do not get cut-off by the viewport on the left or the right

<img width="1514" alt="Screen Shot 2022-12-20 at 12 50 46 PM" src="https://user-images.githubusercontent.com/8811312/208754868-9604803d-dc9b-4856-bc86-1381b937ea11.png">
<img width="497" alt="Screen Shot 2022-12-20 at 12 51 47 PM" src="https://user-images.githubusercontent.com/8811312/208754879-022ae189-5734-4a2f-b122-295a26783346.png">
<img width="629" alt="Screen Shot 2022-12-20 at 12 51 25 PM" src="https://user-images.githubusercontent.com/8811312/208754881-b0f59b2f-ab08-4389-975d-fcd81dc71fdf.png">

cc @NoRedInk/design 
