### PR TITLE
Allow for any example to support any # of external links, and scootch block guidance up

### DIFF
--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -25,6 +25,7 @@ type alias Example state msg =
     , view : EllieLink.Config -> state -> List (Html msg)
     , categories : List Category
     , keyboardSupport : List KeyboardSupport
+    , extraResources : List ( String, String )
     }
 
 
@@ -59,6 +60,7 @@ wrapMsg wrapMsg_ unwrapMsg example =
                 (example.view ellieLinkConfig state)
     , categories = example.categories
     , keyboardSupport = example.keyboardSupport
+    , extraResources = example.extraResources
     }
 
 
@@ -91,6 +93,7 @@ wrapState wrapState_ unwrapState example =
                 |> Maybe.withDefault []
     , categories = example.categories
     , keyboardSupport = example.keyboardSupport
+    , extraResources = example.extraResources
     }
 
 
@@ -158,29 +161,28 @@ view_ ellieLinkConfig example =
 extraLinks : (msg -> msg2) -> Example state msg -> Header.Attribute route msg2
 extraLinks f example =
     Header.extraNav (fullName example)
-        [ Html.map f (docsLink example)
-        , Html.map f (srcLink example)
-        ]
+        (List.map (\( a, b ) -> extraNavLink a b) example.extraResources
+            ++ [ Html.map f (docsLink example)
+               , Html.map f (srcLink example)
+               ]
+        )
 
 
 docsLink : Example state msg -> Html msg2
 docsLink example =
-    let
-        link =
-            "https://package.elm-lang.org/packages/NoRedInk/noredink-ui/latest/"
-                ++ String.replace "." "-" (fullName example)
-    in
-    ClickableText.link ("Elm " ++ example.name ++ " docs")
-        [ ClickableText.linkExternal link ]
+    "https://package.elm-lang.org/packages/NoRedInk/noredink-ui/latest/"
+        ++ String.replace "." "-" (fullName example)
+        |> extraNavLink ("Elm " ++ example.name ++ " docs")
 
 
 srcLink : Example state msg -> Html msg2
 srcLink example =
-    let
-        link =
-            String.replace "." "/" (fullName example)
-                ++ ".elm"
-                |> (++) "https://github.com/NoRedInk/noredink-ui/blob/master/src/"
-    in
-    ClickableText.link (example.name ++ " internals")
-        [ ClickableText.linkExternal link ]
+    String.replace "." "/" (fullName example)
+        ++ ".elm"
+        |> (++) "https://github.com/NoRedInk/noredink-ui/blob/master/src/"
+        |> extraNavLink (example.name ++ " internals")
+
+
+extraNavLink : String -> String -> Html msg
+extraNavLink name destination =
+    ClickableText.link name [ ClickableText.linkExternal destination ]

--- a/styleguide-app/Example.elm
+++ b/styleguide-app/Example.elm
@@ -170,7 +170,8 @@ docsLink example =
             "https://package.elm-lang.org/packages/NoRedInk/noredink-ui/latest/"
                 ++ String.replace "." "-" (fullName example)
     in
-    ClickableText.link "Docs" [ ClickableText.linkExternal link ]
+    ClickableText.link ("Elm " ++ example.name ++ " docs")
+        [ ClickableText.linkExternal link ]
 
 
 srcLink : Example state msg -> Html msg2
@@ -181,4 +182,5 @@ srcLink example =
                 ++ ".elm"
                 |> (++) "https://github.com/NoRedInk/noredink-ui/blob/master/src/"
     in
-    ClickableText.link "Source" [ ClickableText.linkExternal link ]
+    ClickableText.link (example.name ++ " internals")
+        [ ClickableText.linkExternal link ]

--- a/styleguide-app/Examples/Accordion.elm
+++ b/styleguide-app/Examples/Accordion.elm
@@ -70,6 +70,7 @@ example =
         ]
     , view = view
     , categories = [ Layout ]
