### PR TITLE
Bat/block adjustments

### DIFF
--- a/src/Nri/Ui/Mark/V2.elm
+++ b/src/Nri/Ui/Mark/V2.elm
@@ -340,6 +340,7 @@ viewBalloon config label =
               -- if the border radius of the balloon changes, this value might need to change as well
               Css.minWidth (Css.px 30)
             , Css.maxWidth (Css.px 150)
+            , Css.textAlign Css.center
             , Css.property "word-break" "break-word"
             , Css.batch <|
                 case config.labelPosition of

--- a/src/Nri/Ui/Mark/V2.elm
+++ b/src/Nri/Ui/Mark/V2.elm
@@ -336,6 +336,9 @@ viewBalloon config label =
             [ Css.padding3 Css.zero (Css.px 6) (Css.px 1)
             , Css.property "box-shadow" "none"
             , Css.property "width" "max-content"
+            , -- this min-width prevents the arrow from gapping at the corners where the balloon is rounded
+              -- if the border radius of the balloon changes, this value might need to change as well
+              Css.minWidth (Css.px 30)
             , Css.maxWidth (Css.px 150)
             , Css.property "word-break" "break-word"
             , Css.batch <|

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -98,7 +98,20 @@ example =
                 offsets =
                     Block.getLabelPositions state.labelMeasurementsById
             in
-            [ -- absolutely positioned elements that overflow in the x direction
+            [ Heading.h2 [ Heading.plaintext "About" ]
+            , Text.mediumBody
+                [ Text.html
+                    [ p []
+                        [ text "You might also know the Block element as a “Display Element”. Learn more in "
+                        , ClickableText.link "Display Elements and Scaffolding Container: additional things to know"
+                            [ ClickableText.linkExternal "https://paper.dropbox.com/doc/Display-Elements-and-Scaffolding-Container-additional-things-to-know--BwRhBMKyXFFSWz~1mljN29bcAg-6vszpNDLoYIiMyg7Wv66s"
+                            , ClickableText.rightIcon UiIcon.openInNewTab
+                            , ClickableText.css [ Css.verticalAlign Css.baseline ]
+                            ]
+                        ]
+                    ]
+                ]
+            , -- absolutely positioned elements that overflow in the x direction
               -- cause a horizontal scrollbar unless you explicitly hide overflowing x content
               Css.Global.global [ Css.Global.selector "body" [ Css.overflowX Css.hidden ] ]
             , ControlView.view
@@ -119,22 +132,6 @@ example =
                           }
                         ]
                 }
-            , Heading.h2
-                [ Heading.plaintext "About"
-                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
-                ]
-            , Text.mediumBody
-                [ Text.html
-                    [ p []
-                        [ text "You might also know the Block element as a “Display Element”. Learn more in "
-                        , ClickableText.link "Display Elements and Scaffolding Container: additional things to know"
-                            [ ClickableText.linkExternal "https://paper.dropbox.com/doc/Display-Elements-and-Scaffolding-Container-additional-things-to-know--BwRhBMKyXFFSWz~1mljN29bcAg-6vszpNDLoYIiMyg7Wv66s"
-                            , ClickableText.rightIcon UiIcon.openInNewTab
-                            , ClickableText.css [ Css.verticalAlign Css.baseline ]
-                            ]
-                        ]
-                    ]
-                ]
             , Heading.h2
                 [ Heading.plaintext "Interactive example"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -22,11 +22,13 @@ import Html.Styled.Attributes exposing (css)
 import Markdown
 import Nri.Ui.Block.V4 as Block
 import Nri.Ui.Button.V10 as Button
+import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V6 as Table
 import Nri.Ui.Text.V6 as Text
+import Nri.Ui.UiIcon.V1 as UiIcon
 import Task
 
 
@@ -117,6 +119,22 @@ example =
                           }
                         ]
                 }
+            , Heading.h2
+                [ Heading.plaintext "About"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
+            , Text.mediumBody
+                [ Text.html
+                    [ p []
+                        [ text "You might also know the Block element as a “Display Element”. Learn more in "
+                        , ClickableText.link "Display Elements and Scaffolding Container: additional things to know"
+                            [ ClickableText.linkExternal "https://paper.dropbox.com/doc/Display-Elements-and-Scaffolding-Container-additional-things-to-know--BwRhBMKyXFFSWz~1mljN29bcAg-6vszpNDLoYIiMyg7Wv66s"
+                            , ClickableText.rightIcon UiIcon.openInNewTab
+                            , ClickableText.css [ Css.verticalAlign Css.baseline ]
+                            ]
+                        ]
+                    ]
+                ]
             , Heading.h2
                 [ Heading.plaintext "Interactive example"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]


### PR DESCRIPTION
Fixes A11-2177

# Label text alignment
## Before
<img width="270" alt="Screen Shot 2023-01-11 at 1 26 40 PM" src="https://user-images.githubusercontent.com/8811312/211910746-c04d2d40-7e88-4e83-8386-9b3ec7180c12.png">

## After

<img width="275" alt="Screen Shot 2023-01-11 at 1 26 12 PM" src="https://user-images.githubusercontent.com/8811312/211910739-aabcc74c-c73d-45a6-beb7-d04b268e54a7.png">


# Label min width
## Before

<img width="273" alt="Screen Shot 2023-01-11 at 1 27 07 PM" src="https://user-images.githubusercontent.com/8811312/211910743-e3793492-325a-480d-9127-0965b1ac512e.png">


## After

<img width="271" alt="Screen Shot 2023-01-11 at 1 27 18 PM" src="https://user-images.githubusercontent.com/8811312/211910741-98538173-8124-4bab-a776-6320d0859354.png">


# About section

I think this looks kinda janky. At some point, I'd like to do a project to allow any example page to add arbitrary links to get added to the links section of the header in the upper right. But I don't think I have time to do so this week. I can make copy adjustments or move the link down in the page?

## After

<img width="1464" alt="image" src="https://user-images.githubusercontent.com/8811312/211910089-9c8f6283-f065-4f0e-af71-c0ac46713d80.png">

---

cc @NoRedInk/design 