### PR TITLE
Remove external link visual affordance for clickablesvgs

### DIFF
--- a/src/ClickableAttributes.elm
+++ b/src/ClickableAttributes.elm
@@ -6,6 +6,7 @@ module ClickableAttributes exposing
     , linkSpa
     , linkExternal, linkExternalWithTracking
     , toLinkAttributes
+    , linkExternalInternal, linkExternalWithTrackingInternal
     )
 
 {-|
@@ -25,6 +26,11 @@ module ClickableAttributes exposing
 @docs linkSpa
 @docs linkExternal, linkExternalWithTracking
 @docs toLinkAttributes
+
+
+## external link helpers without any affordances
+
+@docs linkExternalInternal, linkExternalWithTrackingInternal
 
 -}
 
@@ -131,16 +137,34 @@ linkWithTracking { track, url } ({ clickableAttributes } as config) =
 
 {-| -}
 linkExternal : String -> Config a route msg -> Config a route msg
-linkExternal url ({ clickableAttributes } as config) =
-    { config
-        | clickableAttributes = { clickableAttributes | linkType = External, urlString = Just url }
-        , rightIcon = Just opensInNewTab
-    }
+linkExternal url =
+    withExternalAffordance >> linkExternalInternal url
 
 
 {-| -}
 linkExternalWithTracking : { track : msg, url : String } -> Config a route msg -> Config a route msg
-linkExternalWithTracking { track, url } ({ clickableAttributes } as config) =
+linkExternalWithTracking attrs =
+    withExternalAffordance >> linkExternalWithTrackingInternal attrs
+
+
+{-| -}
+linkExternalInternal : String -> { attributes | clickableAttributes : ClickableAttributes route msg } -> { attributes | clickableAttributes : ClickableAttributes route msg }
+linkExternalInternal url ({ clickableAttributes } as config) =
+    { config
+        | clickableAttributes =
+            { clickableAttributes
+                | linkType = External
+                , urlString = Just url
+            }
+    }
+
+
+{-| -}
+linkExternalWithTrackingInternal :
+    { track : msg, url : String }
+    -> { attributes | clickableAttributes : ClickableAttributes route msg }
+    -> { attributes | clickableAttributes : ClickableAttributes route msg }
+linkExternalWithTrackingInternal { track, url } ({ clickableAttributes } as config) =
     { config
         | clickableAttributes =
             { clickableAttributes
@@ -148,7 +172,6 @@ linkExternalWithTracking { track, url } ({ clickableAttributes } as config) =
                 , urlString = Just url
                 , onClick = Just track
             }
-        , rightIcon = Just opensInNewTab
     }
 
 
@@ -259,6 +282,12 @@ toEnabledLinkAttributes routeToString clickableAttributes =
                     Attributes.href stringUrl
                         :: targetBlank
             )
+
+
+{-| -}
+withExternalAffordance : { attributes | rightIcon : Maybe Svg.Svg } -> { attributes | rightIcon : Maybe Svg.Svg }
+withExternalAffordance config =
+    { config | rightIcon = Just opensInNewTab }
 
 
 opensInNewTab : Svg

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -167,13 +167,13 @@ linkWithTracking config =
 {-| -}
 linkExternal : String -> Attribute msg
 linkExternal url =
-    set (ClickableAttributes.linkExternal url)
+    set (ClickableAttributes.linkExternalInternal url)
 
 
 {-| -}
 linkExternalWithTracking : { track : msg, url : String } -> Attribute msg
 linkExternalWithTracking config =
-    set (ClickableAttributes.linkExternalWithTracking config)
+    set (ClickableAttributes.linkExternalWithTrackingInternal config)
 
 
 


### PR DESCRIPTION
There are too many cases where clickable svgs appear next to each and are external links for this change to go cleanly currently. We will need to figure out how to deal with the AL separately:

<img width="154" alt="Screen Shot 2023-01-23 at 4 15 51 PM" src="https://user-images.githubusercontent.com/8811312/214175218-2001f3a7-fda1-430e-8ca9-9e2dad9bc40d.png">

See https://noredink.slack.com/archives/C9MEFL3KL/p1674515210335959