### PR TITLE
Tessa/header links

### DIFF
--- a/src/Nri/Ui/Header/V1.elm
+++ b/src/Nri/Ui/Header/V1.elm
@@ -234,6 +234,7 @@ viewExtraNav ( label, values ) =
                 , Css.alignItems Css.center
                 , Css.justifyContent Css.flexStart
                 , Css.flexWrap Css.wrap
+                , Css.property "column-gap" (.value Spacing.horizontalSpacerPx)
                 ]
             ]
             (List.map

--- a/src/Nri/Ui/Header/V1.elm
+++ b/src/Nri/Ui/Header/V1.elm
@@ -150,6 +150,20 @@ view attrs { breadCrumbs, isCurrentRoute } =
     let
         config =
             customize attrs
+
+        ( extraContent_, extraNav_ ) =
+            -- when there's no content in the "extra content" hole to the right of the breadcrumbs,
+            -- put the extra nav  there. If there is content there, put the links directly above the description.
+            case config.extraContent of
+                [] ->
+                    ( [ viewJust viewExtraNav config.extraNav ]
+                    , Html.text ""
+                    )
+
+                _ ->
+                    ( config.extraContent
+                    , viewJust viewExtraNav config.extraNav
+                    )
     in
     Html.div
         [ css
@@ -189,10 +203,10 @@ view attrs { breadCrumbs, isCurrentRoute } =
                     _ ->
                         Html.div [] (breadcrumbsView :: config.extraSubheadContent)
                 ]
-                :: config.extraContent
+                :: extraContent_
             )
+        , extraNav_
         , viewJust (viewDescription config.pageWidth) config.description
-        , viewJust viewExtraNav config.extraNav
         ]
 
 

--- a/src/Nri/Ui/Header/V1.elm
+++ b/src/Nri/Ui/Header/V1.elm
@@ -40,7 +40,8 @@ extraContent value =
     Attribute (\soFar -> { soFar | extraContent = value })
 
 
-{-| -}
+{-| This attribute is unused and will be removed in the next version of Header.
+-}
 extraSubheadContent : List (Html msg) -> Attribute route msg
 extraSubheadContent value =
     Attribute (\soFar -> { soFar | extraSubheadContent = value })

--- a/src/Nri/Ui/Header/V1.elm
+++ b/src/Nri/Ui/Header/V1.elm
@@ -156,19 +156,29 @@ view attrs { breadCrumbs, isCurrentRoute } =
             -- put the extra nav  there. If there is content there, put the links directly above the description.
             case config.extraContent of
                 [] ->
-                    ( [ viewJust viewExtraNav config.extraNav ]
+                    ( [ viewJust (viewExtraNav []) config.extraNav ]
                     , Html.text ""
                     )
 
                 _ ->
                     ( config.extraContent
-                    , viewJust viewExtraNav config.extraNav
+                    , viewJust
+                        (viewExtraNav
+                            [ Spacing.centeredContentWithSidePaddingAndCustomWidth config.pageWidth
+                            ]
+                        )
+                        config.extraNav
                     )
     in
     Html.div
         [ css
             [ Css.backgroundColor Colors.gray96
             , Css.borderBottom3 (Css.px 1) Css.solid Colors.gray92
+            , Css.paddingTop (Css.px 30)
+            , Css.paddingBottom (Css.px 20)
+            , Media.withMedia [ MediaQuery.mobile ]
+                [ Css.important (Css.padding2 (Css.px 20) (Css.px 15))
+                ]
             ]
         , AttributesExtra.nriDescription "Nri-Header"
         ]
@@ -177,12 +187,7 @@ view attrs { breadCrumbs, isCurrentRoute } =
                 [ Spacing.centeredContentWithSidePaddingAndCustomWidth config.pageWidth
                 , Css.alignItems Css.center
                 , Css.displayFlex
-                , Css.paddingTop (Css.px 30)
-                , Css.paddingBottom (Css.px 20)
-                , Media.withMedia [ MediaQuery.mobile ]
-                    [ Css.important (Css.padding2 (Css.px 20) (Css.px 15))
-                    , Css.flexDirection Css.column
-                    ]
+                , Media.withMedia [ MediaQuery.mobile ] [ Css.flexDirection Css.column ]
                 ]
                 :: config.containerAttributes
             )
