### PR TITLE
Add tts capabilities to question box - phx-465

### DIFF
--- a/src/Nri/Ui/QuestionBox/V3.elm
+++ b/src/Nri/Ui/QuestionBox/V3.elm
@@ -321,10 +321,19 @@ viewGuidance config referencingId markdown_ =
                 ]
 
         Nothing ->
-            viewSpeechBubble config
-                referencingId
-                [ Balloon.markdown markdown_
-                , Balloon.css [ Css.margin2 (Css.px 10) (Css.px 20) ]
+            div
+                [ css
+                    [ Css.displayFlex
+                    , Css.justifyContent Css.flexEnd
+                    , Css.position Css.relative
+                    ]
+                ]
+                [ config.leftButton
+                , viewSpeechBubble config
+                    referencingId
+                    [ Balloon.markdown markdown_
+                    , Balloon.css [ Css.margin2 (Css.px 10) (Css.px 20) ]
+                    ]
                 ]
 
 

--- a/src/Nri/Ui/QuestionBox/V3.elm
+++ b/src/Nri/Ui/QuestionBox/V3.elm
@@ -281,7 +281,13 @@ viewBalloon config referencingId attributes =
     Balloon.view
         ([ Balloon.html
             (List.filterMap identity
-                [ Maybe.map (viewGuidance config referencingId) config.markdown
+                [ Just <|
+                    div [ css [ Css.displayFlex ] ]
+                        (List.filterMap identity
+                            [ Just config.leftButton
+                            , Maybe.map (viewGuidance config referencingId) config.markdown
+                            ]
+                        )
                 , viewActions config.character config.actions
                 ]
             )
@@ -293,7 +299,7 @@ viewBalloon config referencingId attributes =
 
 
 viewGuidance :
-    { config | id : Maybe String, character : Maybe { name : String, icon : Svg }, leftButton : Html msg }
+    { config | id : Maybe String, character : Maybe { name : String, icon : Svg } }
     -> Maybe String
     -> String
     -> Html msg
@@ -309,8 +315,7 @@ viewGuidance config referencingId markdown_ =
                     , Css.position Css.relative
                     ]
                 ]
-                [ config.leftButton
-                , viewCharacter character_
+                [ viewCharacter character_
                 , viewSpeechBubble config
                     referencingId
                     [ Balloon.markdown markdown_
@@ -321,19 +326,10 @@ viewGuidance config referencingId markdown_ =
                 ]
 
         Nothing ->
-            div
-                [ css
-                    [ Css.displayFlex
-                    , Css.justifyContent Css.flexEnd
-                    , Css.position Css.relative
-                    ]
-                ]
-                [ config.leftButton
-                , viewSpeechBubble config
-                    referencingId
-                    [ Balloon.markdown markdown_
-                    , Balloon.css [ Css.margin2 (Css.px 10) (Css.px 20) ]
-                    ]
+            viewSpeechBubble config
+                referencingId
+                [ Balloon.markdown markdown_
+                , Balloon.css [ Css.margin2 (Css.px 10) (Css.px 20) ]
                 ]
 
 

--- a/src/Nri/Ui/QuestionBox/V3.elm
+++ b/src/Nri/Ui/QuestionBox/V3.elm
@@ -3,8 +3,8 @@ module Nri.Ui.QuestionBox.V3 exposing
     , id, markdown, actions, character
     , standalone, pointingTo
     , containerCss
-    , guidanceId
     , setTextToSpeechView
+    , guidanceId
     )
 
 {-|
@@ -14,6 +14,7 @@ module Nri.Ui.QuestionBox.V3 exposing
 @docs id, markdown, actions, character
 @docs standalone, pointingTo
 @docs containerCss
+@docs setTextToSpeechView
 
 @docs guidanceId
 
@@ -95,6 +96,8 @@ containerCss styles =
     Attribute (\config -> { config | containerCss = config.containerCss ++ styles })
 
 
+{-| Adds an arbitrary HTML on the left of the question box for the text to speech button
+-}
 setTextToSpeechView : Html msg -> Attribute msg
 setTextToSpeechView textToSpeechView =
     Attribute (\config -> { config | textToSpeechView = Just textToSpeechView })

--- a/src/Nri/Ui/QuestionBox/V3.elm
+++ b/src/Nri/Ui/QuestionBox/V3.elm
@@ -3,7 +3,7 @@ module Nri.Ui.QuestionBox.V3 exposing
     , id, markdown, actions, character
     , standalone, pointingTo
     , containerCss
-    , setLeftButton
+    , setLeftActions
     , guidanceId
     )
 
@@ -14,7 +14,7 @@ module Nri.Ui.QuestionBox.V3 exposing
 @docs id, markdown, actions, character
 @docs standalone, pointingTo
 @docs containerCss
-@docs setLeftButton
+@docs setLeftActions
 
 @docs guidanceId
 
@@ -48,7 +48,7 @@ type alias Config msg =
     , type_ : QuestionBoxType msg
     , character : Maybe { name : String, icon : Svg }
     , containerCss : List Css.Style
-    , leftButton : Html msg
+    , leftActions : Html msg
     }
 
 
@@ -60,7 +60,7 @@ defaultConfig =
     , type_ = Standalone
     , character = Just { name = "Panda", icon = CharacterIcon.panda }
     , containerCss = []
-    , leftButton = text ""
+    , leftActions = text ""
     }
 
 
@@ -96,9 +96,9 @@ containerCss styles =
 
 {-| Adds an arbitrary HTML on the left of the question box for the text to speech button
 -}
-setLeftButton : Html msg -> Attribute msg
-setLeftButton leftButton =
-    Attribute (\config -> { config | leftButton = leftButton })
+setLeftActions : Html msg -> Attribute msg
+setLeftActions leftActions =
+    Attribute (\config -> { config | leftActions = leftActions })
 
 
 setType : QuestionBoxType msg -> Attribute msg
@@ -284,7 +284,7 @@ viewBalloon config referencingId attributes =
                 [ Just <|
                     div [ css [ Css.displayFlex ] ]
                         (List.filterMap identity
-                            [ Just config.leftButton
+                            [ Just config.leftActions
                             , Maybe.map (viewGuidance config referencingId) config.markdown
                             ]
                         )

--- a/src/Nri/Ui/QuestionBox/V3.elm
+++ b/src/Nri/Ui/QuestionBox/V3.elm
@@ -3,7 +3,7 @@ module Nri.Ui.QuestionBox.V3 exposing
     , id, markdown, actions, character
     , standalone, pointingTo
     , containerCss
-    , setTextToSpeechView
+    , setLeftButton
     , guidanceId
     )
 
@@ -14,7 +14,7 @@ module Nri.Ui.QuestionBox.V3 exposing
 @docs id, markdown, actions, character
 @docs standalone, pointingTo
 @docs containerCss
-@docs setTextToSpeechView
+@docs setLeftButton
 
 @docs guidanceId
 
@@ -25,7 +25,6 @@ import Accessibility.Styled.Key as Key
 import Browser.Dom exposing (Element)
 import Css
 import Css.Global
-import Css.Media exposing (withMedia)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes as Attributes exposing (css)
 import Nri.Ui.Balloon.V2 as Balloon
@@ -33,7 +32,6 @@ import Nri.Ui.Button.V10 as Button
 import Nri.Ui.CharacterIcon.V1 as CharacterIcon
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (nriDescription)
-import Nri.Ui.MediaQuery.V1 exposing (..)
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Position exposing (xOffsetPx)
 
@@ -50,7 +48,7 @@ type alias Config msg =
     , type_ : QuestionBoxType msg
     , character : Maybe { name : String, icon : Svg }
     , containerCss : List Css.Style
-    , textToSpeechView : Maybe (Html msg)
+    , leftButton : Html msg
     }
 
 
@@ -62,7 +60,7 @@ defaultConfig =
     , type_ = Standalone
     , character = Just { name = "Panda", icon = CharacterIcon.panda }
     , containerCss = []
-    , textToSpeechView = Nothing
+    , leftButton = text ""
     }
 
 
@@ -98,9 +96,9 @@ containerCss styles =
 
 {-| Adds an arbitrary HTML on the left of the question box for the text to speech button
 -}
-setTextToSpeechView : Html msg -> Attribute msg
-setTextToSpeechView textToSpeechView =
-    Attribute (\config -> { config | textToSpeechView = Just textToSpeechView })
+setLeftButton : Html msg -> Attribute msg
+setLeftButton leftButton =
+    Attribute (\config -> { config | leftButton = leftButton })
 
 
 setType : QuestionBoxType msg -> Attribute msg
@@ -295,7 +293,7 @@ viewBalloon config referencingId attributes =
 
 
 viewGuidance :
-    { config | id : Maybe String, character : Maybe { name : String, icon : Svg }, textToSpeechView : Maybe (Html msg) }
+    { config | id : Maybe String, character : Maybe { name : String, icon : Svg }, leftButton : Html msg }
     -> Maybe String
     -> String
     -> Html msg
@@ -311,37 +309,16 @@ viewGuidance config referencingId markdown_ =
                     , Css.position Css.relative
                     ]
                 ]
