### PR TITLE
More involved review suggestions for QuestionBox V4

### DIFF
--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -807,19 +807,19 @@ update msg state =
                     [ "label-1"
                     , "label-3"
                     ]
-                    ++ List.map (\ids -> measureQuestionBox ids Nothing)
-                        [ ( "paragraph-0", "block-0", "question-box-0" )
-                        , ( "paragraph-1", "block-1", "question-box-1" )
-                        , ( "paragraph-2", "block-2", "question-box-2" )
-                        , ( "paragraph-3", "block-3", "question-box-3" )
-                        , ( "paragraph-4", "block-4", "question-box-4" )
-                        , ( "paragraph-5", "block-5", "question-box-5" )
-                        , ( "paragraph-6", "block-6", "question-box-6" )
-                        , ( "paragraph-7", "block-7", "question-box-7" )
-                        , ( "paragraph-8", "block-8", "left-viewport-question-box-example" )
-                        , ( "paragraph-9", "block-9", "right-viewport-question-box-example" )
+                    ++ List.map measureQuestionBox
+                        [ { paragraphId = "paragraph-0", blockId = "block-0", questionBoxId = "question-box-0", containerId = Nothing }
+                        , { paragraphId = "paragraph-1", blockId = "block-1", questionBoxId = "question-box-1", containerId = Nothing }
+                        , { paragraphId = "paragraph-2", blockId = "block-2", questionBoxId = "question-box-2", containerId = Nothing }
+                        , { paragraphId = "paragraph-3", blockId = "block-3", questionBoxId = "question-box-3", containerId = Nothing }
+                        , { paragraphId = "paragraph-4", blockId = "block-4", questionBoxId = "question-box-4", containerId = Nothing }
+                        , { paragraphId = "paragraph-5", blockId = "block-5", questionBoxId = "question-box-5", containerId = Nothing }
+                        , { paragraphId = "paragraph-6", blockId = "block-6", questionBoxId = "question-box-6", containerId = Nothing }
+                        , { paragraphId = "paragraph-7", blockId = "block-7", questionBoxId = "question-box-7", containerId = Nothing }
+                        , { paragraphId = "paragraph-8", blockId = "block-8", questionBoxId = "left-viewport-question-box-example", containerId = Nothing }
+                        , { paragraphId = "paragraph-9", blockId = "block-9", questionBoxId = "right-viewport-question-box-example", containerId = Nothing }
+                        , { paragraphId = "paragraph-10", blockId = "block-10", questionBoxId = "question-box-10", containerId = Just "container-10" }
                         ]
-                    ++ [ measureQuestionBox ( "paragraph-10", "block-10", "question-box-10" ) (Just "container-10") ]
                 )
             )
 
@@ -854,8 +854,8 @@ measureBlockLabel labelId =
         |> Task.attempt (GotBlockLabelMeasurements labelId)
 
 
-measureQuestionBox : ( String, String, String ) -> Maybe String -> Cmd Msg
-measureQuestionBox ( paragraphId, blockId, questionBoxId ) maybeContainerId =
+measureQuestionBox : { paragraphId : String, blockId : String, questionBoxId : String, containerId : Maybe String } -> Cmd Msg
+measureQuestionBox { paragraphId, blockId, questionBoxId, containerId } =
     Task.map4
         (\paragraph block questionBox container ->
             { block = block
@@ -867,11 +867,7 @@ measureQuestionBox ( paragraphId, blockId, questionBoxId ) maybeContainerId =
         (Dom.getElement paragraphId)
         (Dom.getElement blockId)
         (Dom.getElement questionBoxId)
-        (case maybeContainerId of
-            Just containerId ->
-                Dom.getElement containerId |> Task.map Just
-
-            Nothing ->
-                Task.succeed Nothing
+        (Maybe.map (Dom.getElement >> Task.map Just) containerId
+            |> Maybe.withDefault (Task.succeed Nothing)
         )
         |> Task.attempt (GotQuestionBoxMeasurements questionBoxId)

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -26,6 +26,7 @@ import Nri.Ui.Block.V4 as Block
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.MediaQuery.V1 exposing (..)
@@ -146,7 +147,7 @@ view ellieLinkConfig state =
             ]
         ]
     , Heading.h3
-        [ Heading.plaintext "QuestionBox.pointingTo"
+        [ Heading.plaintext "QuestionBox.pointingTo (positioned against the viewport)"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
     , inParagraph "paragraph-8"
@@ -182,6 +183,28 @@ view ellieLinkConfig state =
         , QuestionBox.actions
             [ { label = "Yes", onClick = NoOp }
             , { label = "No", onClick = NoOp }
+            ]
+        ]
+    , Heading.h3
+        [ Heading.plaintext "QuestionBox.pointingTo (positioned against an ancestor)"
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+        ]
+    , Container.view
+        [ Container.id "container-10"
+        , Container.css [ Css.position Css.relative ]
+        , Container.html
+            [ inParagraph "paragraph-10"
+                [ Block.view
+                    [ Block.plaintext "Dave"
+                    , Block.id "block-10"
+                    ]
+                , Block.view [ Block.plaintext " scared his replacement cousin coming out of his room wearing a gorilla mask." ]
+                ]
+            , QuestionBox.view
+                [ QuestionBox.pointingTo "block-10" (Dict.get "question-box-10" state.questionBoxMeasurementsById)
+                , QuestionBox.id "question-box-10"
+                , QuestionBox.markdown "Who?"
+                ]
             ]
         ]
     , Table.view
@@ -506,37 +529,6 @@ view ellieLinkConfig state =
                     , Code.fromModule moduleName "markdown " ++ Code.string "Pointing at the blank"
                     ]
           }
