### PR TITLE
add textAlign left to clickableTextButtonStyles

### DIFF
--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -544,6 +544,7 @@ clickableTextButtonStyles =
     , Css.padding Css.zero
     , Css.borderStyle Css.none
     , Css.backgroundColor Css.transparent
+    , Css.textAlign Css.left
     ]
 
 


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Fixes the text alignment change in [this context](https://github.com/NoRedInk/NoRedInk/pull/42496#pullrequestreview-1296063485).

## :framed_picture: What does this change look like?

<img width="209" alt="" src="https://user-images.githubusercontent.com/5647344/218553476-e3b62f23-6620-4939-a91b-18c0abe5feec.png">