### PR TITLE
:wrench: Menu tooltips

### DIFF
--- a/component-catalog-app/Examples/Menu.elm
+++ b/component-catalog-app/Examples/Menu.elm
@@ -139,11 +139,12 @@ view ellieLinkConfig state =
         , version = version
         , update = UpdateControls
         , settings = state.settings
-        , mainType = Just "RootHtml.Html { focus : Maybe String, isOpen : Bool }"
+        , mainType = Just "RootHtml.Html Msg"
         , extraCode =
             [ "import Nri.Ui.Button.V10 as Button"
             , "import Nri.Ui.ClickableSvg.V2 as ClickableSvg"
             , "import Nri.Ui.ClickableText.V3 as ClickableText"
+            , "\ntype Msg = ToggleMenu { focus : Maybe String, isOpen : Bool } | ToggleTooltip Bool"
             ]
         , renderExample = Code.unstyledView
         , toExampleCode =
@@ -152,8 +153,7 @@ view ellieLinkConfig state =
                     code : String
                     code =
                         moduleName
-                            ++ ".view "
-                            ++ "identity -- TODO: you will need a real msg type here"
+                            ++ ".view ToggleMenu"
                             ++ Code.listMultiline
                                 (("Menu.isOpen " ++ Code.bool (isOpen "interactiveExample"))
                                     :: List.map Tuple.first settings

--- a/component-catalog-app/Examples/Menu.elm
+++ b/component-catalog-app/Examples/Menu.elm
@@ -123,6 +123,7 @@ view ellieLinkConfig state =
     let
         menuAttributes =
             Control.currentValue state.settings
+                |> .attributes
                 |> List.map Tuple.second
 
         isOpen name =
@@ -148,7 +149,7 @@ view ellieLinkConfig state =
             ]
         , renderExample = Code.unstyledView
         , toExampleCode =
-            \settings ->
+            \{ attributes } ->
                 let
                     code : String
                     code =
@@ -156,7 +157,7 @@ view ellieLinkConfig state =
                             ++ ".view ToggleMenu"
                             ++ Code.listMultiline
                                 (("Menu.isOpen " ++ Code.bool (isOpen "interactiveExample"))
-                                    :: List.map Tuple.first settings
+                                    :: List.map Tuple.first attributes
                                 )
                                 1
                             ++ Code.newlineWithIndent 1
@@ -357,11 +358,20 @@ type alias State =
 
 
 type alias Settings =
-    List ( String, Menu.Attribute Msg )
+    { attributes : List ( String, Menu.Attribute Msg )
+    , withTooltip : Bool
+    }
 
 
 initSettings : Control Settings
 initSettings =
+    Control.record Settings
+        |> Control.field "attributes" initSettingAttributes
+        |> Control.field "withTooltip" (Control.bool False)
+
+
+initSettingAttributes : Control (List ( String, Menu.Attribute Msg ))
+initSettingAttributes =
     ControlExtra.list
         |> ControlExtra.optionalListItem "alignment" controlAlignment
         |> ControlExtra.optionalBoolListItem "isDisabled" ( "Menu.isDisabled True", Menu.isDisabled True )

--- a/component-catalog-app/Examples/Menu.elm
+++ b/component-catalog-app/Examples/Menu.elm
@@ -160,8 +160,20 @@ view ellieLinkConfig state =
                                     :: List.map Tuple.first attributes
                                 )
                                 1
