### PR TITLE
Question box  -- positioning wrt the viewport edges

### DIFF
--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -60,6 +60,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (nriDescription)
 import Nri.Ui.Mark.V2 as Mark exposing (Mark)
 import Nri.Ui.MediaQuery.V1 as MediaQuery
+import Position exposing (xOffsetPx)
 
 
 {-|
@@ -176,7 +177,7 @@ getLabelPositions labelMeasurementsById =
                               , { totalHeight = height + e.labelContent.element.height
                                 , arrowHeight = height
                                 , zIndex = maxRowIndex - index
-                                , xOffset = xOffset e.label
+                                , xOffset = xOffsetPx e.label
                                 }
                               )
                                 :: acc
@@ -204,7 +205,7 @@ splitByOverlaps =
             -- consider the elements from left to right
             (groupWithSort (\( _, a ) -> a.label.element.x)
                 (\( _, a ) ( _, b ) ->
-                    (a.label.element.x + xOffset a.label + a.label.element.width) >= (b.label.element.x + xOffset b.label)
+                    (a.label.element.x + xOffsetPx a.label + a.label.element.width) >= (b.label.element.x + xOffsetPx b.label)
                 )
             )
 
@@ -214,29 +215,6 @@ groupWithSort sortBy groupBy =
     List.sortBy sortBy
         >> List.Extra.groupWhile groupBy
         >> List.map (\( first, rem ) -> first :: rem)
-
-
-xOffset : Dom.Element -> Float
-xOffset { element, viewport } =
-    let
-        xMax =
-            viewport.x + viewport.width
-    in
-    -- if the element is cut off by the viewport on the left side,
-    -- we need to adjust rightward by the cut-off amount
-    if element.x < viewport.x then
-        viewport.x - element.x
-
-    else
-    -- if the element is cut off by the viewport on the right side,
-    -- we need to adjust leftward by the cut-off amount
-    if
-        xMax < (element.x + element.width)
-    then
-        xMax - (element.x + element.width)
-
-    else
-        0
 
 
 

--- a/src/Nri/Ui/Mark/V2.elm
+++ b/src/Nri/Ui/Mark/V2.elm
@@ -331,6 +331,7 @@ viewBalloon config label =
 
                 Nothing ->
                     Css.batch []
