### PR TITLE
Adjust guidance and error behavior

### DIFF
--- a/src/InputErrorAndGuidanceInternal.elm
+++ b/src/InputErrorAndGuidanceInternal.elm
@@ -125,36 +125,50 @@ describedBy idValue config =
 
 view : String -> Css.Style -> { config | guidance : Guidance, error : ErrorState } -> Html msg
 view idValue marginTop config =
-    case ( getErrorMessage config.error, config.guidance ) of
+    let
+        maybeError =
+            getErrorMessage config.error
+    in
+    case ( maybeError, config.guidance ) of
         ( Just m, _ ) ->
-            Message.view
-                [ Message.tiny
-                , Message.error
-                , Message.plaintext m
-                , Message.alertRole
-                , Message.id (errorId idValue)
-                , Message.custom [ Live.polite ]
-                , Message.css
-                    [ Css.important (Css.paddingTop Css.zero)
-                    , Css.important (Css.paddingBottom Css.zero)
-                    , marginTop
-                    ]
-                ]
+            renderErrorMessage idValue marginTop m
 
         ( _, Just guidanceMessage ) ->
-            Text.caption
-                [ Text.id (guidanceId idValue)
-                , Text.plaintext guidanceMessage
-                , Text.css
-                    [ Css.important (Css.paddingTop Css.zero)
-                    , Css.important (Css.paddingBottom Css.zero)
-                    , Css.important marginTop
-                    , Css.lineHeight (Css.num 1)
-                    ]
-                ]
+            renderGuidance idValue marginTop guidanceMessage
 
         _ ->
             Html.text ""
+
+
+renderErrorMessage : String -> Css.Style -> String -> Html msg
+renderErrorMessage idValue marginTop m =
+    Message.view
+        [ Message.tiny
+        , Message.error
+        , Message.plaintext m
+        , Message.alertRole
+        , Message.id (errorId idValue)
+        , Message.custom [ Live.polite ]
+        , Message.css
+            [ Css.important (Css.paddingTop Css.zero)
+            , Css.important (Css.paddingBottom Css.zero)
+            , marginTop
+            ]
+        ]
+
+
+renderGuidance : String -> Css.Style -> String -> Html msg
+renderGuidance idValue marginTop guidanceMessage =
+    Text.caption
+        [ Text.id (guidanceId idValue)
+        , Text.plaintext guidanceMessage
+        , Text.css
+            [ Css.important (Css.paddingTop Css.zero)
+            , Css.important (Css.paddingBottom Css.zero)
+            , Css.important marginTop
+            , Css.lineHeight (Css.num 1)
+            ]
+        ]
 
 
 smallMargin : Css.Style

--- a/src/InputErrorAndGuidanceInternal.elm
+++ b/src/InputErrorAndGuidanceInternal.elm
@@ -146,13 +146,22 @@ apply { ifError, ifGuidance } config =
             getErrorMessage config.error
     in
     case ( maybeError, config.guidance ) of
-        ( Just errorMessage, _ ) ->
+        ( Just errorMessage, Just guidanceMessage ) ->
+            if errorMessage /= guidanceMessage then
+                [ ifGuidance guidanceMessage
+                , ifError errorMessage
+                ]
+
+            else
+                [ ifError errorMessage ]
+
+        ( Just errorMessage, Nothing ) ->
             [ ifError errorMessage ]
 
-        ( _, Just guidanceMessage ) ->
+        ( Nothing, Just guidanceMessage ) ->
             [ ifGuidance guidanceMessage ]
 
-        _ ->
+        ( Nothing, Nothing ) ->
             []
 
 

--- a/src/InputErrorAndGuidanceInternal.elm
+++ b/src/InputErrorAndGuidanceInternal.elm
@@ -3,6 +3,7 @@ module InputErrorAndGuidanceInternal exposing
     , Guidance, noGuidance, setGuidance
     , getIsInError, getErrorMessage
     , describedBy, view, smallMargin
+    , guidanceId, errorId
     )
 
 {-|
@@ -11,6 +12,7 @@ module InputErrorAndGuidanceInternal exposing
 @docs Guidance, noGuidance, setGuidance
 @docs getIsInError, getErrorMessage
 @docs describedBy, view, smallMargin
+@docs guidanceId, errorId
 
 -}
 

--- a/src/InputErrorAndGuidanceInternal.elm
+++ b/src/InputErrorAndGuidanceInternal.elm
@@ -148,8 +148,8 @@ apply { ifError, ifGuidance } config =
     case ( maybeError, config.guidance ) of
         ( Just errorMessage, Just guidanceMessage ) ->
             if errorMessage /= guidanceMessage then
