### PR TITLE
Allow more flexible QuestionBox anchors

### DIFF
--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -85,6 +85,20 @@ describe("UI tests", function () {
     await callback(option);
   };
 
+  const questionBoxProcessing = async (name, location) => {
+    await goTo(name, location);
+
+    const [button] = await page.$x("//button[contains(., 'Measure & render')]");
+    await button.click();
+
+    await percySnapshot(page, name);
+
+    const results = await new AxePuppeteer(page)
+      .disableRules(skippedRules[name] || [])
+      .analyze();
+    handleAxeResults(name, results);
+  };
+
   const messageProcessing = async (name, location) => {
     await goTo(name, location);
     await percySnapshot(page, name);
@@ -160,6 +174,7 @@ describe("UI tests", function () {
   };
 
   const specialProcessing = {
+    QuestionBox: questionBoxProcessing,
     Message: messageProcessing,
     Modal: modalProcessing,
     Page: pageProcessing,

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -12,7 +12,6 @@ module Nri.Ui.Block.V2 exposing
     , bottomSpacingPx
     , yellow, cyan, magenta, green, blue, purple, brown
     , withQuestionBox
-    , class
     )
 
 {-|
@@ -54,11 +53,6 @@ You will need these helpers if you want to prevent label overlaps. (Which is to 
 ### Add a question box
 
 @docs withQuestionBox
-
-
-### Possibly deprecated???
-
-@docs class
 
 -}
 
@@ -250,7 +244,7 @@ parseString =
 
 
 renderContent :
-    { config | class : Maybe String, bottomSpacingPx : Maybe Float }
+    { config | bottomSpacingPx : Maybe Float }
     -> Content msg
     -> List Css.Style
     -> Html msg
@@ -273,7 +267,6 @@ renderContent config content_ markStyles =
                 :: markStyles
             )
         , nriDescription "block-segment-container"
-        , AttributesExtra.maybe Attributes.class config.class
         ]
         (case content_ of
             Word [] str ->
@@ -285,10 +278,7 @@ renderContent config content_ markStyles =
                 ]
 
             Blank questionBoxAttributes ->
-                [ viewBlank
-                    [ Css.lineHeight (Css.int 1)
-                    ]
-                    { class = Nothing }
+                [ viewBlank [ Css.lineHeight (Css.int 1) ]
                     questionBoxAttributes
                 ]
 
@@ -298,7 +288,6 @@ renderContent config content_ markStyles =
                     , Css.paddingBottom topBottomSpace
                     , Css.lineHeight Css.initial
                     ]
-                    { class = Nothing }
                     []
                 ]
         )
@@ -504,12 +493,6 @@ brown =
 
 
 {-| -}
-class : String -> Attribute msg
-class class_ =
-    Attribute (\config -> { config | class = Just class_ })
-
-
-{-| -}
 labelId : String -> Attribute msg
 labelId id_ =
     Attribute (\config -> { config | labelId = Just id_ })
@@ -538,7 +521,6 @@ defaultConfig =
     , labelPosition = Nothing
     , theme = Yellow
     , emphasize = False
-    , class = Nothing
     , bottomSpacingPx = Nothing
     , questionBox = []
     }
@@ -551,7 +533,6 @@ type alias Config msg =
     , labelPosition : Maybe LabelPosition
     , theme : Theme
     , emphasize : Bool
-    , class : Maybe String
     , bottomSpacingPx : Maybe Float
     , questionBox : List (QuestionBox.Attribute msg)
     }
@@ -589,10 +570,9 @@ render config =
 
 viewBlank :
     List Css.Style
-    -> { config | class : Maybe String }
     -> List (QuestionBox.Attribute msg)
     -> Html msg
-viewBlank styles config questionBoxAttributes =
+viewBlank styles questionBoxAttributes =
     span
         [ css
             [ Css.border3 (Css.px 2) Css.dashed Colors.navy
@@ -611,7 +591,6 @@ viewBlank styles config questionBoxAttributes =
                 Css.position Css.relative
             , Css.batch styles
             ]
-        , AttributesExtra.maybe Attributes.class config.class
         ]
         (case questionBoxAttributes of
             x :: _ ->

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -358,10 +358,33 @@ type alias Palette =
     { backgroundColor : Color, borderColor : Color }
 
 
-toMark : { config | emphasize : Bool, label : Maybe String } -> Palette -> Maybe Mark
+toMark :
+    { config
+        | emphasize : Bool
+        , label : Maybe String
+        , content : List (Content msg)
+    }
+    -> Palette
+    -> Maybe Mark
 toMark config { backgroundColor, borderColor } =
-    case ( config.label, config.emphasize ) of
-        ( _, True ) ->
+    case ( config.label, config.content, config.emphasize ) of
+        ( Just l, FullHeightBlank :: [], _ ) ->
+            Just
+                { name = Just l
+                , startStyles = []
+                , styles = []
+                , endStyles = []
+                }
+
+        ( Just l, _, False ) ->
+            Just
+                { name = Just l
+                , startStyles = []
+                , styles = []
+                , endStyles = []
+                }
+
+        ( _, _, True ) ->
             let
                 borderWidth =
                     Css.px 1
@@ -393,15 +416,7 @@ toMark config { backgroundColor, borderColor } =
                     ]
                 }
 
-        ( Just l, False ) ->
-            Just
-                { name = Just l
-                , startStyles = []
-                , styles = []
-                , endStyles = []
-                }
-
-        ( Nothing, False ) ->
+        ( Nothing, _, False ) ->
             Nothing
 
 
@@ -481,7 +496,7 @@ type Attribute msg
 
 defaultConfig : Config msg
 defaultConfig =