-                ([ config.textToSpeechView
-                    |> Maybe.map
-                        (div
-                            [ css
-                                [ Css.position Css.relative
-                                , Css.zIndex (Css.int 1)
-                                , Css.left (Css.px -24)
-                                , Css.top (Css.px 8)
-                                , withMedia [ quizEngineMobile ]
-                                    [ Css.left Css.auto
-                                    , Css.top Css.auto
-                                    , Css.float Css.left
-                                    , Css.padding4 Css.zero (Css.px 5) Css.zero Css.zero
-                                    , Css.position Css.static
-                                    ]
-                                ]
-                            ]
-                            << List.singleton
-                        )
-                 , Just <| viewCharacter character_
-                 , Just <|
-                    viewSpeechBubble config
-                        referencingId
-                        [ Balloon.markdown markdown_
-                        , Balloon.onLeft
-                        , Balloon.alignArrowEnd
-                        , Balloon.css [ Css.minHeight (Css.px 46) ]
-                        ]
-                 ]
-                    |> List.filterMap identity
-                )
+                [ config.leftButton
+                , viewCharacter character_
+                , viewSpeechBubble config
+                    referencingId
+                    [ Balloon.markdown markdown_
+                    , Balloon.onLeft
+                    , Balloon.alignArrowEnd
+                    , Balloon.css [ Css.minHeight (Css.px 46) ]
+                    ]
+                ]
 
         Nothing ->
             viewSpeechBubble config

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -23,6 +23,7 @@ import Html.Styled.Attributes as Attributes exposing (css)
 import Markdown
 import Nri.Ui.Block.V4 as Block
 import Nri.Ui.Button.V10 as Button