-                [ ifGuidance guidanceMessage
-                , ifError errorMessage
+                [ ifError errorMessage
+                , ifGuidance guidanceMessage
                 ]
 
             else

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -243,8 +243,8 @@ view { label, selected } attributes =
             }
     in
     checkboxContainer config_
-        [ viewCheckbox config_
-        , let
+        ([ viewCheckbox config_
+         , let
             ( icon, disabledIcon ) =
                 case selected of
                     Selected ->
@@ -261,14 +261,15 @@ view { label, selected } attributes =
                         ( CheckboxIcons.checkedPartially idValue
                         , CheckboxIcons.checkedPartiallyDisabled
                         )
-          in
-          if config.isDisabled then
+           in
+           if config.isDisabled then
             viewDisabledLabel config_ disabledIcon
 
-          else
+           else
             viewEnabledLabel config_ icon
-        , InputErrorAndGuidanceInternal.view config_.identifier (Css.marginTop Css.zero) config_
-        ]
+         ]
+            ++ InputErrorAndGuidanceInternal.view config_.identifier (Css.marginTop Css.zero) config_
+        )
 
 
 {-| If your selectedness is always selected or not selected,

--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -17,6 +17,7 @@ module Nri.Ui.Message.V3 exposing
   - adds `hideIconForMobile` and `hideIconFor`
   - use `Shadows`
   - use internal `Content` module
+  - make the tiny Message's icon size smaller
 
 Changes from V2:
 
@@ -759,7 +760,7 @@ getIcon customIcon size theme =
         ( iconSize, marginRight ) =
             case size of
                 Tiny ->
-                    ( px 20, Css.marginRight (Css.px 5) )
+                    ( px 18, Css.marginRight (Css.px 5) )
 
                 Large ->
                     ( px 35, Css.marginRight (Css.px 10) )

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -403,8 +403,8 @@ view { label, name, value, valueToString, selectedValue } attributes =
                         text ""
                     ]
                 ]
-             , InputErrorAndGuidanceInternal.view idValue (Css.marginTop Css.zero) config
              ]
+                ++ InputErrorAndGuidanceInternal.view idValue (Css.marginTop Css.zero) config
                 ++ (if isChecked then
                         disclosedElements
 
@@ -437,7 +437,7 @@ viewLockedButton { idValue, label } config =
             Nothing ->
                 Extra.none
         ]
-        [ Html.div
+        ([ Html.div
             [ class "Nri-RadioButton-LockedPremiumButton"
             , css
                 [ outline Css.none
@@ -482,8 +482,9 @@ viewLockedButton { idValue, label } config =
                 , premiumPennant
                 ]
             ]
-        , InputErrorAndGuidanceInternal.view idValue (Css.marginTop Css.zero) config
-        ]
+         ]
+            ++ InputErrorAndGuidanceInternal.view idValue (Css.marginTop Css.zero) config
+        )
 
 
 premiumPennant : Html msg

--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -299,19 +299,20 @@ view label attributes =
                 ++ config.containerCss
             )
         ]
-        [ viewSelect
+        ([ viewSelect
             { id = id_
             , disabled = disabled_
             }
             config
-        , InputLabelInternal.view
+         , InputLabelInternal.view
             { for = id_
             , label = label
             , theme = InputStyles.Standard
             }
             config
-        , InputErrorAndGuidanceInternal.view id_ InputErrorAndGuidanceInternal.smallMargin config
-        ]
+         ]
+            ++ InputErrorAndGuidanceInternal.view id_ InputErrorAndGuidanceInternal.smallMargin config
+        )
 
 
 viewSelect : { id : String, disabled : Bool } -> Config a -> Html a

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -350,7 +350,7 @@ view_ label config =
     Html.styled (Html.node "nri-textarea-v5")
         [ Css.display Css.block, Css.position Css.relative, Css.batch config.containerCss ]
         autoresizeAttrs