@@ -217,15 +222,15 @@ viewDescription pageWidth description_ =
             [ Spacing.centeredContentWithSidePaddingAndCustomWidth pageWidth
             , Css.color Colors.gray45
             , Css.important (Css.margin Css.auto)
-            , Css.important (Css.paddingBottom (Css.px 20))
+            , Css.important (Css.paddingTop (Css.px 20))
             ]
         , Text.plaintext description_
         ]
 
 
-viewExtraNav : ( String, List (Html msg) ) -> Html msg
-viewExtraNav ( label, values ) =
-    Html.nav [ Aria.label label ]
+viewExtraNav : List Css.Style -> ( String, List (Html msg) ) -> Html msg
+viewExtraNav styles ( label, values ) =
+    Html.nav [ Aria.label label, css styles ]
         [ Html.ul
             [ css
                 [ Css.margin Css.zero

--- a/src/Nri/Ui/Header/V1.elm
+++ b/src/Nri/Ui/Header/V1.elm
@@ -1,16 +1,42 @@
 module Nri.Ui.Header.V1 exposing
-    ( view
-    , Attribute, aTagAttributes, extraContent, description, extraSubheadContent, customPageWidth, breadCrumbsLabel
+    ( view, Attribute
+    , aTagAttributes, customPageWidth, breadCrumbsLabel
+    , extraContent, description, extraNav
+    , extraSubheadContent
     )
 
 {-|
 
-@docs view
-@docs Attribute, aTagAttributes, extraContent, description, extraSubheadContent, customPageWidth, breadCrumbsLabel
+
+## Changelog
+
+
+### Patch changes
+
+  - marked extraSubheadContent as deprecated
+  - added extraNav
+
+@docs view, Attribute
+
+
+## Customize the header
+
+@docs aTagAttributes, customPageWidth, breadCrumbsLabel
+
+
+## Add additional content to the header
+
+@docs extraContent, description, extraNav
+
+
+### Deprecated, to be removed:
+
+@docs extraSubheadContent
 
 -}
 
 import Accessibility.Styled as Html exposing (Html)
+import Accessibility.Styled.Aria as Aria
 import Css
 import Css.Media as Media
 import Html.Styled.Attributes exposing (css)
@@ -38,6 +64,22 @@ aTagAttributes aTagAttributes_ =
 extraContent : List (Html msg) -> Attribute route msg
 extraContent value =
     Attribute (\soFar -> { soFar | extraContent = value })
+
+
+{-| -}
+extraNav : String -> List (Html msg) -> Attribute route msg
+extraNav label value =
+    Attribute
+        (\soFar ->
+            { soFar
+                | extraNav =
+                    if List.isEmpty value then
+                        Nothing
+
+                    else
+                        Just ( label, value )
+            }
+        )
 
 
 {-| This attribute is unused and will be removed in the next version of Header.
@@ -78,6 +120,7 @@ type alias Config route msg =
     , description : Maybe String
     , pageWidth : Css.Px
     , breadCrumbsLabel : String
+    , extraNav : Maybe ( String, List (Html msg) )
     }
 
 
@@ -91,6 +134,7 @@ customize =
         , description = Nothing
         , pageWidth = MediaQuery.mobileBreakpoint
         , breadCrumbsLabel = "breadcrumbs"
+        , extraNav = Nothing
         }
 
 
@@ -148,6 +192,7 @@ view attrs { breadCrumbs, isCurrentRoute } =
                 :: config.extraContent
             )
         , viewJust (viewDescription config.pageWidth) config.description
+        , viewJust viewExtraNav config.extraNav
         ]
 
 
@@ -161,4 +206,24 @@ viewDescription pageWidth description_ =
             , Css.important (Css.paddingBottom (Css.px 20))
             ]
         , Text.plaintext description_