-        , { description = "**Plain block, with parent div with position relative**"
-          , example =
-                tableExampleInPositionRelative "paragraph-10"
-                    "container-10"
-                    [ Block.view
-                        [ Block.plaintext "Dave"
-                        , Block.id "block-10"
-                        ]
-                    , Block.view [ Block.plaintext " scared his replacement cousin coming out of his room wearing a gorilla mask." ]
-                    ]
-                    [ QuestionBox.pointingTo "block-10" (Dict.get "question-box-10" state.questionBoxMeasurementsById)
-                    , QuestionBox.id "question-box-10"
-                    , QuestionBox.markdown "Who?"
-                    ]
-          , pattern =
-                tableExampleCodeRelative
-                    [ Code.fromModule "Block" "view"
-                        ++ Code.listMultiline
-                            [ Code.fromModule "Block" "id " ++ Code.string "block-10"
-                            , Code.fromModule "Block" "plaintext " ++ Code.string "Dave"
-                            ]
-                            3
-                    , "…"
-                    ]
-                    [ Code.fromModule moduleName "id " ++ Code.string "question-box-10"
-                    , Code.fromModule moduleName "pointingTo "
-                        ++ Code.string "block-id"
-                        ++ (Code.newlineWithIndent 3 ++ Code.withParens "Dict.get \"question-box-10\" model.questionBoxMeasurement")
-                    , Code.fromModule moduleName "markdown " ++ Code.string "Who?"
-                    ]
-          }
         ]
     ]
 
@@ -549,22 +541,6 @@ tableExample paragraphId paragraphContents questionBoxAttributes =
 tableExampleCode : List String -> List String -> String
 tableExampleCode blockAttributes questionBoxAttributes =
     "div []"