-        [ Html.styled Html.textarea
+        ([ Html.styled Html.textarea
             [ InputStyles.input config.theme
             , Css.boxSizing Css.borderBox
             , case config.height of
@@ -396,14 +396,15 @@ view_ label config =
                 ++ List.map (Attributes.map never) config.custom
             )
             []
-        , InputLabelInternal.view
+         , InputLabelInternal.view
             { for = idValue
             , label = label
             , theme = config.theme
             }
             config
-        , InputErrorAndGuidanceInternal.view idValue InputErrorAndGuidanceInternal.smallMargin config
-        ]
+         ]
+            ++ InputErrorAndGuidanceInternal.view idValue InputErrorAndGuidanceInternal.smallMargin config
+        )
 
 
 calculateMinHeight : Theme -> Height -> Css.Px

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -835,7 +835,7 @@ view label attributes =
                 :: config.containerCss
             )
         ]
-        [ input
+        ([ input
             (maybeStep
                 ++ List.map (Attributes.map never) (List.reverse config.custom)
                 ++ [ Attributes.id idValue
@@ -896,13 +896,13 @@ view label attributes =
                    ]
             )
             []
-        , InputLabelInternal.view
+         , InputLabelInternal.view
             { for = idValue
             , label = label
             , theme = config.inputStyle
             }
             config
-        , Maybe.map2
+         , Maybe.map2
             (\view_ onStringInput_ ->
                 view_
                     { label = label
@@ -914,8 +914,9 @@ view label attributes =
             eventsAndValues.floatingContent
             eventsAndValues.onInput
             |> Maybe.withDefault (Html.text "")
-        , InputErrorAndGuidanceInternal.view idValue InputErrorAndGuidanceInternal.smallMargin config
-        ]
+         ]
+            ++ InputErrorAndGuidanceInternal.view idValue InputErrorAndGuidanceInternal.smallMargin config
+        )
 
 
 {-| Gives you the default DOM element id that will be used by a `TextInput.view` with the given label.

--- a/tests/Spec/InputErrorAndGuidance.elm
+++ b/tests/Spec/InputErrorAndGuidance.elm
@@ -76,13 +76,13 @@ emptyErrorAndGuidance =
 viewQuery : { guidance : Guidance, error : ErrorState } -> Query.Single msg
 viewQuery config =
     Html.Styled.div []
-        [ Html.Styled.input
+        (Html.Styled.input
             [ Html.Styled.Attributes.id inputId
             , InputErrorAndGuidanceInternal.describedBy inputId config
             ]
             []
-        , InputErrorAndGuidanceInternal.view inputId (Css.batch []) config
-        ]
+            :: InputErrorAndGuidanceInternal.view inputId (Css.batch []) config
+        )
         |> Html.Styled.toUnstyled
         |> Query.fromHtml
 

--- a/tests/Spec/InputErrorAndGuidance.elm
+++ b/tests/Spec/InputErrorAndGuidance.elm
@@ -1,0 +1,34 @@
+module Spec.InputErrorAndGuidance exposing (spec)
+
+import Css
+import Expect
+import Html.Styled
+import InputErrorAndGuidanceInternal exposing (ErrorState, Guidance)
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+
+
+spec : Test
+spec =
+    describe "InputErrorAndGuidanceInternal"
+        [ test "Renders an empty node when no guidance or error is present" <|
+            \() ->
+                viewQuery emptyErrorAndGuidance
+                    |> Query.children []
+                    |> Query.count (Expect.equal 0)
+        ]
+
+
+emptyErrorAndGuidance : { guidance : Guidance, error : ErrorState }
+emptyErrorAndGuidance =
+    { guidance = InputErrorAndGuidanceInternal.noGuidance
+    , error = InputErrorAndGuidanceInternal.noError
+    }
+
+
+viewQuery : { guidance : Guidance, error : ErrorState } -> Query.Single msg
+viewQuery =
+    InputErrorAndGuidanceInternal.view "test-id" (Css.batch [])
+        >> Html.Styled.toUnstyled
+        >> Query.fromHtml

--- a/tests/Spec/InputErrorAndGuidance.elm
+++ b/tests/Spec/InputErrorAndGuidance.elm
@@ -31,6 +31,16 @@ spec =
                         , hasGuidance "Password must be at least 8 characters long."
                         , Query.hasNot [ Selector.id errorId ]
                         ]
+        , test "Renders an error node when error is present and guidance is not" <|
+            \() ->
+                emptyErrorAndGuidance
+                    |> InputErrorAndGuidanceInternal.setErrorMessage (Just "Password must be at least 8 characters long.")
+                    |> viewQuery
+                    |> Expect.all
+                        [ hasInputDescribedBy [ errorId ]
+                        , hasError "Password must be at least 8 characters long."
+                        , Query.hasNot [ Selector.id guidanceId ]
+                        ]
         ]
 
 
@@ -84,5 +94,13 @@ hasGuidance : String -> Query.Single msg -> Expectation
 hasGuidance content =
     Query.has
         [ Selector.id guidanceId
+        , Selector.containing [ Selector.text content ]
+        ]
+
+
+hasError : String -> Query.Single msg -> Expectation
+hasError content =
+    Query.has
+        [ Selector.id errorId
         , Selector.containing [ Selector.text content ]
         ]

--- a/tests/Spec/InputErrorAndGuidance.elm
+++ b/tests/Spec/InputErrorAndGuidance.elm
@@ -52,6 +52,17 @@ spec =
                         , hasGuidance "Password is required."
                         , hasError "Password must be at least 8 characters long."
                         ]
