### PR TITLE
Question box -- clarify the API

### DIFF
--- a/styleguide-app/Code.elm
+++ b/styleguide-app/Code.elm
@@ -8,7 +8,7 @@ module Code exposing
     , tuple
     , record, recordMultiline
     , newlineWithIndent, newlines
-    , withParens
+    , withParens, withParensMultiline
     , anonymousFunction, always
     , caseExpression
     , browserElement, unstyledView
@@ -27,7 +27,7 @@ module Code exposing
 @docs tuple
 @docs record, recordMultiline
 @docs newlineWithIndent, newlines
-@docs withParens
+@docs withParens, withParensMultiline
 @docs anonymousFunction, always
 @docs caseExpression
 @docs browserElement, unstyledView
@@ -172,6 +172,16 @@ newlineWithIndent indent =
 withParens : String -> String
 withParens val =
     "(" ++ val ++ ")"
+
+
+{-| -}
+withParensMultiline : List String -> Int -> String
+withParensMultiline items indent =
+    let
+        indents =
+            newlineWithIndent indent
+    in
+    indents ++ "(" ++ String.join indents items ++ indents ++ ")"
 
 
 {-| -}

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -432,16 +432,6 @@ initControl =
                     |> Control.field "xOffset" (ControlExtra.float 0)
                 )
             )
-        |> ControlExtra.optionalListItem "bottomSpacingPx"
-            (Control.map
-                (\v ->
-                    ( Code.fromModule moduleName "bottomSpacingPx "
-                        ++ Code.withParens (Code.maybeFloat (Just v))
-                    , Block.bottomSpacingPx (Just v)
-                    )
-                )
-                (ControlExtra.float 40)
-            )
         |> ControlExtra.optionalListItem "theme"
             (CommonControls.choice moduleName
                 [ ( "yellow", Block.yellow )

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -239,7 +239,7 @@ example =
             , Table.view
                 [ Table.custom
                     { header = text "Pattern name & description"
-                    , view = .description >> Markdown.toHtml Nothing >> List.map fromUnstyled >> span []
+                    , view = .description >> Markdown.toHtml Nothing >> List.map fromUnstyled >> div []
                     , width = Css.px 125
                     , cellStyles = always [ Css.padding2 Css.zero (Css.px 7), Css.verticalAlign Css.top ]
                     , sort = Nothing

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -20,6 +20,7 @@ import EllieLink
 import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
+import Markdown
 import Nri.Ui.Block.V2 as Block
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.V1 as Colors
@@ -208,9 +209,9 @@ view ellieLinkConfig state =
             ]
         ]
     , Table.view
-        [ Table.string
-            { header = "Pattern"
-            , value = .shownWith
+        [ Table.custom
+            { header = text "Pattern name & description"
+            , view = .description >> Markdown.toHtml Nothing >> List.map fromUnstyled >> div []
             , width = Css.pct 15
             , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.top ]
             , sort = Nothing
@@ -222,8 +223,21 @@ view ellieLinkConfig state =
             , cellStyles = always []
             , sort = Nothing
             }
+        , Table.custom
+            { header = text "Code"
+            , view = \{ pattern } -> code [] [ text pattern ]
+            , width = Css.px 50
+            , cellStyles =
+                always
+                    [ Css.padding2 (Css.px 14) (Css.px 7)
+                    , Css.verticalAlign Css.top
+                    , Css.fontSize (Css.px 12)
+                    , Css.whiteSpace Css.preWrap
+                    ]
+            , sort = Nothing
+            }
         ]
-        [ { shownWith = "Emphasis block"
+        [ { description = "**Emphasis block**"
           , example =
                 inParagraph
                     [ Block.view [ Block.plaintext "Spongebob has a beautiful plant " ]
@@ -240,8 +254,23 @@ view ellieLinkConfig state =
                         ]
                     , Block.view [ Block.plaintext " his TV." ]
                     ]
+          , pattern =
+                Code.fromModule "Block" "view"
+                    ++ Code.listMultiline
+                        [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 138) -- typically the questionBoxMeasurement's height + 8"
+                        , Code.fromModule "Block" "withQuestionBox"
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "id " ++ Code.string "question-box"
+                                , Code.fromModule moduleName "pointingTo " ++ "model.questionBoxMeasurement"
+                                , Code.fromModule moduleName "markdown " ++ Code.string "“Above” is a preposition."
+                                , Code.fromModule moduleName "actions " ++ Code.list [ "…" ]
+                                ]
+                                2
+                        , "…"
+                        ]
+                        1
           }
-        , { shownWith = "Label block"
+        , { description = "**Label block**"
           , example =
                 inParagraph
                     [ Block.view [ Block.plaintext "Spongebob has a beautiful plant " ]
@@ -265,8 +294,23 @@ view ellieLinkConfig state =
                         ]
                     , Block.view [ Block.plaintext "." ]
                     ]
+          , pattern =
+                Code.fromModule "Block" "view"
+                    ++ Code.listMultiline
+                        [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 230) -- typically the questionBoxMeasurement's height + 8"
+                        , Code.fromModule "Block" "withQuestionBox"
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "id " ++ Code.string "question-box"
+                                , Code.fromModule moduleName "pointingTo " ++ "model.questionBoxMeasurement"
+                                , Code.fromModule moduleName "markdown " ++ Code.string "Which word is the preposition?"
+                                , Code.fromModule moduleName "actions " ++ Code.list [ "…" ]
+                                ]
+                                2
+                        , "…"
+                        ]
+                        1
           }
-        , { shownWith = "Blank block"
+        , { description = "**Blank block**"
           , example =
                 inParagraph
                     [ Block.view
@@ -290,8 +334,23 @@ view ellieLinkConfig state =
                         ]
                     , Block.view [ Block.plaintext " gifts with comic book pages." ]
                     ]
+          , pattern =
+                Code.fromModule "Block" "view"
+                    ++ Code.listMultiline
+                        [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 185) -- typically the questionBoxMeasurement's height + 8"
+                        , Code.fromModule "Block" "withQuestionBox"
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "id " ++ Code.string "question-box"
+                                , Code.fromModule moduleName "pointingTo " ++ "model.questionBoxMeasurement"
+                                , Code.fromModule moduleName "markdown " ++ Code.string "Which verb matches the subject?"
+                                , Code.fromModule moduleName "actions " ++ Code.list [ "…" ]
+                                ]
+                                2
+                        , "…"
+                        ]
+                        1
           }
