### PR TITLE
Position.xOffsetPxAgainstContainer positioning logic suggestion

### DIFF
--- a/src/Nri/Ui/QuestionBox/V4.elm
+++ b/src/Nri/Ui/QuestionBox/V4.elm
@@ -240,7 +240,7 @@ viewPointingTo config blockId measurements =
 
                 -- calculate the max position of the question box, so it will not render outside the viewport
                 maybeMaxPosition =
-                    container |> Maybe.map (\containerElement -> containerElement.element.x + containerElement.element.width - questionBox.element.width - offset) |> Debug.log "maxPosition"
+                    container |> Maybe.map (\containerElement -> containerElement.element.x + containerElement.element.width - questionBox.element.width - offset)
 
                 position =
                     -- position in the middle of the block

--- a/src/Nri/Ui/QuestionBox/V4.elm
+++ b/src/Nri/Ui/QuestionBox/V4.elm
@@ -33,7 +33,7 @@ import Nri.Ui.CharacterIcon.V1 as CharacterIcon
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (nriDescription)
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
-import Position exposing (xOffsetPx)
+import Position exposing (xOffsetPx, xOffsetPxAgainstContainer)
 
 
 {-| -}
@@ -212,51 +212,47 @@ viewPointingTo :
     -> Html msg
 viewPointingTo config blockId measurements =
     let
+        -- the xoffset is used to translate the questionbox so that it remains in the viewport
+        -- or in its non-static positioned ancestor (depending on whether container measurements are passed in or not)
         xOffset =
-            Maybe.map xOffsetPx adjustedQuestionBoxPosition
-                |> Maybe.withDefault 0
+            case ( centeredQuestionBoxPosition, Maybe.andThen .container measurements ) of
+                ( Just qbPosition, Just container ) ->
+                    xOffsetPxAgainstContainer { container = container, element = qbPosition }
 
-        adjustedQuestionBoxPosition =
+                ( Just qbPosition, Nothing ) ->
+                    xOffsetPx qbPosition
+
+                _ ->
+                    0
+
+        centeredQuestionBoxPosition =
             Maybe.map
                 (\({ questionBox } as m) ->
                     let
                         element =
                             questionBox.element
                     in
-                    { questionBox | element = { element | x = newQuestionBoxPosition m } }
+                    { questionBox | element = { element | x = centeredQuestionBoxLeftPx m } }
                 )
                 measurements
 
-        newQuestionBoxPosition { block, questionBox, container } =
-            let
-                -- calculate the offset between the viewport and the container
-                offset =
-                    case container of
-                        Just containerElement ->
-                            containerElement.element.x
+        centeredQuestionBoxLeftPx { block, questionBox, container } =
+            -- position in the middle of the block
+            (block.element.x + (block.element.width / 2))
+                - -- against the middle of the question box
+                  (questionBox.element.width / 2)
 
-                        Nothing ->
-                            0
-
-                -- calculate the max position of the question box, so it will not render outside the viewport
-                maybeMaxPosition =
-                    container |> Maybe.map (\containerElement -> containerElement.element.x + containerElement.element.width - questionBox.element.width - offset)
-
-                position =
-                    -- position in the middle of the block
-                    (block.element.x + (block.element.width / 2))
-                        - -- against the middle of the question box
-                          (questionBox.element.width / 2)
-                        -- subtract offset from the container, when container is provided
-                        - offset
-            in
-            case maybeMaxPosition of
-                Just maxPosition ->
-                    max (min maxPosition position) 0
+        -- calculate the offset between the viewport and the container
+        -- since we know container element will have non-static positioning, the question box will positioned against it
+        -- instead of against the entire viewport. So we need to offset the left value for the absolutely positioned QB, or
+        -- else the QB will be aligned too far to the right.
+        containerOffset =
+            case Maybe.andThen .container measurements of
+                Just containerElement ->
+                    containerElement.element.x
 
                 Nothing ->