+            , Css.border3 (Css.px 2) Css.solid Colors.greenDark
             ]
         , Balloon.css
             [ Css.padding3 Css.zero (Css.px 6) (Css.px 1)

--- a/src/Nri/Ui/Mark/V2.elm
+++ b/src/Nri/Ui/Mark/V2.elm
@@ -331,7 +331,6 @@ viewBalloon config label =
 
                 Nothing ->
                     Css.batch []
-            , Css.border3 (Css.px 2) Css.solid Colors.greenDark
             ]
         , Balloon.css
             [ Css.padding3 Css.zero (Css.px 6) (Css.px 1)

--- a/src/Nri/Ui/QuestionBox/V2.elm
+++ b/src/Nri/Ui/QuestionBox/V2.elm
@@ -158,7 +158,7 @@ viewPointingTo config content element =
                 |> Maybe.withDefault 0
     in
     span
-        [ css (Css.position Css.relative :: config.containerCss)
+        [ css [ Css.position Css.relative ]
         , nriDescription "pointing-to-container"
         ]
         (List.append
@@ -182,6 +182,7 @@ viewPointingTo config content element =
                         ]
                     , Css.minWidth (Css.px 300)
                     , Css.textAlign Css.center
+                    , Css.batch config.containerCss
                     , Css.border3 (Css.px 2) Css.solid Colors.red
                     ]
                 , Balloon.css <|

--- a/src/Nri/Ui/QuestionBox/V2.elm
+++ b/src/Nri/Ui/QuestionBox/V2.elm
@@ -26,6 +26,7 @@ import Nri.Ui.CharacterIcon.V1 as CharacterIcon
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (nriDescription)
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
+import Position exposing (xOffsetPx)
 
 
 {-| -}
@@ -149,6 +150,11 @@ viewStandalone config =
 {-| -}
 viewPointingTo : Config msg -> List (Html msg) -> Maybe Element -> Html msg
 viewPointingTo config content element =
+    let
+        xOffset =
+            Maybe.map xOffsetPx element
+                |> Maybe.withDefault 0
+    in
     span
         [ css (Css.position Css.relative :: config.containerCss)
         , nriDescription "pointing-to-container"
@@ -169,6 +175,13 @@ viewPointingTo config content element =
                 [ viewBalloon config
                     [ Balloon.onBottom
                     , Balloon.nriDescription "pointing-to-balloon"
+                    , Balloon.css <|
+                        if xOffset /= 0 then
+                            [ Css.property "transform" ("translateX(" ++ String.fromFloat xOffset ++ "px)")
+                            ]
+
+                        else
+                            []
                     ]
                 ]
             ]

--- a/src/Nri/Ui/QuestionBox/V2.elm
+++ b/src/Nri/Ui/QuestionBox/V2.elm
@@ -163,28 +163,34 @@ viewPointingTo config content element =
         ]
         (List.append
             content
-            [ div
-                [ AttributesExtra.maybe Attributes.id config.id
-                , css
+            [ viewBalloon config
+                [ Balloon.onBottom
+                , Balloon.nriDescription "pointing-to-balloon"
+                , case config.id of
+                    Just id_ ->
+                        Balloon.id id_
+
+                    Nothing ->
+                        Balloon.css []
+                , Balloon.containerCss
                     [ Css.position Css.absolute
                     , Css.top (Css.pct 100)
                     , Css.left (Css.pct 50)
-                    , Css.transform (Css.translateX (Css.pct -50))
+                    , Css.transforms
+                        [ Css.translateX (Css.pct -50)
+                        , Css.translateY (Css.px 8)
+                        ]
                     , Css.minWidth (Css.px 300)
                     , Css.textAlign Css.center
+                    , Css.border3 (Css.px 2) Css.solid Colors.red
                     ]
-                ]
-                [ viewBalloon config
-                    [ Balloon.onBottom
-                    , Balloon.nriDescription "pointing-to-balloon"
-                    , Balloon.css <|
-                        if xOffset /= 0 then
-                            [ Css.property "transform" ("translateX(" ++ String.fromFloat xOffset ++ "px)")
-                            ]
+                , Balloon.css <|
+                    if xOffset /= 0 then
+                        [ Css.property "transform" ("translateX(" ++ String.fromFloat xOffset ++ "px)")
+                        ]
 
-                        else
-                            []
-                    ]
+                    else
+                        []
                 ]
             ]
         )

--- a/src/Nri/Ui/QuestionBox/V2.elm
+++ b/src/Nri/Ui/QuestionBox/V2.elm
@@ -15,6 +15,7 @@ module Nri.Ui.QuestionBox.V2 exposing
 
 -}
 
+import Browser.Dom exposing (Element)
 import Css
 import Css.Global
 import Html.Styled exposing (..)
@@ -90,7 +91,7 @@ setType type_ =
 
 type QuestionBoxType msg
     = Standalone
-    | PointingTo (List (Html msg))
+    | PointingTo (List (Html msg)) (Maybe Element)
 
 
 {-| This is the default type of question box. It doesn't have a programmatic or direct visual relationship to any piece of content.
@@ -105,9 +106,9 @@ standalone =
 Typically, you would use this type of `QuestionBox` type with a `Block`.
 
 -}
-pointingTo : List (Html msg) -> Attribute msg
-pointingTo =
-    setType << PointingTo
+pointingTo : List (Html msg) -> Maybe Element -> Attribute msg
+pointingTo content element =
+    setType (PointingTo content element)
 
 
 {-|
@@ -127,8 +128,8 @@ view attributes =
         Standalone ->
             viewStandalone config
 
-        PointingTo content ->
-            viewPointingTo config content
+        PointingTo content element ->
+            viewPointingTo config content element
 
 
 {-| -}
@@ -146,8 +147,8 @@ viewStandalone config =
 
 
 {-| -}
-viewPointingTo : Config msg -> List (Html msg) -> Html msg
-viewPointingTo config content =
+viewPointingTo : Config msg -> List (Html msg) -> Maybe Element -> Html msg
+viewPointingTo config content element =
     span
         [ css (Css.position Css.relative :: config.containerCss)
         , nriDescription "pointing-to-container"

--- a/src/Nri/Ui/QuestionBox/V2.elm
+++ b/src/Nri/Ui/QuestionBox/V2.elm
@@ -183,7 +183,6 @@ viewPointingTo config content element =
                     , Css.minWidth (Css.px 300)
                     , Css.textAlign Css.center
                     , Css.batch config.containerCss
-                    , Css.border3 (Css.px 2) Css.solid Colors.red
                     ]
                 , Balloon.css <|
                     if xOffset /= 0 then

--- a/src/Nri/Ui/QuestionBox/V2.elm
+++ b/src/Nri/Ui/QuestionBox/V2.elm
@@ -106,6 +106,8 @@ standalone =
 
 Typically, you would use this type of `QuestionBox` type with a `Block`.
 
+You will need to pass a measurement, taken using Dom.Browser, in order for the question box to be positioned correctly horizontally so that it doesn't get cut off by the viewport.
+
 -}
 pointingTo : List (Html msg) -> Maybe Element -> Attribute msg
 pointingTo content element =

--- a/src/Position.elm
+++ b/src/Position.elm
@@ -1,0 +1,33 @@
+module Position exposing (xOffsetPx)
+
+{-| -}
+
+import Browser.Dom as Dom
+
+
+{-| Figure out how much an element needs to shift along the horizontal axis in order to not be cut off by the viewport.
+
+Uses Brower.Dom's Element measurement.
+
+-}
+xOffsetPx : Dom.Element -> Float
+xOffsetPx { element, viewport } =
+    let
+        xMax =
+            viewport.x + viewport.width
+    in
+    -- if the element is cut off by the viewport on the left side,
+    -- we need to adjust rightward by the cut-off amount
+    if element.x < viewport.x then
+        viewport.x - element.x
+
+    else
+    -- if the element is cut off by the viewport on the right side,
+    -- we need to adjust leftward by the cut-off amount
+    if
+        xMax < (element.x + element.width)
+    then
+        xMax - (element.x + element.width)
+
+    else
+        0

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -11,6 +11,7 @@ import Category exposing (Category(..))
 import Code
 import CommonControls
 import Css
+import Css.Global
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
@@ -97,7 +98,10 @@ example =
                 offsets =
                     Block.getLabelPositions state.labelMeasurementsById
             in
-            [ ControlView.view
+            [ -- absolutely positioned elements that overflow in the x direction
+              -- cause a horizontal scrollbar unless you explicitly hide overflowing x content
+              Css.Global.global [ Css.Global.selector "body" [ Css.overflowX Css.hidden ] ]
+            , ControlView.view
                 { ellieLinkConfig = ellieLinkConfig
                 , name = moduleName
                 , version = version

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -133,7 +133,7 @@ view ellieLinkConfig state =
                         ]
                     )
                     (Dict.get "left-viewport-question-box-example" state.questionBoxMeasurementsById)
-                , QuestionBox.markdown "Is ”the“ an article?"
+                , QuestionBox.markdown "Articles are important to get right! Is “the” an article?"
                 , QuestionBox.actions
                     [ { label = "Yes", onClick = NoOp }
                     , { label = "No", onClick = NoOp }
@@ -161,6 +161,29 @@ view ellieLinkConfig state =
             , Block.labelId "warning-label-id"
             , Block.labelPosition (Dict.get "warning-label-id" offsets)
             ]
+        ]
+    , inParagraph
+        [ Block.view [ Block.plaintext "You also need to be careful with content that can get cut off on the right side of the viewport" ]
+        , [ QuestionBox.view
+                [ QuestionBox.id "right-viewport-question-box-example"
+                , QuestionBox.pointingTo
+                    (Block.view
+                        [ Block.plaintext "!"
+                        , Block.label "warning"
+                        , Block.brown
+                        , Block.labelId "warning-2-label-id"
+                        , Block.labelPosition (Dict.get "warning-2-label-id" offsets)
+                        , Block.bottomSpacingPx (getBottomSpacingFor "right-viewport-question-box-example")
+                        ]
+                    )
+                    (Dict.get "right-viewport-question-box-example" state.questionBoxMeasurementsById)
+                , QuestionBox.markdown "Were you careful? It's important to be careful!"
+                , QuestionBox.actions
+                    [ { label = "Yes", onClick = NoOp }
+                    , { label = "No", onClick = NoOp }
+                    ]
+                ]
+          ]
         ]
     , Table.view
         [ Table.string
@@ -521,6 +544,7 @@ update msg state =
                     , "article-label-id"
                     , "tricky-label-id"
                     , "warning-label-id"
+                    , "warning-2-label-id"
                     ]
                     ++ List.map measureQuestionBox
                         [ "question-box-1"
@@ -529,6 +553,7 @@ update msg state =
                         , "question-box-4"
                         , "question-box-5"
                         , "left-viewport-question-box-example"
+                        , "right-viewport-question-box-example"
                         ]
                 )
             )

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -11,6 +11,7 @@ import Category exposing (Category(..))
 import Code
 import CommonControls
 import Css