+    , extraResources = []
     , keyboardSupport =
         [ { keys = [ Arrow KeyboardSupport.Up ]
           , result = "Moves the focus to the previous accordion header button (wraps focus to the last header button)"

--- a/styleguide-app/Examples/AnimatedIcon.elm
+++ b/styleguide-app/Examples/AnimatedIcon.elm
@@ -39,6 +39,7 @@ example =
     , version = version
     , categories = [ Animations, Icons ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Balloon.elm
+++ b/styleguide-app/Examples/Balloon.elm
@@ -38,6 +38,7 @@ example =
     , version = version
     , categories = [ Messaging ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -22,13 +22,11 @@ import Html.Styled.Attributes exposing (css)
 import Markdown
 import Nri.Ui.Block.V4 as Block
 import Nri.Ui.Button.V10 as Button
-import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V6 as Table
 import Nri.Ui.Text.V6 as Text
-import Nri.Ui.UiIcon.V1 as UiIcon
 import Task
 
 
@@ -49,7 +47,11 @@ example =
     , version = version
     , categories = [ Interactions ]
     , keyboardSupport = []
-    , extraResources = []
+    , extraResources =
+        [ ( "Display Elements and Scaffolding Container: additional things to know"
+          , "https://paper.dropbox.com/doc/Display-Elements-and-Scaffolding-Container-additional-things-to-know--BwRhBMKyXFFSWz~1mljN29bcAg-6vszpNDLoYIiMyg7Wv66s"
+          )
+        ]
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
@@ -100,18 +102,6 @@ example =
                     Block.getLabelPositions state.labelMeasurementsById
             in
             [ Heading.h2 [ Heading.plaintext "About" ]
-            , Text.mediumBody
-                [ Text.html
-                    [ p []
-                        [ text "You might also know the Block element as a “Display Element”. Learn more in "
-                        , ClickableText.link "Display Elements and Scaffolding Container: additional things to know"
-                            [ ClickableText.linkExternal "https://paper.dropbox.com/doc/Display-Elements-and-Scaffolding-Container-additional-things-to-know--BwRhBMKyXFFSWz~1mljN29bcAg-6vszpNDLoYIiMyg7Wv66s"
-                            , ClickableText.rightIcon UiIcon.openInNewTab
-                            , ClickableText.css [ Css.verticalAlign Css.baseline ]
-                            ]
-                        ]
-                    ]
-                ]
             , -- absolutely positioned elements that overflow in the x direction
               -- cause a horizontal scrollbar unless you explicitly hide overflowing x content
               Css.Global.global [ Css.Global.selector "body" [ Css.overflowX Css.hidden ] ]

--- a/styleguide-app/Examples/Block.elm
+++ b/styleguide-app/Examples/Block.elm
@@ -49,6 +49,7 @@ example =
     , version = version
     , categories = [ Interactions ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/BreadCrumbs.elm
+++ b/styleguide-app/Examples/BreadCrumbs.elm
@@ -48,6 +48,7 @@ example =
     , version = version
     , categories = [ Layout ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -72,6 +72,7 @@ example =
     , view = \ellieLinkConfig state -> [ viewButtonExamples ellieLinkConfig state ]
     , categories = [ Buttons ]
     , keyboardSupport = []
+    , extraResources = []
     }
 
 

--- a/styleguide-app/Examples/Carousel.elm
+++ b/styleguide-app/Examples/Carousel.elm
@@ -134,6 +134,7 @@ example =
     { name = moduleName
     , version = version
     , categories = [ Layout ]
+    , extraResources = []
     , keyboardSupport =
         [ { keys = [ KeyboardSupport.Tab ]
           , result = "Move focus to the currently-selected Tab's tab panel"

--- a/styleguide-app/Examples/Checkbox.elm
+++ b/styleguide-app/Examples/Checkbox.elm
@@ -97,6 +97,7 @@ example =
                 )
             ]
     , categories = [ Inputs ]
+    , extraResources = []
     , keyboardSupport =
         [ { keys = [ Space ]
           , result = "Select or deselect the checkbox (may cause page scroll)"

--- a/styleguide-app/Examples/ClickableSvg.elm
+++ b/styleguide-app/Examples/ClickableSvg.elm
@@ -37,6 +37,7 @@ example =
     , version = version
     , categories = [ Buttons, Icons ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/ClickableText.elm
+++ b/styleguide-app/Examples/ClickableText.elm
@@ -56,6 +56,7 @@ example =
     , view = \ellieLinkConfig state -> [ viewExamples ellieLinkConfig state ]
     , categories = [ Buttons ]
     , keyboardSupport = []
+    , extraResources = []
     }
 
 

--- a/styleguide-app/Examples/Colors.elm
+++ b/styleguide-app/Examples/Colors.elm
@@ -43,6 +43,7 @@ example =
     , version = 1
     , categories = [ Atoms ]
     , keyboardSupport = []
+    , extraResources = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Confetti.elm
+++ b/styleguide-app/Examples/Confetti.elm
@@ -35,6 +35,7 @@ example =
     , version = version
     , categories = [ Animations ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions =

--- a/styleguide-app/Examples/Container.elm
+++ b/styleguide-app/Examples/Container.elm
@@ -37,6 +37,7 @@ example =
     , version = version
     , categories = [ Layout ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/DisclosureIndicator.elm
+++ b/styleguide-app/Examples/DisclosureIndicator.elm
@@ -37,6 +37,7 @@ example =
     , version = version
     , categories = [ Animations, Icons ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Divider.elm
+++ b/styleguide-app/Examples/Divider.elm
@@ -28,6 +28,7 @@ example =
     , version = 2
     , categories = [ Layout ]
     , keyboardSupport = []
+    , extraResources = []
     , state = {}
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Fonts.elm
+++ b/styleguide-app/Examples/Fonts.elm
@@ -32,6 +32,7 @@ example =
     , version = 1
     , categories = [ Text, Atoms ]
     , keyboardSupport = []
+    , extraResources = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Header.elm
+++ b/styleguide-app/Examples/Header.elm
@@ -44,6 +44,7 @@ example =
     , version = version
     , categories = [ Layout ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init Nothing
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Heading.elm
+++ b/styleguide-app/Examples/Heading.elm
@@ -34,6 +34,7 @@ example =
     , version = version
     , categories = [ Text, Layout ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Highlighter.elm
+++ b/styleguide-app/Examples/Highlighter.elm
@@ -205,6 +205,7 @@ example =
             ]
     , categories = [ Text, Interactions ]
     , keyboardSupport = []
+    , extraResources = []
     }
 
 

--- a/styleguide-app/Examples/HighlighterToolbar.elm
+++ b/styleguide-app/Examples/HighlighterToolbar.elm
@@ -63,6 +63,7 @@ example =
             ]
     , categories = [ Buttons, Interactions ]
     , keyboardSupport = []
+    , extraResources = []
     }
 
 

--- a/styleguide-app/Examples/IconExamples.elm
+++ b/styleguide-app/Examples/IconExamples.elm
@@ -50,6 +50,7 @@ example config =
     , version = config.version
     , categories = [ Icons ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init config
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Loading.elm
+++ b/styleguide-app/Examples/Loading.elm
@@ -87,6 +87,7 @@ example =
     , version = 1
     , categories = [ Animations ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions = subscriptions

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -57,6 +57,7 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , categories = [ Layout ]
+    , extraResources = []
     , keyboardSupport =
         [ { keys = [ Space ], result = "Opens the menu" }
         , { keys = [ Enter ], result = "Opens the menu" }

--- a/styleguide-app/Examples/Message.elm
+++ b/styleguide-app/Examples/Message.elm
@@ -136,6 +136,7 @@ example =
     , version = version
     , categories = [ Messaging ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Modal.elm
+++ b/styleguide-app/Examples/Modal.elm
@@ -119,6 +119,7 @@ example =
     { name = moduleName
     , version = version
     , categories = [ Layout, Messaging ]
+    , extraResources = []
     , keyboardSupport =
         [ { keys = [ KeyboardSupport.Tab ]
           , result = "Moves focus to the next button within the modal or wraps back to the first element within the modal."

--- a/styleguide-app/Examples/Page.elm
+++ b/styleguide-app/Examples/Page.elm
@@ -59,6 +59,7 @@ example =
     , version = version
     , categories = [ Messaging ]
     , keyboardSupport = []
+    , extraResources = []
     , state = controlSettings
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Pagination.elm
+++ b/styleguide-app/Examples/Pagination.elm
@@ -38,6 +38,7 @@ example =
     , version = version
     , categories = [ Layout ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Panel.elm
+++ b/styleguide-app/Examples/Panel.elm
@@ -36,6 +36,7 @@ example =
     , version = version
     , categories = [ Layout ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/PremiumCheckbox.elm
+++ b/styleguide-app/Examples/PremiumCheckbox.elm
@@ -74,6 +74,7 @@ example =
             , exampleView
             ]
     , categories = [ Inputs ]
+    , extraResources = []
     , keyboardSupport =
         [ { keys = [ Space ]
           , result = "Select or deselect the checkbox (may cause page scroll)"

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -55,6 +55,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Interactions ]
     , keyboardSupport = []
+    , extraResources = []
     , preview = [ QuestionBox.view [ QuestionBox.markdown "Is good?" ] ]
     , view = view
     }

--- a/styleguide-app/Examples/RadioButton.elm
+++ b/styleguide-app/Examples/RadioButton.elm
@@ -55,6 +55,7 @@ example =
     , preview = preview
     , view = view
     , categories = [ Inputs ]
+    , extraResources = []
     , keyboardSupport =
         [ { keys = [ Arrow Left ]
           , result = "Move the focus & select the radio button to the left"

--- a/styleguide-app/Examples/RingGauge.elm
+++ b/styleguide-app/Examples/RingGauge.elm
@@ -45,6 +45,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Progress, Icons ]
     , keyboardSupport = []
+    , extraResources = []
     , preview =
         [ 25, 50, 75, 99 ]
             |> List.map

--- a/styleguide-app/Examples/SegmentedControl.elm
+++ b/styleguide-app/Examples/SegmentedControl.elm
@@ -125,6 +125,7 @@ example =
                 }
             ]
     , categories = [ Layout, Inputs ]
+    , extraResources = []
     , keyboardSupport =
         [ { keys = [ KeyboardSupport.Tab ]
           , result = "Move focus to the currently-selected Control's content"

--- a/styleguide-app/Examples/Select.elm
+++ b/styleguide-app/Examples/Select.elm
@@ -41,6 +41,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Inputs ]
     , keyboardSupport = []
+    , extraResources = []
     , preview =
         [ Select.view "Label" [ Select.custom [ Key.tabbable False ] ]
         , Select.view "Hidden label"

--- a/styleguide-app/Examples/Shadows.elm
+++ b/styleguide-app/Examples/Shadows.elm
@@ -32,6 +32,7 @@ example =
     , version = 1
     , categories = [ Atoms ]
     , keyboardSupport = []
+    , extraResources = []
     , state = ()
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/SideNav.elm
+++ b/styleguide-app/Examples/SideNav.elm
@@ -36,6 +36,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Layout ]
     , keyboardSupport = []
+    , extraResources = []
     , preview = [ viewPreview ]
     , view = view
     }

--- a/styleguide-app/Examples/SortableTable.elm
+++ b/styleguide-app/Examples/SortableTable.elm
@@ -40,6 +40,7 @@ example =
     , version = version
     , categories = [ Layout ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Spacing.elm
+++ b/styleguide-app/Examples/Spacing.elm
@@ -38,6 +38,7 @@ example =
     , version = version
     , categories = [ Layout ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Switch.elm
+++ b/styleguide-app/Examples/Switch.elm
@@ -86,6 +86,7 @@ example =
                 )
             ]
     , categories = [ Category.Inputs ]
+    , extraResources = []
     , keyboardSupport =
         [ { keys = [ Space ]
           , result = "Toggle the Switch state"

--- a/styleguide-app/Examples/Table.elm
+++ b/styleguide-app/Examples/Table.elm
@@ -43,6 +43,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Layout ]
     , keyboardSupport = []
+    , extraResources = []
     , preview =
         [ Table.view
             [ Table.string

--- a/styleguide-app/Examples/Tabs.elm
+++ b/styleguide-app/Examples/Tabs.elm
@@ -42,6 +42,7 @@ example =
     { name = moduleName
     , version = version
     , categories = [ Layout ]
+    , extraResources = []
     , keyboardSupport =
         [ { keys = [ KeyboardSupport.Tab ]
           , result = "Move focus to the currently-selected Tab's tab panel"

--- a/styleguide-app/Examples/Text.elm
+++ b/styleguide-app/Examples/Text.elm
@@ -37,6 +37,7 @@ example =
     , version = version
     , categories = [ Text ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/TextArea.elm
+++ b/styleguide-app/Examples/TextArea.elm
@@ -42,6 +42,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , categories = [ Inputs ]
     , keyboardSupport = []
+    , extraResources = []
     , preview =
         [ Html.div [ css [ Css.position Css.relative ] ]
             [ Html.textarea

--- a/styleguide-app/Examples/TextInput.elm
+++ b/styleguide-app/Examples/TextInput.elm
@@ -39,6 +39,7 @@ example =
     , version = version
     , categories = [ Inputs ]
     , keyboardSupport = []
+    , extraResources = []
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none

--- a/styleguide-app/Examples/Tooltip.elm
+++ b/styleguide-app/Examples/Tooltip.elm
@@ -45,6 +45,7 @@ example =
     { name = moduleName
     , version = version
     , categories = [ Messaging ]
+    , extraResources = []
     , keyboardSupport =
         [ { keys = [ Esc ]
           , result = "Hitting escape while focusing a tooltip trigger closes all tooltips. Note that hovered-but-not-focused tooltips can't be closed this way."


### PR DESCRIPTION
## Before

<img width="1455" alt="Screen Shot 2023-01-20 at 4 26 27 PM" src="https://user-images.githubusercontent.com/8811312/213822731-0176bb47-e364-45a1-9508-23c03e170f47.png">


## After

<img width="1497" alt="Screen Shot 2023-01-20 at 4 26 13 PM" src="https://user-images.githubusercontent.com/8811312/213822727-c93094be-ca0b-4605-bdd4-82f478c66860.png">


Note that I also tried to make the destination of "Docs" and "Source" more clear. I think it's less clean, but hopefully more usable?

cc @NoRedInk/design 