+        ]
+
+
+viewExtraNav : ( String, List (Html msg) ) -> Html msg
+viewExtraNav ( label, values ) =
+    Html.nav [ Aria.label label ]
+        [ Html.ul
+            [ css
+                [ Css.margin Css.zero
+                , Css.padding Css.zero
+                , Css.displayFlex
+                , Css.alignItems Css.center
+                , Css.justifyContent Css.flexStart
+                , Css.flexWrap Css.wrap
+                ]
+            ]
+            (List.map
+                (\i -> Html.li [ css [ Css.listStyle Css.none ] ] [ i ])
+                values
+            )
         ]

--- a/styleguide-app/App.elm
+++ b/styleguide-app/App.elm
@@ -18,6 +18,7 @@ import InputMethod exposing (InputMethod)
 import Json.Decode as Decode
 import Nri.Ui.CssVendorPrefix.V1 as VendorPrefixed
 import Nri.Ui.FocusRing.V1 as FocusRing
+import Nri.Ui.Header.V1 as Header
 import Nri.Ui.MediaQuery.V1 exposing (mobile)
 import Nri.Ui.Page.V3 as Page
 import Nri.Ui.SideNav.V4 as SideNav
@@ -277,10 +278,7 @@ viewExample : Model key -> Example a Examples.Msg -> Html Msg
 viewExample model example =
     Example.view { packageDependencies = model.elliePackageDependencies } example
         |> Html.map (UpdateModuleStates example.name)
-        |> viewLayout model
-            [ Example.extraLinks example
-                |> Html.map (UpdateModuleStates example.name)
-            ]
+        |> viewLayout model [ Example.extraLinks (UpdateModuleStates example.name) example ]
 
 
 notFound : Html Msg
@@ -319,7 +317,7 @@ viewCategory model category =
         )
 
 
-viewLayout : Model key -> List (Html Msg) -> Html Msg -> Html Msg
+viewLayout : Model key -> List (Header.Attribute (Routes.Route Examples.State Examples.Msg) Msg) -> Html Msg -> Html Msg
 viewLayout model headerExtras content =
     Html.div []
         [ Routes.viewHeader model.route headerExtras

--- a/styleguide-app/CommonControls.elm
+++ b/styleguide-app/CommonControls.elm
@@ -6,7 +6,7 @@ module CommonControls exposing
     , customIcon
     , specificColor
     , string
-    , content, exampleHtml
+    , content
     , httpError, badBodyString
     , guidanceAndErrorMessage
     , disabledListItem, premiumDisplay
@@ -25,7 +25,7 @@ module CommonControls exposing
 ### Content
 
 @docs string
-@docs content, exampleHtml
+@docs content
 @docs httpError, badBodyString
 @docs guidanceAndErrorMessage
 

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -12,6 +12,7 @@ import KeyboardSupport exposing (KeyboardSupport)
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
+import Nri.Ui.Header.V1 as Header
 
 
 type alias Example state msg =
@@ -154,33 +155,15 @@ view_ ellieLinkConfig example =
     ]
 
 
-extraLinks : Example state msg -> Html msg
-extraLinks example =
-    Html.nav [ Aria.label (fullName example) ]
-        [ Html.ul
-            [ Attributes.css
-                [ margin zero
-                , padding zero
-                , displayFlex
-                , alignItems center
-                , justifyContent flexStart
-                , flexWrap Css.wrap
-                ]
-            ]
-            (List.map
-                (\i ->
-                    Html.li
-                        [ Attributes.css
-                            [ Css.listStyle Css.none ]
-                        ]
-                        [ i ]
-                )
-                [ docsLink example, srcLink example ]
-            )
+extraLinks : (msg -> msg2) -> Example state msg -> Header.Attribute route msg2
+extraLinks f example =
+    Header.extraNav (fullName example)
+        [ Html.map f (docsLink example)
+        , Html.map f (srcLink example)
         ]
 
 
-docsLink : Example state msg -> Html msg
+docsLink : Example state msg -> Html msg2
 docsLink example =
     let
         link =
@@ -192,7 +175,7 @@ docsLink example =
         ]
 
 
-srcLink : Example state msg -> Html msg
+srcLink : Example state msg -> Html msg2
 srcLink example =
     let
         link =

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -170,9 +170,7 @@ docsLink example =
             "https://package.elm-lang.org/packages/NoRedInk/noredink-ui/latest/"
                 ++ String.replace "." "-" (fullName example)
     in
