### PR TITLE
Fix missing whitespace for Highlighter.staticMarkdown with Highlightable.formMarkdown

### DIFF
--- a/component-catalog-app/Examples/Highlighter.elm
+++ b/component-catalog-app/Examples/Highlighter.elm
@@ -123,6 +123,13 @@ example =
                     , sort = Nothing
                     }
                 , Table.string
+                    { header = "Highlightable."
+                    , value = .highlightable
+                    , width = Css.pct 10
+                    , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+                    , sort = Nothing
+                    }
+                , Table.string
                     { header = "Description"
                     , value = .description
                     , width = Css.pct 30
@@ -144,6 +151,7 @@ example =
                 ]
                 [ { viewName = "static"
                   , tool = "buildMarker"
+                  , highlightable = "init"
                   , description = "One word highlighted"
                   , example =
                         Highlighter.static
@@ -163,6 +171,7 @@ example =
                   }
                 , { viewName = "static"
                   , tool = "buildMarker"
+                  , highlightable = "init"
                   , description = "Multiple words highlighted separately"
                   , example =
                         Highlighter.static
@@ -182,6 +191,7 @@ example =
                   }
                 , { viewName = "static"
                   , tool = "buildMarker"
+                  , highlightable = "init"
                   , description = "Multiple words highlighted & joined"
                   , example =
                         Highlighter.static
@@ -200,23 +210,37 @@ example =
                   }
                 , { viewName = "static"
                   , tool = "buildMarker"
+                  , highlightable = "init"
                   , description = "Multiple kinds of highlights without overlaps"
                   , example = Highlighter.static { id = "example-3a", highlightables = multipleHighlightsHighlightables }
                   }
                 , { viewName = "staticMarkdown"
                   , tool = "buildMarker"
+                  , highlightable = "init"
                   , description = "Multiple kinds of highlights without overlaps and with interpreted Markdown"
                   , example = Highlighter.staticMarkdown { id = "example-3b", highlightables = multipleHighlightsHighlightables }
                   }
                 , { viewName = "staticWithTags"
                   , tool = "buildMarkerWithBorder"
+                  , highlightable = "init"
                   , description = "Multiple kinds of highlights without overlaps"
                   , example = Highlighter.staticWithTags { id = "example-4a", highlightables = multipleHighlightsHighlightablesWithBorder }
                   }
                 , { viewName = "staticMarkdownWithTags"
                   , tool = "buildMarkerWithBorder"
+                  , highlightable = "init"
                   , description = "Multiple kinds of highlights without overlaps and with interpreted Markdown"
                   , example = Highlighter.staticMarkdownWithTags { id = "example-4b", highlightables = multipleHighlightsHighlightablesWithBorder }
+                  }
+                , { viewName = "staticMarkdown"
+                  , tool = "buildMarker"
+                  , highlightable = "fromMarkdown"
+                  , description = "Interpreting empty markdown anchor tags as highlights."
+                  , example =
+                        Highlighter.staticMarkdown
+                            { id = "example-5"
+                            , highlightables = Highlightable.fromMarkdown "Select your [favorite phrase]() in **your** writing."
+                            }
                   }
                 ]
             ]