-                    -- make sure that the position is positive and is rendered inside the viewport
-                    max position 0
+                    0
     in
     viewBalloon config
         (Just blockId)
@@ -273,7 +269,7 @@ viewPointingTo config blockId measurements =
                 case measurements of
                     Just measurements_ ->
                         [ Css.position Css.absolute
-                        , Css.left (Css.px (newQuestionBoxPosition measurements_))
+                        , Css.left (Css.px (centeredQuestionBoxLeftPx measurements_ - containerOffset))
                         ]
 
                     Nothing ->

--- a/src/Position.elm
+++ b/src/Position.elm
@@ -1,4 +1,4 @@
-module Position exposing (xOffsetPx)
+module Position exposing (xOffsetPx, xOffsetPxAgainstContainer)
 
 {-| -}
 
@@ -31,3 +31,13 @@ xOffsetPx { element, viewport } =
 
     else
         0
+
+
+{-| Figure out how much an element needs to shift along the horizontal axis in order to not overflow its ancestor.
+
+Uses Brower.Dom's Element measurement.
+
+-}
+xOffsetPxAgainstContainer : { container : Dom.Element, element : Dom.Element } -> Float
+xOffsetPxAgainstContainer config =
+    0

--- a/src/Position.elm
+++ b/src/Position.elm
@@ -40,4 +40,28 @@ Uses Brower.Dom's Element measurement.
 -}
 xOffsetPxAgainstContainer : { container : Dom.Element, element : Dom.Element } -> Float
 xOffsetPxAgainstContainer config =
-    0
+    let
+        container =
+            config.container.element
+
+        element =
+            config.element.element
+
+        xMax =
+            container.x + container.width
+    in
+    -- if the element is cut off by the container on the left side,
+    -- we need to adjust rightward by the cut-off amount
+    if element.x < container.x then
+        container.x - element.x
+
+    else
+    -- if the element is cut off by the container on the right side,
+    -- we need to adjust leftward by the cut-off amount
+    if
+        xMax < (element.x + element.width)
+    then
+        xMax - (element.x + element.width)
+
+    else
+        0

--- a/tests/Spec/Position.elm
+++ b/tests/Spec/Position.elm
@@ -54,19 +54,57 @@ xOffsetPxSpec =
     ]
 
 
-xOffsetPxSpecAgainstContainer : List Test
-xOffsetPxSpecAgainstContainer =
-    [ todo "When the element is in line with the left edge of its container, does not shift"
-    , todo "when the element is in line with the right edge of its container, does not shift"
-    , todo "when the element overflows its container on the left side, shift to the right"
-    , todo "when the element overflows its container on the right side, shift to the left"
-    , todo "when the element overflows its container on both sides, align to the left side of the container"
-    ]
-
-
 element : { viewportX : Float, viewportWidth : Float, elementX : Float, elementWidth : Float } -> Element
 element { viewportX, viewportWidth, elementWidth, elementX } =
     { scene = { width = 1000, height = 1000 }
     , viewport = { x = viewportX, y = 0, width = viewportWidth, height = 500 }
     , element = { x = elementX, width = elementWidth, y = 0, height = 10 }
+    }
+
+
+xOffsetPxSpecAgainstContainer : List Test
+xOffsetPxSpecAgainstContainer =
+    [ test "When the element is in line with the left edge of its container, does not shift" <|
+        \() ->
+            { element = measurement { x = 0, width = 200 }
+            , container = measurement { x = 0, width = 500 }
+            }
+                |> Position.xOffsetPxAgainstContainer
+                |> Expect.equal 0
+    , test "when the element is in line with the right edge of its container, does not shift" <|
+        \() ->
+            { element = measurement { x = 300, width = 200 }
+            , container = measurement { x = 0, width = 500 }
+            }
+                |> Position.xOffsetPxAgainstContainer
+                |> Expect.equal 0
+    , test "when the element overflows its container on the left side, shift to the right" <|
+        \() ->
+            { element = measurement { x = -100, width = 200 }
+            , container = measurement { x = 0, width = 500 }
+            }
+                |> Position.xOffsetPxAgainstContainer
+                |> Expect.equal 100
+    , test "when the element overflows its container on the right side, shift to the left" <|
+        \() ->
+            { element = measurement { x = 400, width = 200 }
+            , container = measurement { x = 0, width = 500 }
+            }
+                |> Position.xOffsetPxAgainstContainer
+                |> Expect.equal -100
+    , test "when the element overflows its container on both sides, align to the left side of the container" <|
+        \() ->
+            { element = measurement { x = -100, width = 300 }
+            , container = measurement { x = 0, width = 100 }
+            }
+                |> Position.xOffsetPxAgainstContainer
+                |> Expect.equal 100
+    ]
+
+
+measurement : { x : Float, width : Float } -> Element
+measurement { width, x } =
+    { scene = { width = 1000, height = 1000 }
+    , viewport = { x = 0, y = 0, width = 1000, height = 2000 }
+    , element = { x = x, width = width, y = 0, height = 10 }
     }