+import Css.Global
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
@@ -74,7 +75,10 @@ view ellieLinkConfig state =
             Dict.get id state.questionBoxMeasurementsById
                 |> Maybe.map (.element >> .height)
     in
-    [ ControlView.view
+    [ -- absolutely positioned elements that overflow in the x direction
+      -- cause a horizontal scrollbar unless you explicitly hide overflowing x content
+      Css.Global.global [ Css.Global.selector "body" [ Css.overflowX Css.hidden ] ]
+    , ControlView.view
         { ellieLinkConfig = ellieLinkConfig
         , name = moduleName
         , version = version

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -66,6 +66,13 @@ view ellieLinkConfig state =
             , QuestionBox.id interactiveExampleId
             )
                 :: Control.currentValue state.attributes
+
+        offsets =
+            Block.getLabelPositions state.labelMeasurementsById
+
+        getBottomSpacingFor id =
+            Dict.get id state.questionBoxMeasurementsById
+                |> Maybe.map (.element >> .height)
     in
     [ ControlView.view
         { ellieLinkConfig = ellieLinkConfig
@@ -110,23 +117,51 @@ view ellieLinkConfig state =
         ]
     , Text.caption
         [ Text.plaintext "Click \"Measure & render\" to reposition the noninteractive examples' labels and question boxes to avoid overlaps given the current viewport."
-        , Text.css [ Css.marginBottom Spacing.verticalSpacerPx |> Css.important ]
+        , Text.css [ Css.marginBottom (Css.px 80) |> Css.important ]
         ]
-    , viewExamplesTable state
-    ]
-
-
-viewExamplesTable : State -> Html Msg
-viewExamplesTable state =
-    let
-        offsets =
-            Block.getLabelPositions state.labelMeasurementsById
-
-        getBottomSpacingFor id =
-            Dict.get id state.questionBoxMeasurementsById
-                |> Maybe.map (.element >> .height)
-    in
-    Table.view
+    , inParagraph
+        [ [ QuestionBox.view
+                [ QuestionBox.id "left-viewport-question-box-example"
+                , QuestionBox.pointingTo
+                    (Block.view
+                        [ Block.plaintext "A"
+                        , Block.magenta
+                        , Block.label "this is an article. \"An\" is also an article."
+                        , Block.labelId "article-label-id"
+                        , Block.labelPosition (Dict.get "article-label-id" offsets)
+                        , Block.bottomSpacingPx (getBottomSpacingFor "left-viewport-question-box-example")
+                        ]
+                    )
+                , QuestionBox.markdown "Is ”the“ an article?"
+                , QuestionBox.actions
+                    [ { label = "Yes", onClick = NoOp }
+                    , { label = "No", onClick = NoOp }
+                    ]
+                ]
+          ]
+        , Block.view [ Block.plaintext " " ]
+        , Block.view
+            [ Block.plaintext "tricky"
+            , Block.label "this is an adjective"
+            , Block.yellow
+            , Block.labelId "tricky-label-id"
+            , Block.labelPosition (Dict.get "tricky-label-id" offsets)
+            ]
+        , Block.view [ Block.plaintext " " ]
+        , Block.view
+            [ Block.plaintext "example"
+            , Block.cyan
+            ]
+        , Block.view [ Block.plaintext ". Be sure to be " ]
+        , Block.view
+            [ Block.plaintext "careful with content that can get cut off on the left side of the viewport!"
+            , Block.label "warning"
+            , Block.green
+            , Block.labelId "warning-label-id"
+            , Block.labelPosition (Dict.get "warning-label-id" offsets)
+            ]
+        ]
+    , Table.view
         [ Table.string
             { header = "QuestionBox type"
             , value = .pattern
@@ -302,6 +337,7 @@ viewExamplesTable state =
                     ]
           }
         ]
+    ]
 
 
 inParagraph : List (List (Html msg)) -> Html msg
