### PR TITLE
Adds a little highlight toolbar preview

### DIFF
--- a/styleguide-app/Examples/HighlighterToolbar.elm
+++ b/styleguide-app/Examples/HighlighterToolbar.elm
@@ -12,9 +12,13 @@ import Css exposing (Color)
 import Debug.Control as Control exposing (Control)
 import Debug.Control.View as ControlView
 import Example exposing (Example)
+import Html.Styled exposing (..)
+import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.HighlighterToolbar.V1 as HighlighterToolbar
+import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.UiIcon.V1 as UiIcon
 
 
 moduleName : String
@@ -36,7 +40,13 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , preview =
-        []
+        [ div [ css [ Css.displayFlex, Css.justifyContent Css.spaceBetween ] ]
+            [ highlighterPreview Colors.mustard
+            , highlighterPreview Colors.magenta
+            , highlighterPreview Colors.cyan
+            , toolPreview Colors.white Colors.gray75 UiIcon.eraser
+            ]
+        ]
     , view =
         \ellieLinkConfig state ->
             [ ControlView.view
@@ -64,6 +74,27 @@ example =
     , categories = [ Buttons, Interactions ]
     , keyboardSupport = []
     }
+
+
+highlighterPreview : Color -> Html msg
+highlighterPreview color =
+    toolPreview color color (Svg.withColor Colors.white UiIcon.highlighter)
+
+
+toolPreview : Color -> Color -> Svg.Svg -> Html msg
+toolPreview color border icon =
+    span
+        [ css
+            [ Css.backgroundColor color
+            , Css.width (Css.px 35)
+            , Css.height (Css.px 35)
+            , Css.borderRadius (Css.pct 50)
+            , Css.padding (Css.px 6)
+            , Css.border3 (Css.px 1) Css.solid border
+            ]
+        ]
+        [ Svg.toHtml icon
+        ]
 
 
 type Tag

--- a/styleguide-app/Examples/HighlighterToolbar.elm
+++ b/styleguide-app/Examples/HighlighterToolbar.elm
@@ -18,6 +18,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.HighlighterToolbar.V1 as HighlighterToolbar
 import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 
 
@@ -40,12 +41,10 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , preview =
-        [ div [ css [ Css.displayFlex, Css.justifyContent Css.spaceBetween ] ]
-            [ highlighterPreview Colors.mustard
-            , highlighterPreview Colors.magenta
-            , highlighterPreview Colors.cyan
-            , toolPreview Colors.white Colors.gray75 UiIcon.eraser
-            ]
+        [ highlighterPreview Colors.mustard "Claim"
+        , highlighterPreview Colors.magenta "Evidence"
+        , highlighterPreview Colors.cyan "Reasoning"
+        , toolPreview Colors.white Colors.gray75 UiIcon.eraser "Remove highlight"
         ]
     , view =
         \ellieLinkConfig state ->
@@ -76,24 +75,28 @@ example =
     }
 
 
-highlighterPreview : Color -> Html msg
+highlighterPreview : Color -> String -> Html msg
 highlighterPreview color =
     toolPreview color color (Svg.withColor Colors.white UiIcon.highlighter)
 
 
-toolPreview : Color -> Color -> Svg.Svg -> Html msg
-toolPreview color border icon =
-    span
-        [ css
-            [ Css.backgroundColor color
-            , Css.width (Css.px 35)
-            , Css.height (Css.px 35)
-            , Css.borderRadius (Css.pct 50)
-            , Css.padding (Css.px 6)
-            , Css.border3 (Css.px 1) Css.solid border
+toolPreview : Color -> Color -> Svg.Svg -> String -> Html msg
+toolPreview color border icon name =
+    div [ css [ Css.displayFlex, Css.alignItems Css.center, Css.marginBottom (Css.px 4) ] ]
+        [ span
+            [ css
+                [ Css.backgroundColor color
+                , Css.width (Css.px 35)
+                , Css.height (Css.px 35)
+                , Css.borderRadius (Css.pct 50)
+                , Css.padding (Css.px 6)
+                , Css.border3 (Css.px 1) Css.solid border
+                , Css.marginRight (Css.px 4)
+                ]
             ]
-        ]
-        [ Svg.toHtml icon
+            [ Svg.toHtml icon
+            ]
+        , Text.smallBody [ Text.plaintext name, Text.css [ Css.color Colors.navy ] ]
         ]
 
 


### PR DESCRIPTION
## Context

Fixes A11-2300

## :framed_picture: What does this change look like?

<img width="213" alt="Screen Shot 2023-02-13 at 3 14 15 PM" src="https://user-images.githubusercontent.com/8811312/218586992-46e1e50d-0cd5-4294-a483-f811f5872dde.png">
cc @NoRedInk/design a lil highlighter toolbar preview! Much simplified -- not sure if you have ideas about how to include the label text in the preview, or if you think this is sufficient for easy browsing through the catalog?