-        , { shownWith = "Labelled blank block"
+        , { description = "**Labelled blank block**"
           , example =
                 inParagraph
                     [ Block.view
@@ -321,8 +380,23 @@ view ellieLinkConfig state =
                         ]
                     , Block.view [ Block.plaintext " his replacement cousin coming out of his room wearing a gorilla mask." ]
                     ]
+          , pattern =
+                Code.fromModule "Block" "view"
+                    ++ Code.listMultiline
+                        [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 230) -- typically the questionBoxMeasurement's height + 8"
+                        , Code.fromModule "Block" "withQuestionBox"
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "id " ++ Code.string "question-box"
+                                , Code.fromModule moduleName "pointingTo " ++ "model.questionBoxMeasurement"
+                                , Code.fromModule moduleName "markdown " ++ Code.string "What did he do?"
+                                , Code.fromModule moduleName "actions " ++ Code.list [ "…" ]
+                                ]
+                                2
+                        , "…"
+                        ]
+                        1
           }
-        , { shownWith = "Blank with emphasis block"
+        , { description = "**Blank with emphasis block**"
           , example =
                 div []
                     [ inParagraph
@@ -370,6 +444,7 @@ view ellieLinkConfig state =
                             ]
                         ]
                     ]
+          , pattern = "TODO"
           }
         ]
     ]

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -71,10 +71,6 @@ view ellieLinkConfig state =
 
         offsets =
             Block.getLabelPositions state.labelMeasurementsById
-
-        getBottomSpacingFor id =
-            Dict.get id state.questionBoxMeasurementsById
-                |> Maybe.map (.element >> .height >> (+) 8)
     in
     [ -- absolutely positioned elements that overflow in the x direction
       -- cause a horizontal scrollbar unless you explicitly hide overflowing x content

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -396,52 +396,72 @@ view ellieLinkConfig state =
                         ]
                         1
           }