@@ -476,6 +512,9 @@ update msg state =
                     , "label-3"
                     , "label-4"
                     , "label-5"
+                    , "article-label-id"
+                    , "tricky-label-id"
+                    , "warning-label-id"
                     ]
                     ++ List.map measureQuestionBox
                         [ "question-box-1"
@@ -483,6 +522,7 @@ update msg state =
                         , "question-box-3"
                         , "question-box-4"
                         , "question-box-5"
+                        , "left-viewport-question-box-example"
                         ]
                 )
             )

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -132,6 +132,7 @@ view ellieLinkConfig state =
                         , Block.bottomSpacingPx (getBottomSpacingFor "left-viewport-question-box-example")
                         ]
                     )
+                    (Dict.get "left-viewport-question-box-example" state.questionBoxMeasurementsById)
                 , QuestionBox.markdown "Is ”the“ an article?"
                 , QuestionBox.actions
                     [ { label = "Yes", onClick = NoOp }
@@ -212,6 +213,7 @@ view ellieLinkConfig state =
                                     , Block.bottomSpacingPx (getBottomSpacingFor "question-box-1")
                                     ]
                                 )
+                                (Dict.get "question-box-1" state.questionBoxMeasurementsById)
                             , QuestionBox.markdown "“Above” is a preposition."
                             , QuestionBox.actions [ { label = "Try again", onClick = NoOp } ]
                             ]
