### PR TITLE
Extract animated arrows to AnimatedIcon

### DIFF
--- a/src/Nri/Ui/AnimatedIcon/V1.elm
+++ b/src/Nri/Ui/AnimatedIcon/V1.elm
@@ -71,4 +71,4 @@ arrowOpenClose isOpen =
           else
             Css.transform (Css.rotate (Css.deg -180))
         ]
-        UiIcon.arrowLeft
+        (Nri.Ui.Svg.V1.withViewBox "0 0 25 25" UiIcon.arrowLeft)

--- a/src/Nri/Ui/AnimatedIcon/V1.elm
+++ b/src/Nri/Ui/AnimatedIcon/V1.elm
@@ -1,13 +1,14 @@
-module Nri.Ui.AnimatedIcon.V1 exposing (mobileOpenClose)
+module Nri.Ui.AnimatedIcon.V1 exposing (mobileOpenClose, arrowOpenClose)
 
 {-|
 
-@docs mobileOpenClose
+@docs mobileOpenClose, arrowOpenClose
 
 -}
 
 import Css
 import Nri.Ui.Svg.V1
+import Nri.Ui.UiIcon.V1 as UiIcon
 import Svg.Styled as Svg
 import Svg.Styled.Attributes as Attributes
 
@@ -56,3 +57,18 @@ mobileOpenClose isOpen =
             , Css.scaleX 1.3
             ]
         ]
+
+
+{-| An arrow that animates between pointing down and pointing up.
+-}
+arrowOpenClose : Bool -> Nri.Ui.Svg.V1.Svg
+arrowOpenClose isOpen =
+    Nri.Ui.Svg.V1.withCss
+        [ Css.property "transition" "transform 0.1s"
+        , if isOpen then
+            Css.transform (Css.rotate (Css.deg -90))
+
+          else
+            Css.transform (Css.rotate (Css.deg -180))
+        ]
+        UiIcon.arrowLeft

--- a/src/Nri/Ui/AnimatedIcon/V1.elm
+++ b/src/Nri/Ui/AnimatedIcon/V1.elm
@@ -1,8 +1,8 @@
-module Nri.Ui.AnimatedIcon.V1 exposing (mobileOpenClose, arrowRightDown)
+module Nri.Ui.AnimatedIcon.V1 exposing (mobileOpenClose, arrowRightDown, arrowDownUp)
 
 {-|
 
-@docs mobileOpenClose, arrowRightDown
+@docs mobileOpenClose, arrowRightDown, arrowDownUp
 
 -}
 
@@ -71,4 +71,25 @@ arrowRightDown isOpen =
           else
             Css.transform (Css.rotate (Css.deg -180))
         ]
-        (Nri.Ui.Svg.V1.withViewBox "0 0 25 25" UiIcon.arrowLeft)
+        squareArrowLeft
+
+
+{-| An arrow that animates between pointing down and pointing up. Typically used as a fly-out menu indicator.
+-}
+arrowDownUp : Bool -> Nri.Ui.Svg.V1.Svg
+arrowDownUp isOpen =
+    Nri.Ui.Svg.V1.withCss
+        [ Css.property "transition" "transform 0.4s"
+        , Css.property "transform-origin" "center"
+        , if isOpen then
+            Css.transform (Css.rotate (Css.deg 90))
+
+          else
+            Css.transform (Css.rotate (Css.deg -90))
+        ]
+        squareArrowLeft
+
+
+squareArrowLeft : Nri.Ui.Svg.V1.Svg
+squareArrowLeft =
+    Nri.Ui.Svg.V1.withViewBox "0 0 25 25" UiIcon.arrowLeft

--- a/src/Nri/Ui/AnimatedIcon/V1.elm
+++ b/src/Nri/Ui/AnimatedIcon/V1.elm
@@ -1,8 +1,8 @@
-module Nri.Ui.AnimatedIcon.V1 exposing (mobileOpenClose, arrowOpenClose)
+module Nri.Ui.AnimatedIcon.V1 exposing (mobileOpenClose, arrowRightDown)
 
 {-|
 
-@docs mobileOpenClose, arrowOpenClose
+@docs mobileOpenClose, arrowRightDown
 
 -}
 