+import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
@@ -557,14 +558,12 @@ init =
 type alias State =
     { attributes : Control (List ( String, QuestionBox.Attribute Msg ))
     , labelMeasurementsById :
-        Dict
-            String
+        Dict String
             { label : Element
             , labelContent : Element
             }
     , questionBoxMeasurementsById :
-        Dict
-            String
+        Dict String
             { block : Element
             , paragraph : Element
             , questionBox : Element
@@ -583,6 +582,35 @@ initAttributes =
                     )
                 )
                 (Control.stringTextarea initialMarkdown)
+            )
+        |> ControlExtra.optionalListItem "textToSpeechView"
+            ([ ( "Play button"
+               , Control.value
+                    ( Code.fromModule moduleName "setTextToSpeechView" ++ Code.string """
+                        ( ClickableSvg.button "Play"
+                                UiIcon.playInCircle
+                                [ ClickableSvg.exactSize 32
+                                , ClickableSvg.css
+                                    [ Css.borderRadius (Css.px 32)
+                                    , Css.backgroundColor Colors.white
+                                    ]
+                                ]
+                        )
+                      """
+                    , QuestionBox.setTextToSpeechView
+                        (ClickableSvg.button "Play"
+                            UiIcon.playInCircle
+                            [ ClickableSvg.exactSize 32
+                            , ClickableSvg.css
+                                [ Css.borderRadius (Css.px 32)
+                                , Css.backgroundColor Colors.white
+                                ]
+                            ]
+                        )
+                    )
+               )
+             ]
+                |> Control.choice
             )
         |> ControlExtra.listItem "actions"
             (Control.map
@@ -661,16 +689,14 @@ type Msg
     | GetMeasurements
     | GotBlockLabelMeasurements
         String
-        (Result
-            Dom.Error
+        (Result Dom.Error
             { label : Element
             , labelContent : Element
             }
         )
     | GotQuestionBoxMeasurements
         String
-        (Result
-            Dom.Error
+        (Result Dom.Error
             { block : Element
             , paragraph : Element
             , questionBox : Element

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -590,7 +590,7 @@ initAttributes =
         |> ControlExtra.optionalListItem "leftButton"
             ([ ( "Play button"
                , Control.value
-                    ( Code.fromModule moduleName "setLeftButton" ++ Code.string """
+                    ( Code.fromModule moduleName "setLeftActions" ++ Code.string """
                         ([ ClickableSvg.button "Play"
                             UiIcon.playInCircle
                             [ ClickableSvg.exactSize 32
@@ -616,7 +616,7 @@ initAttributes =
                                     ]
                                 ]
                         )                      """
-                    , QuestionBox.setLeftButton
+                    , QuestionBox.setLeftActions
                         ([ ClickableSvg.button "Play"
                             UiIcon.playInCircle
                             [ ClickableSvg.exactSize 32

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -558,12 +558,14 @@ init =
 type alias State =
     { attributes : Control (List ( String, QuestionBox.Attribute Msg ))
     , labelMeasurementsById :
-        Dict String
+        Dict
+            String
             { label : Element
             , labelContent : Element
             }
     , questionBoxMeasurementsById :
-        Dict String
+        Dict
+            String
             { block : Element
             , paragraph : Element
             , questionBox : Element
@@ -689,14 +691,16 @@ type Msg
     | GetMeasurements
     | GotBlockLabelMeasurements
         String
-        (Result Dom.Error
+        (Result
+            Dom.Error
             { label : Element
             , labelContent : Element
             }
         )
     | GotQuestionBoxMeasurements
         String
-        (Result Dom.Error
+        (Result
+            Dom.Error
             { block : Element
             , paragraph : Element
             , questionBox : Element

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -587,20 +587,35 @@ initAttributes =
                 )
                 (Control.stringTextarea initialMarkdown)
             )
-        |> ControlExtra.optionalListItem "textToSpeechView"
+        |> ControlExtra.optionalListItem "leftButton"
             ([ ( "Play button"
                , Control.value
-                    ( Code.fromModule moduleName "setTextToSpeechView" ++ Code.string """
-                        ( ClickableSvg.button "Play"
-                                UiIcon.playInCircle
-                                [ ClickableSvg.exactSize 32
-                                , ClickableSvg.css
-                                    [ Css.borderRadius (Css.px 32)
-                                    , Css.backgroundColor Colors.white
+                    ( Code.fromModule moduleName "setLeftButton" ++ Code.string """
+                        ([ ClickableSvg.button "Play"
+                            UiIcon.playInCircle
+                            [ ClickableSvg.exactSize 32
+                            , ClickableSvg.css
+                                [ Css.borderRadius (Css.px 32)
+                                , Css.backgroundColor Colors.white
+                                ]
+                            ]
+                         ]
+                            |> div
+                                [ css
+                                    [ Css.position Css.absolute
+                                    , Css.zIndex (Css.int 1)
+                                    , Css.left (Css.px -24)
+                                    , Css.top (Css.px 8)
+                                    , withMedia [ quizEngineMobile ]
+                                        [ Css.left Css.auto
+                                        , Css.top Css.auto
+                                        , Css.float Css.left
+                                        , Css.padding4 Css.zero (Css.px 5) Css.zero Css.zero
+                                        , Css.position Css.static
+                                        ]
                                     ]
                                 ]
-                        )
-                      """
+                        )                      """
                     , QuestionBox.setLeftButton
                         ([ ClickableSvg.button "Play"
                             UiIcon.playInCircle

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -602,7 +602,7 @@ initAttributes =
                          ]
                             |> div
                                 [ css
-                                    [ Css.position Css.absolute
+                                    [ Css.position Css.relative
                                     , Css.zIndex (Css.int 1)
                                     , Css.left (Css.px -24)
                                     , Css.top (Css.px 8)
@@ -628,7 +628,7 @@ initAttributes =
                          ]
                             |> div
                                 [ css
-                                    [ Css.position Css.absolute
+                                    [ Css.position Css.relative
                                     , Css.zIndex (Css.int 1)
                                     , Css.left (Css.px -24)
                                     , Css.top (Css.px 8)

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -12,6 +12,7 @@ import Code
 import CommonControls
 import Css
 import Css.Global
+import Css.Media exposing (withMedia)
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
@@ -27,6 +28,7 @@ import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.MediaQuery.V1 exposing (..)
 import Nri.Ui.QuestionBox.V3 as QuestionBox
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
@@ -599,8 +601,8 @@ initAttributes =
                                 ]
                         )
                       """
-                    , QuestionBox.setTextToSpeechView
-                        (ClickableSvg.button "Play"
+                    , QuestionBox.setLeftButton
+                        ([ ClickableSvg.button "Play"
                             UiIcon.playInCircle
                             [ ClickableSvg.exactSize 32
                             , ClickableSvg.css
@@ -608,6 +610,22 @@ initAttributes =
                                 , Css.backgroundColor Colors.white
                                 ]
                             ]
+                         ]
+                            |> div
+                                [ css
+                                    [ Css.position Css.absolute
+                                    , Css.zIndex (Css.int 1)
+                                    , Css.left (Css.px -24)
+                                    , Css.top (Css.px 8)
+                                    , withMedia [ quizEngineMobile ]
+                                        [ Css.left Css.auto
+                                        , Css.top Css.auto
+                                        , Css.float Css.left
+                                        , Css.padding4 Css.zero (Css.px 5) Css.zero Css.zero
+                                        , Css.position Css.static
+                                        ]
+                                    ]
+                                ]
                         )
                     )
                )

--- a/tests/Spec/Nri/Ui/QuestionBox.elm
+++ b/tests/Spec/Nri/Ui/QuestionBox.elm
@@ -1,0 +1,64 @@
+module Spec.Nri.Ui.QuestionBox exposing (spec)
+
+import Expect
+import Html.Styled
+import Nri.Ui.QuestionBox.V3 as QuestionBox
+import Nri.Ui.UiIcon.V1 as UiIcon
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (..)
+
+
+spec : Test
+spec =
+    describe "Nri.Ui.QuestionBox.V4"
+        [ test "renders markdown as character guidance" <|
+            \() ->
+                [ QuestionBox.markdown "This is **important**!" ]
+                    |> testContext
+                    |> Expect.all
+                        [ Query.has
+                            [ text "This is "
+                            , all [ tag "strong", containing [ text "important" ] ]
+                            ]
+                        , Query.has [ character "Panda" ]
+                        ]
+        , test "renders markdown as guidance with custom character" <|
+            \() ->
+                [ QuestionBox.markdown "This is **important**!"
+                , QuestionBox.character (Just { name = "Apply", icon = UiIcon.apple })
+                ]
+                    |> testContext
+                    |> Expect.all
+                        [ Query.has
+                            [ text "This is "
+                            , all [ tag "strong", containing [ text "important" ] ]
+                            ]
+                        , Query.has [ character "Apply" ]
+                        ]
+        , test "renders markdown as guidance without character" <|
+            \() ->
+                [ QuestionBox.markdown "This is **important**!"
+                , QuestionBox.character Nothing
+                ]
+                    |> testContext
+                    |> Expect.all
+                        [ Query.has
+                            [ text "This is "
+                            , all [ tag "strong", containing [ text "important" ] ]
+                            ]
+                        , Query.hasNot [ character "Panda" ]
+                        ]
+        ]
+
+
+character : String -> Selector
+character name =
+    all [ tag "svg", containing [ tag "title", text (name ++ " says") ] ]
+
+
+testContext : List (QuestionBox.Attribute m) -> Query.Single m
+testContext =
+    QuestionBox.view
+        >> Html.Styled.toUnstyled
+        >> Query.fromHtml

--- a/tests/Spec/Nri/Ui/QuestionBox.elm
+++ b/tests/Spec/Nri/Ui/QuestionBox.elm
@@ -43,7 +43,7 @@ spec =
         , test "renders extra HTML content with default character" <|
             \() ->
                 [ QuestionBox.markdown exampleGuidanceContent
-                , QuestionBox.setLeftButton (Html.Styled.text readAloudContent)
+                , QuestionBox.setLeftActions (Html.Styled.text readAloudContent)
                 ]
                     |> testContext
                     |> Expect.all
@@ -54,7 +54,7 @@ spec =
         , test "renders extra HTML content with custom character" <|
             \() ->
                 [ QuestionBox.markdown exampleGuidanceContent
-                , QuestionBox.setLeftButton (Html.Styled.text readAloudContent)
+                , QuestionBox.setLeftActions (Html.Styled.text readAloudContent)
                 , QuestionBox.character (Just { name = "Apply", icon = UiIcon.apple })
                 ]
                     |> testContext
@@ -66,7 +66,7 @@ spec =
         , test "renders extra HTML content without character" <|
             \() ->
                 [ QuestionBox.markdown exampleGuidanceContent
-                , QuestionBox.setLeftButton (Html.Styled.text readAloudContent)
+                , QuestionBox.setLeftActions (Html.Styled.text readAloudContent)
                 , QuestionBox.character Nothing
                 ]
                     |> testContext

--- a/tests/Spec/Nri/Ui/QuestionBox.elm
+++ b/tests/Spec/Nri/Ui/QuestionBox.elm
@@ -14,42 +14,85 @@ spec =
     describe "Nri.Ui.QuestionBox.V4"
         [ test "renders markdown as character guidance" <|
             \() ->
-                [ QuestionBox.markdown "This is **important**!" ]
+                [ QuestionBox.markdown exampleGuidanceContent ]
                     |> testContext
                     |> Expect.all
-                        [ Query.has
-                            [ text "This is "
-                            , all [ tag "strong", containing [ text "important" ] ]
-                            ]
+                        [ Query.has exampleGuidance
                         , Query.has [ character "Panda" ]
                         ]
         , test "renders markdown as guidance with custom character" <|
             \() ->
-                [ QuestionBox.markdown "This is **important**!"
+                [ QuestionBox.markdown exampleGuidanceContent
                 , QuestionBox.character (Just { name = "Apply", icon = UiIcon.apple })
                 ]
                     |> testContext
                     |> Expect.all
-                        [ Query.has
-                            [ text "This is "
-                            , all [ tag "strong", containing [ text "important" ] ]
-                            ]
+                        [ Query.has exampleGuidance
                         , Query.has [ character "Apply" ]
                         ]
         , test "renders markdown as guidance without character" <|
             \() ->
-                [ QuestionBox.markdown "This is **important**!"
+                [ QuestionBox.markdown exampleGuidanceContent
                 , QuestionBox.character Nothing
                 ]
                     |> testContext
                     |> Expect.all
-                        [ Query.has
-                            [ text "This is "
-                            , all [ tag "strong", containing [ text "important" ] ]
-                            ]
+                        [ Query.has exampleGuidance
+                        , Query.hasNot [ character "Panda" ]
+                        ]
+        , test "renders extra HTML content with default character" <|
+            \() ->
+                [ QuestionBox.markdown exampleGuidanceContent
+                , QuestionBox.setLeftButton (Html.Styled.text readAloudContent)
+                ]
+                    |> testContext
+                    |> Expect.all
+                        [ Query.has [ text readAloudContent ]
+                        , Query.has exampleGuidance
+                        , Query.has [ character "Panda" ]
+                        ]
+        , test "renders extra HTML content with custom character" <|
+            \() ->
+                [ QuestionBox.markdown exampleGuidanceContent
+                , QuestionBox.setLeftButton (Html.Styled.text readAloudContent)
+                , QuestionBox.character (Just { name = "Apply", icon = UiIcon.apple })
+                ]
+                    |> testContext
+                    |> Expect.all
+                        [ Query.has [ text readAloudContent ]
+                        , Query.has exampleGuidance
+                        , Query.has [ character "Apply" ]
+                        ]
+        , test "renders extra HTML content without character" <|
+            \() ->
+                [ QuestionBox.markdown exampleGuidanceContent
+                , QuestionBox.setLeftButton (Html.Styled.text readAloudContent)
+                , QuestionBox.character Nothing
+                ]
+                    |> testContext
+                    |> Expect.all
+                        [ Query.has [ text readAloudContent ]
+                        , Query.has exampleGuidance
                         , Query.hasNot [ character "Panda" ]
                         ]
         ]
+
+
+exampleGuidanceContent : String
+exampleGuidanceContent =
+    "This is **important**!"
+
+
+exampleGuidance : List Selector
+exampleGuidance =
+    [ text "This is "
+    , all [ tag "strong", containing [ text "important" ] ]
+    ]
+
+
+readAloudContent : String
+readAloudContent =
+    "Read aloud play/pause/continue interface"
 
 
 character : String -> Selector


### PR DESCRIPTION
This adds a new option to the question box to allow the user to add a text-to-speech button inside the component. This is an arbitrary HTML that will be presented to the user on the left side.
This will be shown as the following:
<img width="1061" alt="image" src="https://user-images.githubusercontent.com/17324511/215150632-b7bac42f-c929-4019-85e3-dcf22db75ea3.png">
