### PR TITLE
Bat/highlighter markdown

### DIFF
--- a/src/Nri/Ui/Highlightable/V1.elm
+++ b/src/Nri/Ui/Highlightable/V1.elm
@@ -1,6 +1,7 @@
 module Nri.Ui.Highlightable.V1 exposing
     ( Highlightable, Type(..), UIState(..), Attribute(..)
     , init, initFragment, initFragments
+    , fromMarkdown
     , splitHighlightableOnWords, splitWords
     , blur, clearHint, hint, hover
     , set, toggle
@@ -28,6 +29,7 @@ refactor to make it an actual type.
 # Initializers
 
 @docs init, initFragment, initFragments
+@docs fromMarkdown
 
 
 # Transformations
@@ -198,6 +200,20 @@ initFragments marked text_ =
         |> List.map Just
         |> List.intersperse Nothing
         |> List.indexedMap spaceOrInit
+
+
+{-| How do we know which elements should be marked, if all we have is a markdown string?
+
+We do some funky parsing to interpret empty anchor tags and tagged spans as highlighted!
+
+    fromMarkdown "for example, [this phrase]() will show as highlighted"
+
+will result in a list of highlightables where "this phrase" is marked with the default marker.
+
+-}
+fromMarkdown : String -> List (Highlightable marker)
+fromMarkdown markdownString =
+    []
 
 
 {-| -}

--- a/src/Nri/Ui/Highlightable/V1.elm
+++ b/src/Nri/Ui/Highlightable/V1.elm
@@ -240,28 +240,31 @@ fromMarkdown markdownString =
 
                 Markdown.Inline.Link "" maybeTitle inlines ->
                     -- empty links should be interpreted as content that's supposed to be highlighted!
-                    List.concatMap (highlightableFromInline (Just defaultMark) identity) inlines
+                    List.concatMap (highlightableFromInline (Just defaultMark) mapStrings) inlines
 
                 Markdown.Inline.Link url maybeTitle inlines ->
-                    List.concatMap (highlightableFromInline maybeMark identity) inlines
+                    List.concatMap (highlightableFromInline maybeMark mapStrings) inlines
 
                 Markdown.Inline.Image _ _ inlines ->
-                    List.concatMap (highlightableFromInline maybeMark identity) inlines
+                    List.concatMap (highlightableFromInline maybeMark mapStrings) inlines
 
                 Markdown.Inline.HtmlInline _ _ inlines ->
-                    List.concatMap (highlightableFromInline maybeMark identity) inlines
+                    List.concatMap (highlightableFromInline maybeMark mapStrings) inlines
 
                 Markdown.Inline.Emphasis level inlines ->
                     let
                         marker =
                             String.repeat level "*"
+
+                        addMarkers str =
+                            marker ++ str ++ marker
                     in
                     List.concatMap
-                        (highlightableFromInline maybeMark (\str -> marker ++ str ++ marker))
+                        (highlightableFromInline maybeMark (mapStrings >> addMarkers))
                         inlines
 
                 Markdown.Inline.Custom _ inlines ->
-                    List.concatMap (highlightableFromInline maybeMark identity) inlines
+                    List.concatMap (highlightableFromInline maybeMark mapStrings) inlines
 
         highlightableFromBlock : Markdown.Block.Block b i -> List (Highlightable ())
         highlightableFromBlock block =

--- a/src/Nri/Ui/Highlightable/V1.elm
+++ b/src/Nri/Ui/Highlightable/V1.elm
@@ -330,9 +330,9 @@ fromMarkdown markdownString =
                 -- ensure that adjacent highlights are in a single mark element
                 (\segment ( lastInteractiveHighlight, acc ) ->
                     ( segment.marked
-                    , case ( segment.marked, acc ) of
-                        ( Just marker, last :: remainder ) ->
-                            if Just marker == last.marked then
+                    , case acc of
+                        last :: remainder ->
+                            if segment.marked == last.marked then
                                 { segment | text = segment.text ++ last.text }
                                     :: remainder
 

--- a/src/Nri/Ui/Highlightable/V1.elm
+++ b/src/Nri/Ui/Highlightable/V1.elm
@@ -326,6 +326,25 @@ fromMarkdown markdownString =
     else
         Markdown.Block.parse Nothing markdownString
             |> List.concatMap highlightableFromBlock
+            |> List.foldr
+                -- ensure that adjacent highlights are in a single mark element
+                (\segment ( lastInteractiveHighlight, acc ) ->
+                    ( segment.marked
+                    , case ( segment.marked, acc ) of
+                        ( Just marker, last :: remainder ) ->
+                            if Just marker == last.marked then
+                                { segment | text = segment.text ++ last.text }
+                                    :: remainder
+
+                            else
+                                segment :: acc
+
+                        _ ->
+                            segment :: acc
+                    )
+                )
+                ( Nothing, [] )
+            |> Tuple.second
 
 
 {-| -}

--- a/src/Nri/Ui/Highlightable/V1.elm
+++ b/src/Nri/Ui/Highlightable/V1.elm
@@ -49,7 +49,6 @@ just a single whitespace.
 
 -}
 
-import Markdown
 import Markdown.Block
 import Markdown.Inline
 import Nri.Ui.Colors.V1 as Colors

--- a/src/Nri/Ui/Highlightable/V1.elm
+++ b/src/Nri/Ui/Highlightable/V1.elm
@@ -243,7 +243,31 @@ fromMarkdown markdownString =
                     List.concatMap (highlightableFromInline (Just defaultMark) mapStrings) inlines
 
                 Markdown.Inline.Link url maybeTitle inlines ->
-                    List.concatMap (highlightableFromInline maybeMark mapStrings) inlines
+                    let
+                        lastIndex =
+                            List.length inlines - 1
+
+                        addLinkOpening i str =
+                            if i == 0 then
+                                "[" ++ str
+
+                            else
+                                str
+
+                        addLinkClosing i str =
+                            if i == lastIndex then
+                                str ++ "](" ++ url ++ ")"
+
+                            else
+                                str
+                    in
+                    List.indexedMap
+                        (\i ->
+                            highlightableFromInline maybeMark
+                                (mapStrings >> addLinkOpening i >> addLinkClosing i)
+                        )
+                        inlines
+                        |> List.concat
 
                 Markdown.Inline.Image _ _ inlines ->
                     List.concatMap (highlightableFromInline maybeMark mapStrings) inlines

--- a/src/Nri/Ui/Highlightable/V1.elm
+++ b/src/Nri/Ui/Highlightable/V1.elm
@@ -8,17 +8,13 @@ module Nri.Ui.Highlightable.V1 exposing
     , attributeSorter
     )
 
-{-| A Highlightable represents a span of text, typically a word, and its state.
+{-| The next version of Highlightable should remove `groupIndex.`
+
+A Highlightable represents a span of text, typically a word, and its state.
 
 Highlightable is the unit by which text-wrapping happens. Depending on how the
 Highlighter is initialized, it's very possible for a Highlightable to consist of
 just a single whitespace.
-
-A consecutive array of Highlightables sharing the same groupIndex form a fragment,
-which gets highlighted together as a group in response to user action such as
-clicking and dragging. Fragment as a concept only exists in how functions and
-variables are named, and is not expressed as a concrete type. We probably should
-refactor to make it an actual type.
 
 
 # Types

--- a/tests/Spec/Nri/Ui/Highlightable.elm
+++ b/tests/Spec/Nri/Ui/Highlightable.elm
@@ -79,6 +79,14 @@ fromMarkdownSpec =
         \() ->
             testFromMarkdown "A sentence without highlighted content"
                 [ ( "A sentence without highlighted content", Nothing ) ]
+    , test "does not strip emphasized content" <|
+        \() ->
+            testFromMarkdown "A *sentence without* **highlighted content**"
+                [ ( "A ", Nothing )
+                , ( "*sentence without*", Nothing )
+                , ( " ", Nothing )
+                , ( "**highlighted content**", Nothing )
+                ]
     , test "marks a single segment as highlighted" <|
         \() ->
             testFromMarkdown "[fake link]()"

--- a/tests/Spec/Nri/Ui/Highlightable.elm
+++ b/tests/Spec/Nri/Ui/Highlightable.elm
@@ -79,6 +79,10 @@ fromMarkdownSpec =
         \() ->
             testFromMarkdown "A sentence without highlighted content"
                 [ ( "A sentence without highlighted content", Nothing ) ]
+    , test "marks a single segment as highlighted" <|
+        \() ->
+            testFromMarkdown "[fake link]()"
+                [ ( "fake link", Just defaultMark ) ]
     , test "does mark content that's intended to be highlighted" <|
         \() ->
             testFromMarkdown "A sentence with [highlighted content]()"
@@ -92,5 +96,22 @@ fromMarkdownSpec =
                 , ( "*emphasized *", Nothing )
                 , ( "*highlighted content*", Just defaultMark )
                 , ( "*!*", Nothing )
+                ]
+    , test "marks content that's intended to be highlighted that also contains an emphasis" <|
+        \() ->
+            testFromMarkdown "A sentence with [highlighted *and partially emphasized* content]()"
+                [ ( "A sentence with ", Nothing )
+                , ( "highlighted *and partially emphasized* content", Just defaultMark )
+                ]
+    , test "does not highlight actual links" <|
+        \() ->
+            testFromMarkdown "I am a [real link](google.com)"
+                [ ( "I am a ", Nothing )
+                , ( "[real link](google.com)", Nothing )
+                ]
+    , test "does not get confused by parentheses" <|
+        \() ->
+            testFromMarkdown "main thought (parenthetical)"
+                [ ( "main thought (parenthetical)", Nothing )
                 ]
     ]

--- a/tests/Spec/Nri/Ui/Highlightable.elm
+++ b/tests/Spec/Nri/Ui/Highlightable.elm
@@ -82,11 +82,7 @@ fromMarkdownSpec =
     , test "does not strip emphasized content" <|
         \() ->
             testFromMarkdown "A *sentence without* **highlighted content**"
-                [ ( "A ", Nothing )
-                , ( "*sentence without*", Nothing )
-                , ( " ", Nothing )
-                , ( "**highlighted content**", Nothing )
-                ]
+                [ ( "A *sentence without* **highlighted content**", Nothing ) ]
     , test "marks a single segment as highlighted" <|
         \() ->
             testFromMarkdown "[fake link]()"
@@ -100,8 +96,7 @@ fromMarkdownSpec =
     , test "marks content that's intended to be highlighted within an emphasis" <|
         \() ->
             testFromMarkdown "A sentence with *emphasized [highlighted content]()!*"
-                [ ( "A sentence with ", Nothing )
-                , ( "*emphasized *", Nothing )
+                [ ( "A sentence with *emphasized *", Nothing )
                 , ( "*highlighted content*", Just defaultMark )
                 , ( "*!*", Nothing )
                 ]
@@ -114,8 +109,7 @@ fromMarkdownSpec =
     , test "does not highlight actual links" <|
         \() ->
             testFromMarkdown "I am a [real link](google.com)"
-                [ ( "I am a ", Nothing )
-                , ( "[real link](google.com)", Nothing )
+                [ ( "I am a [real link](google.com)", Nothing )
                 ]
     , test "does not get confused by parentheses" <|
         \() ->

--- a/tests/Spec/Nri/Ui/Highlightable.elm
+++ b/tests/Spec/Nri/Ui/Highlightable.elm
@@ -2,8 +2,10 @@ module Spec.Nri.Ui.Highlightable exposing (spec)
 
 import Expect
 import Fuzz exposing (..)
+import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Highlightable.V1 as Highlightable
 import Nri.Ui.Highlighter.V2 as Highlighter
+import Nri.Ui.HighlighterTool.V1 as Tool
 import String.Extra
 import Test exposing (..)
 
@@ -49,4 +51,46 @@ spec =
                 Highlightable.splitWords a
                     |> List.length
                     |> Expect.equal expected
+        , describe "fromMarkdown" fromMarkdownSpec
         ]
+
+
+fromMarkdownSpec : List Test
+fromMarkdownSpec =
+    let
+        testFromMarkdown startingString expected =
+            Highlightable.fromMarkdown startingString
+                |> List.map (\{ text, marked } -> ( text, marked ))
+                |> Expect.equal expected
+
+        defaultMark =
+            Tool.buildMarker
+                { highlightColor = Colors.highlightYellow
+                , hoverColor = Colors.highlightYellow
+                , hoverHighlightColor = Colors.highlightYellow
+                , kind = ()
+                , name = Nothing
+                }
+    in
+    [ test "with an empty string, produces empty list of Highlightables" <|
+        \() ->
+            testFromMarkdown "" []
+    , test "does not mark non-highlighted content" <|
+        \() ->
+            testFromMarkdown "A sentence without highlighted content"
+                [ ( "A sentence without highlighted content", Nothing ) ]
+    , test "does mark content that's intended to be highlighted" <|
+        \() ->
+            testFromMarkdown "A sentence with [highlighted content]()"
+                [ ( "A sentence with ", Nothing )
+                , ( "highlighted content", Just defaultMark )
+                ]
+    , test "marks content that's intended to be highlighted within an emphasis" <|
+        \() ->
+            testFromMarkdown "A sentence with *emphasized [highlighted content]()!*"
+                [ ( "A sentence with ", Nothing )
+                , ( "*emphasized *", Nothing )
+                , ( "*highlighted content*", Just defaultMark )
+                , ( "*!*", Nothing )
+                ]
+    ]

--- a/tests/Spec/Nri/Ui/Highlightable.elm
+++ b/tests/Spec/Nri/Ui/Highlightable.elm
@@ -1,0 +1,52 @@
+module Spec.Nri.Ui.Highlightable exposing (spec)
+
+import Expect
+import Fuzz exposing (..)
+import Nri.Ui.Highlightable.V1 as Highlightable
+import Nri.Ui.Highlighter.V2 as Highlighter
+import String.Extra
+import Test exposing (..)
+
+
+spec : Test
+spec =
+    describe "Highlightable"
+        [ describe "roundtrip from initFragment via toTuplesByFragment"
+            [ fuzz (list string) "toTuplesByFragment (initFragment [str]) ... == [str]" <|
+                \strings ->
+                    let
+                        fragment =
+                            strings
+                                |> List.map (Tuple.pair [])
+                                |> Highlightable.initFragment Nothing 0
+
+                        roundtripText =
+                            Highlighter.asFragmentTuples fragment
+                                |> List.head
+                                |> Maybe.map Tuple.second
+
+                        expected =
+                            String.Extra.nonEmpty (String.join "" strings)
+                    in
+                    Expect.equal roundtripText expected
+            ]
+        , fuzz Fuzz.string "splitWords" <|
+            \a ->
+                let
+                    expected =
+                        String.split " " a
+                            |> List.length
+                            |> (*) 2
+                            |> (\x ->
+                                    if x > 1 then
+                                        x - 1
+
+                                    else
+                                        x
+                               )
+                            |> max 0
+                in
+                Highlightable.splitWords a
+                    |> List.length
+                    |> Expect.equal expected
+        ]


### PR DESCRIPTION
Fixes A11-2006

Adds a helper, `Highlightable.fromMarkdown : String.String -> List.List (Nri.Ui.Highlightable.V1.Highlightable ())`, that interprets empty links as needing to be tagged with highlights.