@@ -236,6 +238,7 @@ view ellieLinkConfig state =
                                     , Block.yellow
                                     ]
                                 )
+                                (Dict.get "question-box-2" state.questionBoxMeasurementsById)
                             , QuestionBox.markdown "Which word is the preposition?"
                             , QuestionBox.actions
                                 [ { label = "above", onClick = NoOp }
@@ -265,6 +268,7 @@ view ellieLinkConfig state =
                                     [ Block.bottomSpacingPx (getBottomSpacingFor "question-box-3")
                                     ]
                                 )
+                                (Dict.get "question-box-3" state.questionBoxMeasurementsById)
                             , QuestionBox.markdown "Which verb matches the subject?"
                             , QuestionBox.actions
                                 [ { label = "wrap", onClick = NoOp }
@@ -298,6 +302,7 @@ view ellieLinkConfig state =
                                     , Block.cyan
                                     ]
                                 )
+                                (Dict.get "question-box-4" state.questionBoxMeasurementsById)
                             , QuestionBox.markdown "What did he do?"
                             , QuestionBox.actions
                                 [ { label = "scared", onClick = NoOp }
@@ -325,6 +330,7 @@ view ellieLinkConfig state =
                                     , Block.bottomSpacingPx (getBottomSpacingFor "question-box-5")
                                     ]
                                 )
+                                (Dict.get "question-box-5" state.questionBoxMeasurementsById)
                             , QuestionBox.markdown "What did he do?"
                             , QuestionBox.actions
                                 [ { label = "scared", onClick = NoOp }
@@ -444,7 +450,7 @@ initAttributes =
             )
         |> ControlExtra.optionalListItem "type"
             (CommonControls.choice moduleName
-                [ ( "pointingTo []", QuestionBox.pointingTo [ anchor ] )
+                [ ( "pointingTo [] Nothing", QuestionBox.pointingTo [ anchor ] Nothing )
                 , ( "standalone", QuestionBox.standalone )
                 ]
             )


### PR DESCRIPTION
Fixes A11-2118

https://user-images.githubusercontent.com/8811312/208976916-29959b4b-f432-4c08-a045-2837c263a431.mov

## Left edge
<img width="403" alt="Screen Shot 2022-12-21 at 11 25 14 AM" src="https://user-images.githubusercontent.com/8811312/208977062-ab71c0a3-789a-45b4-b7f6-c5a01ca52c56.png">

## Right edge

I am not certain I can reasonably account for the character width when repositioning -- I think panda may just have to get cut off on the edge. Or he could sit all the way inside the question box? It didn't seem worth solving for right now, given that the character design may not be final.

<img width="387" alt="Screen Shot 2022-12-21 at 11 25 19 AM" src="https://user-images.githubusercontent.com/8811312/208977059-9e34943f-9e36-486a-9501-8c4a46a417ec.png">

cc @NoRedInk/design 