### PR TITLE
Highlighter supports auto-expanding adjacent highlights

### DIFF
--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -3,6 +3,7 @@ Nri.Ui.Block.V1,upgrade to V4
 Nri.Ui.Block.V2,upgrade to V4
 Nri.Ui.Block.V3,upgrade to V4
 Nri.Ui.Checkbox.V6,upgrade to V7
+Nri.Ui.Highlighter.V1,upgrade to V2
 Nri.Ui.Mark.V1,upgrade to V2
 Nri.Ui.QuestionBox.V1,upgrade to V3
 Nri.Ui.QuestionBox.V2,upgrade to V3

--- a/elm.json
+++ b/elm.json
@@ -42,6 +42,7 @@
         "Nri.Ui.Heading.V3",
         "Nri.Ui.Highlightable.V1",
         "Nri.Ui.Highlighter.V1",
+        "Nri.Ui.Highlighter.V2",
         "Nri.Ui.HighlighterTool.V1",
         "Nri.Ui.HighlighterToolbar.V1",
         "Nri.Ui.Html.Attributes.V2",

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -73,6 +73,9 @@ hint = 'upgrade to V2'
 [forbidden."Nri.Ui.Heading.V2"]
 hint = 'upgrade to V3'
 
+[forbidden."Nri.Ui.Highlighter.V1"]
+hint = 'upgrade to V2'
+
 [forbidden."Nri.Ui.Icon.V3"]
 hint = 'upgrade to V5'
 usages = ['styleguide-app/../src/Nri/Ui/Modal/V3.elm']