-    ClickableText.link "Docs"
-        [ ClickableText.linkExternal link
-        ]
+    ClickableText.link "Docs" [ ClickableText.linkExternal link ]
 
 
 srcLink : Example state msg -> Html msg2
@@ -183,7 +181,4 @@ srcLink example =
                 ++ ".elm"
                 |> (++) "https://github.com/NoRedInk/noredink-ui/blob/master/src/"
     in
-    ClickableText.link "Source"
-        [ ClickableText.linkExternal link
-        , ClickableText.css [ Css.marginLeft (Css.px 20) ]
-        ]
+    ClickableText.link "Source" [ ClickableText.linkExternal link ]

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -13,6 +13,8 @@ import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Header.V1 as Header
+import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.UiIcon.V1 as UiIcon
 
 
 type alias Example state msg =
@@ -170,7 +172,10 @@ docsLink example =
             "https://package.elm-lang.org/packages/NoRedInk/noredink-ui/latest/"
                 ++ String.replace "." "-" (fullName example)
     in
-    ClickableText.link "Docs" [ ClickableText.linkExternal link ]
+    ClickableText.link "Docs"
+        [ ClickableText.linkExternal link
+        , ClickableText.rightIcon (Svg.withLabel "Opens in a new tab" UiIcon.openInNewTab)
+        ]
 
 
 srcLink : Example state msg -> Html msg2
@@ -181,4 +186,7 @@ srcLink example =
                 ++ ".elm"
                 |> (++) "https://github.com/NoRedInk/noredink-ui/blob/master/src/"
     in
-    ClickableText.link "Source" [ ClickableText.linkExternal link ]
+    ClickableText.link "Source"
+        [ ClickableText.linkExternal link
+        , ClickableText.rightIcon (Svg.withLabel "Opens in a new tab" UiIcon.openInNewTab)
+        ]

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -2,7 +2,7 @@ module Example exposing (Example, extraLinks, fullName, preview, view, wrapMsg, 
 
 import Accessibility.Styled.Aria as Aria
 import Category exposing (Category)
-import Css exposing (..)
+import Css
 import EllieLink
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes

--- a/styleguide-app/Examples/Header.elm
+++ b/styleguide-app/Examples/Header.elm
@@ -9,7 +9,6 @@ module Examples.Header exposing (example, State, Msg)
 import Accessibility.Styled.Role as Role
 import Category exposing (Category(..))
 import Code
-import CommonControls
 import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra

--- a/styleguide-app/Examples/Header.elm
+++ b/styleguide-app/Examples/Header.elm
@@ -22,6 +22,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Header.V1 as Header
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Select.V8 as Select
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.UiIcon.V1 as UiIcon
 
@@ -43,7 +44,7 @@ example =
     , version = version
     , categories = [ Layout ]
     , keyboardSupport = []
-    , state = init
+    , state = init Nothing
     , update = update
     , subscriptions = \_ -> Sub.none
     , preview = [ viewPreview ]
@@ -143,17 +144,28 @@ viewPreview =
 {-| -}
 type alias State =
     { control : Control Settings
+    , selection : Maybe String
     }
 
 
-init : State
-init =
+init : Maybe String -> State
+init selection =
     { control =
         ControlExtra.list
             |> ControlExtra.optionalListItem "extraContent"
                 (Control.value
                     ( "Header.extraContent [ Html.text \"…\" ]"
-                    , Header.extraContent CommonControls.exampleHtml
+                    , Header.extraContent
+                        [ Select.view "Tortilla Selector"
+                            [ Select.choices identity
+                                [ { label = "Tacos", value = "tacos" }
+                                , { label = "Burritos", value = "burritos" }
+                                , { label = "Enchiladas", value = "enchiladas" }
+                                ]
+                            , Select.value selection
+                            ]
+                            |> map Select
+                        ]
                     )
                 )
             |> ControlExtra.optionalListItem "description"
@@ -180,6 +192,7 @@ init =
                     )
                     (ControlExtra.float 750)
                 )