@@ -59,10 +59,10 @@ mobileOpenClose isOpen =
         ]
 
 
-{-| An arrow that animates between pointing down and pointing up.
+{-| An arrow that animates between pointing right and pointing down. Typically used for disclosures and accordions.
 -}
-arrowOpenClose : Bool -> Nri.Ui.Svg.V1.Svg
-arrowOpenClose isOpen =
+arrowRightDown : Bool -> Nri.Ui.Svg.V1.Svg
+arrowRightDown isOpen =
     Nri.Ui.Svg.V1.withCss
         [ Css.property "transition" "transform 0.1s"
         , if isOpen then

--- a/src/Nri/Ui/DisclosureIndicator/V2.elm
+++ b/src/Nri/Ui/DisclosureIndicator/V2.elm
@@ -1,6 +1,6 @@
 module Nri.Ui.DisclosureIndicator.V2 exposing (medium, large)
 
-{-|
+{-| TODO: Remove this module, in favor of Nri.Ui.AnimatedIcon.
 
 
 # Changes from V1

--- a/src/Nri/Ui/UiIcon/V1.elm
+++ b/src/Nri/Ui/UiIcon/V1.elm
@@ -523,7 +523,7 @@ arrowDown =
 {-| -}
 arrowLeft : Nri.Ui.Svg.V1.Svg
 arrowLeft =
-    -- If changing the path or viewport, please verify that AnimatedIcon.arrowOpenCloseRightDown does not regress.
+    -- If changing the path or viewport, please verify that AnimatedIcon.arrowRightDown and arrowDownUp do not regress.
     Nri.Ui.Svg.V1.init "0 5 25 15"
         [ Svg.path
             [ Attributes.fillRule "evenodd"

--- a/src/Nri/Ui/UiIcon/V1.elm
+++ b/src/Nri/Ui/UiIcon/V1.elm
@@ -523,7 +523,7 @@ arrowDown =
 {-| -}
 arrowLeft : Nri.Ui.Svg.V1.Svg
 arrowLeft =
-    -- If changing the path or viewport, please verify that AnimatedIcon.arrowOpenClose does not regress.
+    -- If changing the path or viewport, please verify that AnimatedIcon.arrowOpenCloseRightDown does not regress.
     Nri.Ui.Svg.V1.init "0 5 25 15"
         [ Svg.path
             [ Attributes.fillRule "evenodd"

--- a/src/Nri/Ui/UiIcon/V1.elm
+++ b/src/Nri/Ui/UiIcon/V1.elm
@@ -523,6 +523,7 @@ arrowDown =
 {-| -}
 arrowLeft : Nri.Ui.Svg.V1.Svg
 arrowLeft =
+    -- If changing the path or viewport, please verify that AnimatedIcon.arrowOpenClose does not regress.
     Nri.Ui.Svg.V1.init "0 5 25 15"
         [ Svg.path
             [ Attributes.fillRule "evenodd"

--- a/styleguide-app/Examples/AnimatedIcon.elm
+++ b/styleguide-app/Examples/AnimatedIcon.elm
@@ -82,6 +82,9 @@ example =
                         , { sectionName = "arrowRightDown"
                           , code = toCode "arrowRightDown"
                           }
+                        , { sectionName = "arrowDownUp"
+                          , code = toCode "arrowDownUp"
+                          }
                         ]
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
@@ -111,6 +114,7 @@ example =
                 ]
                 [ { name = "mobileOpenClose", render = AnimatedIcon.mobileOpenClose }
                 , { name = "arrowRightDown", render = AnimatedIcon.arrowRightDown }
+                , { name = "arrowDownUp", render = AnimatedIcon.arrowDownUp }
                 ]
             ]
     }

--- a/styleguide-app/Examples/AnimatedIcon.elm
+++ b/styleguide-app/Examples/AnimatedIcon.elm
@@ -14,10 +14,12 @@ import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Examples.IconExamples as IconExamples
+import Html.Styled exposing (..)
 import Nri.Ui.AnimatedIcon.V1 as AnimatedIcon
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.Table.V6 as Table
 
 
 moduleName : String
@@ -44,6 +46,8 @@ example =
         IconExamples.preview
             [ AnimatedIcon.mobileOpenClose False
             , AnimatedIcon.mobileOpenClose True
+            , AnimatedIcon.arrowOpenClose False
+            , AnimatedIcon.arrowOpenClose True
             ]
     , view =
         \ellieLinkConfig state ->
@@ -69,22 +73,45 @@ example =
                                     ++ viewName
                                     ++ " "
                                     ++ Tuple.first settings.isOpen
-                                    ++ "\n  |> Svg.withCss [ Css.maxWidth (Css.px 45) ]"
+                                    ++ "\n  |> Svg.withCss [ Css.maxWidth (Css.px 30) ]"
                                     ++ "\n  |> Svg.toHtml"
                         in
-                        [ { sectionName = "Code"
+                        [ { sectionName = "mobileOpenClose"
                           , code = toCode "mobileOpenClose"
+                          }
+                        , { sectionName = "arrowOpenClose"
+                          , code = toCode "arrowOpenClose"
                           }
                         ]
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
-            , AnimatedIcon.mobileOpenClose (Tuple.second attributes.isOpen)
-                |> Svg.withCss
-                    [ Css.maxWidth (Css.px 30)
-                    , Css.border3 (Css.px 2) Css.solid Colors.red
-                    , Css.boxSizing Css.borderBox
-                    ]
-                |> Svg.toHtml
+            , Table.view
+                [ Table.custom
+                    { header = text "Rendered"
+                    , view =
+                        \{ render } ->
+                            render (Tuple.second attributes.isOpen)
+                                |> Svg.withCss
+                                    [ Css.maxWidth (Css.px 30)
+                                    , Css.border3 (Css.px 2) Css.solid Colors.red
+                                    , Css.boxSizing Css.borderBox
+                                    ]
+                                |> Svg.toHtml
+                    , width = Css.px 10
+                    , cellStyles = always []
+                    , sort = Nothing
+                    }
+                , Table.string
+                    { header = "Name"
+                    , value = .name
+                    , width = Css.px 10
+                    , cellStyles = always []
+                    , sort = Nothing
+                    }
+                ]
+                [ { name = "mobileOpenClose", render = AnimatedIcon.mobileOpenClose }
+                , { name = "arrowOpenClose", render = AnimatedIcon.arrowOpenClose }
+                ]
             ]
     }
 

--- a/styleguide-app/Examples/AnimatedIcon.elm
+++ b/styleguide-app/Examples/AnimatedIcon.elm
@@ -46,8 +46,8 @@ example =
         IconExamples.preview
             [ AnimatedIcon.mobileOpenClose False
             , AnimatedIcon.mobileOpenClose True
-            , AnimatedIcon.arrowOpenClose False
-            , AnimatedIcon.arrowOpenClose True
+            , AnimatedIcon.arrowRightDown False
+            , AnimatedIcon.arrowRightDown True
             ]
     , view =
         \ellieLinkConfig state ->
@@ -79,8 +79,8 @@ example =
                         [ { sectionName = "mobileOpenClose"
                           , code = toCode "mobileOpenClose"
                           }
-                        , { sectionName = "arrowOpenClose"
-                          , code = toCode "arrowOpenClose"
+                        , { sectionName = "arrowRightDown"
+                          , code = toCode "arrowRightDown"
                           }
                         ]
                 }
@@ -110,7 +110,7 @@ example =
                     }
                 ]
                 [ { name = "mobileOpenClose", render = AnimatedIcon.mobileOpenClose }
-                , { name = "arrowOpenClose", render = AnimatedIcon.arrowOpenClose }
+                , { name = "arrowRightDown", render = AnimatedIcon.arrowRightDown }
                 ]
             ]
     }


### PR DESCRIPTION
Previously, `arrowRightDown` came from DisclosureIndicator, which is now deprecated, and arrowDownUp was inlined in Menu.

https://user-images.githubusercontent.com/8811312/211615812-b40900a8-e571-4459-bf57-8472e6583845.mov

cc @NoRedInk/design 