--- a/tests/Spec/Position.elm
+++ b/tests/Spec/Position.elm
@@ -10,41 +10,58 @@ import Test exposing (..)
 
 spec : Test
 spec =
-    describe "xOffsetPx"
-        [ test "when the element is in line with the left edge of the viewport, does not shift" <|
-            \() ->
-                element { viewportX = 0, viewportWidth = 100, elementX = 0, elementWidth = 50 }
-                    |> Position.xOffsetPx
-                    |> Expect.equal 0
-        , test "when the element is in line with the right edge of the viewport, does not shift" <|
-            \() ->
-                element { viewportX = 0, viewportWidth = 100, elementX = 50, elementWidth = 50 }
-                    |> Position.xOffsetPx
-                    |> Expect.equal 0
-        , test "when the viewport cuts off the element on the left side, shift to the right" <|
-            \() ->
-                let
-                    cutOffAmount =
-                        100
-                in
-                element { viewportX = 0, viewportWidth = 500, elementX = -cutOffAmount, elementWidth = 200 }
-                    |> Position.xOffsetPx
-                    |> Expect.equal cutOffAmount
-        , test "when the viewport cuts off the element on the right side, shift to the left" <|
-            \() ->
-                let
-                    cutOffAmount =
-                        100
-                in
-                element { viewportX = 0, viewportWidth = 0, elementX = 0, elementWidth = cutOffAmount }
-                    |> Position.xOffsetPx
-                    |> Expect.equal -cutOffAmount
-        , test "when the viewport cuts off the element on both sides, align to the left side of the viewport" <|
-            \() ->
-                element { viewportX = 0, viewportWidth = 100, elementX = -100, elementWidth = 300 }
-                    |> Position.xOffsetPx
-                    |> Expect.equal 100
+    describe "Position"
+        [ describe "xOffsetPx" xOffsetPxSpec
+        , describe "xOffsetPxAgainstAncestor" xOffsetPxSpecAgainstContainer
         ]
+
+
+xOffsetPxSpec : List Test
+xOffsetPxSpec =
+    [ test "when the element is in line with the left edge of the viewport, does not shift" <|
+        \() ->
+            element { viewportX = 0, viewportWidth = 100, elementX = 0, elementWidth = 50 }
+                |> Position.xOffsetPx
+                |> Expect.equal 0
+    , test "when the element is in line with the right edge of the viewport, does not shift" <|
+        \() ->
+            element { viewportX = 0, viewportWidth = 100, elementX = 50, elementWidth = 50 }
+                |> Position.xOffsetPx
+                |> Expect.equal 0
+    , test "when the viewport cuts off the element on the left side, shift to the right" <|
+        \() ->
+            let
+                cutOffAmount =
+                    100
+            in
+            element { viewportX = 0, viewportWidth = 500, elementX = -cutOffAmount, elementWidth = 200 }
+                |> Position.xOffsetPx
+                |> Expect.equal cutOffAmount
+    , test "when the viewport cuts off the element on the right side, shift to the left" <|
+        \() ->
+            let
+                cutOffAmount =
+                    100
+            in
+            element { viewportX = 0, viewportWidth = 0, elementX = 0, elementWidth = cutOffAmount }
+                |> Position.xOffsetPx
+                |> Expect.equal -cutOffAmount
+    , test "when the viewport cuts off the element on both sides, align to the left side of the viewport" <|
+        \() ->
+            element { viewportX = 0, viewportWidth = 100, elementX = -100, elementWidth = 300 }
+                |> Position.xOffsetPx
+                |> Expect.equal 100
+    ]
+
+
+xOffsetPxSpecAgainstContainer : List Test
+xOffsetPxSpecAgainstContainer =
+    [ todo "When the element is in line with the left edge of its container, does not shift"
+    , todo "when the element is in line with the right edge of its container, does not shift"
+    , todo "when the element overflows its container on the left side, shift to the right"
+    , todo "when the element overflows its container on the right side, shift to the left"
+    , todo "when the element overflows its container on both sides, align to the left side of the container"
+    ]
 
 
 element : { viewportX : Float, viewportWidth : Float, elementX : Float, elementWidth : Float } -> Element

--- a/tests/Spec/Position.elm
+++ b/tests/Spec/Position.elm
@@ -1,0 +1,55 @@
+module Spec.Position exposing (spec)
+
+{-| -}
+
+import Browser.Dom exposing (Element)
+import Expect
+import Position
+import Test exposing (..)
+
+
+spec : Test
+spec =
+    describe "xOffsetPx"
+        [ test "when the element is in line with the left edge of the viewport, does not shift" <|
+            \() ->
+                element { viewportX = 0, viewportWidth = 100, elementX = 0, elementWidth = 50 }
+                    |> Position.xOffsetPx
+                    |> Expect.equal 0
+        , test "when the element is in line with the right edge of the viewport, does not shift" <|
+            \() ->
+                element { viewportX = 0, viewportWidth = 100, elementX = 50, elementWidth = 50 }
+                    |> Position.xOffsetPx
+                    |> Expect.equal 0
+        , test "when the viewport cuts off the element on the left side, shift to the right" <|
+            \() ->
+                let
+                    cutOffAmount =
+                        100
+                in
+                element { viewportX = 0, viewportWidth = 500, elementX = -cutOffAmount, elementWidth = 200 }
+                    |> Position.xOffsetPx
+                    |> Expect.equal cutOffAmount
+        , test "when the viewport cuts off the element on the right side, shift to the left" <|
+            \() ->
+                let
+                    cutOffAmount =
+                        100
+                in
+                element { viewportX = 0, viewportWidth = 0, elementX = 0, elementWidth = cutOffAmount }
+                    |> Position.xOffsetPx
+                    |> Expect.equal -cutOffAmount
+        , test "when the viewport cuts off the element on both sides, align to the left side of the viewport" <|
+            \() ->
+                element { viewportX = 0, viewportWidth = 100, elementX = -100, elementWidth = 300 }
+                    |> Position.xOffsetPx
+                    |> Expect.equal 100
+        ]
+
+
+element : { viewportX : Float, viewportWidth : Float, elementX : Float, elementWidth : Float } -> Element
+element { viewportX, viewportWidth, elementWidth, elementX } =
+    { scene = { width = 1000, height = 1000 }
+    , viewport = { x = viewportX, y = 0, width = viewportWidth, height = 500 }
+    , element = { x = elementX, width = elementWidth, y = 0, height = 10 }
+    }


### PR DESCRIPTION
- adds tests against Position.xOffsetPx
- adds tests for and implements new function Position.xOffsetPxAgainstContainer
- uses Position.xOffsetPx and Position.xOffsetPxAgainstContainer in QuestionBox positioning code, depending on whether container measurements are passed in or not