### PR TITLE
Adjustable labeled blank block themes

### DIFF
--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -237,6 +237,7 @@ xOffset { element, viewport } =
 type Content
     = String_ String
     | Blank
+    | FullHeightBlank
 
 
 parseString : String -> List Content
@@ -258,7 +259,16 @@ renderContent config content_ markStyles =
                 [ text str ]
 
             Blank ->
-                [ viewBlank [] { class = Nothing } ]
+                [ viewBlank [ Css.lineHeight (Css.int 1) ] { class = Nothing } ]
+
+            FullHeightBlank ->
+                [ viewBlank
+                    [ Css.paddingTop topBottomSpace
+                    , Css.paddingBottom topBottomSpace
+                    , Css.lineHeight Css.initial
+                    ]
+                    { class = Nothing }
+                ]
         )
 
 
@@ -498,7 +508,7 @@ render config =
                         , labelId = config.labelId
                         , labelContentId = Maybe.map labelContentId config.labelId
                         }
-                        [ Blank ]
+                        [ FullHeightBlank ]
 
                 Nothing ->
                     [ viewBlank
@@ -533,7 +543,6 @@ viewBlank styles config =
             , Css.minWidth (Css.px 80)
             , Css.display Css.inlineBlock
             , Css.borderRadius (Css.px 4)
-            , Css.lineHeight (Css.int 1)
             , Css.batch styles
             ]
         , AttributesExtra.maybe Attributes.class config.class

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -331,13 +331,20 @@ example =
                             , Block.view [ Block.plaintext " being used." ]
                             ]
                   }
-                , { pattern = Code.fromModule moduleName "view " ++ Code.list [ Code.fromModule moduleName "label " ++ Code.string "[label text]" ]
+                , { pattern =
+                        Code.fromModule moduleName "view "
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "label " ++ Code.string "[label text]"
+                                , Code.fromModule moduleName "purple"
+                                ]
+                                1
                   , description = "**Labeled blank block**\n\nA labelled blank in the sentence"
                   , example =
                         inParagraph
                             [ Block.view [ Block.plaintext "If a volcano is extinct, " ]
                             , Block.view
                                 [ Block.label "pronoun"
+                                , Block.purple
                                 , Block.labelId pronounId
                                 , Block.labelPosition (Dict.get pronounId offsets)
                                 ]

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -36,7 +36,7 @@ moduleName =
 
 version : Int
 version =
-    1
+    2
 
 
 {-| -}


### PR DESCRIPTION
Fixes A11-2096

https://user-images.githubusercontent.com/8811312/208780742-53bc4be7-fea5-4820-a3ad-e55acc97ac81.mov

| Code  | Before | After |
| ------------- | ------------- |------------- |
| `Block.view [ Block.emphasize ]`  | <img width="102" alt="image" src="https://user-images.githubusercontent.com/8811312/208780995-23861994-69a7-4171-892c-f5438442995f.png">   | <img width="96" alt="image" src="https://user-images.githubusercontent.com/8811312/208780936-6713e932-c72e-4f6c-b467-44c5f1d6f3a8.png">
| `Block.view [ Block.label "Fruit", Block.cyan ]`  |  <img width="101" alt="Screen Shot 2022-12-20 at 3 47 11 PM" src="https://user-images.githubusercontent.com/8811312/208781215-60ddf938-dfa1-4a52-9008-2a6dec7b7075.png"> | <img width="92" alt="Screen Shot 2022-12-20 at 3 46 53 PM" src="https://user-images.githubusercontent.com/8811312/208781214-0e44da5d-7d9c-4298-b7ca-34db7f3d230a.png"> |

Essentially this change means that it will be more difficult to wrap a Blank with the emphasis styles. You will still be able to use `Block.content []...` to nest a blank in the highlighted styles.

cc @NoRedInk/design 