-        , { description = "**Blank with emphasis block**"
+        , { description = "**Blank with emphasis block** with the question box pointing to the entire emphasis"
           , example =
-                div []
-                    [ inParagraph
-                        [ Block.view
-                            [ Block.emphasize
-                            , Block.cyan
-                            , Block.content (Block.phrase "Moana " ++ [ Block.blank ])
-                            , Block.bottomSpacingPx (getBottomSpacingFor "question-box-5")
-                            , Block.withQuestionBox
-                                [ QuestionBox.id "question-box-5"
-                                , QuestionBox.pointingTo (Dict.get "question-box-5" state.questionBoxMeasurementsById)
-                                , QuestionBox.markdown "Pointing at the entire emphasis"
+                inParagraph
+                    [ Block.view
+                        [ Block.emphasize
+                        , Block.cyan
+                        , Block.content (Block.phrase "Moana " ++ [ Block.blank ])
+                        , Block.bottomSpacingPx (getBottomSpacingFor "question-box-5")
+                        , Block.withQuestionBox
+                            [ QuestionBox.id "question-box-5"
+                            , QuestionBox.pointingTo (Dict.get "question-box-5" state.questionBoxMeasurementsById)
+                            , QuestionBox.markdown "Pointing at the entire emphasis"
+                            ]
+                        ]
+                    ]
+          , pattern =
+                Code.fromModule "Block" "view"
+                    ++ Code.listMultiline
+                        [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 80) -- typically the questionBoxMeasurement's height + 8"
+                        , Code.fromModule "Block" "withQuestionBox"
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "id " ++ Code.string "question-box"
+                                , Code.fromModule moduleName "pointingTo " ++ "model.questionBoxMeasurement"
+                                , Code.fromModule moduleName "markdown " ++ Code.string "Pointing at the entire emphasis"
+                                , Code.fromModule moduleName "actions " ++ Code.list [ "…" ]
                                 ]
-                            ]
+                                2
+                        , "…"
                         ]
-                    , inParagraph
-                        [ Block.view
-                            [ Block.emphasize
-                            , Block.cyan
-                            , Block.content
-                                (Block.wordWithQuestionBox "Moana"
-                                    [ QuestionBox.id "question-box-6"
-                                    , QuestionBox.pointingTo (Dict.get "question-box-6" state.questionBoxMeasurementsById)
-                                    , QuestionBox.markdown "Pointing at first word"
-                                    ]
-                                    :: [ Block.space, Block.blank ]
-                                )
-                            , Block.bottomSpacingPx (getBottomSpacingFor "question-box-6")
-                            ]
+                        1
+          }
+        , { description = "**Blank with emphasis block** with the question box pointing to a particular word"
+          , example =
+                inParagraph
+                    [ Block.view
+                        [ Block.emphasize
+                        , Block.cyan
+                        , Block.content
+                            (Block.wordWithQuestionBox "Moana"
+                                [ QuestionBox.id "question-box-6"
+                                , QuestionBox.pointingTo (Dict.get "question-box-6" state.questionBoxMeasurementsById)
+                                , QuestionBox.markdown "Pointing at first word"
+                                ]
+                                :: [ Block.space, Block.blank ]
+                            )
+                        , Block.bottomSpacingPx (getBottomSpacingFor "question-box-6")
                         ]
-                    , inParagraph
-                        [ Block.view
-                            [ Block.emphasize
-                            , Block.cyan
-                            , Block.content
-                                (Block.phrase "Moana "
-                                    ++ [ Block.blankWithQuestionBox
-                                            [ QuestionBox.id "question-box-7"
-                                            , QuestionBox.pointingTo (Dict.get "question-box-7" state.questionBoxMeasurementsById)
-                                            , QuestionBox.markdown "Pointing at the blank"
-                                            ]
-                                       ]
-                                )
-                            , Block.bottomSpacingPx (getBottomSpacingFor "question-box-7")
-                            ]
+                    ]
+          , pattern = "TODO"
+          }
+        , { description = "**Blank with emphasis block** with the question box pointing to a blank"
+          , example =
+                inParagraph
+                    [ Block.view
+                        [ Block.emphasize
+                        , Block.cyan
+                        , Block.content
+                            (Block.phrase "Moana "
+                                ++ [ Block.blankWithQuestionBox
+                                        [ QuestionBox.id "question-box-7"
+                                        , QuestionBox.pointingTo (Dict.get "question-box-7" state.questionBoxMeasurementsById)
+                                        , QuestionBox.markdown "Pointing at the blank"
+                                        ]
+                                   ]
+                            )
+                        , Block.bottomSpacingPx (getBottomSpacingFor "question-box-7")
                         ]
                     ]
           , pattern = "TODO"

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -382,18 +382,11 @@ view ellieLinkConfig state =
         , { description = "**Labelled blank block**"
           , example =
                 inParagraph
-                    [ Block.view
-                        [ Block.plaintext "Dave"
-                        , Block.label "subject"
-                        , Block.labelId "label-3"
-                        , Block.labelPosition (Dict.get "label-3" offsets)
-                        , Block.yellow
-                        ]
-                    , Block.view [ Block.plaintext " " ]
+                    [ Block.view [ Block.plaintext "Dave " ]
                     , Block.view
                         [ Block.label "verb"
-                        , Block.labelId "label-4"
-                        , Block.labelPosition (Dict.get "label-4" offsets)
+                        , Block.labelId "label-3"
+                        , Block.labelPosition (Dict.get "label-3" offsets)
                         , Block.bottomSpacingPx (getBottomSpacingFor "question-box-4")
                         , Block.cyan
                         , Block.withQuestionBox
@@ -694,7 +687,6 @@ update msg state =
                     [ "label-1"
                     , "label-2"
                     , "label-3"
-                    , "label-4"
                     , "article-label-id"
                     , "tricky-label-id"
                     , "warning-label-id"

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -237,7 +237,36 @@ view ellieLinkConfig state =
             , sort = Nothing
             }
         ]
-        [ { description = "**Emphasis block**"
+        [ { description = "**Plain block**"
+          , example =
+                inParagraph
+                    [ Block.view
+                        [ Block.plaintext "Dave"
+                        , Block.bottomSpacingPx (getBottomSpacingFor "question-box-0")
+                        , Block.withQuestionBox
+                            [ QuestionBox.id "question-box-0"
+                            , QuestionBox.pointingTo (Dict.get "question-box-0" state.questionBoxMeasurementsById)
+                            , QuestionBox.markdown "Who?"
+                            ]
+                        ]
+                    , Block.view [ Block.plaintext " scared his replacement cousin coming out of his room wearing a gorilla mask." ]
+                    ]
+          , pattern =
+                Code.fromModule "Block" "view"
+                    ++ Code.listMultiline
+                        [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 230) -- typically the questionBoxMeasurement's height + 8"
+                        , Code.fromModule "Block" "withQuestionBox"
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "id " ++ Code.string "question-box"
+                                , Code.fromModule moduleName "pointingTo " ++ "model.questionBoxMeasurement"
+                                , Code.fromModule moduleName "markdown " ++ Code.string "Who?"
+                                ]
+                                2
+                        , "…"
+                        ]
+                        1
+          }
+        , { description = "**Emphasis block**"
           , example =
                 inParagraph
                     [ Block.view [ Block.plaintext "Spongebob has a beautiful plant " ]
@@ -672,7 +701,8 @@ update msg state =
                     , "warning-2-label-id"
                     ]
                     ++ List.map measureQuestionBox
-                        [ "question-box-1"
+                        [ "question-box-0"
+                        , "question-box-1"
                         , "question-box-2"
                         , "question-box-3"
                         , "question-box-4"

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -450,8 +450,7 @@ view ellieLinkConfig state =
                         [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 80) -- typically the questionBoxMeasurement's height + 8"
                         , Code.fromModule "Block" "content"
                             ++ Code.withParensMultiline
-                                [ Code.fromModule "Block" "wordWithQuestionBox "
-                                    ++ Code.string "Moana"
+                                [ (Code.fromModule "Block" "wordWithQuestionBox " ++ Code.string "Moana")
                                     ++ Code.listMultiline
                                         [ Code.fromModule moduleName "id " ++ Code.string "question-box"
                                         , Code.fromModule moduleName "pointingTo " ++ "model.questionBoxMeasurement"
@@ -484,7 +483,30 @@ view ellieLinkConfig state =
                         , Block.bottomSpacingPx (getBottomSpacingFor "question-box-7")
                         ]
                     ]
-          , pattern = "TODO"
+          , pattern =
+                Code.fromModule "Block" "view"
+                    ++ Code.listMultiline
+                        [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 80) -- typically the questionBoxMeasurement's height + 8"
+                        , Code.fromModule "Block" "content"
+                            ++ Code.withParensMultiline
+                                [ Code.fromModule "Block" "phrase " ++ Code.string "Moana"
+                                , " ++ "
+                                    ++ Code.listMultiline
+                                        [ Code.fromModule "Block" "blankWithQuestionBox"
+                                            ++ Code.listMultiline
+                                                [ Code.fromModule moduleName "id " ++ Code.string "question-box"
+                                                , Code.fromModule moduleName "pointingTo " ++ "model.questionBoxMeasurement"
+                                                , Code.fromModule moduleName "markdown " ++ Code.string "Pointing at the blank"
+                                                , Code.fromModule moduleName "actions " ++ Code.list [ "…" ]
+                                                ]
+                                                4
+                                        ]
+                                        3
+                                ]
+                                2
+                        , "…"
+                        ]
+                        1
           }
         ]
     ]

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -130,7 +130,22 @@ view ellieLinkConfig state =
         ]
     , Text.caption
         [ Text.plaintext "Click \"Measure & render\" to reposition the noninteractive examples' labels and question boxes to avoid overlaps given the current viewport."
-        , Text.css [ Css.marginBottom (Css.px 80) |> Css.important ]
+        ]
+    , Heading.h3
+        [ Heading.plaintext "QuestionBox.standalone"
+        , Heading.css [ Css.margin2 Spacing.verticalSpacerPx Css.zero ]
+        ]
+    , QuestionBox.view
+        [ QuestionBox.standalone
+        , QuestionBox.markdown "Which words tell you **when** the party is?"
+        , QuestionBox.actions
+            [ { label = "is having", onClick = NoOp }
+            , { label = "after the football game", onClick = NoOp }
+            ]
+        ]
+    , Heading.h3
+        [ Heading.plaintext "QuestionBox.pointingTo"
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
     , inParagraph
         [ Block.view
@@ -194,14 +209,7 @@ view ellieLinkConfig state =
         ]
     , Table.view
         [ Table.string
-            { header = "QuestionBox type"
-            , value = .pattern
-            , width = Css.pct 15
-            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.top, Css.fontWeight Css.bold ]
-            , sort = Nothing
-            }
-        , Table.string
-            { header = "Block pattern"
+            { header = "Pattern"
             , value = .shownWith
             , width = Css.pct 15
             , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.top ]
@@ -215,22 +223,7 @@ view ellieLinkConfig state =
             , sort = Nothing
             }
         ]
-        [ { pattern = "standalone"
-          , shownWith = ""
-          , example =
-                div [ css [ Css.margin2 Spacing.verticalSpacerPx Css.zero ] ]
-                    [ QuestionBox.view
-                        [ QuestionBox.standalone
-                        , QuestionBox.markdown "Which words tell you **when** the party is?"
-                        , QuestionBox.actions
-                            [ { label = "is having", onClick = NoOp }
-                            , { label = "after the football game", onClick = NoOp }
-                            ]
-                        ]
-                    ]
-          }
-        , { pattern = "pointingTo"
-          , shownWith = "Emphasis block"
+        [ { shownWith = "Emphasis block"
           , example =
                 inParagraph
                     [ Block.view [ Block.plaintext "Spongebob has a beautiful plant " ]
@@ -248,8 +241,7 @@ view ellieLinkConfig state =
                     , Block.view [ Block.plaintext " his TV." ]
                     ]
           }
-        , { pattern = "pointingTo"
-          , shownWith = "Label block"
+        , { shownWith = "Label block"
           , example =
                 inParagraph
                     [ Block.view [ Block.plaintext "Spongebob has a beautiful plant " ]
@@ -274,8 +266,7 @@ view ellieLinkConfig state =
                     , Block.view [ Block.plaintext "." ]
                     ]
           }
-        , { pattern = "pointingTo"
-          , shownWith = "Blank block"
+        , { shownWith = "Blank block"
           , example =
                 inParagraph
                     [ Block.view
@@ -300,8 +291,7 @@ view ellieLinkConfig state =
                     , Block.view [ Block.plaintext " gifts with comic book pages." ]
                     ]
           }
-        , { pattern = "pointingTo"
-          , shownWith = "Labelled blank block"
+        , { shownWith = "Labelled blank block"
           , example =
                 inParagraph
                     [ Block.view
@@ -332,8 +322,7 @@ view ellieLinkConfig state =
                     , Block.view [ Block.plaintext " his replacement cousin coming out of his room wearing a gorilla mask." ]
                     ]
           }
-        , { pattern = "pointingTo"
-          , shownWith = "Blank with emphasis block"
+        , { shownWith = "Blank with emphasis block"
           , example =
                 div []
                     [ inParagraph

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -437,14 +437,34 @@ view ellieLinkConfig state =
                             (Block.wordWithQuestionBox "Moana"
                                 [ QuestionBox.id "question-box-6"
                                 , QuestionBox.pointingTo (Dict.get "question-box-6" state.questionBoxMeasurementsById)
-                                , QuestionBox.markdown "Pointing at first word"
+                                , QuestionBox.markdown "Pointing at the first word"
                                 ]
                                 :: [ Block.space, Block.blank ]
                             )
                         , Block.bottomSpacingPx (getBottomSpacingFor "question-box-6")
                         ]
                     ]
-          , pattern = "TODO"
+          , pattern =
+                Code.fromModule "Block" "view"
+                    ++ Code.listMultiline
+                        [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 80) -- typically the questionBoxMeasurement's height + 8"
+                        , Code.fromModule "Block" "content"
+                            ++ Code.withParensMultiline
+                                [ Code.fromModule "Block" "wordWithQuestionBox "
+                                    ++ Code.string "Moana"
+                                    ++ Code.listMultiline
+                                        [ Code.fromModule moduleName "id " ++ Code.string "question-box"
+                                        , Code.fromModule moduleName "pointingTo " ++ "model.questionBoxMeasurement"
+                                        , Code.fromModule moduleName "markdown " ++ Code.string "Pointing at the first word"
+                                        , Code.fromModule moduleName "actions " ++ Code.list [ "…" ]
+                                        ]
+                                        3
+                                , ":: " ++ Code.list [ "Block.space", "Block.blank" ]
+                                ]
+                                2
+                        , "…"
+                        ]
+                        1
           }
         , { description = "**Blank with emphasis block** with the question box pointing to a blank"
           , example =

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -155,16 +155,15 @@ view ellieLinkConfig state =
             , Block.label "this is an article. \"An\" is also an article."
             , Block.labelId "article-label-id"
             , Block.labelPosition (Dict.get "article-label-id" offsets)
-            , Block.bottomSpacingPx (getBottomSpacingFor "left-viewport-question-box-example")
             , Block.withQuestionBox
                 [ QuestionBox.id "left-viewport-question-box-example"
-                , QuestionBox.pointingTo (Dict.get "left-viewport-question-box-example" state.questionBoxMeasurementsById)
                 , QuestionBox.markdown "Articles are important to get right! Is “the” an article?"
                 , QuestionBox.actions
                     [ { label = "Yes", onClick = NoOp }
                     , { label = "No", onClick = NoOp }
                     ]
                 ]
+                (Dict.get "left-viewport-question-box-example" state.questionBoxMeasurementsById)
             ]
         , Block.view [ Block.plaintext " " ]
         , Block.view
@@ -196,16 +195,15 @@ view ellieLinkConfig state =
             , Block.brown
             , Block.labelId "warning-2-label-id"
             , Block.labelPosition (Dict.get "warning-2-label-id" offsets)
-            , Block.bottomSpacingPx (getBottomSpacingFor "right-viewport-question-box-example")
             , Block.withQuestionBox
                 [ QuestionBox.id "right-viewport-question-box-example"
-                , QuestionBox.pointingTo (Dict.get "right-viewport-question-box-example" state.questionBoxMeasurementsById)
                 , QuestionBox.markdown "Were you careful? It's important to be careful!"
                 , QuestionBox.actions
                     [ { label = "Yes", onClick = NoOp }
                     , { label = "No", onClick = NoOp }
                     ]
                 ]
+                (Dict.get "right-viewport-question-box-example" state.questionBoxMeasurementsById)
             ]
         ]
     , Table.view
@@ -242,26 +240,22 @@ view ellieLinkConfig state =
                 inParagraph
                     [ Block.view
                         [ Block.plaintext "Dave"
-                        , Block.bottomSpacingPx (getBottomSpacingFor "question-box-0")
-                        , Block.withQuestionBox
-                            [ QuestionBox.id "question-box-0"
-                            , QuestionBox.pointingTo (Dict.get "question-box-0" state.questionBoxMeasurementsById)
-                            , QuestionBox.markdown "Who?"
-                            ]
+                        , Block.withQuestionBox [ QuestionBox.id "question-box-0", QuestionBox.markdown "Who?" ]
+                            (Dict.get "question-box-0" state.questionBoxMeasurementsById)
                         ]
                     , Block.view [ Block.plaintext " scared his replacement cousin coming out of his room wearing a gorilla mask." ]
                     ]
           , pattern =
                 Code.fromModule "Block" "view"
                     ++ Code.listMultiline
-                        [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 230) -- typically the questionBoxMeasurement's height + 8"
-                        , Code.fromModule "Block" "withQuestionBox"
+                        [ Code.fromModule "Block" "withQuestionBox"
                             ++ Code.listMultiline
                                 [ Code.fromModule moduleName "id " ++ Code.string "question-box"
                                 , Code.fromModule moduleName "pointingTo " ++ "model.questionBoxMeasurement"
                                 , Code.fromModule moduleName "markdown " ++ Code.string "Who?"
                                 ]
                                 2
+                            ++ (Code.newlineWithIndent 2 ++ "model.questionBoxMeasurement")
                         , "…"
                         ]
                         1
@@ -273,28 +267,26 @@ view ellieLinkConfig state =
                     , Block.view
                         [ Block.plaintext "above"
                         , Block.emphasize
-                        , Block.bottomSpacingPx (getBottomSpacingFor "question-box-1")
                         , Block.withQuestionBox
                             [ QuestionBox.id "question-box-1"
-                            , QuestionBox.pointingTo (Dict.get "question-box-1" state.questionBoxMeasurementsById)
                             , QuestionBox.markdown "“Above” is a preposition."
                             , QuestionBox.actions [ { label = "Try again", onClick = NoOp } ]
                             ]
+                            (Dict.get "question-box-1" state.questionBoxMeasurementsById)
                         ]
                     , Block.view [ Block.plaintext " his TV." ]
                     ]
           , pattern =
                 Code.fromModule "Block" "view"
                     ++ Code.listMultiline
-                        [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 138) -- typically the questionBoxMeasurement's height + 8"
-                        , Code.fromModule "Block" "withQuestionBox"
+                        [ Code.fromModule "Block" "withQuestionBox"
                             ++ Code.listMultiline
                                 [ Code.fromModule moduleName "id " ++ Code.string "question-box"
-                                , Code.fromModule moduleName "pointingTo " ++ "model.questionBoxMeasurement"
                                 , Code.fromModule moduleName "markdown " ++ Code.string "“Above” is a preposition."
                                 , Code.fromModule moduleName "actions " ++ Code.list [ "…" ]
                                 ]
                                 2
+                            ++ (Code.newlineWithIndent 2 ++ "model.questionBoxMeasurement")
                         , "…"
                         ]
                         1
@@ -308,11 +300,9 @@ view ellieLinkConfig state =
                         , Block.label "where"
                         , Block.labelId "label-1"
                         , Block.labelPosition (Dict.get "label-1" offsets)
-                        , Block.bottomSpacingPx (getBottomSpacingFor "question-box-2")
                         , Block.yellow
                         , Block.withQuestionBox
                             [ QuestionBox.id "question-box-2"
-                            , QuestionBox.pointingTo (Dict.get "question-box-2" state.questionBoxMeasurementsById)
                             , QuestionBox.markdown "Which word is the preposition?"
                             , QuestionBox.actions
                                 [ { label = "above", onClick = NoOp }
@@ -320,21 +310,21 @@ view ellieLinkConfig state =
                                 , { label = "TV", onClick = NoOp }
                                 ]
                             ]
+                            (Dict.get "question-box-2" state.questionBoxMeasurementsById)
                         ]
                     , Block.view [ Block.plaintext "." ]
                     ]
           , pattern =
                 Code.fromModule "Block" "view"
                     ++ Code.listMultiline
-                        [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 230) -- typically the questionBoxMeasurement's height + 8"
-                        , Code.fromModule "Block" "withQuestionBox"
+                        [ Code.fromModule "Block" "withQuestionBox"
                             ++ Code.listMultiline
                                 [ Code.fromModule moduleName "id " ++ Code.string "question-box"
-                                , Code.fromModule moduleName "pointingTo " ++ "model.questionBoxMeasurement"
                                 , Code.fromModule moduleName "markdown " ++ Code.string "Which word is the preposition?"
                                 , Code.fromModule moduleName "actions " ++ Code.list [ "…" ]
                                 ]
                                 2
+                            ++ (Code.newlineWithIndent 2 ++ "model.questionBoxMeasurement")
                         , "…"
                         ]
                         1
@@ -350,31 +340,29 @@ view ellieLinkConfig state =
                         ]
                     , Block.view [ Block.plaintext " " ]
                     , Block.view
-                        [ Block.bottomSpacingPx (getBottomSpacingFor "question-box-3")
-                        , Block.withQuestionBox
+                        [ Block.withQuestionBox
                             [ QuestionBox.id "question-box-3"
-                            , QuestionBox.pointingTo (Dict.get "question-box-3" state.questionBoxMeasurementsById)
                             , QuestionBox.markdown "Which verb matches the subject?"
                             , QuestionBox.actions
                                 [ { label = "wrap", onClick = NoOp }
                                 , { label = "wraps", onClick = NoOp }
                                 ]
                             ]
+                            (Dict.get "question-box-3" state.questionBoxMeasurementsById)
                         ]
                     , Block.view [ Block.plaintext " gifts with comic book pages." ]
                     ]
           , pattern =
                 Code.fromModule "Block" "view"
                     ++ Code.listMultiline
-                        [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 185) -- typically the questionBoxMeasurement's height + 8"
-                        , Code.fromModule "Block" "withQuestionBox"
+                        [ Code.fromModule "Block" "withQuestionBox"
                             ++ Code.listMultiline
                                 [ Code.fromModule moduleName "id " ++ Code.string "question-box"
-                                , Code.fromModule moduleName "pointingTo " ++ "model.questionBoxMeasurement"
                                 , Code.fromModule moduleName "markdown " ++ Code.string "Which verb matches the subject?"
                                 , Code.fromModule moduleName "actions " ++ Code.list [ "…" ]
                                 ]
                                 2
+                            ++ (Code.newlineWithIndent 2 ++ "model.questionBoxMeasurement")
                         , "…"
                         ]
                         1
@@ -387,11 +375,9 @@ view ellieLinkConfig state =
                         [ Block.label "verb"
                         , Block.labelId "label-3"
                         , Block.labelPosition (Dict.get "label-3" offsets)
-                        , Block.bottomSpacingPx (getBottomSpacingFor "question-box-4")
                         , Block.cyan
                         , Block.withQuestionBox
                             [ QuestionBox.id "question-box-4"
-                            , QuestionBox.pointingTo (Dict.get "question-box-4" state.questionBoxMeasurementsById)
                             , QuestionBox.markdown "What did he do?"
                             , QuestionBox.actions
                                 [ { label = "scared", onClick = NoOp }
@@ -399,21 +385,21 @@ view ellieLinkConfig state =
                                 , { label = "scarified", onClick = NoOp }
                                 ]
                             ]
+                            (Dict.get "question-box-4" state.questionBoxMeasurementsById)
                         ]
                     , Block.view [ Block.plaintext " his replacement cousin coming out of his room wearing a gorilla mask." ]
                     ]
           , pattern =
                 Code.fromModule "Block" "view"
                     ++ Code.listMultiline
-                        [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 230) -- typically the questionBoxMeasurement's height + 8"
-                        , Code.fromModule "Block" "withQuestionBox"
+                        [ Code.fromModule "Block" "withQuestionBox"
                             ++ Code.listMultiline
                                 [ Code.fromModule moduleName "id " ++ Code.string "question-box"
-                                , Code.fromModule moduleName "pointingTo " ++ "model.questionBoxMeasurement"
                                 , Code.fromModule moduleName "markdown " ++ Code.string "What did he do?"
                                 , Code.fromModule moduleName "actions " ++ Code.list [ "…" ]
                                 ]
                                 2
+                            ++ (Code.newlineWithIndent 2 ++ "model.questionBoxMeasurement")
                         , "…"
                         ]
                         1
@@ -425,26 +411,24 @@ view ellieLinkConfig state =
                         [ Block.emphasize
                         , Block.cyan
                         , Block.content (Block.phrase "Moana " ++ [ Block.blank ])
-                        , Block.bottomSpacingPx (getBottomSpacingFor "question-box-5")
                         , Block.withQuestionBox
                             [ QuestionBox.id "question-box-5"
-                            , QuestionBox.pointingTo (Dict.get "question-box-5" state.questionBoxMeasurementsById)
                             , QuestionBox.markdown "Pointing at the entire emphasis"
                             ]
+                            (Dict.get "question-box-5" state.questionBoxMeasurementsById)
                         ]
                     ]
           , pattern =
                 Code.fromModule "Block" "view"
                     ++ Code.listMultiline
-                        [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 80) -- typically the questionBoxMeasurement's height + 8"
-                        , Code.fromModule "Block" "withQuestionBox"
+                        [ Code.fromModule "Block" "withQuestionBox"
                             ++ Code.listMultiline
                                 [ Code.fromModule moduleName "id " ++ Code.string "question-box"
-                                , Code.fromModule moduleName "pointingTo " ++ "model.questionBoxMeasurement"
                                 , Code.fromModule moduleName "markdown " ++ Code.string "Pointing at the entire emphasis"
                                 , Code.fromModule moduleName "actions " ++ Code.list [ "…" ]
                                 ]
                                 2
+                            ++ (Code.newlineWithIndent 2 ++ "model.questionBoxMeasurement")
                         , "…"
                         ]
                         1
@@ -458,19 +442,17 @@ view ellieLinkConfig state =
                         , Block.content
                             (Block.wordWithQuestionBox "Moana"
                                 [ QuestionBox.id "question-box-6"
-                                , QuestionBox.pointingTo (Dict.get "question-box-6" state.questionBoxMeasurementsById)
                                 , QuestionBox.markdown "Pointing at the first word"
                                 ]
+                                (Dict.get "question-box-6" state.questionBoxMeasurementsById)
                                 :: [ Block.space, Block.blank ]
                             )
-                        , Block.bottomSpacingPx (getBottomSpacingFor "question-box-6")
                         ]
                     ]
           , pattern =
                 Code.fromModule "Block" "view"
                     ++ Code.listMultiline
-                        [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 80) -- typically the questionBoxMeasurement's height + 8"
-                        , Code.fromModule "Block" "content"
+                        [ Code.fromModule "Block" "content"
                             ++ Code.withParensMultiline
                                 [ (Code.fromModule "Block" "wordWithQuestionBox " ++ Code.string "Moana")
                                     ++ Code.listMultiline
@@ -480,6 +462,7 @@ view ellieLinkConfig state =
                                         , Code.fromModule moduleName "actions " ++ Code.list [ "…" ]
                                         ]
                                         3
+                                    ++ (Code.newlineWithIndent 3 ++ "model.questionBoxMeasurement")
                                 , ":: " ++ Code.list [ "Block.space", "Block.blank" ]
                                 ]
                                 2
@@ -497,19 +480,17 @@ view ellieLinkConfig state =
                             (Block.phrase "Moana "
                                 ++ [ Block.blankWithQuestionBox
                                         [ QuestionBox.id "question-box-7"
-                                        , QuestionBox.pointingTo (Dict.get "question-box-7" state.questionBoxMeasurementsById)
                                         , QuestionBox.markdown "Pointing at the blank"
                                         ]
+                                        (Dict.get "question-box-7" state.questionBoxMeasurementsById)
                                    ]
                             )
-                        , Block.bottomSpacingPx (getBottomSpacingFor "question-box-7")
                         ]
                     ]
           , pattern =
                 Code.fromModule "Block" "view"
                     ++ Code.listMultiline
-                        [ Code.fromModule "Block" "bottomSpacingPx " ++ "(Just 80) -- typically the questionBoxMeasurement's height + 8"
-                        , Code.fromModule "Block" "content"
+                        [ Code.fromModule "Block" "content"
                             ++ Code.withParensMultiline
                                 [ Code.fromModule "Block" "phrase " ++ Code.string "Moana"
                                 , " ++ "
@@ -517,11 +498,11 @@ view ellieLinkConfig state =
                                         [ Code.fromModule "Block" "blankWithQuestionBox"
                                             ++ Code.listMultiline
                                                 [ Code.fromModule moduleName "id " ++ Code.string "question-box"
-                                                , Code.fromModule moduleName "pointingTo " ++ "model.questionBoxMeasurement"
                                                 , Code.fromModule moduleName "markdown " ++ Code.string "Pointing at the blank"
                                                 , Code.fromModule moduleName "actions " ++ Code.list [ "…" ]
                                                 ]
                                                 4
+                                            ++ (Code.newlineWithIndent 4 ++ "model.questionBoxMeasurement")
                                         ]
                                         3
                                 ]

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -30,7 +30,7 @@ contentSpec =
                 |> Query.has [ Selector.text "blank" ]
     , test "blank with question box" <|
         \() ->
-            [ Block.withQuestionBox [ QuestionBox.markdown "Question Box content" ] ]
+            [ Block.withQuestionBox [ QuestionBox.markdown "Question Box content" ] Nothing ]
                 |> toQuery
                 |> Query.has
                     [ Selector.text "blank"
@@ -47,7 +47,7 @@ contentSpec =
     , test "plaintext with question box" <|
         \() ->
             [ Block.plaintext "Yo"
-            , Block.withQuestionBox [ QuestionBox.markdown "Question Box content" ]
+            , Block.withQuestionBox [ QuestionBox.markdown "Question Box content" ] Nothing
             ]
                 |> toQuery
                 |> Expect.all
@@ -65,7 +65,7 @@ contentSpec =
     , test "content with blankWithQuestionBox" <|
         \() ->
             [ Block.content
-                [ Block.blankWithQuestionBox [ QuestionBox.markdown "Question Box content" ] ]
+                [ Block.blankWithQuestionBox [ QuestionBox.markdown "Question Box content" ] Nothing ]
             ]
                 |> toQuery
                 |> Query.has
@@ -75,7 +75,7 @@ contentSpec =
     , test "content with wordWithQuestionBox" <|
         \() ->
             [ Block.content
-                [ Block.wordWithQuestionBox "word" [ QuestionBox.markdown "Question Box content" ] ]
+                [ Block.wordWithQuestionBox "word" [ QuestionBox.markdown "Question Box content" ] Nothing ]
             ]
                 |> toQuery
                 |> Query.has


### PR DESCRIPTION
- restructures the examples. The table now only shows the `pointingTo` views, since that's where the complexity comes in
- adds more code examples, to hopefully illustrate the API a bit better
- removes padding bottom helper from Block. instead, `Block.withQuestionBox`, `Block.wordWithQuestionBox`, and `blankWithQuestionBox` now require a `Maybe Dom.Element` measurement, which is used by Block to add the appropriate spacing and to mark the QuestionBox as of the `pointingTo` variety