--- a/src/Nri/Ui/Highlighter/V2.elm
+++ b/src/Nri/Ui/Highlighter/V2.elm
@@ -10,6 +10,7 @@ module Nri.Ui.Highlighter.V2 exposing
 
 {-| Changes from V1:
 
+  - When rendering with a markdown helper, spaces will now be preserved instead of being "eaten"
   - Remove emptyIntent, which is not used
   - adds setting for joining adjacent interactive highlights of the same type
 

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -311,9 +311,17 @@ testRendersMarkdownContent testName view =
                     |> ensureViewHasNot [ Selector.tag "a" ]
                     |> expectView
                         (Expect.all
-                            [ highlightable 0 [ Selector.text " prefer indirect " ]
+                            [ highlightable 0
+                                [ Selector.all
+                                    [ Selector.tag "em"
+                                    , Selector.containing [ Selector.text "Pothos" ]
+                                    ]
+                                , Selector.text " "
+                                , Selector.text "prefer indirect"
+                                , Selector.text " "
+                                ]
                             , highlightable 1 [ Selector.text "light" ]
-                            , highlightable 2 [ Selector.text " to direct light." ]
+                            , highlightable 2 [ Selector.text " ", Selector.text "to direct light." ]
                             , Query.has
                                 [ Selector.tag "em"
                                 , Selector.containing [ Selector.text "Pothos" ]

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -243,18 +243,6 @@ keyboardTests =
 
 markdownTests : List Test
 markdownTests =
-    let
-        start view =
-            startWithoutMarker view highlightables
-
-        highlightables =
-            Highlightable.initFragments Nothing
-                "*Pothos* indirect light"
-
-        testRendersRawContent testName view =
-            test (testName ++ " does not interpret content as markdown")
-                (\() -> expectViewHas [ Selector.text "*Pothos*" ] (start view))
-    in
     [ testRendersRawContent "view" Highlighter.view
     , testRendersMarkdownContent "viewMarkdown" Highlighter.viewMarkdown
     , testRendersRawContent "static" Highlighter.static
@@ -262,6 +250,16 @@ markdownTests =
     , testRendersRawContent "staticWithTags" Highlighter.staticWithTags
     , testRendersMarkdownContent "staticMarkdownWithTags" Highlighter.staticMarkdownWithTags
     ]
+
+
+testRendersRawContent : String -> (Highlighter.Model String -> Html msg) -> Test
+testRendersRawContent testName view =
+    test (testName ++ " does not interpret content as markdown")
+        (\() ->
+            Highlightable.initFragments Nothing "*Pothos* indirect light"
+                |> startWithoutMarker view
+                |> expectViewHas [ Selector.text "*Pothos*" ]
+        )
 
 
 testRendersMarkdownContent : String -> (Highlighter.Model String -> Html msg) -> Test

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -262,7 +262,7 @@ testRendersRawContent testName view =
                     |> expectView
                         (Expect.all
                             [ [ "*Pothos*", " ", "prefer", " ", "indirect", " ", "[light]()", " ", "to", " ", "direct", " ", "light." ]
-                                |> List.indexedMap (\i word -> highlightable i word)
+                                |> List.indexedMap (\i word -> highlightable i [ Selector.text word ])
                                 |> Expect.all
                             , Query.hasNot [ mark ]
                             ]
@@ -273,9 +273,9 @@ testRendersRawContent testName view =
                     |> startWithoutMarker view
                     |> expectView
                         (Expect.all
-                            [ [ "*Pothos* prefer indirect ", "light", " to direct light." ]
-                                |> List.indexedMap (\i word -> highlightable i word)
-                                |> Expect.all
+                            [ highlightable 0 [ Selector.text "*Pothos* prefer indirect " ]
+                            , highlightable 1 [ Selector.text "light" ]
+                            , highlightable 2 [ Selector.text " to direct light." ]
                             , Query.has [ mark, Selector.containing [ Selector.text "light" ] ]
                             ]
                         )
@@ -293,7 +293,7 @@ testRendersMarkdownContent testName view =
                     |> expectView
                         (Expect.all
                             [ [ "Pothos", " ", "prefer", " ", "indirect", " ", "light", " ", "to", " ", "direct", " ", "light." ]
-                                |> List.indexedMap (\i word -> highlightable i word)
+                                |> List.indexedMap (\i word -> highlightable i [ Selector.text word ])
                                 |> Expect.all
                             , Query.has
                                 [ Selector.tag "em"
@@ -311,9 +311,9 @@ testRendersMarkdownContent testName view =
                     |> ensureViewHasNot [ Selector.tag "a" ]
                     |> expectView
                         (Expect.all
-                            [ [ " prefer indirect ", "light", " to direct light." ]
-                                |> List.indexedMap (\i word -> highlightable i word)
-                                |> Expect.all
+                            [ highlightable 0 [ Selector.text " prefer indirect " ]
+                            , highlightable 1 [ Selector.text "light" ]
+                            , highlightable 2 [ Selector.text " to direct light." ]
                             , Query.has
                                 [ Selector.tag "em"
                                 , Selector.containing [ Selector.text "Pothos" ]
@@ -438,11 +438,11 @@ mark =
     Selector.tag "mark"
 
 
-highlightable : Int -> String -> Query.Single msg -> Expectation
-highlightable index string =
+highlightable : Int -> List Selector -> Query.Single msg -> Expectation
+highlightable index selector =
     Query.findAll [ Selector.class "highlighter-highlightable" ]
         >> Query.index index
-        >> Query.has [ Selector.text string ]
+        >> Query.has selector
 
 
 space : TestContext -> TestContext


### PR DESCRIPTION
## Context

While working on A11-1825, I noticed that when we switched to using the highlighter view, the whitespace around the mark element was lost. This is because Highlighter.staticMarkdown uses a markdown implementation that (reasonably) trims whitespace. However, we definitely want to keep all our whitespace within the context of a paragraph!

So this PR changes the highlighter implementation such that when we're rendering as markdown, we trim whitespace and then re-add it as to the rendered markdown as separate text nodes.

## :framed_picture: What does this change look like?

### Before

<img width="1197" alt="Screen Shot 2023-02-15 at 2 58 08 PM" src="https://user-images.githubusercontent.com/8811312/219185242-6acc1e7e-c303-4366-95c3-895fcaa632a8.png">


### After

<img width="1197" alt="Screen Shot 2023-02-15 at 2 58 23 PM" src="https://user-images.githubusercontent.com/8811312/219185258-99dd1062-7a1f-415e-889d-8ebc1459b1a9.png">


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the comopnent