+        , test "Renders an error node instead of a guidance node when the error is identical to the guidance" <|
+            \() ->
+                emptyErrorAndGuidance
+                    |> InputErrorAndGuidanceInternal.setGuidance "Password must be at least 8 characters long."
+                    |> InputErrorAndGuidanceInternal.setErrorMessage (Just "Password must be at least 8 characters long.")
+                    |> viewQuery
+                    |> Expect.all
+                        [ hasInputDescribedBy [ errorId ]
+                        , hasError "Password must be at least 8 characters long."
+                        , Query.hasNot [ Selector.id guidanceId ]
+                        ]
         ]
 
 

--- a/tests/Spec/InputErrorAndGuidance.elm
+++ b/tests/Spec/InputErrorAndGuidance.elm
@@ -48,7 +48,7 @@ spec =
                     |> InputErrorAndGuidanceInternal.setErrorMessage (Just "Password must be at least 8 characters long.")
                     |> viewQuery
                     |> Expect.all
-                        [ hasInputDescribedBy [ guidanceId, errorId ]
+                        [ hasInputDescribedBy [ errorId, guidanceId ]
                         , hasGuidance "Password is required."
                         , hasError "Password must be at least 8 characters long."
                         ]

--- a/tests/Spec/InputErrorAndGuidance.elm
+++ b/tests/Spec/InputErrorAndGuidance.elm
@@ -41,6 +41,17 @@ spec =
                         , hasError "Password must be at least 8 characters long."
                         , Query.hasNot [ Selector.id guidanceId ]
                         ]
+        , test "Renders an error node and a guidance node when error and guidance are present and non-identical" <|
+            \() ->
+                emptyErrorAndGuidance
+                    |> InputErrorAndGuidanceInternal.setGuidance "Password is required."
+                    |> InputErrorAndGuidanceInternal.setErrorMessage (Just "Password must be at least 8 characters long.")
+                    |> viewQuery
+                    |> Expect.all
+                        [ hasInputDescribedBy [ guidanceId, errorId ]
+                        , hasGuidance "Password is required."
+                        , hasError "Password must be at least 8 characters long."
+                        ]
         ]
 
 


### PR DESCRIPTION
Fixes A11-2192

<details><summary> Outdated screenshots</summary>

### Checkbox

<img width="328" alt="Screen Shot 2023-01-17 at 11 55 54 AM" src="https://user-images.githubusercontent.com/8811312/212987321-5db68c29-d402-45d8-b370-f533045c0f24.png">

(Checkbox doesn't support an error state)

### RadioButton

<img width="260" alt="Screen Shot 2023-01-17 at 11 56 40 AM" src="https://user-images.githubusercontent.com/8811312/212987317-d68ca50b-3a0a-47a0-a624-bcd7eec3b5a8.png">


### Select

<img width="157" alt="Screen Shot 2023-01-17 at 11 57 08 AM" src="https://user-images.githubusercontent.com/8811312/212987314-8f88158e-c0fd-4298-8f5d-4b713d9c0b6f.png">


### TextArea

<img width="252" alt="Screen Shot 2023-01-17 at 11 57 28 AM" src="https://user-images.githubusercontent.com/8811312/212987313-85299ce9-a368-432c-a9fd-23713866fa91.png">


### TextInput

<img width="174" alt="Screen Shot 2023-01-17 at 11 52 05 AM" src="https://user-images.githubusercontent.com/8811312/212987309-f4feb931-1de7-4c38-bc3f-734e8f927c33.png">

---

cc @NoRedInk/design 

I put the error after the guidance because conceptually it made sense to me to put new stuff after existing stuff. But I kinda think it looks bad? And might look better if the purple error were next to the purple outlines? Let me know if you agree that I should flip the guidance and the error message. 🙏 

</details>