### PR TITLE
:label: Bump for version 22.0.0, removing old, unused modules

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "21.15.0",
+    "version": "22.0.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Ui",


### PR DESCRIPTION
Fixes A11-2240

## What changes does this release include?

- https://github.com/NoRedInk/noredink-ui/pull/1252
- https://github.com/NoRedInk/noredink-ui/pull/1269


## How has the API changed?

```
This is a MAJOR change.

---- REMOVED MODULES - MAJOR ----

    Nri.Ui.AssetPath
    Nri.Ui.Balloon.V1
    Nri.Ui.Block.V1
    Nri.Ui.Block.V2
    Nri.Ui.Checkbox.V6
    Nri.Ui.DisclosureIndicator.V2
    Nri.Ui.Highlighter.V1
    Nri.Ui.Mark.V1
    Nri.Ui.Menu.V3
    Nri.Ui.QuestionBox.V1


---- Nri.Ui.Header.V1 - MAJOR ----

    Removed:
        extraSubheadContent : List (Html msg) -> Attribute route msg


```