+    , selection = Nothing
     }
 
 
@@ -190,6 +203,7 @@ type alias Settings =
 {-| -}
 type Msg
     = UpdateControl (Control Settings)
+    | Select String
 
 
 update : Msg -> State -> ( State, Cmd Msg )
@@ -197,3 +211,6 @@ update msg state =
     case msg of
         UpdateControl settings ->
             ( { state | control = settings }, Cmd.none )
+
+        Select value ->
+            ( { state | selection = Just value }, Cmd.none )

--- a/styleguide-app/Examples/Header.elm
+++ b/styleguide-app/Examples/Header.elm
@@ -177,12 +177,6 @@ init selection =
                     )
                     (Control.string "This page has some good content.")
                 )
-            |> ControlExtra.optionalListItem "extraSubheadContent"
-                (Control.value
-                    ( "Header.extraSubheadContent [ Html.text \"…\" ]"
-                    , Header.extraSubheadContent CommonControls.exampleHtml
-                    )
-                )
             |> ControlExtra.optionalListItem "customPageWidth"
                 (Control.map
                     (\width ->

--- a/styleguide-app/Examples/Header.elm
+++ b/styleguide-app/Examples/Header.elm
@@ -18,6 +18,7 @@ import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.BreadCrumbs.V2 as BreadCrumbs
+import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Header.V1 as Header
@@ -165,6 +166,23 @@ init selection =
                             , Select.value selection
                             ]
                             |> map Select
+                        ]
+                    )
+                )
+            |> ControlExtra.optionalListItem "extraNav"
+                (Control.value
+                    ( Code.fromModule "Header" "extraNav "
+                        ++ Code.string "Resources"
+                        ++ Code.listMultiline
+                            [ Code.fromModule "ClickableText" "link " ++ Code.string "Zendesk" ++ " []"
+                            , Code.fromModule "ClickableText" "link " ++ Code.string "FAQ" ++ " []"
+                            , Code.fromModule "ClickableText" "link " ++ Code.string "About" ++ " []"
+                            ]
+                            2
+                    , Header.extraNav "Resources"
+                        [ ClickableText.link "Zendesk" []
+                        , ClickableText.link "FAQ" []
+                        , ClickableText.link "About" []
                         ]
                     )
                 )

--- a/styleguide-app/Routes.elm
+++ b/styleguide-app/Routes.elm
@@ -103,16 +103,17 @@ fromLocation examples location =
         |> Result.withDefault All
 
 
-viewHeader : Route state msg -> List (Html msg2) -> Html msg2
+viewHeader : Route state msg -> List (Header.Attribute (Route state msg) msg2) -> Html msg2
 viewHeader currentRoute extraContent =
     breadCrumbs currentRoute
         |> Maybe.map
             (\crumbs ->
                 Header.view
-                    [ Header.aTagAttributes (\r -> [ Attributes.href ("/" ++ toString r) ])
-                    , Header.extraContent extraContent
-                    , Header.customPageWidth (Css.px 1400)
-                    ]
+                    ([ Header.aTagAttributes (\r -> [ Attributes.href ("/" ++ toString r) ])
+                     , Header.customPageWidth (Css.px 1400)
+                     ]
+                        ++ extraContent
+                    )
                     { breadCrumbs = crumbs
                     , isCurrentRoute = (==) currentRoute
                     }


### PR DESCRIPTION
Prep for fixing https://github.com/NoRedInk/NoRedInk/pull/41606#issuecomment-1337448191  -- we want the progress table links to appear on a new line without messing with the extraContent in the header.


## Without extra content

The nav appears in-line with the breadcrumbs.

<img width="1375" alt="Screen Shot 2022-12-27 at 11 12 54 AM" src="https://user-images.githubusercontent.com/8811312/209706199-db5da578-41fe-4365-8513-a1cf123b0ed6.png">


## With extra content

The nav shows up on a new line.


<img width="1393" alt="Screen Shot 2022-12-27 at 11 13 02 AM" src="https://user-images.githubusercontent.com/8811312/209706200-8ad67ae9-c026-445a-aac1-808caeec8a4e.png">

cc @NoRedInk/design 