-        ++ Code.listMultiline
-            [ "p [ id \"paragraph-id\" ]" ++ Code.listMultiline blockAttributes 2
-            , Code.fromModule moduleName "view" ++ Code.listMultiline questionBoxAttributes 2
-            ]
-            1
-
-
-tableExampleInPositionRelative : String -> String -> List (Html msg) -> List (QuestionBox.Attribute msg) -> Html msg
-tableExampleInPositionRelative paragraphId containerId paragraphContents questionBoxAttributes =
-    div [ Attributes.id containerId, Attributes.css [ Css.position Css.relative ] ]
-        [ inParagraph paragraphId paragraphContents, QuestionBox.view questionBoxAttributes ]
-
-
-tableExampleCodeRelative : List String -> List String -> String
-tableExampleCodeRelative blockAttributes questionBoxAttributes =
-    "div [Attributes.id containerId, Attributes.css [ Css.position.relative ]]"
         ++ Code.listMultiline
             [ "p [ id \"paragraph-id\" ]" ++ Code.listMultiline blockAttributes 2
             , Code.fromModule moduleName "view" ++ Code.listMultiline questionBoxAttributes 2

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -197,6 +197,7 @@ view ellieLinkConfig state =
                 [ Block.view
                     [ Block.plaintext "Dave"
                     , Block.id "block-10"
+                    , Block.emphasize
                     ]
                 , Block.view [ Block.plaintext " scared his replacement cousin coming out of his room wearing a gorilla mask." ]
                 ]
@@ -219,7 +220,7 @@ While these visions did appear.
         , Container.html
             [ inParagraph "paragraph-11"
                 [ Block.view [ Block.plaintext "Bottom scared a bunch of people when it turned out he wasn't wearing a donkey " ]
-                , Block.view [ Block.plaintext "mask", Block.id "block-11" ]
+                , Block.view [ Block.plaintext "mask", Block.id "block-11", Block.emphasize ]
                 , Block.view [ Block.plaintext "." ]
                 ]
             , QuestionBox.view

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -191,7 +191,7 @@ view ellieLinkConfig state =
         ]
     , Container.view
         [ Container.id "container-10"
-        , Container.css [ Css.position Css.relative ]
+        , Container.css [ Css.marginTop Spacing.verticalSpacerPx, Css.position Css.relative ]
         , Container.html
             [ inParagraph "paragraph-10"
                 [ Block.view
@@ -203,7 +203,29 @@ view ellieLinkConfig state =
             , QuestionBox.view
                 [ QuestionBox.pointingTo "block-10" (Dict.get "question-box-10" state.questionBoxMeasurementsById)
                 , QuestionBox.id "question-box-10"
-                , QuestionBox.markdown "Who?"
+                , QuestionBox.markdown
+                    """
+If we shadows have offended,
+Think but this, and all is mended,
+That you have but slumbered here
+While these visions did appear.
+"""
+                ]
+            ]
+        ]
+    , Container.view
+        [ Container.id "container-11"
+        , Container.css [ Css.marginTop Spacing.verticalSpacerPx, Css.position Css.relative ]
+        , Container.html
+            [ inParagraph "paragraph-11"
+                [ Block.view [ Block.plaintext "Bottom scared a bunch of people when it turned out he wasn't wearing a donkey " ]
+                , Block.view [ Block.plaintext "mask", Block.id "block-11" ]
+                , Block.view [ Block.plaintext "." ]
+                ]
+            , QuestionBox.view
+                [ QuestionBox.pointingTo "block-11" (Dict.get "question-box-11" state.questionBoxMeasurementsById)
+                , QuestionBox.id "question-box-11"
+                , QuestionBox.markdown "Give me your hands, if we be friends,\nAnd Robin shall restore amends."
                 ]
             ]
         ]
@@ -795,6 +817,7 @@ update msg state =
                         , { paragraphId = "paragraph-8", blockId = "block-8", questionBoxId = "left-viewport-question-box-example", containerId = Nothing }
                         , { paragraphId = "paragraph-9", blockId = "block-9", questionBoxId = "right-viewport-question-box-example", containerId = Nothing }
                         , { paragraphId = "paragraph-10", blockId = "block-10", questionBoxId = "question-box-10", containerId = Just "container-10" }
+                        , { paragraphId = "paragraph-11", blockId = "block-11", questionBoxId = "question-box-11", containerId = Just "container-11" }
                         ]
                 )
             )

--- a/styleguide-app/Examples/QuestionBox.elm
+++ b/styleguide-app/Examples/QuestionBox.elm
@@ -191,7 +191,11 @@ view ellieLinkConfig state =
         ]
     , Container.view
         [ Container.id "container-10"
-        , Container.css [ Css.marginTop Spacing.verticalSpacerPx, Css.position Css.relative ]
+        , Container.css
+            [ Css.marginTop Spacing.verticalSpacerPx
+            , Css.position Css.relative
+            , Css.maxWidth Css.fitContent
+            ]
         , Container.html
             [ inParagraph "paragraph-10"
                 [ Block.view
@@ -216,7 +220,11 @@ While these visions did appear.
         ]
     , Container.view
         [ Container.id "container-11"
-        , Container.css [ Css.marginTop Spacing.verticalSpacerPx, Css.position Css.relative ]
+        , Container.css
+            [ Css.marginTop Spacing.verticalSpacerPx
+            , Css.position Css.relative
+            , Css.maxWidth Css.fitContent
+            ]
         , Container.html
             [ inParagraph "paragraph-11"
                 [ Block.view [ Block.plaintext "Bottom scared a bunch of people when it turned out he wasn't wearing a donkey " ]


### PR DESCRIPTION
Before, it was difficult to tell visually what the question box was being positioned against. My hope is adding the Container wrapper and an example with the question box typically positioned at the right of the content will make the behavior more clear.

## Before

![localhost_8000_ (7)](https://user-images.githubusercontent.com/8811312/218535441-a9016b1a-9379-4de2-b76b-bd25d611a9b0.png)

## After

![localhost_8000_ (6)](https://user-images.githubusercontent.com/8811312/218535420-a9e173dd-f5c6-4d29-8c82-59d88f460a33.png)
