### PR TITLE
add `Menu.clickableSvgWithoutIndicator`

### DIFF
--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -2,7 +2,7 @@ module Nri.Ui.Menu.V4 exposing
     ( view, Attribute
     , isOpen, isDisabled
     , opensOnHover
-    , defaultTrigger, button, clickableText, clickableSvg
+    , defaultTrigger, button, clickableText, clickableSvg, clickableSvgWithoutIndicator
     , buttonId
     , navMenuList, disclosure, dialog
     , menuWidth, menuId, menuZIndex
@@ -32,7 +32,7 @@ A togglable menu view and related buttons.
 
 ## Triggering button options
 
-@docs defaultTrigger, button, clickableText, clickableSvg
+@docs defaultTrigger, button, clickableText, clickableSvg, clickableSvgWithoutIndicator
 @docs buttonId
 
 
@@ -384,6 +384,23 @@ clickableSvg title icon additionalAttributes =
                 ([ ClickableSvg.custom buttonAttributes
                  , ClickableSvg.disabled menuConfig.isDisabled
                  , ClickableSvg.rightIcon (AnimatedIcon.arrowDownUp menuConfig.isOpen)
+                 ]
+                    ++ additionalAttributes
+                )
+        )
+        |> setButton
+
+
+{-| Use ClickableSvg as the triggering element for the Menu without a dropdown indicator
+-}
+clickableSvgWithoutIndicator : String -> Svg.Svg -> List (ClickableSvg.Attribute msg) -> Attribute msg
+clickableSvgWithoutIndicator title icon additionalAttributes =
+    Button
+        (\menuConfig buttonAttributes ->
+            ClickableSvg.button title
+                icon
+                ([ ClickableSvg.custom buttonAttributes
+                 , ClickableSvg.disabled menuConfig.isDisabled
                  ]
                     ++ additionalAttributes
                 )

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -436,7 +436,7 @@ controlTrigger =
                     |> Control.field "withBorder" (ControlExtra.bool True)
                 )
           )
-          , ( "clickableSvgWithoutIndicator"
+        , ( "clickableSvgWithoutIndicator"
           , Control.map
                 (\( ( iconStr, icon ), ( withBorderStr, withBorder ) ) ->
                     ( "Menu.clickableSvgWithoutIndicator "

--- a/styleguide-app/Examples/Menu.elm
+++ b/styleguide-app/Examples/Menu.elm
@@ -436,6 +436,36 @@ controlTrigger =
                     |> Control.field "withBorder" (ControlExtra.bool True)
                 )
           )
+          , ( "clickableSvgWithoutIndicator"
+          , Control.map
+                (\( ( iconStr, icon ), ( withBorderStr, withBorder ) ) ->
+                    ( "Menu.clickableSvgWithoutIndicator "
+                        ++ Code.string "Menu"
+                        ++ " "
+                        ++ iconStr
+                        ++ " "
+                        ++ Code.list
+                            (if withBorder then
+                                [ "ClickableSvg.withBorder", "ClickableSvg.exactWidth 55" ]
+
+                             else
+                                []
+                            )
+                    , Menu.clickableSvgWithoutIndicator "Menu"
+                        icon
+                        (if withBorder then
+                            [ ClickableSvg.withBorder, ClickableSvg.exactWidth 55 ]
+
+                         else
+                            []
+                        )
+                    )
+                )
+                (Control.record (\a b -> ( a, b ))
+                    |> Control.field "icon" (CommonControls.rotatedUiIcon 1)
+                    |> Control.field "withBorder" (ControlExtra.bool True)
+                )
+          )
         ]
 
 


### PR DESCRIPTION
adds the option to have a clickable svg without an indicator.

`clickableSvg`:

<img width="78" alt="" src="https://user-images.githubusercontent.com/5647344/217635000-e87560df-3eb8-4bdf-a50d-8b4e4f006e41.png">

`clickableSvgWithoutIndicator`:

<img width="88" alt="" src="https://user-images.githubusercontent.com/5647344/217635219-d3e4824a-0887-448a-badd-f44ffd8378c9.png">