-    { content = []
+    { content = [ FullHeightBlank ]
     , label = Nothing
     , labelId = Nothing
     , labelPosition = Nothing
@@ -517,40 +532,15 @@ render config =
     in
     span
         [ css [ Css.position Css.relative ] ]
-        ((case config.content of
-            [] ->
-                Mark.viewWithBalloonTags
-                    { renderSegment = renderContent config
-                    , backgroundColor = palette.backgroundColor
-                    , maybeMarker =
-                        case maybeMark of
-                            Just _ ->
-                                Just
-                                    { name = config.label
-                                    , startStyles = []
-                                    , styles = []
-                                    , endStyles = []
-                                    }
-
-                            Nothing ->
-                                Nothing
-                    , labelPosition = config.labelPosition
-                    , labelId = config.labelId
-                    , labelContentId = Maybe.map labelContentId config.labelId
-                    }
-                    [ FullHeightBlank ]
-
-            _ ->
-                Mark.viewWithBalloonTags
-                    { renderSegment = renderContent config
-                    , backgroundColor = palette.backgroundColor
-                    , maybeMarker = maybeMark
-                    , labelPosition = config.labelPosition
-                    , labelId = config.labelId
-                    , labelContentId = Maybe.map labelContentId config.labelId
-                    }
-                    config.content
-         )
+        (Mark.viewWithBalloonTags
+            { renderSegment = renderContent config
+            , backgroundColor = palette.backgroundColor
+            , maybeMarker = maybeMark
+            , labelPosition = config.labelPosition
+            , labelId = config.labelId
+            , labelContentId = Maybe.map labelContentId config.labelId
+            }
+            config.content
             ++ (case config.questionBox of
                     [] ->
                         []

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -1,7 +1,8 @@
 module Nri.Ui.Block.V2 exposing
     ( view, Attribute
     , plaintext, content
-    , Content, phrase, blank
+    , Content, phrase
+    , blank, blankWithQuestionBox
     , emphasize
     , label
     , labelId, labelContentId
@@ -20,7 +21,8 @@ module Nri.Ui.Block.V2 exposing
 ## Content
 
 @docs plaintext, content
-@docs Content, phrase, blank
+@docs Content, phrase
+@docs blank, blankWithQuestionBox
 
 
 ## Content customization
@@ -231,7 +233,7 @@ groupWithSort sortBy groupBy =
 {-| -}
 type Content msg
     = String_ String
-    | Blank
+    | Blank (List (QuestionBox.Attribute msg))
     | FullHeightBlank
 
 
@@ -267,12 +269,12 @@ renderContent config content_ markStyles =
             String_ str ->
                 [ text str ]
 
-            Blank ->
+            Blank questionBoxAttributes ->
                 [ viewBlank
                     [ Css.lineHeight (Css.int 1)
                     ]
                     { class = Nothing }
-                    []
+                    questionBoxAttributes
                 ]
 
             FullHeightBlank ->
@@ -297,6 +299,13 @@ phrase =
 -}
 blank : Content msg
 blank =
+    Blank []
+
+
+{-| You will only need to use this helper if you're also using `content` to construct a more complex Block. For a less complex blank Block, don't include content or plaintext in the list of attributes.
+-}
+blankWithQuestionBox : List (QuestionBox.Attribute msg) -> Content msg
+blankWithQuestionBox =
     Blank
 
 

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -521,38 +521,26 @@ render config =
     in
     case config.content of
         [] ->
-            case maybeMark of
-                Just mark ->
-                    Mark.viewWithBalloonTags
-                        { renderSegment = renderContent config
-                        , backgroundColor = palette.backgroundColor
-                        , maybeMarker =
+            Mark.viewWithBalloonTags
+                { renderSegment = renderContent config
+                , backgroundColor = palette.backgroundColor
+                , maybeMarker =
+                    case maybeMark of
+                        Just _ ->
                             Just
                                 { name = config.label
                                 , startStyles = []
                                 , styles = []
                                 , endStyles = []
                                 }
-                        , labelPosition = config.labelPosition
-                        , labelId = config.labelId
-                        , labelContentId = Maybe.map labelContentId config.labelId
-                        }
-                        [ FullHeightBlank ]
 
-                Nothing ->
-                    [ viewBlank
-                        [ Css.paddingTop topBottomSpace
-                        , Css.paddingBottom topBottomSpace
-                        , case config.bottomSpacingPx of
-                            Just by ->
-                                Css.marginBottom (Css.px by)
-
-                            Nothing ->
-                                Css.batch []
-                        ]
-                        config
-                        maybeQuestionBox
-                    ]
+                        Nothing ->
+                            Nothing
+                , labelPosition = config.labelPosition
+                , labelId = config.labelId
+                , labelContentId = Maybe.map labelContentId config.labelId
+                }
+                [ FullHeightBlank ]
 
         _ ->
             Mark.viewWithBalloonTags

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -8,6 +8,7 @@ module Nri.Ui.Block.V2 exposing
     , LabelPosition, getLabelPositions, labelPosition
     , bottomSpacingPx
     , yellow, cyan, magenta, green, blue, purple, brown
+    , withQuestionBox
     , class
     )
 
@@ -44,7 +45,12 @@ You will need these helpers if you want to prevent label overlaps. (Which is to 
 @docs yellow, cyan, magenta, green, blue, purple, brown
 
 
-### General attributes
+### Add a question box
+
+@docs withQuestionBox
+
+
+### Possibly deprecated???
 
 @docs class
 
@@ -60,6 +66,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (nriDescription)
 import Nri.Ui.Mark.V2 as Mark exposing (Mark)
 import Nri.Ui.MediaQuery.V1 as MediaQuery
+import Nri.Ui.QuestionBox.V2 as QuestionBox
 import Position exposing (xOffsetPx)
 
 
@@ -68,7 +75,7 @@ import Position exposing (xOffsetPx)
     Block.view [ Block.plaintext "Hello, world!" ]
 
 -}
-view : List Attribute -> List (Html msg)
+view : List (Attribute msg) -> List (Html msg)
 view attributes =
     attributes
         |> List.foldl (\(Attribute attribute) b -> attribute b) defaultConfig
@@ -81,7 +88,7 @@ view attributes =
 
 {-| Provide the main content of the block as a plain-text string. You can also use `content` for more complex cases, including a blank appearing within an emphasis.
 -}
-plaintext : String -> Attribute
+plaintext : String -> Attribute msg
 plaintext content_ =
     Attribute <| \config -> { config | content = parseString content_ }
 
@@ -94,20 +101,20 @@ plaintext content_ =
         ]
 
 -}
-content : List Content -> Attribute
+content : List Content -> Attribute msg
 content content_ =
     Attribute <| \config -> { config | content = content_ }
 
 
 {-| Mark content as emphasized.
 -}
-emphasize : Attribute
+emphasize : Attribute msg
 emphasize =
     Attribute <| \config -> { config | emphasize = True }
 
 
 {-| -}
-label : String -> Attribute
+label : String -> Attribute msg
 label label_ =
     Attribute <| \config -> { config | label = Just label_, emphasize = True }
 
@@ -124,14 +131,14 @@ type alias LabelPosition =
 
 {-| Use `getLabelPositions` to calculate what these values should be.
 -}
-labelPosition : Maybe LabelPosition -> Attribute
+labelPosition : Maybe LabelPosition -> Attribute msg
 labelPosition offset =
     Attribute <| \config -> { config | labelPosition = offset }
 
 
 {-| When using a `QuestionBox` that is `pointingTo` a block, you may want to add bottom spacing to the block in order to avoid having the QuestionBox cover meaningful content.
 -}
-bottomSpacingPx : Maybe Float -> Attribute
+bottomSpacingPx : Maybe Float -> Attribute msg
 bottomSpacingPx offset =
     Attribute <| \config -> { config | bottomSpacingPx = offset }
 
@@ -398,57 +405,63 @@ topBottomSpace =
 
 
 {-| -}
-yellow : Attribute
+yellow : Attribute msg
 yellow =
     Attribute (\config -> { config | theme = Yellow })
 
 
 {-| -}
-cyan : Attribute
+cyan : Attribute msg
 cyan =
     Attribute (\config -> { config | theme = Cyan })
 
 
 {-| -}
-magenta : Attribute
+magenta : Attribute msg
 magenta =
     Attribute (\config -> { config | theme = Magenta })
 
 
 {-| -}
-green : Attribute
+green : Attribute msg
 green =
     Attribute (\config -> { config | theme = Green })
 
 
 {-| -}
-blue : Attribute
+blue : Attribute msg
 blue =
     Attribute (\config -> { config | theme = Blue })
 
 
 {-| -}
-purple : Attribute
+purple : Attribute msg
 purple =
     Attribute (\config -> { config | theme = Purple })
 
 
 {-| -}
-brown : Attribute
+brown : Attribute msg
 brown =
     Attribute (\config -> { config | theme = Brown })
 
 
 {-| -}
-class : String -> Attribute
+class : String -> Attribute msg
 class class_ =
     Attribute (\config -> { config | class = Just class_ })
 
 
 {-| -}
-labelId : String -> Attribute
+labelId : String -> Attribute msg
 labelId id_ =
     Attribute (\config -> { config | labelId = Just id_ })
+
+
+{-| -}
+withQuestionBox : List (QuestionBox.Attribute msg) -> Attribute msg
+withQuestionBox attributes =
+    Attribute (\config -> { config | questionBox = attributes })
 
 
 
@@ -456,11 +469,11 @@ labelId id_ =
 
 
 {-| -}
-type Attribute
-    = Attribute (Config -> Config)
+type Attribute msg
+    = Attribute (Config msg -> Config msg)
 
 
-defaultConfig : Config
+defaultConfig : Config msg
 defaultConfig =
     { content = []
     , label = Nothing
@@ -470,10 +483,11 @@ defaultConfig =
     , emphasize = False
     , class = Nothing
     , bottomSpacingPx = Nothing
+    , questionBox = []
     }
 
 
-type alias Config =
+type alias Config msg =
     { content : List Content
     , label : Maybe String
     , labelId : Maybe String
@@ -482,10 +496,11 @@ type alias Config =
     , emphasize : Bool
     , class : Maybe String
     , bottomSpacingPx : Maybe Float
+    , questionBox : List (QuestionBox.Attribute msg)
     }
 
 
-render : Config -> List (Html msg)
+render : Config msg -> List (Html msg)
 render config =
     let
         palette =

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -277,9 +277,12 @@ renderContent config content_ markStyles =
                 , QuestionBox.view questionBoxAttributes
                 ]
 
+            Blank [] ->
+                [ viewBlank [ Css.lineHeight (Css.int 1) ] ]
+
             Blank questionBoxAttributes ->
                 [ viewBlank [ Css.lineHeight (Css.int 1) ]
-                    questionBoxAttributes
+                , QuestionBox.view questionBoxAttributes
                 ]
 
             FullHeightBlank ->
@@ -288,7 +291,6 @@ renderContent config content_ markStyles =
                     , Css.paddingBottom topBottomSpace
                     , Css.lineHeight Css.initial
                     ]
