### PR TITLE
Fix markdown parsing on button

### DIFF
--- a/styleguide-app/Examples/Button.elm
+++ b/styleguide-app/Examples/Button.elm
@@ -154,7 +154,7 @@ initDebugControls =
                 , ( "link", Control.value Link )
                 ]
             )
-        |> Control.field "label" (Control.string "Label")
+        |> Control.field "label" (Control.string "Label **bold**   *emphasis*")
         |> Control.field "attributes"
             (ControlExtra.list
                 |> CommonControls.icon moduleName Button.icon


### PR DESCRIPTION
Fixes https://github.com/NoRedInk/noredink-ui/issues/1253

Markdown string used for both screenshots: "Label **bold**   *emphasis*"

### Before

<img width="729" alt="Screen Shot 2023-01-31 at 3 56 27 PM" src="https://user-images.githubusercontent.com/8811312/215902701-d59a9857-4a73-4dc5-93d0-3c647b2beb4b.png">


### After
<img width="712" alt="Screen Shot 2023-01-31 at 3 55 31 PM" src="https://user-images.githubusercontent.com/8811312/215902565-bdb0b18d-ff4a-4caa-98ab-97f23ce92f2b.png">


--

cc @NoRedInk/design I've changed the default label text for buttons so it's clear there's a markdown renderer involved. TBH, I was totally surprised by the issue here, because I thought the string was plaintext! LMK if you want the default to go back to plaintext. Happy to change it.