### PR TITLE
Ensure rightIcon attributes don't change pre-existing rendering

### DIFF
--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -621,15 +621,9 @@ renderLink ((ButtonOrLink config) as link_) =
         ([ Attributes.class ("Nri-Ui-Clickable-Svg-" ++ linkFunctionName)
          , Attributes.class FocusRing.customClass
          , Attributes.css (buttonOrLinkStyles config theme ++ config.customStyles)
-         , Aria.disabled config.disabled
          , Aria.label config.label
          ]
-            ++ (if not config.disabled then
-                    extraAttrs
-
-                else
-                    []
-               )
+            ++ extraAttrs
             ++ config.customAttributes
         )
         (renderIcons config theme.includeBorder)

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -498,7 +498,8 @@ quizEngineMobileCss styles =
     css [ Css.Media.withMedia [ MediaQuery.quizEngineMobile ] styles ]
 
 
-{-| -}
+{-| WARNING: Not implemented! This attribute is temporarily reverted due to <https://github.com/NoRedInk/NoRedInk/pull/41952#issuecomment-1372393691>.
+-}
 rightIcon : Svg -> Attribute msg
 rightIcon icon =
     set (\config -> { config | rightIcon = Just icon })

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -465,21 +465,41 @@ viewContent config =
 
                 Large ->
                     Css.px 4
+
+        iconAndTextContainer =
+            span
+                [ Attributes.css
+                    [ Css.display Css.inlineFlex
+                    , Css.alignItems Css.center
+                    , Css.property "line-height" "normal"
+                    , Css.fontSize fontSize
+                    ]
+                ]
+                >> List.singleton
     in
-    span
-        [ Attributes.css
-            [ Css.displayFlex
-            , Css.alignItems Css.center
-            , Css.property "line-height" "normal"
-            , Css.fontSize fontSize
-            ]
-        ]
-        (List.filterMap identity
-            [ Maybe.map (viewIcon (Css.marginRight iconSize :: config.iconStyles))
-                config.icon
-            , Just (span [ ExtraAttributes.nriDescription "clickable-text-label" ] [ text config.label ])
-            , Maybe.map (viewIcon [ Css.marginLeft iconSize ]) config.rightIcon
-            ]
+    span [ Attributes.css [ Css.fontSize fontSize ] ]
+        (case ( config.icon, config.rightIcon ) of
+            ( Just leftIcon, Just rightIcon_ ) ->
+                iconAndTextContainer
+                    [ viewIcon (Css.marginRight iconSize :: config.iconStyles) leftIcon
+                    , span [ ExtraAttributes.nriDescription "clickable-text-label" ] [ text config.label ]
+                    , viewIcon [ Css.marginLeft iconSize ] rightIcon_
+                    ]
+
+            ( Just leftIcon, Nothing ) ->
+                iconAndTextContainer
+                    [ viewIcon (Css.marginRight iconSize :: config.iconStyles) leftIcon
+                    , span [ ExtraAttributes.nriDescription "clickable-text-label" ] [ text config.label ]
+                    ]
+
+            ( Nothing, Just rightIcon_ ) ->
+                iconAndTextContainer
+                    [ span [ ExtraAttributes.nriDescription "clickable-text-label" ] [ text config.label ]
+                    , viewIcon [ Css.marginLeft iconSize ] rightIcon_
+                    ]
+
+            ( Nothing, Nothing ) ->
+                [ text config.label ]
         )
 
 


### PR DESCRIPTION
Fixes https://github.com/NoRedInk/NoRedInk/pull/41952#issuecomment-1372393691

Note that this removes rightIcon support from ClickableSvg. It is still available from ClickableText and Button.

See https://github.com/NoRedInk/noredink-ui/pull/1188 for original PR adding rightIcon