### PR TITLE
add elm language server to nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation {
     elmPackages.elm
     elmPackages.elm-format
     elmPackages.elm-test
+    elmPackages.elm-language-server
     elmPackages.elm-verify-examples
     elmPackages.elm-review
     elmPackages.elm-json


### PR DESCRIPTION
for those who want to use the language server, this makes it available in the path when using direnv.

for those that don't want to use the language server this shouldn't have any effect.