--- a/src/Nri/Ui/Highlighter/V2.elm
+++ b/src/Nri/Ui/Highlighter/V2.elm
@@ -11,6 +11,7 @@ module Nri.Ui.Highlighter.V2 exposing
 {-| Changes from V1:
 
   - Remove emptyIntent, which is not used
+  - adds setting for joining adjacent interactive highlights of the same type
 
 Highlighter provides a view/model/update to display a view to highlight text and show marks.
 
@@ -79,6 +80,7 @@ type alias Model marker =
       id : String
     , highlightables : List (Highlightable marker) -- The actual highlightable elements
     , marker : Tool.Tool marker -- Currently used marker
+    , joinAdjacentInteractiveHighlights : Bool
 
     -- Internal state to track user's interactions
     , mouseDownIndex : Maybe Int
@@ -103,17 +105,22 @@ type Initialized
 
 
 {-| Setup initial model
+
+joinAdjacentInteractiveHighlights - When true, and static highlightables are sandwiched by highlighted interactive highlightables of the same type, apply the highlight to the static highlightable as well.
+
 -}
 init :
     { id : String
     , highlightables : List (Highlightable marker)
     , marker : Tool.Tool marker
+    , joinAdjacentInteractiveHighlights : Bool
     }
     -> Model marker
 init config =
     { id = config.id
     , highlightables = config.highlightables
     , marker = config.marker
+    , joinAdjacentInteractiveHighlights = config.joinAdjacentInteractiveHighlights
     , mouseDownIndex = Nothing
     , mouseOverIndex = Nothing
     , isInitialized = NotInitialized

--- a/src/Nri/Ui/Highlighter/V2.elm
+++ b/src/Nri/Ui/Highlighter/V2.elm
@@ -1,0 +1,993 @@
+module Nri.Ui.Highlighter.V2 exposing
+    ( Model, Msg(..), PointerMsg(..)
+    , init, update
+    , view, static, staticWithTags
+    , viewMarkdown, staticMarkdown, staticMarkdownWithTags
+    , Intent(..), emptyIntent, hasChanged, HasChanged(..)
+    , removeHighlights
+    , asFragmentTuples, usedMarkers, text
+    )
+
+{-| Changes from V1:
+
+  - TODO
+
+Highlighter provides a view/model/update to display a view to highlight text and show marks.
+
+
+# Types
+
+@docs Model, Msg, PointerMsg
+
+
+# Init/View/Update
+
+@docs init, update
+
+@docs view, static, staticWithTags
+@docs viewMarkdown, staticMarkdown, staticMarkdownWithTags
+
+
+## Intents
+
+@docs Intent, emptyIntent, hasChanged, HasChanged
+
+
+# Setters
+
+@docs removeHighlights
+
+
+# Getters
+
+@docs asFragmentTuples, usedMarkers, text
+
+
+# Events
+
+TODO: Add documentation about how to wire in event listeners and subscriptions so the highlighter is functional!
+
+-}
+
+import Accessibility.Styled.Key as Key
+import Browser.Dom as Dom
+import Css
+import Highlighter.Grouping as Grouping
+import Highlighter.Internal as Internal
+import Html.Styled as Html exposing (Attribute, Html, p, span)
+import Html.Styled.Attributes exposing (attribute, class, css)
+import Html.Styled.Events as Events
+import Json.Decode
+import List.Extra
+import Markdown.Block
+import Markdown.Inline
+import Nri.Ui.Highlightable.V1 as Highlightable exposing (Highlightable)
+import Nri.Ui.HighlighterTool.V1 as Tool
+import Nri.Ui.Html.Attributes.V2 as AttributesExtra
+import Nri.Ui.Mark.V2 as Mark
+import Sort exposing (Sorter)
+import Sort.Set
+import String.Extra
+import Task
+
+
+
+-- Model
+
+
+{-| Model of a highlighter
+-}
+type alias Model marker =
+    { -- Used to identify a highlighter. This is necessary when there are
+      -- multiple highlighters on the same page because we add listeners
+      -- in javascript (see ./highlighter.js) and because we move focus by id for keyboard users.
+      id : String
+    , highlightables : List (Highlightable marker) -- The actual highlightable elements
+    , marker : Tool.Tool marker -- Currently used marker
+
+    -- Internal state to track user's interactions
+    , mouseDownIndex : Maybe Int
+    , mouseOverIndex : Maybe Int
+    , isInitialized : Initialized
+    , hasChanged : HasChanged
+    , selectionStartIndex : Maybe Int
+    , selectionEndIndex : Maybe Int
+    , focusIndex : Maybe Int
+    }
+
+
+{-| -}
+type HasChanged
+    = Changed
+    | NotChanged
+
+
+type Initialized
+    = Initialized
+    | NotInitialized
+
+
+{-| Setup initial model
+-}
+init :
+    { id : String
+    , highlightables : List (Highlightable marker)
+    , marker : Tool.Tool marker
+    }
+    -> Model marker
+init config =
+    { id = config.id
+    , highlightables = config.highlightables
+    , marker = config.marker
+    , mouseDownIndex = Nothing
+    , mouseOverIndex = Nothing
+    , isInitialized = NotInitialized
+    , hasChanged = NotChanged
+    , selectionStartIndex = Nothing
+    , selectionEndIndex = Nothing
+    , focusIndex =
+        List.Extra.findIndex (\highlightable -> .type_ highlightable == Highlightable.Interactive) config.highlightables
+    }
+
+
+{-| Get unique markers that have been used.
+-}
+usedMarkers : Sorter marker -> Model marker -> Sort.Set.Set marker
+usedMarkers sorter { highlightables } =
+    highlightables
+        |> List.filterMap
+            (\highlightable ->
+                if String.Extra.isBlank highlightable.text then
+                    Nothing
+
+                else
+                    highlightable.marked
+                        |> Maybe.map .kind
+            )
+        |> Sort.Set.fromList sorter
+
+
+{-| Get a list of fragment texts and whether or not they are marked.
+Useful for encoding answers.
+-}
+asFragmentTuples : List (Highlightable marker) -> List ( Maybe marker, String )
+asFragmentTuples highlightables =
+    highlightables
+        |> List.Extra.groupWhile (\a b -> a.groupIndex == b.groupIndex)
+        |> List.map
+            (\( first, rest ) ->
+                ( first.marked
+                    |> Maybe.map .kind
+                , text (first :: rest)
+                )
+            )
+
+
+{-| Fetch the text from a series of highlightables.
+-}
+text : List (Highlightable marker) -> String
+text highlightables =
+    List.map .text highlightables
+        |> String.concat
+
+
+
+-- UPDATE
+
+
+{-| -}
+type Msg marker
+    = Pointer PointerMsg
+    | Keyboard KeyboardMsg
+    | Focused (Result Dom.Error ())
+
+
+{-| Messages used by highlighter when interacting with a mouse or finger.
+-}
+type PointerMsg
+    = Down Int
+    | Out Int
+    | Over Int
+      -- the `Maybe String`s here are for detecting touchend events via
+      -- subscription--we listen at the document level but get the id associated
+      -- with the subscription when it fires messages. Mouse-triggered events
+      -- will not have this info!
+    | Move (Maybe String) Int
+    | Up (Maybe String)
+    | Ignored
+
+
+type KeyboardMsg
+    = MoveLeft Int
+    | MoveRight Int
+    | SelectionExpandLeft Int
+    | SelectionExpandRight Int
+    | SelectionApplyTool Int
+    | SelectionReset Int
+    | ToggleHighlight Int
+
+
+{-| Possible intents or "external effects" that the Highlighter can request (see `perform`).
+-}
+type Intent
+    = Intent
+        { listenTo : ListenTo
+        , changed : HasChanged
+        }
+
+
+type alias ListenTo =
+    Maybe String
+
+
+{-| -}
+emptyIntent : Intent
+emptyIntent =
+    Intent
+        { listenTo = Nothing
+        , changed = NotChanged
+        }
+
+
+{-| Get intent based on the resulting model from `update`.
+
+  - This ensures that we initialize the highlighter in JS exactly once.
+  - Sets the `hasChanged` flag if the model has changed. This is used by the user of `Highlighter` to
+    determine whether they want to execute follow up actions.
+
+-}
+withIntent : ( Model m, Cmd (Msg m) ) -> ( Model m, Cmd (Msg m), Intent )
+withIntent ( new, cmd ) =
+    ( { new | isInitialized = Initialized, hasChanged = NotChanged }
+    , cmd
+    , Intent
+        { listenTo =
+            case new.isInitialized of
+                Initialized ->
+                    Nothing
+
+                NotInitialized ->
+                    Just new.id
+        , changed = new.hasChanged
+        }
+    )
+
+
+{-| Check if the highlighter has changed.
+-}
+hasChanged : Intent -> HasChanged
+hasChanged (Intent { changed }) =
+    changed
+
+
+{-| Actions are used as an intermediate algebra from pointer events to actual changes to the model.
+-}
+type Action marker
+    = Focus Int
+    | Blur Int
+    | Hint Int Int
+    | Hover Int
+    | MouseDown Int
+    | MouseOver Int
+    | MouseUp
+    | RemoveHint
+    | Save (Tool.MarkerModel marker)
+    | Toggle Int (Tool.MarkerModel marker)
+    | StartSelection Int
+    | ExpandSelection Int
+    | ResetSelection
+
+
+{-| Update for highlighter returning additional info about whether there was a change
+-}
+update : Msg marker -> Model marker -> ( Model marker, Cmd (Msg marker), Intent )
+update msg model =
+    withIntent <|
+        case msg of
+            Pointer pointerMsg ->
+                pointerEventToActions pointerMsg model
+                    |> performActions model
+
+            Keyboard keyboardMsg ->
+                keyboardEventToActions keyboardMsg model
+                    |> performActions model
+
+            Focused _ ->
+                ( model, Cmd.none )
+
+
+nextInteractiveIndex : Int -> List (Highlightable marker) -> Maybe Int
+nextInteractiveIndex index highlightables =
+    let
+        isInteractive highlightable =
+            .type_ highlightable == Highlightable.Interactive
+
+        interactiveHighlightables =
+            List.filter isInteractive highlightables
+    in
+    List.foldl
+        (\x ( maybeNextIndex, hasIndexMatched ) ->
+            if hasIndexMatched then
+                ( Just x.groupIndex, False )
+
+            else
+                ( maybeNextIndex, x.groupIndex == index )
+        )
+        ( Nothing, False )
+        interactiveHighlightables
+        |> Tuple.first
+
+
+previousInteractiveIndex : Int -> List (Highlightable marker) -> Maybe Int
+previousInteractiveIndex index highlightables =
+    let
+        isInteractive highlightable =
+            .type_ highlightable == Highlightable.Interactive
+
+        interactiveHighlightables =
+            List.filter isInteractive highlightables
+    in
+    List.foldr
+        (\x ( maybeNextIndex, hasIndexMatched ) ->
+            if hasIndexMatched then
+                ( Just x.groupIndex, False )
+
+            else
+                ( maybeNextIndex, x.groupIndex == index )
+        )
+        ( Nothing, False )
+        interactiveHighlightables
+        |> Tuple.first
+
+
+keyboardEventToActions : KeyboardMsg -> Model marker -> List (Action marker)
+keyboardEventToActions msg model =
+    case msg of
+        MoveLeft index ->
+            case previousInteractiveIndex index model.highlightables of
+                Nothing ->
+                    []
+
+                Just i ->
+                    [ Focus i, ResetSelection, RemoveHint ]
+
+        MoveRight index ->
+            case nextInteractiveIndex index model.highlightables of
+                Nothing ->
+                    []
+
+                Just i ->
+                    [ Focus i, ResetSelection, RemoveHint ]
+
+        SelectionExpandLeft index ->
+            case previousInteractiveIndex index model.highlightables of
+                Nothing ->
+                    []
+
+                Just i ->
+                    Focus i
+                        :: (case model.selectionStartIndex of
+                                Just startIndex ->
+                                    [ ExpandSelection i, Hint startIndex i ]
+
+                                Nothing ->
+                                    [ StartSelection index, ExpandSelection i, Hint index i ]
+                           )
+
+        SelectionExpandRight index ->
+            case nextInteractiveIndex index model.highlightables of
+                Nothing ->
+                    []
+
+                Just i ->
+                    Focus i
+                        :: (case model.selectionStartIndex of
+                                Just startIndex ->
+                                    [ ExpandSelection i, Hint startIndex i ]
+
+                                Nothing ->
+                                    [ StartSelection index, ExpandSelection i, Hint index i ]
+                           )
+
+        SelectionApplyTool index ->
+            case model.marker of
+                Tool.Marker marker ->
+                    [ Save marker, ResetSelection, Focus index ]
+
+                Tool.Eraser _ ->
+                    [ RemoveHint, ResetSelection, Focus index ]
+
+        SelectionReset index ->
+            [ ResetSelection, RemoveHint, Focus index ]
+
+        ToggleHighlight index ->
+            case model.marker of
+                Tool.Marker marker ->
+                    [ Toggle index marker
+                    , Focus index
+                    ]
+
+                Tool.Eraser _ ->
+                    [ MouseOver index
+                    , Hint index index
+                    , MouseUp
+                    , RemoveHint
+                    , Focus index
+                    ]
+
+
+{-| Pointer events to actions.
+-}
+pointerEventToActions : PointerMsg -> Model marker -> List (Action marker)
+pointerEventToActions msg model =
+    case msg of
+        Ignored ->
+            []
+
+        Move _ eventIndex ->
+            case model.mouseDownIndex of
+                Just downIndex ->
+                    [ MouseOver eventIndex
+                    , Hint downIndex eventIndex
+                    ]
+
+                Nothing ->
+                    -- We're dealing with a touch move that hasn't been where
+                    -- the initial touch down was not over a highlightable
+                    -- region. We need to pretend like the first move into the
+                    -- highlightable region was actually a touch down.
+                    pointerEventToActions (Down eventIndex) model
+
+        Over eventIndex ->
+            case model.mouseDownIndex of
+                Just downIndex ->
+                    [ MouseOver eventIndex
+                    , Hint downIndex eventIndex
+                    ]
+
+                Nothing ->
+                    [ MouseOver eventIndex
+                    , Hover eventIndex
+                    ]
+
+        Down eventIndex ->
+            [ MouseOver eventIndex
+            , MouseDown eventIndex
+            , Hint eventIndex eventIndex
+            ]
+
+        Up _ ->
+            let
+                save marker =
+                    case ( model.mouseOverIndex, model.mouseDownIndex ) of
+                        ( Just overIndex, Just downIndex ) ->
+                            if overIndex == downIndex then
+                                [ Toggle downIndex marker ]
+
+                            else
+                                [ Save marker ]
+
+                        ( Nothing, Just downIndex ) ->
+                            [ Save marker ]
+
+                        _ ->
+                            []
+            in
+            case model.marker of
+                Tool.Marker marker ->
+                    MouseUp :: save marker
+
+                Tool.Eraser _ ->
+                    [ MouseUp, RemoveHint ]
+
+        Out eventIndex ->
+            [ Blur eventIndex ]
+
+
+{-| We fold over actions using (Model marker) as the accumulator.
+-}
+performActions : Model marker -> List (Action marker) -> ( Model marker, Cmd (Msg m) )
+performActions model actions =
+    List.foldl performAction ( model, [] ) actions
+        |> Tuple.mapSecond Cmd.batch
+
+
+{-| Performs actual changes to the model, or emit a command.
+-}
+performAction : Action marker -> ( Model marker, List (Cmd (Msg m)) ) -> ( Model marker, List (Cmd (Msg m)) )
+performAction action ( model, cmds ) =
+    case action of
+        Focus index ->
+            ( { model | focusIndex = Just index }, Task.attempt Focused (Dom.focus (highlightableId model.id index)) :: cmds )
+
+        Blur index ->
+            ( { model | highlightables = Internal.blurAt index model.highlightables }, cmds )
+
+        Hover index ->
+            ( { model | highlightables = Internal.hoverAt index model.highlightables }, cmds )
+
+        Hint start end ->
+            ( { model | highlightables = Internal.hintBetween start end model.highlightables }, cmds )
+
+        Save marker ->
+            ( { model
+                | highlightables = Internal.saveHinted marker model.highlightables
+                , hasChanged = Changed
+              }
+            , cmds
+            )
+
+        Toggle index marker ->
+            ( { model
+                | highlightables = Internal.toggleHinted index marker model.highlightables
+                , hasChanged = Changed
+              }
+            , cmds
+            )
+
+        RemoveHint ->
+            ( { model
+                | highlightables = Internal.removeHinted model.highlightables
+                , hasChanged = Changed
+              }
+            , cmds
+            )
+
+        MouseDown index ->
+            ( { model | mouseDownIndex = Just index }, cmds )
+
+        MouseOver index ->
+            ( { model | mouseOverIndex = Just index }, cmds )
+
+        MouseUp ->
+            ( { model | mouseDownIndex = Nothing }, cmds )
+
+        StartSelection index ->
+            ( { model | selectionStartIndex = Just index }, cmds )
+
+        ExpandSelection index ->
+            ( { model | selectionEndIndex = Just index }, cmds )
+
+        ResetSelection ->
+            ( { model | selectionStartIndex = Nothing, selectionEndIndex = Nothing }, cmds )
+
+
+{-| -}
+removeHighlights : Model marker -> Model marker
+removeHighlights model =
+    { model | highlightables = Internal.removeHighlights model.highlightables }
+
+
+
+-- VIEWS
+
+
+{-| -}
+view : { config | id : String, highlightables : List (Highlightable marker), focusIndex : Maybe Int, marker : Tool.Tool marker } -> Html (Msg marker)
+view config =
+    view_ { showTagsInline = False, maybeTool = Just config.marker }
+        (viewHighlightable False config)
+        config
+
+
+{-| Same as `view`, but will render strings like "_blah_" inside of emphasis tags.
+
+WARNING: the version of markdown used here is extremely limited, as the highlighter content needs to be entirely in-line content. Lists & other block-level elements will _not_ render as they usually would!
+
+WARNING: markdown is rendered highlightable by highlightable, so be sure to provide highlightables like ["_New York Times_"]["*New York Times*"], NOT like ["_New ", "York ", "Times_"]["*New ", "York ", "Times*"]
+
+-}
+viewMarkdown : { config | id : String, highlightables : List (Highlightable marker), focusIndex : Maybe Int, marker : Tool.Tool marker } -> Html (Msg marker)
+viewMarkdown config =
+    view_ { showTagsInline = False, maybeTool = Just config.marker }
+        (viewHighlightable True config)
+        config
+
+
+{-| -}
+static : { config | id : String, highlightables : List (Highlightable marker) } -> Html msg
+static config =
+    view_ { showTagsInline = False, maybeTool = Nothing }
+        (viewHighlightableSegment
+            { interactiveHighlighterId = Nothing
+            , focusIndex = Nothing
+            , eventListeners = []
+            , maybeTool = Nothing
+            , renderMarkdown = False
+            }
+        )
+        config
+
+
+{-| Same as `static`, but will render strings like "_blah_" inside of emphasis tags.
+
+WARNING: the version of markdown used here is extremely limited, as the highlighter content needs to be entirely in-line content. Lists & other block-level elements will _not_ render as they usually would!
+
+WARNING: markdown is rendered highlightable by highlightable, so be sure to provide highlightables like ["_New York Times_"]["*New York Times*"], NOT like ["_New ", "York ", "Times_"]["*New ", "York ", "Times*"]
+
+-}
+staticMarkdown : { config | id : String, highlightables : List (Highlightable marker) } -> Html msg
+staticMarkdown config =
+    view_ { showTagsInline = False, maybeTool = Nothing }
+        (viewHighlightableSegment
+            { interactiveHighlighterId = Nothing
+            , focusIndex = Nothing
+            , eventListeners = []
+            , maybeTool = Nothing
+            , renderMarkdown = True
+            }
+        )
+        config
+
+
+{-| -}
+staticWithTags : { config | id : String, highlightables : List (Highlightable marker) } -> Html msg
+staticWithTags config =
+    let
+        viewStaticHighlightableWithTags : Highlightable marker -> List Css.Style -> Html msg
+        viewStaticHighlightableWithTags =
+            viewHighlightableSegment
+                { interactiveHighlighterId = Nothing
+                , focusIndex = Nothing
+                , eventListeners = []
+                , maybeTool = Nothing
+                , renderMarkdown = False
+                }
+    in
+    view_ { showTagsInline = True, maybeTool = Nothing }
+        viewStaticHighlightableWithTags
+        config
+
+
+{-| Same as `staticWithTags`, but will render strings like "_blah_" inside of emphasis tags.
+
+WARNING: the version of markdown used here is extremely limited, as the highlighter content needs to be entirely in-line content. Lists & other block-level elements will _not_ render as they usually would!
+
+WARNING: markdown is rendered highlightable by highlightable, so be sure to provide highlightables like ["_New York Times_"]["*New York Times*"], NOT like ["_New ", "York ", "Times_"]["*New ", "York ", "Times*"]
+
+-}
+staticMarkdownWithTags : { config | id : String, highlightables : List (Highlightable marker) } -> Html msg
+staticMarkdownWithTags config =
+    let
+        viewStaticHighlightableWithTags : Highlightable marker -> List Css.Style -> Html msg
+        viewStaticHighlightableWithTags =
+            viewHighlightableSegment
+                { interactiveHighlighterId = Nothing
+                , focusIndex = Nothing
+                , eventListeners = []
+                , maybeTool = Nothing
+                , renderMarkdown = True
+                }
+    in
+    view_ { showTagsInline = True, maybeTool = Nothing }
+        viewStaticHighlightableWithTags
+        config
+
+
+view_ :
+    { showTagsInline : Bool, maybeTool : Maybe (Tool.Tool marker) }
+    -> (Highlightable marker -> List Css.Style -> Html msg)
+    -> { config | id : String, highlightables : List (Highlightable marker) }
+    -> Html msg
+view_ groupConfig viewSegment { id, highlightables } =
+    p [ Html.Styled.Attributes.id id, class "highlighter-container" ]
+        (viewSegments groupConfig viewSegment highlightables)
+
+
+viewSegments :
+    { showTagsInline : Bool, maybeTool : Maybe (Tool.Tool marker) }
+    -> (Highlightable marker -> List Css.Style -> Html msg)
+    -> List (Highlightable marker)
+    -> List (Html msg)
+viewSegments groupConfig viewSegment highlightables =
+    highlightables
+        |> Grouping.buildGroups
+        |> List.concatMap (groupContainer groupConfig viewSegment)
+
+
+{-| When elements are marked, wrap them in a single `mark` html node.
+-}
+groupContainer :
+    { showTagsInline : Bool
+    , maybeTool : Maybe (Tool.Tool marker)
+    }
+    -> (Highlightable marker -> List Css.Style -> Html msg)
+    -> List (Highlightable marker)
+    -> List (Html msg)
+groupContainer config viewSegment highlightables =
+    let
+        toMark : Highlightable marker -> Tool.MarkerModel marker -> Mark.Mark
+        toMark highlightable marker =
+            { name = marker.name
+            , startStyles = marker.startGroupClass
+            , styles = highlightableStyle config.maybeTool highlightable
+            , endStyles = marker.endGroupClass
+            }
+
+        viewMark =
+            if config.showTagsInline then
+                Mark.viewWithInlineTags
+
+            else
+                Mark.view
+    in
+    highlightables
+        |> List.map (\highlightable -> ( highlightable, Maybe.map (toMark highlightable) highlightable.marked ))
+        |> viewMark viewSegment
+
+
+viewHighlightable :
+    Bool
+    -> { config | id : String, focusIndex : Maybe Int, marker : Tool.Tool marker }
+    -> Highlightable marker
+    -> List Css.Style
+    -> Html (Msg marker)
+viewHighlightable renderMarkdown config highlightable =
+    case highlightable.type_ of
+        Highlightable.Interactive ->
+            viewHighlightableSegment
+                { interactiveHighlighterId = Just config.id
+                , focusIndex = config.focusIndex
+                , eventListeners =
+                    [ onPreventDefault "mouseover" (Pointer <| Over highlightable.groupIndex)
+                    , onPreventDefault "mouseleave" (Pointer <| Out highlightable.groupIndex)
+                    , onPreventDefault "mouseup" (Pointer <| Up Nothing)
+                    , onPreventDefault "mousedown" (Pointer <| Down highlightable.groupIndex)
+                    , onPreventDefault "touchstart" (Pointer <| Down highlightable.groupIndex)
+                    , attribute "data-interactive" ""
+                    , Key.onKeyDownPreventDefault
+                        [ Key.space (Keyboard <| ToggleHighlight highlightable.groupIndex)
+                        , Key.right (Keyboard <| MoveRight highlightable.groupIndex)
+                        , Key.left (Keyboard <| MoveLeft highlightable.groupIndex)
+                        , Key.shiftRight (Keyboard <| SelectionExpandRight highlightable.groupIndex)
+                        , Key.shiftLeft (Keyboard <| SelectionExpandLeft highlightable.groupIndex)
+                        ]
+                    , Key.onKeyUpPreventDefault
+                        [ Key.shiftRight (Keyboard <| SelectionApplyTool highlightable.groupIndex)
+                        , Key.shiftLeft (Keyboard <| SelectionApplyTool highlightable.groupIndex)
+                        , Key.shift (Keyboard <| SelectionReset highlightable.groupIndex)
+                        ]
+                    ]
+                , maybeTool = Just config.marker
+                , renderMarkdown = renderMarkdown
+                }
+                highlightable
+
+        Highlightable.Static ->
+            viewHighlightableSegment
+                { interactiveHighlighterId = Nothing
+                , focusIndex = config.focusIndex
+                , eventListeners =
+                    -- Static highlightables need listeners as well.
+                    -- because otherwise we miss mouseup events
+                    [ onPreventDefault "mouseup" (Pointer <| Up Nothing)
+                    , onPreventDefault "mousedown" (Pointer <| Down highlightable.groupIndex)
+                    , onPreventDefault "touchstart" (Pointer <| Down highlightable.groupIndex)
+                    , attribute "data-static" ""
+                    ]
+                , maybeTool = Just config.marker
+                , renderMarkdown = renderMarkdown
+                }
+                highlightable
+
+
+viewHighlightableSegment :
+    { interactiveHighlighterId : Maybe String
+    , focusIndex : Maybe Int
+    , eventListeners : List (Attribute msg)
+    , maybeTool : Maybe (Tool.Tool marker)
+    , renderMarkdown : Bool
+    }
+    -> Highlightable marker
+    -> List Css.Style
+    -> Html msg
+viewHighlightableSegment { interactiveHighlighterId, focusIndex, eventListeners, maybeTool, renderMarkdown } highlightable markStyles =
+    let
+        whitespaceClass txt =
+            -- we need to override whitespace styles in order to support
+            -- student-provided paragraph indents in essay writing
+            -- (specifically in Self Reviews)
+            --
+            -- TODO: there *has* to be a better way to do this, but what is it?
+            -- Ideally we would be able to provide `List Css.Style` for these
+            -- cases, since they'll probably be different for the quiz engine
+            -- and essay writing.
+            if txt == "\t" then
+                [ class "highlighter-whitespace-tab" ]
+
+            else if txt == " " then
+                [ class "highlighter-whitespace-single-space" ]
+
+            else if txt == "\n" then
+                [ class "highlighter-whitespace-newline" ]
+
+            else
+                []
+
+        isInteractive =
+            interactiveHighlighterId /= Nothing
+    in
+    span
+        (eventListeners
+            ++ customToHtmlAttributes highlightable.customAttributes
+            ++ whitespaceClass highlightable.text
+            ++ [ attribute "data-highlighter-item-index" <| String.fromInt highlightable.groupIndex
+               , case interactiveHighlighterId of
+                    Just highlighterId ->
+                        Html.Styled.Attributes.id (highlightableId highlighterId highlightable.groupIndex)
+
+                    Nothing ->
+                        AttributesExtra.none
+               , css
+                    (Css.focus [ Css.zIndex (Css.int 1), Css.position Css.relative ]
+                        :: highlightableStyle maybeTool highlightable
+                        ++ markStyles
+                    )
+               , class "highlighter-highlightable"
+               , case highlightable.marked of
+                    Just markedWith ->
+                        class "highlighter-highlighted"
+
+                    _ ->
+                        AttributesExtra.none
+               , if isInteractive then
+                    Key.tabbable
+                        (case focusIndex of
+                            Nothing ->
+                                False
+
+                            Just i ->
+                                highlightable.groupIndex == i
+                        )
+
+                 else
+                    AttributesExtra.none
+               ]
+        )
+        (if renderMarkdown then
+            renderInlineMarkdown highlightable.text
+
+         else
+            [ Html.text highlightable.text ]
+        )
+
+
+renderInlineMarkdown : String -> List (Html msg)
+renderInlineMarkdown text_ =
+    Markdown.Block.parse Nothing text_
+        |> List.map
+            (Markdown.Block.walk
+                (inlinifyMarkdownBlock
+                    >> Markdown.Block.PlainInlines
+                )
+            )
+        |> List.concatMap Markdown.Block.toHtml
+        |> List.map Html.fromUnstyled
+
+
+inlinifyMarkdownBlock : Markdown.Block.Block a b -> List (Markdown.Inline.Inline b)
+inlinifyMarkdownBlock block =
+    case block of
+        Markdown.Block.BlankLine str ->
+            [ Markdown.Inline.Text str ]
+
+        Markdown.Block.ThematicBreak ->
+            []
+
+        Markdown.Block.Heading _ _ inlines ->
+            inlines
+
+        Markdown.Block.CodeBlock _ str ->
+            [ Markdown.Inline.Text str ]
+
+        Markdown.Block.Paragraph _ inlines ->
+            inlines
+
+        Markdown.Block.BlockQuote blocks ->
+            List.concatMap inlinifyMarkdownBlock blocks
+
+        Markdown.Block.List _ blocks ->
+            List.concatMap inlinifyMarkdownBlock (List.concat blocks)
+
+        Markdown.Block.PlainInlines inlines ->
+            inlines
+
+        Markdown.Block.Custom b blocks ->
+            List.concatMap inlinifyMarkdownBlock blocks
+
+
+highlightableId : String -> Int -> String
+highlightableId highlighterId groupIndex =
+    "highlighter-" ++ highlighterId ++ "-highlightable-" ++ String.fromInt groupIndex
+
+
+highlightableStyle : Maybe (Tool.Tool kind) -> Highlightable kind -> List Css.Style
+highlightableStyle tool ({ uiState, marked } as highlightable) =
+    case tool of
+        Nothing ->
+            [ case marked of
+                Just markedWith ->
+                    Css.batch markedWith.highlightClass
+
+                Nothing ->
+                    Css.backgroundColor Css.transparent
+            ]
+
+        Just (Tool.Marker marker) ->
+            [ Css.property "user-select" "none"
+            , case ( uiState, marked ) of
+                ( Highlightable.Hovered, Just markedWith ) ->
+                    -- Override marking with selected tool
+                    Css.batch marker.hoverHighlightClass
+
+                ( Highlightable.Hovered, Nothing ) ->
+                    [ marker.hoverClass
+                    , marker.startGroupClass
+                    , marker.endGroupClass
+                    ]
+                        |> List.concat
+                        |> Css.batch
+
+                ( Highlightable.Hinted, _ ) ->
+                    Css.batch marker.hintClass
+
+                ( Highlightable.None, Just markedWith ) ->
+                    Css.batch markedWith.highlightClass
+
+                ( Highlightable.None, Nothing ) ->
+                    Css.backgroundColor Css.transparent
+            ]
+
+        Just (Tool.Eraser eraser_) ->
+            case marked of
+                Just markedWith ->
+                    [ Css.property "user-select" "none"
+                    , Css.batch markedWith.highlightClass
+                    , Css.batch
+                        (case uiState of
+                            Highlightable.Hinted ->
+                                eraser_.hintClass
+
+                            Highlightable.Hovered ->
+                                eraser_.hoverClass
+
+                            _ ->
+                                []
+                        )
+                    ]
+
+                Nothing ->
+                    [ Css.property "user-select" "none", Css.backgroundColor Css.transparent ]
+
+
+{-| Helper for `on` to preventDefault.
+-}
+onPreventDefault : String -> msg -> Attribute msg
+onPreventDefault name msg =
+    let
+        -- If we attempt to preventDefault on an event which is not cancelable
+        -- Chrome will blow up and complain that:
+        --
+        -- Ignored attempt to cancel a touchmove event with cancelable=false,
+        -- for example because scrolling is in progress and cannot be interrupted.
+        --
+        -- So instead we only preventDefault when it is safe to do so.
+        checkIfCancelable =
+            Json.Decode.field "cancelable" Json.Decode.bool
+                |> Json.Decode.map (\result -> ( msg, result ))
+    in
+    Events.preventDefaultOn name
+        checkIfCancelable
+
+
+customToHtmlAttributes : List Highlightable.Attribute -> List (Attribute msg)
+customToHtmlAttributes =
+    List.map
+        (\attr ->
+            case attr of
+                Highlightable.Class name ->
+                    class name
+
+                Highlightable.Data name value ->
+                    attribute ("data-" ++ name) value
+        )

--- a/src/Nri/Ui/Highlighter/V2.elm
+++ b/src/Nri/Ui/Highlighter/V2.elm
@@ -3,14 +3,14 @@ module Nri.Ui.Highlighter.V2 exposing
     , init, update
     , view, static, staticWithTags
     , viewMarkdown, staticMarkdown, staticMarkdownWithTags
-    , Intent(..), emptyIntent, hasChanged, HasChanged(..)
+    , Intent(..), hasChanged, HasChanged(..)
     , removeHighlights
     , asFragmentTuples, usedMarkers, text
     )
 
 {-| Changes from V1:
 
-  - TODO
+  - Remove emptyIntent, which is not used
 
 Highlighter provides a view/model/update to display a view to highlight text and show marks.
 
@@ -30,7 +30,7 @@ Highlighter provides a view/model/update to display a view to highlight text and
 
 ## Intents
 
-@docs Intent, emptyIntent, hasChanged, HasChanged
+@docs Intent, hasChanged, HasChanged
 
 
 # Setters
@@ -41,11 +41,6 @@ Highlighter provides a view/model/update to display a view to highlight text and
 # Getters
 
 @docs asFragmentTuples, usedMarkers, text
-
-
-# Events
-
-TODO: Add documentation about how to wire in event listeners and subscriptions so the highlighter is functional!
 
 -}
 
@@ -218,15 +213,6 @@ type Intent
 
 type alias ListenTo =
     Maybe String
-
-
-{-| -}
-emptyIntent : Intent
-emptyIntent =
-    Intent
-        { listenTo = Nothing
-        , changed = NotChanged
-        }
 
 
 {-| Get intent based on the resulting model from `update`.

--- a/src/Nri/Ui/Highlighter/V2.elm
+++ b/src/Nri/Ui/Highlighter/V2.elm
@@ -118,7 +118,12 @@ init :
     -> Model marker
 init config =
     { id = config.id
-    , highlightables = config.highlightables
+    , highlightables =
+        if config.joinAdjacentInteractiveHighlights then
+            joinAdjacentInteractiveHighlights config.highlightables
+
+        else
+            config.highlightables
     , marker = config.marker
     , joinAdjacentInteractiveHighlights = config.joinAdjacentInteractiveHighlights
     , mouseDownIndex = Nothing
@@ -294,14 +299,14 @@ update msg model =
 maybeJoinAdjacentInteractiveHighlights : Model m -> Model m
 maybeJoinAdjacentInteractiveHighlights model =
     if model.joinAdjacentInteractiveHighlights then
-        { model | highlightables = joinInteractiveHighlights model.highlightables }
+        { model | highlightables = joinAdjacentInteractiveHighlights model.highlightables }
 
     else
         model
 
 
-joinInteractiveHighlights : List (Highlightable m) -> List (Highlightable m)
-joinInteractiveHighlights highlightables =
+joinAdjacentInteractiveHighlights : List (Highlightable m) -> List (Highlightable m)
+joinAdjacentInteractiveHighlights highlightables =
     highlightables
         |> List.foldr
             (\segment ( lastInteractiveHighlight, staticAcc, acc ) ->

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -343,6 +343,7 @@ initHighlighter settings previousHighlightables =
             else
                 highlightables
         , marker = settings.tool
+        , joinAdjacentInteractiveHighlights = settings.joinAdjacentInteractiveHighlights
         }
 
 
@@ -356,6 +357,7 @@ exampleParagraph =
 
 type alias Settings =
     { splitOnSentences : Bool
+    , joinAdjacentInteractiveHighlights : Bool
     , asMarkdown : Bool
     , tool : Tool.Tool ()
     }
@@ -365,6 +367,7 @@ controlSettings : Control Settings
 controlSettings =
     Control.record Settings
         |> Control.field "splitOnSentences" (Control.bool True)
+        |> Control.field "joinAdjacentInteractiveHighlights" (Control.bool False)
         |> Control.field "asMarkdown" (Control.bool True)
         |> Control.field "tool"
             (Control.choice

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -21,7 +21,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Highlightable.V1 as Highlightable exposing (Highlightable)
-import Nri.Ui.Highlighter.V1 as Highlighter
+import Nri.Ui.Highlighter.V2 as Highlighter
 import Nri.Ui.HighlighterTool.V1 as Tool
 import Nri.Ui.Table.V6 as Table
 
@@ -33,7 +33,7 @@ moduleName =
 
 version : Int
 version =
-    1
+    2
 
 
 {-| -}

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -5,7 +5,7 @@ import Expect exposing (Expectation)
 import Html.Styled exposing (toUnstyled)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Highlightable.V1 as Highlightable exposing (Highlightable)
-import Nri.Ui.Highlighter.V1 as Highlighter
+import Nri.Ui.Highlighter.V2 as Highlighter
 import Nri.Ui.HighlighterTool.V1 as Tool exposing (Tool)
 import ProgramTest exposing (..)
 import Regex exposing (Regex)
@@ -18,7 +18,7 @@ import Test.Html.Selector as Selector
 
 spec : Test
 spec =
-    describe "Nri.Ui.Highlighter.V1"
+    describe "Nri.Ui.Highlighter.V2"
         [ describe "keyboard behavior" keyboardTests
         , describe "markdown behavior" markdownTests
         ]
@@ -249,6 +249,7 @@ markdownTests =
                         { id = "markdown-tests-highlighter-container"
                         , highlightables = highlightables
                         , marker = marker Nothing
+                        , joinAdjacentInteractiveHighlights = False
                         }
                 , update = \_ m -> m
                 , view = view >> toUnstyled
@@ -442,6 +443,7 @@ program name highlightables =
                 { id = "test-highlighter-container"
                 , highlightables = highlightables
                 , marker = marker name
+                , joinAdjacentInteractiveHighlights = False
                 }
         , update =
             \msg model ->

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -3,6 +3,7 @@ module Spec.Nri.Ui.Highlighter exposing (spec)
 import Accessibility.Key as Key
 import Expect exposing (Expectation)
 import Html.Styled exposing (toUnstyled)
+import List.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Highlightable.V1 as Highlightable exposing (Highlightable)
 import Nri.Ui.Highlighter.V2 as Highlighter
@@ -21,6 +22,7 @@ spec =
     describe "Nri.Ui.Highlighter.V2"
         [ describe "keyboard behavior" keyboardTests
         , describe "markdown behavior" markdownTests
+        , describe "joinAdjacentInteractiveHighlights" joinAdjacentInteractiveHighlightsTests
         ]
 
 
@@ -29,19 +31,19 @@ keyboardTests =
     [ test "has a focusable element when there is one" <|
         \() ->
             Highlightable.initFragments Nothing "Pothos indirect light"
-                |> program Nothing
+                |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> ensureTabbable "Pothos"
                 |> done
     , test "has only one element included in the tab sequence" <|
         \() ->
             Highlightable.initFragments Nothing "Pothos indirect light"
-                |> program Nothing
+                |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> ensureOnlyOneInTabSequence (String.words "Pothos indirect light")
                 |> done
     , test "moves focus right on right arrow key" <|
         \() ->
             Highlightable.initFragments Nothing "Pothos indirect light"
-                |> program Nothing
+                |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> ensureTabbable "Pothos"
                 |> rightArrow
                 |> ensureTabbable "indirect"
@@ -56,7 +58,7 @@ keyboardTests =
     , test "moves focus left on left arrow key" <|
         \() ->
             Highlightable.initFragments Nothing "Pothos indirect light"
-                |> program Nothing
+                |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> ensureTabbable "Pothos"
                 |> rightArrow
                 |> ensureTabbable "indirect"
@@ -71,7 +73,7 @@ keyboardTests =
     , test "moves focus right on shift + right arrow" <|
         \() ->
             Highlightable.initFragments Nothing "Pothos indirect light"
-                |> program Nothing
+                |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> ensureTabbable "Pothos"
                 |> shiftRight
                 |> ensureTabbable "indirect"
@@ -83,7 +85,7 @@ keyboardTests =
     , test "moves focus left on shift + left arrow" <|
         \() ->
             Highlightable.initFragments Nothing "Pothos indirect light"
-                |> program Nothing
+                |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> ensureTabbable "Pothos"
                 |> rightArrow
                 |> ensureTabbable "indirect"
@@ -95,7 +97,7 @@ keyboardTests =
     , test "expands selection one element to the right on shift + right arrow and highlight selected elements" <|
         \() ->
             Highlightable.initFragments Nothing "Pothos indirect light"
-                |> program Nothing
+                |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> shiftRight
                 |> releaseShiftRight
                 |> ensureMarked [ "Pothos", " ", "indirect" ]
@@ -109,7 +111,7 @@ keyboardTests =
     , test "expands selection one element to the left on shift + left arrow and highlight selected elements" <|
         \() ->
             Highlightable.initFragments Nothing "Pothos indirect light"
-                |> program Nothing
+                |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> rightArrow
                 |> rightArrow
                 |> shiftLeft
@@ -125,7 +127,7 @@ keyboardTests =
     , test "merges highlights" <|
         \() ->
             Highlightable.initFragments Nothing "Pothos indirect light"
-                |> program Nothing
+                |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> ensureTabbable "Pothos"
                 |> shiftRight
                 |> releaseShiftRight
@@ -140,7 +142,7 @@ keyboardTests =
     , test "selects element on MouseDown and highlights selected element on MouseUp" <|
         \() ->
             Highlightable.initFragments Nothing "Pothos indirect light"
-                |> program Nothing
+                |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> ensureTabbable "Pothos"
                 |> mouseDown "Pothos"
                 |> mouseUp "Pothos"
@@ -149,7 +151,7 @@ keyboardTests =
     , test "selects element on MouseDown, expands selection on MouseOver, and highlights selected elements on MouseUp" <|
         \() ->
             Highlightable.initFragments Nothing "Pothos indirect light"
-                |> program Nothing
+                |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> ensureTabbable "Pothos"
                 |> mouseDown "Pothos"
                 |> mouseOver "indirect"
@@ -159,7 +161,7 @@ keyboardTests =
     , test "Highlights element on Space" <|
         \() ->
             Highlightable.initFragments Nothing "Pothos indirect light"
-                |> program Nothing
+                |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> ensureTabbable "Pothos"
                 |> space
                 |> ensureMarked [ "Pothos" ]
@@ -167,7 +169,7 @@ keyboardTests =
     , test "Removes highlight from element on MouseUp" <|
         \() ->
             Highlightable.initFragments Nothing "Pothos indirect light"
-                |> program Nothing
+                |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> ensureTabbable "Pothos"
                 |> space
                 |> ensureMarked [ "Pothos" ]
@@ -178,7 +180,7 @@ keyboardTests =
     , test "Removes entire highlight from a group of elements on MouseUp" <|
         \() ->
             Highlightable.initFragments Nothing "Pothos indirect light"
-                |> program Nothing
+                |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> ensureTabbable "Pothos"
                 |> shiftRight
                 |> releaseShiftRight
@@ -189,7 +191,7 @@ keyboardTests =
     , test "Removes highlight from element on Space" <|
         \() ->
             Highlightable.initFragments Nothing "Pothos indirect light"
-                |> program Nothing
+                |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> ensureTabbable "Pothos"
                 |> space
                 |> ensureMarked [ "Pothos" ]
@@ -200,7 +202,7 @@ keyboardTests =
         [ test "generic start announcement is made when mark does not include first element" <|
             \() ->
                 Highlightable.initFragments Nothing "Pothos indirect light"
-                    |> program Nothing
+                    |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
                     |> rightArrow
                     |> shiftRight
                     |> releaseShiftRight
@@ -209,7 +211,7 @@ keyboardTests =
         , test "specific start announcement is made when mark does not include first element" <|
             \() ->
                 Highlightable.initFragments Nothing "Pothos indirect light"
-                    |> program (Just "banana")
+                    |> program { name = Just "banana", joinAdjacentInteractiveHighlights = False }
                     |> rightArrow
                     |> ensureTabbable "indirect"
                     |> shiftRight
@@ -223,7 +225,7 @@ keyboardTests =
           test "Focus moves past 3rd element" <|
             \() ->
                 Highlightable.initFragments Nothing "Sir Walter Elliot, of Kellynch Hall, in Somersetshire..."
-                    |> program (Just "Claim")
+                    |> program { name = Just "Claim", joinAdjacentInteractiveHighlights = False }
                     |> shiftRight
                     |> releaseShiftRight
                     |> ensureMarked [ "Sir", " ", "Walter" ]
@@ -352,13 +354,29 @@ ensureOnlyOneInTabSequence words testContext =
 
 
 ensureMarked : List String -> TestContext -> TestContext
-ensureMarked words testContext =
+ensureMarked =
+    ensureMarkIndex 0
+
+
+ensureMarks : List (List String) -> TestContext -> TestContext
+ensureMarks marks testContext =
+    List.Extra.indexedFoldl (\i words -> ensureMarkIndex i words) testContext marks
+
+
+ensureMarkIndex : Int -> List String -> TestContext -> TestContext
+ensureMarkIndex markI words testContext =
     testContext
         |> ensureView
-            (Query.find [ Selector.tag "mark" ]
+            (Query.findAll [ Selector.tag "mark" ]
+                >> Query.index markI
                 >> Query.children [ Selector.class "highlighter-highlightable" ]
                 >> Expect.all (List.indexedMap (\i w -> Query.index i >> Query.has [ Selector.text w ]) words)
             )
+
+
+noneMarked : TestContext -> TestContext
+noneMarked =
+    ensureView (Query.hasNot [ Selector.tag "mark" ])
 
 
 space : TestContext -> TestContext
@@ -413,37 +431,47 @@ mouseUp word =
     MouseHelpers.cancelableMouseUp [ Selector.tag "span", Selector.containing [ Selector.text word ] ]
 
 
+click : String -> TestContext -> TestContext
+click word =
+    mouseDown word >> mouseUp word
+
+
 mouseOver : String -> TestContext -> TestContext
 mouseOver word =
     MouseHelpers.cancelableMouseOver [ Selector.tag "span", Selector.containing [ Selector.text word ] ]
 
 
-marker : Maybe String -> Tool ()
+marker : Maybe String -> Tool String
 marker name =
     Tool.Marker
         (Tool.buildMarker
             { highlightColor = Colors.magenta
             , hoverColor = Colors.magenta
             , hoverHighlightColor = Colors.magenta
-            , kind = ()
+            , kind = Maybe.withDefault "" name
             , name = name
             }
         )
 
 
 type alias TestContext =
-    ProgramTest (Highlighter.Model ()) (Highlighter.Msg ()) ()
+    ProgramTest (Highlighter.Model String) (Highlighter.Msg String) ()
 
 
-program : Maybe String -> List (Highlightable ()) -> TestContext
-program name highlightables =
+program :
+    { name : Maybe String
+    , joinAdjacentInteractiveHighlights : Bool
+    }
+    -> List (Highlightable String)
+    -> TestContext
+program config highlightables =
     ProgramTest.createSandbox
         { init =
             Highlighter.init
                 { id = "test-highlighter-container"
                 , highlightables = highlightables
-                , marker = marker name
-                , joinAdjacentInteractiveHighlights = False
+                , marker = marker config.name
+                , joinAdjacentInteractiveHighlights = config.joinAdjacentInteractiveHighlights
                 }
         , update =
             \msg model ->
@@ -453,3 +481,60 @@ program name highlightables =
         , view = Highlighter.view >> toUnstyled
         }
         |> ProgramTest.start ()
+
+
+joinAdjacentInteractiveHighlightsTests : List Test
+joinAdjacentInteractiveHighlightsTests =
+    [ describe "static segments surrounding a single interactive segment" <|
+        let
+            runTest description { joinAdjacentInteractiveHighlights } =
+                test (description ++ ", static elements should not change state") <|
+                    \() ->
+                        [ Highlightable.init Highlightable.Static Nothing 0 ( [], " " )
+                        , Highlightable.init Highlightable.Interactive Nothing 1 ( [], "word" )
+                        , Highlightable.init Highlightable.Static Nothing 2 ( [], " " )
+                        ]
+                            |> program { name = Nothing, joinAdjacentInteractiveHighlights = joinAdjacentInteractiveHighlights }
+                            |> click "word"
+                            |> ensureMarked [ "word" ]
+                            |> click "word"
+                            |> noneMarked
+                            |> done
+        in
+        [ runTest "not joining adjacent interactive highlights" { joinAdjacentInteractiveHighlights = False }
+        , runTest "joining adjacent interactive highlights" { joinAdjacentInteractiveHighlights = True }
+        ]
+    , describe "interactive segments surrounding a single staticsegment" <|
+        let
+            highlightables =
+                [ Highlightable.init Highlightable.Interactive Nothing 0 ( [], "hello" )
+                , Highlightable.init Highlightable.Static Nothing 1 ( [], " " )
+                , Highlightable.init Highlightable.Interactive Nothing 2 ( [], "world" )
+                ]
+        in
+        [ test "not joining adjacent interactive highlights" <|
+            \() ->
+                highlightables
+                    |> program { name = Nothing, joinAdjacentInteractiveHighlights = False }
+                    |> click "hello"
+                    |> ensureMarks [ [ "hello" ] ]
+                    |> click "world"
+                    |> ensureMarks [ [ "hello" ], [ "world" ] ]
+                    |> click "hello"
+                    |> ensureMarks [ [ "world" ] ]
+                    |> click "world"
+                    |> noneMarked
+                    |> done
+        , test "joining adjacent interactive highlights" <|
+            \() ->
+                highlightables
+                    |> program { name = Nothing, joinAdjacentInteractiveHighlights = True }
+                    |> click "hello"
+                    |> ensureMarks [ [ "hello" ] ]
+                    |> click "world"
+                    |> ensureMarks [ [ "hello", " ", "world" ] ]
+                    |> click "hello"
+                    |> noneMarked
+                    |> done
+        ]
+    ]

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -38,6 +38,7 @@
         "Nri.Ui.Heading.V3",
         "Nri.Ui.Highlightable.V1",
         "Nri.Ui.Highlighter.V1",
+        "Nri.Ui.Highlighter.V2",
         "Nri.Ui.HighlighterTool.V1",
         "Nri.Ui.HighlighterToolbar.V1",
         "Nri.Ui.Html.Attributes.V2",


### PR DESCRIPTION
Adds a new version of highlighter that automatically optionally supports going from this state:

<img width="175" alt="Screen Shot 2023-01-09 at 2 39 53 PM" src="https://user-images.githubusercontent.com/8811312/211413717-a3b35014-f1bb-4567-8367-e2e25623bea9.png">

to this state:

<img width="159" alt="Screen Shot 2023-01-09 at 2 39 59 PM" src="https://user-images.githubusercontent.com/8811312/211413719-59848704-c0d0-444a-a995-39a146d64965.png">

When the highlights are the same type.

When the highlights are _not_ the same type, e.g.:

<img width="168" alt="Screen Shot 2023-01-09 at 2 41 23 PM" src="https://user-images.githubusercontent.com/8811312/211413939-d0b4f8e0-9043-4d94-8ed7-af8e7092d084.png">

they will not be joined.

---

Why do this?

Formatting questions expect highlights to auto-join. In order to do A11-2089, this work is necessary.

Fixes A11-2089