-                    []
                 ]
         )
 
@@ -568,11 +570,8 @@ render config =
         )
 
 
-viewBlank :
-    List Css.Style
-    -> List (QuestionBox.Attribute msg)
-    -> Html msg
-viewBlank styles questionBoxAttributes =
+viewBlank : List Css.Style -> Html msg
+viewBlank styles =
     span
         [ css
             [ Css.border3 (Css.px 2) Css.dashed Colors.navy
@@ -584,23 +583,10 @@ viewBlank styles questionBoxAttributes =
             , Css.minWidth (Css.px 80)
             , Css.display Css.inlineBlock
             , Css.borderRadius (Css.px 4)
-            , if questionBoxAttributes == [] then
-                Css.batch []
-
-              else
-                Css.position Css.relative
             , Css.batch styles
             ]
         ]
-        (case questionBoxAttributes of
-            x :: _ ->
-                [ blankString
-                , QuestionBox.view questionBoxAttributes
-                ]
-
-            [] ->
-                [ blankString ]
-        )
+        [ blankString ]
 
 
 blankString : Html msg

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -1,7 +1,9 @@
 module Nri.Ui.Block.V2 exposing
     ( view, Attribute
-    , plaintext, content
-    , Content, phrase
+    , plaintext
+    , Content, content
+    , phrase, wordWithQuestionBox
+    , space
     , blank, blankWithQuestionBox
     , emphasize
     , label
@@ -20,8 +22,10 @@ module Nri.Ui.Block.V2 exposing
 
 ## Content
 
-@docs plaintext, content
-@docs Content, phrase
+@docs plaintext
+@docs Content, content
+@docs phrase, wordWithQuestionBox
+@docs space
 @docs blank, blankWithQuestionBox
 
 
@@ -232,7 +236,7 @@ groupWithSort sortBy groupBy =
 
 {-| -}
 type Content msg
-    = String_ String
+    = Word (List (QuestionBox.Attribute msg)) String
     | Blank (List (QuestionBox.Attribute msg))
     | FullHeightBlank
 
@@ -242,7 +246,7 @@ parseString =
     String.split " "
         >> List.intersperse " "
         >> List.filter (\str -> str /= "")
-        >> List.map String_
+        >> List.map (Word [])
 
 
 renderContent :
@@ -261,13 +265,24 @@ renderContent config content_ markStyles =
                     Css.batch []
     in
     span
-        [ css (Css.whiteSpace Css.preWrap :: Css.display Css.inlineBlock :: marginBottom :: markStyles)
+        [ css
+            (Css.whiteSpace Css.preWrap
+                :: Css.display Css.inlineBlock
+                :: Css.position Css.relative
+                :: marginBottom
+                :: markStyles
+            )
         , nriDescription "block-segment-container"
         , AttributesExtra.maybe Attributes.class config.class
         ]
         (case content_ of
-            String_ str ->
+            Word [] str ->
                 [ text str ]
+
+            Word questionBoxAttributes str ->
+                [ text str
+                , QuestionBox.view questionBoxAttributes
+                ]
 
             Blank questionBoxAttributes ->
                 [ viewBlank
@@ -293,6 +308,18 @@ renderContent config content_ markStyles =
 phrase : String -> List (Content msg)
 phrase =
     parseString
+
+
+{-| -}
+space : Content msg
+space =
+    Word [] " "
+
+
+{-| -}
+wordWithQuestionBox : String -> List (QuestionBox.Attribute msg) -> Content msg
+wordWithQuestionBox str attrs =
+    Word attrs str
 
 
 {-| You will only need to use this helper if you're also using `content` to construct a more complex Block. For a less complex blank Block, don't include content or plaintext in the list of attributes.

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -268,7 +268,7 @@ renderContent config content_ markStyles =
                 [ text str ]
 
             Blank ->
-                [ viewBlank [ Css.lineHeight (Css.int 1) ] { class = Nothing } ]
+                [ viewBlank [ Css.lineHeight (Css.int 1) ] { class = Nothing } Nothing ]
 
             FullHeightBlank ->
                 [ viewBlank
@@ -277,6 +277,7 @@ renderContent config content_ markStyles =
                     , Css.lineHeight Css.initial
                     ]
                     { class = Nothing }
+                    Nothing
                 ]
         )
 
@@ -508,6 +509,15 @@ render config =
 
         maybeMark =
             toMark config palette
+
+        maybeQuestionBox : Maybe (Html msg)
+        maybeQuestionBox =
+            case config.questionBox of
+                [] ->
+                    Nothing
+
+                _ ->
+                    Just (QuestionBox.view config.questionBox)
     in
     case config.content of
         [] ->
@@ -541,6 +551,7 @@ render config =
                                 Css.batch []
                         ]
                         config
+                        maybeQuestionBox
                     ]
 
         _ ->
@@ -555,8 +566,8 @@ render config =
                 config.content
 
 
-viewBlank : List Css.Style -> { config | class : Maybe String } -> Html msg
-viewBlank styles config =
+viewBlank : List Css.Style -> { config | class : Maybe String } -> Maybe (Html msg) -> Html msg
+viewBlank styles config maybeQuestionBox =
     span
         [ css
             [ Css.border3 (Css.px 2) Css.dashed Colors.navy
@@ -568,17 +579,31 @@ viewBlank styles config =
             , Css.minWidth (Css.px 80)
             , Css.display Css.inlineBlock
             , Css.borderRadius (Css.px 4)
+            , Maybe.map (\_ -> Css.position Css.relative) maybeQuestionBox
+                |> Maybe.withDefault (Css.batch [])
             , Css.batch styles
             ]
         , AttributesExtra.maybe Attributes.class config.class
         ]
-        [ span
-            [ css
-                [ Css.overflowX Css.hidden
-                , Css.width (Css.px 0)
-                , Css.display Css.inlineBlock
-                , Css.verticalAlign Css.bottom
+        (case maybeQuestionBox of
+            Just questionBox ->
+                [ blankString
+                , questionBox
                 ]
+
+            Nothing ->
+                [ blankString ]
+        )
+
+
+blankString : Html msg
+blankString =
+    span
+        [ css
+            [ Css.overflowX Css.hidden
+            , Css.width (Css.px 0)
+            , Css.display Css.inlineBlock
+            , Css.verticalAlign Css.bottom
             ]
-            [ text "blank" ]
         ]
+        [ text "blank" ]

--- a/src/Nri/Ui/Block/V2.elm
+++ b/src/Nri/Ui/Block/V2.elm
@@ -60,10 +60,10 @@ import Accessibility.Styled exposing (..)
 import Browser.Dom as Dom
 import Css exposing (Color)
 import Dict exposing (Dict)
-import Html.Styled.Attributes as Attributes exposing (css)
+import Html.Styled.Attributes exposing (css)
 import List.Extra
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (nriDescription)
+import Nri.Ui.Html.Attributes.V2 exposing (nriDescription)
 import Nri.Ui.Mark.V2 as Mark exposing (Mark)
 import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Nri.Ui.QuestionBox.V2 as QuestionBox

--- a/src/Nri/Ui/QuestionBox/V2.elm
+++ b/src/Nri/Ui/QuestionBox/V2.elm
@@ -92,7 +92,7 @@ setType type_ =
 
 type QuestionBoxType msg
     = Standalone
-    | PointingTo (List (Html msg)) (Maybe Element)
+    | PointingTo (Maybe Element)
 
 
 {-| This is the default type of question box. It doesn't have a programmatic or direct visual relationship to any piece of content.
@@ -102,16 +102,16 @@ standalone =
     setType Standalone
 
 
-{-| This type of `QuestionBox` has an arrow pointing to the relevant part of the question.
+{-| This type of `QuestionBox` is absolutely positioned & has an arrow pointing to its relatively positioned ancestor.
 
-Typically, you would use this type of `QuestionBox` type with a `Block`.
+Typically, you would use this type of `QuestionBox` type with a `Block` by way of `Block.withHtml`.
 
 You will need to pass a measurement, taken using Dom.Browser, in order for the question box to be positioned correctly horizontally so that it doesn't get cut off by the viewport.
 
 -}
-pointingTo : List (Html msg) -> Maybe Element -> Attribute msg
-pointingTo content element =
-    setType (PointingTo content element)
+pointingTo : Maybe Element -> Attribute msg
+pointingTo element =
+    setType (PointingTo element)
 
 
 {-|
@@ -131,8 +131,8 @@ view attributes =
         Standalone ->
             viewStandalone config
 
-        PointingTo content element ->
-            viewPointingTo config content element
+        PointingTo element ->
+            viewPointingTo config element
 
 
 {-| -}
@@ -150,50 +150,42 @@ viewStandalone config =
 
 
 {-| -}
-viewPointingTo : Config msg -> List (Html msg) -> Maybe Element -> Html msg
-viewPointingTo config content element =
+viewPointingTo : Config msg -> Maybe Element -> Html msg
+viewPointingTo config element =
     let
         xOffset =
             Maybe.map xOffsetPx element
                 |> Maybe.withDefault 0
     in
-    span
-        [ css [ Css.position Css.relative ]
-        , nriDescription "pointing-to-container"
-        ]
-        (List.append
-            content
-            [ viewBalloon config
-                [ Balloon.onBottom
-                , Balloon.nriDescription "pointing-to-balloon"
-                , case config.id of
-                    Just id_ ->
-                        Balloon.id id_
+    viewBalloon config
+        [ Balloon.onBottom
+        , Balloon.nriDescription "pointing-to-balloon"
+        , case config.id of
+            Just id_ ->
+                Balloon.id id_
 
-                    Nothing ->
-                        Balloon.css []
-                , Balloon.containerCss
-                    [ Css.position Css.absolute
-                    , Css.top (Css.pct 100)
-                    , Css.left (Css.pct 50)
-                    , Css.transforms
-                        [ Css.translateX (Css.pct -50)
-                        , Css.translateY (Css.px 8)
-                        ]
-                    , Css.minWidth (Css.px 300)
-                    , Css.textAlign Css.center
-                    , Css.batch config.containerCss
-                    ]
-                , Balloon.css <|
-                    if xOffset /= 0 then
-                        [ Css.property "transform" ("translateX(" ++ String.fromFloat xOffset ++ "px)")
-                        ]
-
-                    else
-                        []
+            Nothing ->
+                Balloon.css []
+        , Balloon.containerCss
+            [ Css.position Css.absolute
+            , Css.top (Css.pct 100)
+            , Css.left (Css.pct 50)
+            , Css.transforms
+                [ Css.translateX (Css.pct -50)
+                , Css.translateY (Css.px 8)
                 ]
+            , Css.minWidth (Css.px 300)
+            , Css.textAlign Css.center
+            , Css.batch config.containerCss
             ]
-        )
+        , Balloon.css <|
+            if xOffset /= 0 then
+                [ Css.property "transform" ("translateX(" ++ String.fromFloat xOffset ++ "px)")
+                ]
+
+            else
+                []
+        ]
 
 
 viewBalloon : Config msg -> List (Balloon.Attribute msg) -> Html msg

--- a/src/Nri/Ui/QuestionBox/V2.elm
+++ b/src/Nri/Ui/QuestionBox/V2.elm
@@ -222,6 +222,7 @@ viewGuidance withCharacter markdown_ =
                     [ Balloon.markdown markdown_
                     , Balloon.onLeft
                     , Balloon.alignArrowEnd
+                    , Balloon.css [ Css.minHeight (Css.px 46) ]
                     ]
                 ]
 

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -406,7 +406,7 @@ init =
 
 
 type alias Settings =
-    List ( String, Block.Attribute )
+    List ( String, Block.Attribute Msg )
 
 
 initControl : Control Settings
@@ -466,7 +466,7 @@ initControl =
             (CommonControls.string ( "class", Block.class ) "kiwis-are-good")
 
 
-controlContent : Control ( String, Block.Attribute )
+controlContent : Control ( String, Block.Attribute msg )
 controlContent =
     Control.choice
         [ ( "plaintext"

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -455,8 +455,6 @@ initControl =
             )
         |> ControlExtra.optionalListItem "labelId"
             (CommonControls.string ( Code.fromModule moduleName "labelId", Block.labelId ) "fruit-block")
-        |> ControlExtra.optionalListItem "class"
-            (CommonControls.string ( "class", Block.class ) "kiwis-are-good")
 
 
 controlContent : Control ( String, Block.Attribute msg )

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -76,7 +76,6 @@ example =
                 ]
           , Block.view [ Block.plaintext " it with ketchup." ]
           ]
-            |> List.concat
             |> p [ css [ Fonts.baseFont, Css.fontSize (Css.px 12), Css.margin Css.zero ] ]
         ]
     , view =
@@ -86,14 +85,13 @@ example =
                     Control.currentValue state.settings
 
                 inParagraph =
-                    List.concat
-                        >> p
-                            [ css
-                                [ Css.margin2 (Css.px 30) Css.zero
-                                , Fonts.quizFont
-                                , Css.fontSize (Css.px 30)
-                                ]
+                    p
+                        [ css
+                            [ Css.margin2 (Css.px 30) Css.zero
+                            , Fonts.quizFont
+                            , Css.fontSize (Css.px 30)
                             ]
+                        ]
 
                 offsets =
                     Block.getLabelPositions state.labelMeasurementsById
@@ -127,7 +125,6 @@ example =
               , Block.view (List.map Tuple.second attributes)
               , Block.view [ Block.plaintext " a lot!" ]
               ]
-                |> List.concat
                 |> p
                     [ css
                         [ Fonts.quizFont
@@ -156,32 +153,32 @@ example =
                     , Css.marginTop (Css.px 60)
                     ]
                 ]
-                ([ Block.view
+                [ Block.view
                     [ Block.plaintext "Superman"
                     , Block.magenta
                     , Block.label "subject"
                     , Block.labelId subjectId
                     , Block.labelPosition (Dict.get subjectId offsets)
                     ]
-                 , Block.view [ Block.plaintext " " ]
-                 , Block.view []
-                 , Block.view [ Block.plaintext " " ]
-                 , Block.view
+                , Block.view [ Block.plaintext " " ]
+                , Block.view []
+                , Block.view [ Block.plaintext " " ]
+                , Block.view
                     [ Block.plaintext "gifts"
                     , Block.label "direct object"
                     , Block.yellow
                     , Block.labelId directObjectId
                     , Block.labelPosition (Dict.get directObjectId offsets)
                     ]
-                 , Block.view [ Block.plaintext " " ]
-                 , Block.view
+                , Block.view [ Block.plaintext " " ]
+                , Block.view
                     [ Block.label "preposition"
                     , Block.cyan
                     , Block.labelId prepositionId
                     , Block.labelPosition (Dict.get prepositionId offsets)
                     ]
-                 , Block.view [ Block.plaintext " comic book pages. " ]
-                 , Block.view
+                , Block.view [ Block.plaintext " comic book pages. " ]
+                , Block.view
                     [ (List.concat >> Block.content)
                         [ Block.phrase "This is heroically generous "
                         , [ Block.blank ]
@@ -192,9 +189,7 @@ example =
                     , Block.labelId editorsNoteId
                     , Block.labelPosition (Dict.get editorsNoteId offsets)
                     ]
-                 ]
-                    |> List.concat
-                )
+                ]
             , p
                 [ css
                     [ Fonts.quizFont
@@ -202,47 +197,45 @@ example =
                     , Css.marginTop (Css.px 60)
                     ]
                 ]
-                ([ Block.view
+                [ Block.view
                     [ Block.plaintext "A"
                     , Block.magenta
                     , Block.label "this is an article. \"An\" is also an article."
                     , Block.labelId articleId
                     , Block.labelPosition (Dict.get articleId offsets)
                     ]
-                 , Block.view [ Block.plaintext " " ]
-                 , Block.view
+                , Block.view [ Block.plaintext " " ]
+                , Block.view
                     [ Block.plaintext "tricky"
                     , Block.label "this is an adjective"
                     , Block.yellow
                     , Block.labelId trickyId
                     , Block.labelPosition (Dict.get trickyId offsets)
                     ]
-                 , Block.view [ Block.plaintext " " ]
-                 , Block.view
+                , Block.view [ Block.plaintext " " ]
+                , Block.view
                     [ Block.plaintext "example"
                     , Block.label "the goal of which is to demonstrate horizontal repositioning"
                     , Block.cyan
                     , Block.labelId goalId
                     , Block.labelPosition (Dict.get goalId offsets)
                     ]
-                 , Block.view [ Block.plaintext ". Be sure to be " ]
-                 , Block.view
+                , Block.view [ Block.plaintext ". Be sure to be " ]
+                , Block.view
                     [ Block.plaintext "careful"
                     , Block.label "Shortish content..."
                     , Block.green
                     , Block.labelId shortId
                     , Block.labelPosition (Dict.get shortId offsets)
                     ]
-                 , Block.view
+                , Block.view
                     [ Block.plaintext "!"
                     , Block.label "It's important that the 'lowest' content is rendered on top of all other content."
                     , Block.blue
                     , Block.labelId longId
                     , Block.labelPosition (Dict.get longId offsets)
                     ]
-                 ]
-                    |> List.concat
-                )
+                ]
             , Table.view
                 [ Table.custom
                     { header = text "Pattern name & description"

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -349,7 +349,7 @@ view ellieLinkConfig state =
                             [ QuestionBox.id "question-box-5"
                             , QuestionBox.pointingTo
                                 (Block.view
-                                    [ Block.label "verb"
+                                    [ Block.label "subject & verb"
                                     , Block.labelId "label-5"
                                     , Block.labelPosition (Dict.get "label-5" offsets)
                                     , Block.cyan

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -100,15 +100,24 @@ view ellieLinkConfig state =
         [ Heading.plaintext "Interactive example"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
-    , div
-        [ css
-            [ Css.displayFlex
-            , Css.justifyContent Css.center
-            , Css.alignItems Css.flexStart
-            , Css.minHeight (Css.px 350)
+    , div [ css [ Css.minHeight (Css.px 350) ] ]
+        [ div
+            [ css
+                [ Css.position Css.relative
+                , Css.displayFlex
+                , Css.flexDirection Css.column
+                , Css.justifyContent Css.center
+                , Css.alignItems Css.center
+                ]
+            ]
+            [ UiIcon.sortArrowDown
+                |> Svg.withLabel "Anchor"
+                |> Svg.withWidth (Css.px 30)
+                |> Svg.withHeight (Css.px 30)
+                |> Svg.toHtml
+            , QuestionBox.view (List.map Tuple.second attributes)
             ]
         ]
-        [ QuestionBox.view (List.map Tuple.second attributes) ]
     , Heading.h2
         [ Heading.plaintext "Non-interactive examples"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
@@ -124,26 +133,23 @@ view ellieLinkConfig state =
         , Text.css [ Css.marginBottom (Css.px 80) |> Css.important ]
         ]
     , inParagraph
-        [ [ QuestionBox.view
+        [ Block.view
+            [ Block.plaintext "A"
+            , Block.magenta
+            , Block.label "this is an article. \"An\" is also an article."
+            , Block.labelId "article-label-id"
+            , Block.labelPosition (Dict.get "article-label-id" offsets)
+            , Block.bottomSpacingPx (getBottomSpacingFor "left-viewport-question-box-example")
+            , Block.withQuestionBox
                 [ QuestionBox.id "left-viewport-question-box-example"
-                , QuestionBox.pointingTo
-                    (Block.view
-                        [ Block.plaintext "A"
-                        , Block.magenta
-                        , Block.label "this is an article. \"An\" is also an article."
-                        , Block.labelId "article-label-id"
-                        , Block.labelPosition (Dict.get "article-label-id" offsets)
-                        , Block.bottomSpacingPx (getBottomSpacingFor "left-viewport-question-box-example")
-                        ]
-                    )
-                    (Dict.get "left-viewport-question-box-example" state.questionBoxMeasurementsById)
+                , QuestionBox.pointingTo (Dict.get "left-viewport-question-box-example" state.questionBoxMeasurementsById)
                 , QuestionBox.markdown "Articles are important to get right! Is “the” an article?"
                 , QuestionBox.actions
                     [ { label = "Yes", onClick = NoOp }
                     , { label = "No", onClick = NoOp }
                     ]
                 ]
-          ]
+            ]
         , Block.view [ Block.plaintext " " ]
         , Block.view
             [ Block.plaintext "tricky"
@@ -168,26 +174,23 @@ view ellieLinkConfig state =
         ]
     , inParagraph
         [ Block.view [ Block.plaintext "You also need to be careful with content that can get cut off on the right side of the viewport" ]
-        , [ QuestionBox.view
+        , Block.view
+            [ Block.plaintext "!"
+            , Block.label "warning"
+            , Block.brown
+            , Block.labelId "warning-2-label-id"
+            , Block.labelPosition (Dict.get "warning-2-label-id" offsets)
+            , Block.bottomSpacingPx (getBottomSpacingFor "right-viewport-question-box-example")
+            , Block.withQuestionBox
                 [ QuestionBox.id "right-viewport-question-box-example"
-                , QuestionBox.pointingTo
-                    (Block.view
-                        [ Block.plaintext "!"
-                        , Block.label "warning"
-                        , Block.brown
-                        , Block.labelId "warning-2-label-id"
-                        , Block.labelPosition (Dict.get "warning-2-label-id" offsets)
-                        , Block.bottomSpacingPx (getBottomSpacingFor "right-viewport-question-box-example")
-                        ]
-                    )
-                    (Dict.get "right-viewport-question-box-example" state.questionBoxMeasurementsById)
+                , QuestionBox.pointingTo (Dict.get "right-viewport-question-box-example" state.questionBoxMeasurementsById)
                 , QuestionBox.markdown "Were you careful? It's important to be careful!"
                 , QuestionBox.actions
                     [ { label = "Yes", onClick = NoOp }
                     , { label = "No", onClick = NoOp }
                     ]
                 ]
-          ]
+            ]
         ]
     , Table.view
         [ Table.string
@@ -231,20 +234,17 @@ view ellieLinkConfig state =
           , example =
                 inParagraph
                     [ Block.view [ Block.plaintext "Spongebob has a beautiful plant " ]
-                    , [ QuestionBox.view
+                    , Block.view
+                        [ Block.plaintext "above"
+                        , Block.emphasize
+                        , Block.bottomSpacingPx (getBottomSpacingFor "question-box-1")
+                        , Block.withQuestionBox
                             [ QuestionBox.id "question-box-1"
-                            , QuestionBox.pointingTo
-                                (Block.view
-                                    [ Block.plaintext "above"
-                                    , Block.emphasize
-                                    , Block.bottomSpacingPx (getBottomSpacingFor "question-box-1")
-                                    ]
-                                )
-                                (Dict.get "question-box-1" state.questionBoxMeasurementsById)
+                            , QuestionBox.pointingTo (Dict.get "question-box-1" state.questionBoxMeasurementsById)
                             , QuestionBox.markdown "“Above” is a preposition."
                             , QuestionBox.actions [ { label = "Try again", onClick = NoOp } ]
                             ]
-                      ]
+                        ]
                     , Block.view [ Block.plaintext " his TV." ]
                     ]
           }
@@ -253,19 +253,16 @@ view ellieLinkConfig state =
           , example =
                 inParagraph
                     [ Block.view [ Block.plaintext "Spongebob has a beautiful plant " ]
-                    , [ QuestionBox.view
+                    , Block.view
+                        [ Block.plaintext "above his TV"
+                        , Block.label "where"
+                        , Block.labelId "label-1"
+                        , Block.labelPosition (Dict.get "label-1" offsets)
+                        , Block.bottomSpacingPx (getBottomSpacingFor "question-box-2")
+                        , Block.yellow
+                        , Block.withQuestionBox
                             [ QuestionBox.id "question-box-2"
-                            , QuestionBox.pointingTo
-                                (Block.view
-                                    [ Block.plaintext "above his TV"
-                                    , Block.label "where"
-                                    , Block.labelId "label-1"
-                                    , Block.labelPosition (Dict.get "label-1" offsets)
-                                    , Block.bottomSpacingPx (getBottomSpacingFor "question-box-2")
-                                    , Block.yellow
-                                    ]
-                                )
-                                (Dict.get "question-box-2" state.questionBoxMeasurementsById)
+                            , QuestionBox.pointingTo (Dict.get "question-box-2" state.questionBoxMeasurementsById)
                             , QuestionBox.markdown "Which word is the preposition?"
                             , QuestionBox.actions
                                 [ { label = "above", onClick = NoOp }
@@ -273,7 +270,7 @@ view ellieLinkConfig state =
                                 , { label = "TV", onClick = NoOp }
                                 ]
                             ]
-                      ]
+                        ]
                     , Block.view [ Block.plaintext "." ]
                     ]
           }
@@ -288,21 +285,18 @@ view ellieLinkConfig state =
                         , Block.labelPosition (Dict.get "label-2" offsets)
                         ]
                     , Block.view [ Block.plaintext " " ]
-                    , [ QuestionBox.view
+                    , Block.view
+                        [ Block.bottomSpacingPx (getBottomSpacingFor "question-box-3")
+                        , Block.withQuestionBox
                             [ QuestionBox.id "question-box-3"
-                            , QuestionBox.pointingTo
-                                (Block.view
-                                    [ Block.bottomSpacingPx (getBottomSpacingFor "question-box-3")
-                                    ]
-                                )
-                                (Dict.get "question-box-3" state.questionBoxMeasurementsById)
+                            , QuestionBox.pointingTo (Dict.get "question-box-3" state.questionBoxMeasurementsById)
                             , QuestionBox.markdown "Which verb matches the subject?"
                             , QuestionBox.actions
                                 [ { label = "wrap", onClick = NoOp }
                                 , { label = "wraps", onClick = NoOp }
                                 ]
                             ]
-                      ]
+                        ]
                     , Block.view [ Block.plaintext " gifts with comic book pages." ]
                     ]
           }
@@ -318,18 +312,15 @@ view ellieLinkConfig state =
                         , Block.yellow
                         ]
                     , Block.view [ Block.plaintext " " ]
-                    , [ QuestionBox.view
+                    , Block.view
+                        [ Block.label "verb"
+                        , Block.labelId "label-4"
+                        , Block.labelPosition (Dict.get "label-4" offsets)
+                        , Block.bottomSpacingPx (getBottomSpacingFor "question-box-4")
+                        , Block.cyan
+                        , Block.withQuestionBox
                             [ QuestionBox.id "question-box-4"
-                            , QuestionBox.pointingTo
-                                (Block.view
-                                    [ Block.label "verb"
-                                    , Block.labelId "label-4"
-                                    , Block.labelPosition (Dict.get "label-4" offsets)
-                                    , Block.bottomSpacingPx (getBottomSpacingFor "question-box-4")
-                                    , Block.cyan
-                                    ]
-                                )
-                                (Dict.get "question-box-4" state.questionBoxMeasurementsById)
+                            , QuestionBox.pointingTo (Dict.get "question-box-4" state.questionBoxMeasurementsById)
                             , QuestionBox.markdown "What did he do?"
                             , QuestionBox.actions
                                 [ { label = "scared", onClick = NoOp }
@@ -337,7 +328,7 @@ view ellieLinkConfig state =
                                 , { label = "scarified", onClick = NoOp }
                                 ]
                             ]
-                      ]
+                        ]
                     , Block.view [ Block.plaintext " his replacement cousin coming out of his room wearing a gorilla mask." ]
                     ]
           }
@@ -345,19 +336,16 @@ view ellieLinkConfig state =
           , shownWith = "Blank with emphasis block"
           , example =
                 inParagraph
-                    [ [ QuestionBox.view
+                    [ Block.view
+                        [ Block.label "subject & verb"
+                        , Block.labelId "label-5"
+                        , Block.labelPosition (Dict.get "label-5" offsets)
+                        , Block.cyan
+                        , Block.content (Block.phrase "Dave " ++ [ Block.blank ])
+                        , Block.bottomSpacingPx (getBottomSpacingFor "question-box-5")
+                        , Block.withQuestionBox
                             [ QuestionBox.id "question-box-5"
-                            , QuestionBox.pointingTo
-                                (Block.view
-                                    [ Block.label "subject & verb"
-                                    , Block.labelId "label-5"
-                                    , Block.labelPosition (Dict.get "label-5" offsets)
-                                    , Block.cyan
-                                    , Block.content (Block.phrase "Dave " ++ [ Block.blank ])
-                                    , Block.bottomSpacingPx (getBottomSpacingFor "question-box-5")
-                                    ]
-                                )
-                                (Dict.get "question-box-5" state.questionBoxMeasurementsById)
+                            , QuestionBox.pointingTo (Dict.get "question-box-5" state.questionBoxMeasurementsById)
                             , QuestionBox.markdown "What did he do?"
                             , QuestionBox.actions
                                 [ { label = "scared", onClick = NoOp }
@@ -365,7 +353,7 @@ view ellieLinkConfig state =
                                 , { label = "scarified", onClick = NoOp }
                                 ]
                             ]
-                      ]
+                        ]
                     , Block.view [ Block.plaintext " his replacement cousin coming out of his room wearing a gorilla mask." ]
                     ]
           }
@@ -388,11 +376,6 @@ inParagraph =
 interactiveExampleId : String
 interactiveExampleId =
     "interactive-example-question-box"
-
-
-anchorId : String
-anchorId =
-    "interactive-example-anchor-icon"
 
 
 {-| -}
@@ -477,7 +460,7 @@ initAttributes =
             )
         |> ControlExtra.optionalListItem "type"
             (CommonControls.choice moduleName
-                [ ( "pointingTo [] Nothing", QuestionBox.pointingTo [ anchor ] Nothing )
+                [ ( "pointingTo Nothing", QuestionBox.pointingTo Nothing )
                 , ( "standalone", QuestionBox.standalone )
                 ]
             )
@@ -486,17 +469,6 @@ initAttributes =
             , [ Css.border3 (Css.px 4) Css.dashed Colors.red ]
             )
             { moduleName = moduleName, use = QuestionBox.containerCss }
-
-
-anchor : Html msg
-anchor =
-    div [ Attributes.id anchorId ]
-        [ UiIcon.sortArrowDown
-            |> Svg.withLabel "Anchor"
-            |> Svg.withWidth (Css.px 30)
-            |> Svg.withHeight (Css.px 30)
-            |> Svg.toHtml
-        ]
 
 
 initialMarkdown : String

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -335,26 +335,46 @@ view ellieLinkConfig state =
         , { pattern = "pointingTo"
           , shownWith = "Blank with emphasis block"
           , example =
-                inParagraph
-                    [ Block.view
-                        [ Block.label "subject & verb"
-                        , Block.labelId "label-5"
-                        , Block.labelPosition (Dict.get "label-5" offsets)
-                        , Block.cyan
-                        , Block.content (Block.phrase "Dave " ++ [ Block.blank ])
-                        , Block.bottomSpacingPx (getBottomSpacingFor "question-box-5")
-                        , Block.withQuestionBox
-                            [ QuestionBox.id "question-box-5"
-                            , QuestionBox.pointingTo (Dict.get "question-box-5" state.questionBoxMeasurementsById)
-                            , QuestionBox.markdown "What did he do?"
-                            , QuestionBox.actions
-                                [ { label = "scared", onClick = NoOp }
-                                , { label = "scarred", onClick = NoOp }
-                                , { label = "scarified", onClick = NoOp }
+                div []
+                    [ inParagraph
+                        [ Block.view
+                            [ Block.emphasize
+                            , Block.cyan
+                            , Block.content (Block.phrase "Moana " ++ [ Block.blank ])
+                            , Block.bottomSpacingPx (getBottomSpacingFor "question-box-5")
+                            , Block.withQuestionBox
+                                [ QuestionBox.id "question-box-5"
+                                , QuestionBox.pointingTo (Dict.get "question-box-5" state.questionBoxMeasurementsById)
+                                , QuestionBox.markdown "Pointing at the entire emphasis"
                                 ]
                             ]
                         ]
-                    , Block.view [ Block.plaintext " his replacement cousin coming out of his room wearing a gorilla mask." ]
+                    , inParagraph
+                        [ Block.view
+                            [ Block.emphasize
+                            , Block.cyan
+                            , Block.content (Block.phrase "Moana " ++ [ Block.blank ])
+                            , Block.bottomSpacingPx (getBottomSpacingFor "question-box-6")
+                            , Block.withQuestionBox
+                                [ QuestionBox.id "question-box-6"
+                                , QuestionBox.pointingTo (Dict.get "question-box-6" state.questionBoxMeasurementsById)
+                                , QuestionBox.markdown "Pointing at first word"
+                                ]
+                            ]
+                        ]
+                    , inParagraph
+                        [ Block.view
+                            [ Block.emphasize
+                            , Block.cyan
+                            , Block.content (Block.phrase "Moana " ++ [ Block.blank ])
+                            , Block.bottomSpacingPx (getBottomSpacingFor "question-box-7")
+                            , Block.withQuestionBox
+                                [ QuestionBox.id "question-box-7"
+                                , QuestionBox.pointingTo (Dict.get "question-box-7" state.questionBoxMeasurementsById)
+                                , QuestionBox.markdown "Pointing at the blank"
+                                ]
+                            ]
+                        ]
                     ]
           }
         ]
@@ -515,7 +535,6 @@ update msg state =
                     , "label-2"
                     , "label-3"
                     , "label-4"
-                    , "label-5"
                     , "article-label-id"
                     , "tricky-label-id"
                     , "warning-label-id"
@@ -527,6 +546,8 @@ update msg state =
                         , "question-box-3"
                         , "question-box-4"
                         , "question-box-5"
+                        , "question-box-6"
+                        , "question-box-7"
                         , "left-viewport-question-box-example"
                         , "right-viewport-question-box-example"
                         ]

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -353,13 +353,15 @@ view ellieLinkConfig state =
                         [ Block.view
                             [ Block.emphasize
                             , Block.cyan
-                            , Block.content (Block.phrase "Moana " ++ [ Block.blank ])
+                            , Block.content
+                                (Block.wordWithQuestionBox "Moana"
+                                    [ QuestionBox.id "question-box-6"
+                                    , QuestionBox.pointingTo (Dict.get "question-box-6" state.questionBoxMeasurementsById)
+                                    , QuestionBox.markdown "Pointing at first word"
+                                    ]
+                                    :: [ Block.space, Block.blank ]
+                                )
                             , Block.bottomSpacingPx (getBottomSpacingFor "question-box-6")
-                            , Block.withQuestionBox
-                                [ QuestionBox.id "question-box-6"
-                                , QuestionBox.pointingTo (Dict.get "question-box-6" state.questionBoxMeasurementsById)
-                                , QuestionBox.markdown "Pointing at first word"
-                                ]
                             ]
                         ]
                     , inParagraph

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -361,16 +361,15 @@ view ellieLinkConfig state =
     ]
 
 
-inParagraph : List (List (Html msg)) -> Html msg
+inParagraph : List (Html msg) -> Html msg
 inParagraph =
-    List.concat
-        >> p
-            [ css
-                [ Css.margin2 Spacing.verticalSpacerPx Css.zero
-                , Fonts.quizFont
-                , Css.fontSize (Css.px 30)
-                ]
+    p
+        [ css
+            [ Css.margin2 Spacing.verticalSpacerPx Css.zero
+            , Fonts.quizFont
+            , Css.fontSize (Css.px 30)
             ]
+        ]
 
 
 interactiveExampleId : String

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -73,7 +73,7 @@ view ellieLinkConfig state =
 
         getBottomSpacingFor id =
             Dict.get id state.questionBoxMeasurementsById
-                |> Maybe.map (.element >> .height)
+                |> Maybe.map (.element >> .height >> (+) 8)
     in
     [ -- absolutely positioned elements that overflow in the x direction
       -- cause a horizontal scrollbar unless you explicitly hide overflowing x content

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -366,13 +366,16 @@ view ellieLinkConfig state =
                         [ Block.view
                             [ Block.emphasize
                             , Block.cyan
-                            , Block.content (Block.phrase "Moana " ++ [ Block.blank ])
+                            , Block.content
+                                (Block.phrase "Moana "
+                                    ++ [ Block.blankWithQuestionBox
+                                            [ QuestionBox.id "question-box-7"
+                                            , QuestionBox.pointingTo (Dict.get "question-box-7" state.questionBoxMeasurementsById)
+                                            , QuestionBox.markdown "Pointing at the blank"
+                                            ]
+                                       ]
+                                )
                             , Block.bottomSpacingPx (getBottomSpacingFor "question-box-7")
-                            , Block.withQuestionBox
-                                [ QuestionBox.id "question-box-7"
-                                , QuestionBox.pointingTo (Dict.get "question-box-7" state.questionBoxMeasurementsById)
-                                , QuestionBox.markdown "Pointing at the blank"
-                                ]
                             ]
                         ]
                     ]

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -19,7 +19,7 @@ import Dict exposing (Dict)
 import EllieLink
 import Example exposing (Example)
 import Html.Styled exposing (..)
-import Html.Styled.Attributes as Attributes exposing (css)
+import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Block.V2 as Block
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.V1 as Colors

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -74,10 +74,9 @@ labelIdSpec =
     ]
 
 
-toQuery : List Block.Attribute -> Query.Single a
+toQuery : List (Block.Attribute a) -> Query.Single a
 toQuery block =
     Block.view block
-        |> Html.Styled.p []
         |> Html.Styled.toUnstyled
         |> Query.fromHtml
 

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -6,6 +6,7 @@ import Expect
 import Html.Attributes as Attributes
 import Html.Styled
 import Nri.Ui.Block.V2 as Block
+import Nri.Ui.QuestionBox.V2 as QuestionBox
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector
@@ -27,6 +28,14 @@ contentSpec =
             []
                 |> toQuery
                 |> Query.has [ Selector.text "blank" ]
+    , test "blank with question box" <|
+        \() ->
+            [ Block.withQuestionBox [ QuestionBox.markdown "Question Box content" ] ]
+                |> toQuery
+                |> Query.has
+                    [ Selector.text "blank"
+                    , Selector.text "Question Box content"
+                    ]
     , test "plaintext" <|
         \() ->
             [ Block.plaintext "Yo" ]
@@ -35,11 +44,44 @@ contentSpec =
                     [ Query.hasNot [ Selector.text "blank" ]
                     , Query.has [ Selector.text "Yo" ]
                     ]
+    , test "plaintext with question box" <|
+        \() ->
+            [ Block.plaintext "Yo"
+            , Block.withQuestionBox [ QuestionBox.markdown "Question Box content" ]
+            ]
+                |> toQuery
+                |> Expect.all
+                    [ Query.hasNot [ Selector.text "blank" ]
+                    , Query.has
+                        [ Selector.text "Yo"
+                        , Selector.text "Question Box content"
+                        ]
+                    ]
     , test "content with phrase and blank" <|
         \() ->
             [ Block.content (Block.phrase "Yo hello" ++ [ Block.blank ]) ]
                 |> toQuery
                 |> Query.has [ Selector.text "Yo", Selector.text "blank" ]
+    , test "content with blankWithQuestionBox" <|
+        \() ->
+            [ Block.content
+                [ Block.blankWithQuestionBox [ QuestionBox.markdown "Question Box content" ] ]
+            ]
+                |> toQuery
+                |> Query.has
+                    [ Selector.text "blank"
+                    , Selector.text "Question Box content"
+                    ]
+    , test "content with wordWithQuestionBox" <|
+        \() ->
+            [ Block.content
+                [ Block.wordWithQuestionBox "word" [ QuestionBox.markdown "Question Box content" ] ]
+            ]
+                |> toQuery
+                |> Query.has
+                    [ Selector.text "word"
+                    , Selector.text "Question Box content"
+                    ]
     ]
 
 


### PR DESCRIPTION
Fixes A11-2104

Support anchoring the question box to either the entire emphasis-with-block or to a particular element within it.


<img width="361" alt="image" src="https://user-images.githubusercontent.com/8811312/209014294-a4c0da96-b5ae-4a05-b8fc-20fd735babdb.png">

