### PR TITLE
Automatically add opens in new tab affordance

### DIFF
--- a/src/ClickableAttributes.elm
+++ b/src/ClickableAttributes.elm
@@ -1,5 +1,5 @@
 module ClickableAttributes exposing
-    ( ClickableAttributes, init
+    ( Config, ClickableAttributes, init
     , onClick, submit, opensModal
     , toButtonAttributes
     , href, linkWithMethod, linkWithTracking
@@ -10,7 +10,7 @@ module ClickableAttributes exposing
 
 {-|
 
-@docs ClickableAttributes, init
+@docs Config, ClickableAttributes, init
 
 
 # For buttons

--- a/src/ClickableAttributes.elm
+++ b/src/ClickableAttributes.elm
@@ -71,64 +71,77 @@ init =
 
 
 {-| -}
-onClick : msg -> ClickableAttributes route msg -> ClickableAttributes route msg
-onClick msg clickableAttributes =
-    { clickableAttributes | onClick = Just msg }
+type alias Config attributes route msg =
+    { attributes | clickableAttributes : ClickableAttributes route msg }
 
 
 {-| -}
-submit : ClickableAttributes route msg -> ClickableAttributes route msg
-submit clickableAttributes =
-    { clickableAttributes | buttonType = "submit" }
+onClick : msg -> Config a route msg -> Config a route msg
+onClick msg ({ clickableAttributes } as config) =
+    { config | clickableAttributes = { clickableAttributes | onClick = Just msg } }
 
 
 {-| -}
-opensModal : ClickableAttributes route msg -> ClickableAttributes route msg
-opensModal clickableAttributes =
-    { clickableAttributes | opensModal = True }
+submit : Config a route msg -> Config a route msg
+submit ({ clickableAttributes } as config) =
+    { config | clickableAttributes = { clickableAttributes | buttonType = "submit" } }
 
 
 {-| -}
-href : route -> ClickableAttributes route msg -> ClickableAttributes route msg
-href url clickableAttributes =
-    { clickableAttributes | url = Just url }
+opensModal : Config a route msg -> Config a route msg
+opensModal ({ clickableAttributes } as config) =
+    { config | clickableAttributes = { clickableAttributes | opensModal = True } }
 
 
 {-| -}
-linkSpa : route -> ClickableAttributes route msg -> ClickableAttributes route msg
-linkSpa url clickableAttributes =
-    { clickableAttributes | linkType = SinglePageApp, url = Just url }
+href : route -> Config a route msg -> Config a route msg
+href url ({ clickableAttributes } as config) =
+    { config | clickableAttributes = { clickableAttributes | url = Just url } }
 
 
 {-| -}
-linkWithMethod : { method : String, url : route } -> ClickableAttributes route msg -> ClickableAttributes route msg
-linkWithMethod { method, url } clickableAttributes =
-    { clickableAttributes | linkType = WithMethod method, url = Just url }
+linkSpa : route -> Config a route msg -> Config a route msg
+linkSpa url ({ clickableAttributes } as config) =
+    { config | clickableAttributes = { clickableAttributes | linkType = SinglePageApp, url = Just url } }
 
 
 {-| -}
-linkWithTracking : { track : msg, url : route } -> ClickableAttributes route msg -> ClickableAttributes route msg
-linkWithTracking { track, url } clickableAttributes =
-    { clickableAttributes
-        | linkType = WithTracking
-        , url = Just url
-        , onClick = Just track
+linkWithMethod : { method : String, url : route } -> Config a route msg -> Config a route msg
+linkWithMethod { method, url } ({ clickableAttributes } as config) =
+    { config | clickableAttributes = { clickableAttributes | linkType = WithMethod method, url = Just url } }
+
+
+{-| -}
+linkWithTracking : { track : msg, url : route } -> Config a route msg -> Config a route msg
+linkWithTracking { track, url } ({ clickableAttributes } as config) =
+    { config
+        | clickableAttributes =
+            { clickableAttributes
+                | linkType = WithTracking
+                , url = Just url
+                , onClick = Just track
+            }
     }
 
 
 {-| -}
-linkExternal : String -> ClickableAttributes route msg -> ClickableAttributes route msg
-linkExternal url clickableAttributes =
-    { clickableAttributes | linkType = External, urlString = Just url }
+linkExternal : String -> Config a route msg -> Config a route msg
+linkExternal url ({ clickableAttributes } as config) =
+    { config
+        | clickableAttributes = { clickableAttributes | linkType = External, urlString = Just url }
+    }
 
 
 {-| -}
-linkExternalWithTracking : { track : msg, url : String } -> ClickableAttributes route msg -> ClickableAttributes route msg
-linkExternalWithTracking { track, url } clickableAttributes =
-    { clickableAttributes
-        | linkType = ExternalWithTracking
-        , urlString = Just url
-        , onClick = Just track
+linkExternalWithTracking : { track : msg, url : String } -> Config a route msg -> Config a route msg
+linkExternalWithTracking { track, url } ({ clickableAttributes } as config) =
+    { config
+        | clickableAttributes =
+            { clickableAttributes
+                | linkType = ExternalWithTracking
+                , urlString = Just url
+                , onClick = Just track
+            }
     }
 
 

--- a/src/ClickableAttributes.elm
+++ b/src/ClickableAttributes.elm
@@ -37,6 +37,7 @@ import Html.Styled.Events as Events
 import Json.Decode
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (targetBlank)
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
+import Nri.Ui.UiIcon.V1 as UiIcon
 
 
 {-| -}
@@ -133,6 +134,7 @@ linkExternal : String -> Config a route msg -> Config a route msg
 linkExternal url ({ clickableAttributes } as config) =
     { config
         | clickableAttributes = { clickableAttributes | linkType = External, urlString = Just url }
+        , rightIcon = Just opensInNewTab
     }
 
 
@@ -146,6 +148,7 @@ linkExternalWithTracking { track, url } ({ clickableAttributes } as config) =
                 , urlString = Just url
                 , onClick = Just track
             }
+        , rightIcon = Just opensInNewTab
     }
 
 
@@ -256,3 +259,8 @@ toEnabledLinkAttributes routeToString clickableAttributes =
                     Attributes.href stringUrl
                         :: targetBlank
             )
+
+
+opensInNewTab : Svg
+opensInNewTab =
+    Svg.withLabel "Opens in a new tab" UiIcon.openInNewTab

--- a/src/ClickableAttributes.elm
+++ b/src/ClickableAttributes.elm
@@ -36,6 +36,7 @@ import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Json.Decode
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (targetBlank)
+import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 
 
 {-| -}
@@ -72,7 +73,10 @@ init =
 
 {-| -}
 type alias Config attributes route msg =
-    { attributes | clickableAttributes : ClickableAttributes route msg }
+    { attributes
+        | clickableAttributes : ClickableAttributes route msg
+        , rightIcon : Maybe Svg
+    }
 
 
 {-| -}

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -279,20 +279,10 @@ quizEngineMobileCss styles =
 -- LINKING, CLICKING, and TRACKING BEHAVIOR
 
 
-setClickableAttributes :
-    (ClickableAttributes String msg -> ClickableAttributes String msg)
-    -> Attribute msg
-setClickableAttributes apply =
-    set
-        (\attributes ->
-            { attributes | clickableAttributes = apply attributes.clickableAttributes }
-        )
-
-
 {-| -}
 onClick : msg -> Attribute msg
 onClick msg =
-    setClickableAttributes (ClickableAttributes.onClick msg)
+    set (ClickableAttributes.onClick msg)
 
 
 {-| By default, buttons have type "button". Use this attribute to change the button type to "submit".
@@ -302,20 +292,20 @@ Note: this attribute is not supported by links.
 -}
 submit : Attribute msg
 submit =
-    setClickableAttributes ClickableAttributes.submit
+    set ClickableAttributes.submit
 
 
 {-| Use this attribute when interacting with the button will launch a modal.
 -}
 opensModal : Attribute msg
 opensModal =
-    setClickableAttributes ClickableAttributes.opensModal
+    set ClickableAttributes.opensModal
 
 
 {-| -}
 href : String -> Attribute msg
 href url =
-    setClickableAttributes (ClickableAttributes.href url)
+    set (ClickableAttributes.href url)
 
 
 {-| Use this link for routing within a single page app.
@@ -327,31 +317,31 @@ See <https://github.com/elm-lang/html/issues/110> for details on this implementa
 -}
 linkSpa : String -> Attribute msg
 linkSpa url =
-    setClickableAttributes (ClickableAttributes.linkSpa url)
+    set (ClickableAttributes.linkSpa url)
 
 
 {-| -}
 linkWithMethod : { method : String, url : String } -> Attribute msg
 linkWithMethod config =
-    setClickableAttributes (ClickableAttributes.linkWithMethod config)
+    set (ClickableAttributes.linkWithMethod config)
 
 
 {-| -}
 linkWithTracking : { track : msg, url : String } -> Attribute msg
 linkWithTracking config =
-    setClickableAttributes (ClickableAttributes.linkWithTracking config)
+    set (ClickableAttributes.linkWithTracking config)
 
 
 {-| -}
 linkExternal : String -> Attribute msg
 linkExternal url =
-    setClickableAttributes (ClickableAttributes.linkExternal url)
+    set (ClickableAttributes.linkExternal url)
 
 
 {-| -}
 linkExternalWithTracking : { track : msg, url : String } -> Attribute msg
 linkExternalWithTracking config =
-    setClickableAttributes (ClickableAttributes.linkExternalWithTracking config)
+    set (ClickableAttributes.linkExternalWithTracking config)
 
 
 

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -111,20 +111,10 @@ link name icon attributes =
 -- LINKING, CLICKING, and TRACKING BEHAVIOR
 
 
-setClickableAttributes :
-    (ClickableAttributes String msg -> ClickableAttributes String msg)
-    -> Attribute msg
-setClickableAttributes apply =
-    set
-        (\attributes ->
-            { attributes | clickableAttributes = apply attributes.clickableAttributes }
-        )
-
-
 {-| -}
 onClick : msg -> Attribute msg
 onClick msg =
-    setClickableAttributes (ClickableAttributes.onClick msg)
+    set (ClickableAttributes.onClick msg)
 
 
 {-| By default, buttons have type "button". Use this attribute to change the button type to "submit".
@@ -134,20 +124,20 @@ Note: this attribute is not supported by links.
 -}
 submit : Attribute msg
 submit =
-    setClickableAttributes ClickableAttributes.submit
+    set ClickableAttributes.submit
 
 
 {-| Use this attribute when interacting with the button will launch a modal.
 -}
 opensModal : Attribute msg
 opensModal =
-    setClickableAttributes ClickableAttributes.opensModal
+    set ClickableAttributes.opensModal
 
 
 {-| -}
 href : String -> Attribute msg
 href url =
-    setClickableAttributes (ClickableAttributes.href url)
+    set (ClickableAttributes.href url)
 
 
 {-| Use this link for routing within a single page app.
@@ -159,31 +149,31 @@ See <https://github.com/elm-lang/html/issues/110> for details on this implementa
 -}
 linkSpa : String -> Attribute msg
 linkSpa url =
-    setClickableAttributes (ClickableAttributes.linkSpa url)
+    set (ClickableAttributes.linkSpa url)
 
 
 {-| -}
 linkWithMethod : { method : String, url : String } -> Attribute msg
 linkWithMethod config =
-    setClickableAttributes (ClickableAttributes.linkWithMethod config)
+    set (ClickableAttributes.linkWithMethod config)
 
 
 {-| -}
 linkWithTracking : { track : msg, url : String } -> Attribute msg
 linkWithTracking config =
-    setClickableAttributes (ClickableAttributes.linkWithTracking config)
+    set (ClickableAttributes.linkWithTracking config)
 
 
 {-| -}
 linkExternal : String -> Attribute msg
 linkExternal url =
-    setClickableAttributes (ClickableAttributes.linkExternal url)
+    set (ClickableAttributes.linkExternal url)
 
 
 {-| -}
 linkExternalWithTracking : { track : msg, url : String } -> Attribute msg
 linkExternalWithTracking config =
-    setClickableAttributes (ClickableAttributes.linkExternalWithTracking config)
+    set (ClickableAttributes.linkExternalWithTracking config)
 
 
 

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -292,20 +292,10 @@ quizEngineMobileCss styles =
 -- LINKING, CLICKING, and TRACKING BEHAVIOR
 
 
-setClickableAttributes :
-    (ClickableAttributes String msg -> ClickableAttributes String msg)
-    -> Attribute msg
-setClickableAttributes apply =
-    set
-        (\attributes ->
-            { attributes | clickableAttributes = apply attributes.clickableAttributes }
-        )
-
-
 {-| -}
 onClick : msg -> Attribute msg
 onClick msg =
-    setClickableAttributes (ClickableAttributes.onClick msg)
+    set (ClickableAttributes.onClick msg)
 
 
 {-| By default, buttons have type "button". Use this attribute to change the button type to "submit".
@@ -315,20 +305,20 @@ Note: this attribute is not supported by links.
 -}
 submit : Attribute msg
 submit =
-    setClickableAttributes ClickableAttributes.submit
+    set ClickableAttributes.submit
 
 
 {-| Use this attribute when interacting with the button will launch a modal.
 -}
 opensModal : Attribute msg
 opensModal =
-    setClickableAttributes ClickableAttributes.opensModal
+    set ClickableAttributes.opensModal
 
 
 {-| -}
 href : String -> Attribute msg
 href url =
-    setClickableAttributes (ClickableAttributes.href url)
+    set (ClickableAttributes.href url)
 
 
 {-| Use this link for routing within a single page app.
@@ -340,31 +330,31 @@ See <https://github.com/elm-lang/html/issues/110> for details on this implementa
 -}
 linkSpa : String -> Attribute msg
 linkSpa url =
-    setClickableAttributes (ClickableAttributes.linkSpa url)
+    set (ClickableAttributes.linkSpa url)
 
 
 {-| -}
 linkWithMethod : { method : String, url : String } -> Attribute msg
 linkWithMethod config =
-    setClickableAttributes (ClickableAttributes.linkWithMethod config)
+    set (ClickableAttributes.linkWithMethod config)
 
 
 {-| -}
 linkWithTracking : { track : msg, url : String } -> Attribute msg
 linkWithTracking config =
-    setClickableAttributes (ClickableAttributes.linkWithTracking config)
+    set (ClickableAttributes.linkWithTracking config)
 
 
 {-| -}
 linkExternal : String -> Attribute msg
 linkExternal url =
-    setClickableAttributes (ClickableAttributes.linkExternal url)
+    set (ClickableAttributes.linkExternal url)
 
 
 {-| -}
 linkExternalWithTracking : { track : msg, url : String } -> Attribute msg
 linkExternalWithTracking config =
-    setClickableAttributes (ClickableAttributes.linkExternalWithTracking config)
+    set (ClickableAttributes.linkExternalWithTracking config)
 
 
 {-| Shows inactive styling.

--- a/src/Nri/Ui/SideNav/V4.elm
+++ b/src/Nri/Ui/SideNav/V4.elm
@@ -505,6 +505,7 @@ sharedEntryStyles =
 {-| -}
 type alias EntryConfig route msg =
     { icon : Maybe Svg
+    , rightIcon : Maybe Svg
     , title : String
     , route : Maybe route
     , clickableAttributes : ClickableAttributes route msg
@@ -518,6 +519,7 @@ type alias EntryConfig route msg =
 build : String -> EntryConfig route msg
 build title =
     { icon = Nothing
+    , rightIcon = Nothing
     , title = title
     , route = Nothing
     , clickableAttributes = ClickableAttributes.init

--- a/src/Nri/Ui/SideNav/V4.elm
+++ b/src/Nri/Ui/SideNav/V4.elm
@@ -4,7 +4,8 @@ module Nri.Ui.SideNav.V4 exposing
     , navLabel, navId
     , navCss, navNotMobileCss, navMobileCss, navQuizEngineMobileCss
     , entry, entryWithChildren, html, Entry, Attribute
-    , icon, custom, css, nriDescription, testId, id
+    , icon, rightIcon
+    , custom, css, nriDescription, testId, id
     , onClick
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     , primary, secondary
@@ -27,7 +28,8 @@ module Nri.Ui.SideNav.V4 exposing
 ## Entries
 
 @docs entry, entryWithChildren, html, Entry, Attribute
-@docs icon, custom, css, nriDescription, testId, id
+@docs icon, rightIcon
+@docs custom, css, nriDescription, testId, id
 
 
 ## Behavior
@@ -446,6 +448,15 @@ viewSidebarLeaf config extraStyles entryConfig =
             )
             entryConfig.icon
         , text entryConfig.title
+        , viewJust
+            (\icon_ ->
+                icon_
+                    |> Svg.withWidth (px 20)
+                    |> Svg.withHeight (px 20)
+                    |> Svg.withCss [ marginLeft (px 5) ]
+                    |> Svg.toHtml
+            )
+            entryConfig.rightIcon
         ]
 
 
@@ -539,6 +550,12 @@ type Attribute route msg
 icon : Svg -> Attribute route msg
 icon icon_ =
     Attribute (\attributes -> { attributes | icon = Just icon_ })
+
+
+{-| -}
+rightIcon : Svg -> Attribute route msg
+rightIcon icon_ =
+    Attribute (\attributes -> { attributes | rightIcon = Just icon_ })
 
 
 {-| -}

--- a/src/Nri/Ui/SideNav/V4.elm
+++ b/src/Nri/Ui/SideNav/V4.elm
@@ -622,36 +622,21 @@ secondary =
 -- LINKING, CLICKING, and TRACKING BEHAVIOR
 
 
-setClickableAttributes :
-    Maybe route
-    -> (ClickableAttributes route msg -> ClickableAttributes route msg)
-    -> Attribute route msg
-setClickableAttributes route apply =
-    Attribute
-        (\attributes ->
-            { attributes
-                | route =
-                    case route of
-                        Just r ->
-                            Just r
-
-                        Nothing ->
-                            attributes.route
-                , clickableAttributes = apply attributes.clickableAttributes
-            }
-        )
+setClickableAttributesWithRoute : route -> (EntryConfig route msg -> EntryConfig route msg) -> Attribute route msg
+setClickableAttributesWithRoute route apply =
+    Attribute (\attributes -> apply { attributes | route = Just route })
 
 
 {-| -}
 onClick : msg -> Attribute route msg
 onClick msg =
-    setClickableAttributes Nothing (ClickableAttributes.onClick msg)
+    Attribute (ClickableAttributes.onClick msg)
 
 
 {-| -}
 href : route -> Attribute route msg
 href route =
-    setClickableAttributes (Just route) (ClickableAttributes.href route)
+    setClickableAttributesWithRoute route (ClickableAttributes.href route)
 
 
 {-| Use this link for routing within a single page app.
@@ -663,31 +648,31 @@ See <https://github.com/elm-lang/html/issues/110> for details on this implementa
 -}
 linkSpa : route -> Attribute route msg
 linkSpa route =
-    setClickableAttributes (Just route)
+    setClickableAttributesWithRoute route
         (ClickableAttributes.linkSpa route)
 
 
 {-| -}
 linkWithMethod : { method : String, url : route } -> Attribute route msg
 linkWithMethod config =
-    setClickableAttributes (Just config.url)
+    setClickableAttributesWithRoute config.url
         (ClickableAttributes.linkWithMethod config)
 
 
 {-| -}
 linkWithTracking : { track : msg, url : route } -> Attribute route msg
 linkWithTracking config =
-    setClickableAttributes (Just config.url)
+    setClickableAttributesWithRoute config.url
         (ClickableAttributes.linkWithTracking config)
 
 
 {-| -}
 linkExternal : String -> Attribute route msg
 linkExternal url =
-    setClickableAttributes Nothing (ClickableAttributes.linkExternal url)
+    Attribute (ClickableAttributes.linkExternal url)
 
 
 {-| -}
 linkExternalWithTracking : { track : msg, url : String } -> Attribute route msg
 linkExternalWithTracking config =
-    setClickableAttributes Nothing (ClickableAttributes.linkExternalWithTracking config)
+    Attribute (ClickableAttributes.linkExternalWithTracking config)

--- a/styleguide-app/App.elm
+++ b/styleguide-app/App.elm
@@ -411,7 +411,6 @@ navigation { moduleStates, route, isSideNavOpen, openTooltip } =
         ]
         (SideNav.entry "Usage Guidelines"
             [ SideNav.linkExternal "https://paper.dropbox.com/doc/UI-Style-Guide-and-Caveats--BhJHYronm1RGM1hRfnkvhrZMAg-PvOLxeX3oyujYEzdJx5pu"
-            , SideNav.icon UiIcon.openInNewTab
             ]
             :: SideNav.entry "All" [ SideNav.href Routes.All ]
             :: categoryNavLinks

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -172,10 +172,7 @@ docsLink example =
             "https://package.elm-lang.org/packages/NoRedInk/noredink-ui/latest/"
                 ++ String.replace "." "-" (fullName example)
     in
-    ClickableText.link "Docs"
-        [ ClickableText.linkExternal link
-        , ClickableText.rightIcon (Svg.withLabel "Opens in a new tab" UiIcon.openInNewTab)
-        ]
+    ClickableText.link "Docs" [ ClickableText.linkExternal link ]
 
 
 srcLink : Example state msg -> Html msg2
@@ -186,7 +183,4 @@ srcLink example =
                 ++ ".elm"
                 |> (++) "https://github.com/NoRedInk/noredink-ui/blob/master/src/"
     in
-    ClickableText.link "Source"
-        [ ClickableText.linkExternal link
-        , ClickableText.rightIcon (Svg.withLabel "Opens in a new tab" UiIcon.openInNewTab)
-        ]
+    ClickableText.link "Source" [ ClickableText.linkExternal link ]

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -13,8 +13,6 @@ import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Header.V1 as Header
-import Nri.Ui.Svg.V1 as Svg
-import Nri.Ui.UiIcon.V1 as UiIcon
 
 
 type alias Example state msg =

--- a/styleguide-app/Examples/SideNav.elm
+++ b/styleguide-app/Examples/SideNav.elm
@@ -254,6 +254,7 @@ controlEntryAttributes href =
             )
         |> CommonControls.css { moduleName = "SideNav", use = SideNav.css }
         |> CommonControls.iconNotCheckedByDefault "SideNav" SideNav.icon
+        |> CommonControls.rightIcon "SideNav" SideNav.rightIcon
         |> ControlExtra.optionalBoolListItem "secondary" ( "SideNav.secondary", SideNav.secondary )
         |> ControlExtra.optionalListItem "premiumDisplay"
             (Control.map

--- a/tests/Spec/ClickableAttributes.elm
+++ b/tests/Spec/ClickableAttributes.elm
@@ -2,7 +2,7 @@ module Spec.ClickableAttributes exposing (suite)
 
 import Accessibility.Aria as Aria
 import Accessibility.Role as Role
-import ClickableAttributes exposing (ClickableAttributes)
+import ClickableAttributes
 import Expect
 import Html.Attributes exposing (href)
 import Html.Styled exposing (a, text, toUnstyled)

--- a/tests/Spec/ClickableAttributes.elm
+++ b/tests/Spec/ClickableAttributes.elm
@@ -155,19 +155,20 @@ disabledLinkAttributes =
         ]
 
 
-setupLinkTest : (ClickableAttributes String msg -> ClickableAttributes String msg) -> Query.Single msg
+setupLinkTest : (ClickableAttributes.Config {} String msg -> ClickableAttributes.Config {} String msg) -> Query.Single msg
 setupLinkTest withLink =
-    ClickableAttributes.init
+    { clickableAttributes = ClickableAttributes.init, rightIcon = Nothing }
         |> withLink
-        |> ClickableAttributes.toLinkAttributes
-            { routeToString = identity, isDisabled = False }
+        |> .clickableAttributes
+        |> ClickableAttributes.toLinkAttributes { routeToString = identity, isDisabled = False }
         |> renderTestAnchorTag
 
 
-setupDisabledLinkTest : (ClickableAttributes String msg -> ClickableAttributes String msg) -> Query.Single msg
+setupDisabledLinkTest : (ClickableAttributes.Config {} String msg -> ClickableAttributes.Config {} String msg) -> Query.Single msg
 setupDisabledLinkTest withLink =
-    ClickableAttributes.init
+    { clickableAttributes = ClickableAttributes.init, rightIcon = Nothing }
         |> withLink
+        |> .clickableAttributes
         |> ClickableAttributes.toLinkAttributes
             { routeToString = identity, isDisabled = True }
         |> renderTestAnchorTag


### PR DESCRIPTION
When a Button, ClickableText, ClickableSvg, or SideNav entry link to an external page, automatically add `UiIcon.openInNewTab` icon with "Opens in a new tab" alt text to the right side of the link.

Fixes https://github.com/NoRedInk/noredink-ui/issues/1214

Note that this change also required adding rightIcon support to SideNav:
<img width="322" alt="Screen Shot 2023-01-13 at 2 15 17 PM" src="https://user-images.githubusercontent.com/8811312/212420920-16038e86-fd1a-4362-8a1a-f99fc8c165f4.png">

When upgrading to the version of noredink-ui that includes this change, we should be careful to remove existing left-icon affordances so that the icon doesn't show twice.

cc @NoRedInk/design 