-                            ++ Code.newlineWithIndent 1
-                            ++ "[]"
+                            ++ Code.listMultiline
+                                [ (Code.fromModule moduleName "entry " ++ Code.string "unique-button-id" ++ " <|")
+                                    ++ Code.newlineWithIndent 2
+                                    ++ Code.anonymousFunction "attributes"
+                                        (Code.newlineWithIndent 2
+                                            ++ (Code.fromModule "ClickableText" "button " ++ Code.string "Button")
+                                            ++ Code.listMultiline
+                                                [ Code.fromModule "ClickableText" "small"
+                                                , Code.fromModule "ClickableText" "custom" ++ " attributes"
+                                                ]
+                                                3
+                                        )
+                                ]
+                                1
                 in
                 [ { sectionName = "Example"
                   , code = code
@@ -175,7 +187,14 @@ view ellieLinkConfig state =
     , div [ css [ Css.displayFlex, Css.justifyContent Css.center ] ]
         [ Menu.view (FocusAndToggle "interactiveExample")
             (Menu.isOpen (isOpen "interactiveExample") :: menuAttributes)
-            []
+            [ Menu.entry "customizable-example" <|
+                \attrs ->
+                    ClickableText.button "Button"
+                        [ ClickableText.small
+                        , ClickableText.onClick (ConsoleLog "Interactive example")
+                        , ClickableText.custom attrs
+                        ]
+            ]
         ]
     , Heading.h2
         [ Heading.plaintext "Menu types"

--- a/component-catalog-app/Examples/Menu.elm
+++ b/component-catalog-app/Examples/Menu.elm
@@ -31,6 +31,7 @@ import Nri.Ui.Menu.V4 as Menu
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V6 as Table
 import Nri.Ui.TextInput.V7 as TextInput
+import Nri.Ui.Tooltip.V3 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Set exposing (Set)
 import Svg.Styled as Svg
@@ -186,7 +187,21 @@ view ellieLinkConfig state =
         ]
     , div [ css [ Css.displayFlex, Css.justifyContent Css.center ] ]
         [ Menu.view (FocusAndToggle "interactiveExample")
-            (Menu.isOpen (isOpen "interactiveExample") :: menuAttributes)
+            ((if (Control.currentValue state.settings).withTooltip then
+                [ Menu.withTooltip
+                    [ Tooltip.open (Set.member "tooltip-0" state.openTooltips)
+                    , Tooltip.onToggle (ToggleTooltip "tooltip-0")
+                    , Tooltip.plaintext "Tooltip content"
+                    , Tooltip.fitToContent
+                    ]
+                ]
+
+              else
+                []
+             )
+                ++ Menu.isOpen (isOpen "interactiveExample")
+                :: menuAttributes
+            )
             [ Menu.entry "customizable-example" <|
                 \attrs ->
                     ClickableText.button "Button"
@@ -532,6 +547,7 @@ controlMenuWidth =
 type Msg
     = ConsoleLog String
     | UpdateControls (Control Settings)
+    | ToggleTooltip String Bool
     | FocusAndToggle String { isOpen : Bool, focus : Maybe String }
     | Focused (Result Dom.Error ())
 
@@ -545,6 +561,12 @@ update msg state =
 
         UpdateControls configuration ->
             ( { state | settings = configuration }, Cmd.none )
+
+        ToggleTooltip id True ->
+            ( { state | openTooltips = Set.insert id state.openTooltips }, Cmd.none )
+
+        ToggleTooltip id False ->
+            ( { state | openTooltips = Set.remove id state.openTooltips }, Cmd.none )
 
         FocusAndToggle id { isOpen, focus } ->
             ( { state

--- a/component-catalog-app/Examples/Menu.elm
+++ b/component-catalog-app/Examples/Menu.elm
@@ -146,6 +146,7 @@ view ellieLinkConfig state =
             [ "import Nri.Ui.Button.V10 as Button"
             , "import Nri.Ui.ClickableSvg.V2 as ClickableSvg"
             , "import Nri.Ui.ClickableText.V3 as ClickableText"
+            , "import Nri.Ui.Tooltip.V3 as Tooltip"
             , "\ntype Msg = ToggleMenu { focus : Maybe String, isOpen : Bool } | ToggleTooltip Bool"
             ]
         , renderExample = Code.unstyledView
@@ -157,7 +158,21 @@ view ellieLinkConfig state =
                         moduleName
                             ++ ".view ToggleMenu"
                             ++ Code.listMultiline
-                                (("Menu.isOpen " ++ Code.bool (isOpen "interactiveExample"))
+                                ((if (Control.currentValue state.settings).withTooltip then
+                                    [ Code.fromModule "Menu" "withTooltip"
+                                        ++ Code.listMultiline
+                                            [ Code.fromModule "Tooltip" "open " ++ (Code.bool <| Set.member "tooltip-0" state.openTooltips)
+                                            , Code.fromModule "Tooltip" "onToggle " ++ "ToggleTooltip"
+                                            , Code.fromModule "Tooltip" "plaintext " ++ Code.string "Tooltip content"
+                                            , Code.fromModule "Tooltip" "fitToContent"
+                                            ]
+                                            2
+                                    ]
+
+                                  else
+                                    []
+                                 )
+                                    ++ ("Menu.isOpen " ++ Code.bool (isOpen "interactiveExample"))
                                     :: List.map Tuple.first attributes
                                 )
                                 1

--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -33,6 +33,7 @@ A togglable menu view and related buttons.
 ## Triggering button options
 
 @docs defaultTrigger, button, clickableText, clickableSvg, clickableSvgWithoutIndicator
+@docs withTooltip
 @docs buttonId
 
 
@@ -66,6 +67,7 @@ import Nri.Ui.Fonts.V1
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
 import Nri.Ui.Shadows.V1 as Shadows
 import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.Tooltip.V3 as Tooltip
 import Nri.Ui.WhenFocusLeaves.V1 as WhenFocusLeaves
 
 
@@ -85,6 +87,7 @@ type alias MenuConfig msg =
     , zIndex : Int
     , opensOnHover : Bool
     , purpose : Purpose
+    , tooltipAttributes : List (Tooltip.Attribute msg)
     }
 
 
@@ -100,6 +103,7 @@ defaultConfig =
     , zIndex = 1
     , opensOnHover = False
     , purpose = NavMenu
+    , tooltipAttributes = []
     }
 
 
@@ -326,6 +330,12 @@ defaultButton title attributes =
                     ++ attributes
                 )
         )
+
+
+{-| -}
+withTooltip : List (Tooltip.Attribute msg) -> Attribute msg
+withTooltip tooltipAttributes =
+    Attribute <| \config -> { config | tooltipAttributes = tooltipAttributes }
 
 
 {-| Use Button with default styles as the triggering element for the Menu.

--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -11,7 +11,11 @@ module Nri.Ui.Menu.V4 exposing
     , Entry, group, entry
     )
 
-{-| Changes from V3:
+{-| Patch changes:
+
+  - improve interoperability with Tooltip (Note that tooltip keyboard events are not fully supported!)
+
+Changes from V3:
 
   - improve composability with Button, ClickableText, and ClickableSvg
 
@@ -306,7 +310,8 @@ defaultButton title attributes =
     DefaultTrigger title attributes
 
 
-{-| -}
+{-| Warning: Tooltip keyboard events are not fully supported!
+-}
 withTooltip : List (Tooltip.Attribute msg) -> Attribute msg
 withTooltip tooltipAttributes =
     Attribute <| \config -> { config | tooltipAttributes = tooltipAttributes }

--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -571,16 +571,16 @@ viewCustom focusAndToggle config entries =
                                     [ Aria.hasDialogPopUp ]
                            )
 
-                trigger =
+                trigger tooltipAttributes =
                     case config.button of
                         DefaultTrigger title buttonAttributes ->
-                            viewDefaultTrigger title config buttonAttributes triggerAttributes
+                            viewDefaultTrigger title config buttonAttributes (tooltipAttributes ++ triggerAttributes)
 
                         Button title buttonAttributes ->
-                            viewButton title config buttonAttributes triggerAttributes
+                            viewButton title config buttonAttributes (tooltipAttributes ++ triggerAttributes)
 
                         ClickableText title clickableTextAttributes ->
-                            viewClickableText title config clickableTextAttributes triggerAttributes
+                            viewClickableText title config clickableTextAttributes (tooltipAttributes ++ triggerAttributes)
 
                         ClickableSvg includeIndicator title icon clickableSvgAttributes ->
                             viewClickableSvg includeIndicator
@@ -588,19 +588,16 @@ viewCustom focusAndToggle config entries =
                                 icon
                                 config
                                 clickableSvgAttributes
-                                triggerAttributes
+                                (tooltipAttributes ++ triggerAttributes)
               in
               case config.tooltipAttributes of
                 [] ->
-                    trigger
+                    trigger []
 
                 _ ->
                     Tooltip.view
                         { id = config.menuId ++ "-tooltip"
-                        , trigger =
-                            \tooltipHtmlAttributes ->
-                                -- TODO refactor so that we can pass through the tooltip attributes
-                                trigger
+                        , trigger = trigger
                         }
                         config.tooltipAttributes
             , div [ styleOuterContent contentVisible config ]

--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -3,6 +3,7 @@ module Nri.Ui.Menu.V4 exposing
     , isOpen, isDisabled
     , opensOnHover
     , defaultTrigger, button, clickableText, clickableSvg, clickableSvgWithoutIndicator
+    , withTooltip
     , buttonId
     , navMenuList, disclosure, dialog
     , menuWidth, menuId, menuZIndex
@@ -644,7 +645,19 @@ viewCustom focusAndToggle config entries =
               in
               case config.button of
                 Button standardButton ->
-                    standardButton config buttonAttributes
+                    case config.tooltipAttributes of
+                        [] ->
+                            standardButton config buttonAttributes
+
+                        _ ->
+                            Tooltip.view
+                                { id = config.menuId ++ "-tooltip"
+                                , trigger =
+                                    \tooltipHtmlAttributes ->
+                                        -- TODO refactor so that we can pass through the tooltip attributes
+                                        standardButton config buttonAttributes
+                                }
+                                config.tooltipAttributes
             , div [ styleOuterContent contentVisible config ]
                 [ div
                     [ AttributesExtra.nriDescription "menu-hover-bridge"

--- a/tests/Spec/KeyboardHelpers.elm
+++ b/tests/Spec/KeyboardHelpers.elm
@@ -91,6 +91,15 @@ pressSpaceKey { targetDetails } =
     pressKey { targetDetails = targetDetails, keyCode = 32, shiftKey = False }
 
 
+pressDownArrow :
+    { targetDetails : List ( String, Encode.Value ) }
+    -> List Selector
+    -> ProgramTest model msg effect
+    -> ProgramTest model msg effect
+pressDownArrow { targetDetails } =
+    pressKey { targetDetails = targetDetails, keyCode = 40, shiftKey = False }
+
+
 pressRightArrow :
     { targetDetails : List ( String, Encode.Value ) }
     -> List Selector


### PR DESCRIPTION
## Context

It turns out that our tooltip and our menu component don't play nicely together: either the Menu keyboard events work or the Tooltip keyboard events work.

The API previous to this restricted the behavior such that only the Tooltip keyboard events worked. This is not a state we can work from, since it fully blocks users (keyboard-only users just _won't_ be able to get to the menu contents).

This PR adds first-class tooltip support to Menu, which allows us to choose the Menu keyboard behavior over the Tooltip keyboard behavior. This also significantly improves the user experience of adding a tooltip to a Menu.

Note that the tooltip experience won't be perfect: for example, while focused on the menu's triggering button, hitting escape will _not_ close the tooltip (which is a WCAG failure).

## :framed_picture: What does this change look like?

<img width="238" alt="Screen Shot 2023-02-14 at 4 39 19 PM" src="https://user-images.githubusercontent.com/8811312/218887995-a17866e4-a88b-478b-99b4-aa316394081e.png">

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the comopnent
