### PR TITLE
Select test setup

### DIFF
--- a/component-catalog-app/Examples/Select.elm
+++ b/component-catalog-app/Examples/Select.elm
@@ -18,7 +18,7 @@ import Example exposing (Example)
 import Html.Styled
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
-import Nri.Ui.Select.V9 as Select exposing (Choice)
+import Nri.Ui.Select.V9 as Select
 import Nri.Ui.Text.V6 as Text
 
 
@@ -363,16 +363,9 @@ weightLifterLabel =
     "81 kg 2020 Olympic Weightlifters"
 
 
-toOption : Choosable -> { label : String, value : Choosable }
+toOption : Choosable -> Select.Choice Choosable
 toOption c =
     { label = choosableToLabel c, value = c }
-
-
-grouped : List (Select.ChoicesGroup Choosable)
-grouped =
-    [ { label = texMexLabel, choices = List.map toOption allTexMex }
-    , { label = weightLifterLabel, choices = List.map toOption all81kg2020OlympicWeightlifters }
-    ]
 
 
 initChoices : Control ( String, Select.Attribute Choosable )
@@ -382,7 +375,7 @@ initChoices =
         toOptionString c =
             "{ value = " ++ choosableToCodeString c ++ ", label = \"" ++ choosableToLabel c ++ "\" } "
 
-        toChoice : List Choosable -> ( String, List { label : String, value : Choosable } )
+        toChoice : List Choosable -> ( String, List (Select.Choice Choosable) )
         toChoice choosables =
             ( """Select.choices
         choosableToLabel

--- a/component-catalog-app/Examples/Select.elm
+++ b/component-catalog-app/Examples/Select.elm
@@ -82,22 +82,33 @@ example =
                         ]
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
-            , Select.view label attributes
+            , Select.view label (Select.value state.selectedValue :: attributes)
                 |> Html.Styled.map ChangedTheSelectorValue
-            , Text.mediumBody
-                [ Text.plaintext <|
-                    """
-                    Note that if the value is bound (and why would you ever make a Select where it isn't?)
+            , Text.smallBody
+                [ """
+                    Note that if the value is bound (and why would you ever make a `Select` where it isn't?)
                     then changing the list of options will not change its value.
-                    Furthermore, Select will only fire an event when a new, non-default value is selected.
-                    The current value is
-                """
-                        ++ getABetterNameToString state.selectedValue
-                        ++ "."
-                        ++ """
-                   if you change the "choices" above to "Overflowing text choices" there is no way to change the current value
-                   to Zaphod (the value of the single option with a very long name).
-                """
+                    Furthermore, `Select` will only fire an event when a new value is selected.
+                    This means that if the starting value is `Nothing` and there is no `defaultDisplayText` 
+                    then you cannot select the first item in the list without first selecting another one.
+                    Use the "choices" selector above to get a feel for what that means.
+                """ |> String.lines
+                    |> List.map String.trim
+                    |> String.join " "
+                    |> Text.markdown
+                ]
+            , Text.smallBody
+                [ ("The current value is \""
+                    ++ (case state.selectedValue of
+                            Just tm ->
+                                "Just '" ++ choosableToString tm ++ "'"
+
+                            Nothing ->
+                                "`Nothing`"
+                       )
+                    ++ "\"."
+                  )
+                    |> Text.markdown
                 ]
             ]
     }
@@ -106,7 +117,7 @@ example =
 {-| -}
 type alias State =
     { control : Control Settings
-    , selectedValue : GetABetterName
+    , selectedValue : Maybe Choosable
     }
 
 
@@ -117,24 +128,24 @@ init =
         Control.record Settings
             |> Control.field "label" (Control.string "Tortilla Selector")
             |> Control.field "attributes" initControls
-    , selectedValue = TexMex Tacos
+    , selectedValue = Nothing
     }
 
 
 type alias Settings =
     { label : String
-    , attributes : List ( String, Select.Attribute GetABetterName )
+    , attributes : List ( String, Select.Attribute Choosable )
     }
 
 
-initControls : Control (List ( String, Select.Attribute GetABetterName ))
+initControls : Control (List ( String, Select.Attribute Choosable ))
 initControls =
     ControlExtra.list
         |> ControlExtra.listItem "choices"
             (Control.map
                 (\( code, choices ) ->
-                    ( "Select.choices getABetterNameToString" ++ code
-                    , Select.choices getABetterNameToString choices
+                    ( "Select.choices choosableToString" ++ code
+                    , Select.choices choosableToString choices
                     )
                 )
                 initChoices
@@ -188,69 +199,176 @@ initControls =
         |> CommonControls.icon moduleName Select.icon
 
 
-type TexMex
+type Choosable
     = Tacos
     | Burritos
     | Enchiladas
+    | NixtamalizedCorn
+    | LüXiaojun
+    | ZacaríasBonnat
+    | AntoninoPizzolato
+    | HarrisonMaurus
+    | TragicSingleton
 
 
-type Hitchhiker
-    = Zaphod
+allTexMex : List Choosable
+allTexMex =
+    let
+        help : List Choosable -> List Choosable
+        help list =
+            case list of
+                [] ->
+                    help [ Tacos ]
+
+                Tacos :: _ ->
+                    help <| Burritos :: list
+
+                Burritos :: _ ->
+                    help <| Enchiladas :: list
+
+                Enchiladas :: _ ->
+                    help <| NixtamalizedCorn :: list
+
+                NixtamalizedCorn :: _ ->
+                    List.reverse list
+
+                LüXiaojun :: _ ->
+                    list
+
+                ZacaríasBonnat :: _ ->
+                    list
+
+                AntoninoPizzolato :: _ ->
+                    list
+
+                HarrisonMaurus :: _ ->
+                    list
+
+                TragicSingleton :: _ ->
+                    list
+    in
+    help []
 
 
-type GetABetterName
-    = TexMex TexMex
-    | Hitchhiker Hitchhiker
+all81kg2020OlympicWeightlifters : List Choosable
+all81kg2020OlympicWeightlifters =
+    let
+        help : List Choosable -> List Choosable
+        help list =
+            case list of
+                [] ->
+                    help [ LüXiaojun ]
+
+                LüXiaojun :: _ ->
+                    help <| ZacaríasBonnat :: list
+
+                ZacaríasBonnat :: _ ->
+                    help <| AntoninoPizzolato :: list
+
+                AntoninoPizzolato :: _ ->
+                    help <| HarrisonMaurus :: list
+
+                HarrisonMaurus :: _ ->
+                    List.reverse list
+
+                Tacos :: _ ->
+                    list
+
+                Burritos :: _ ->
+                    list
+
+                Enchiladas :: _ ->
+                    list
+
+                NixtamalizedCorn :: _ ->
+                    list
+
+                TragicSingleton :: _ ->
+                    list
+    in
+    help []
 
 
-getABetterNameToString : GetABetterName -> String
-getABetterNameToString gabn =
-    case gabn of
-        TexMex Tacos ->
+choosableToString : Choosable -> String
+choosableToString tm =
+    case tm of
+        Tacos ->
             "Tacos"
 
-        TexMex Burritos ->
+        Burritos ->
             "Burritos"
 
-        TexMex Enchiladas ->
+        Enchiladas ->
             "Enchiladas"
 
-        Hitchhiker Zaphod ->
-            "Zaphod"
+        NixtamalizedCorn ->
+            """
+                The nixtamalization process was very important in the early Mesoamerican diet,
+                as most of the niacin content in unprocessed maize is bound to hemicellulose,
+                drastically reducing its bioavailability.
+                A population that depends on untreated maize as a staple food risks malnourishment
+                and is more likely to develop deficiency diseases such as pellagra, niacin deficiency,
+                or kwashiorkor, the absence of certain amino acids that maize is deficient in.
+                Maize cooked with lime or other alkali provided bioavailable niacin to Mesoamericans.
+                Beans provided the otherwise missing amino acids required to balance maize for complete protein.
+            """ |> String.trim |> String.lines |> List.map String.trim |> String.join " "
+
+        LüXiaojun ->
+            "Lü Xiaojun"
+
+        ZacaríasBonnat ->
+            "Zacarías Bonnat"
+
+        AntoninoPizzolato ->
+            "Antonino Pizzolato"
+
+        HarrisonMaurus ->
+            "Harrison Maurus"
+
+        TragicSingleton ->
+            "Tragic Singleton that cannot be selected"
 
 
-initChoices : Control ( String, List (Choice GetABetterName) )
+toOption : (a -> String) -> a -> { label : String, value : a }
+toOption toString a =
+    { label = toString a, value = a }
+
+
+toOptionString : (a -> String) -> a -> String
+toOptionString toString a =
+    let
+        str =
+            toString a
+    in
+    "{ label = \"" ++ str ++ "\", value = \"" ++ str ++ "\" } "
+
+
+initChoices : Control ( String, List (Choice Choosable) )
 initChoices =
-    Control.choice
-        [ ( "Short choices"
-          , ( """
-        [ { label = "Tacos", value = TexMex Tacos }
-        , { label = "Burritos", value = TexMex Burritos }
-        , { label = "Enchiladas", value = TexMex Enchiladas }
-        ]"""
-            , [ { label = "Tacos", value = TexMex Tacos }
-              , { label = "Burritos", value = TexMex Burritos }
-              , { label = "Enchiladas", value = TexMex Enchiladas }
-              ]
+    let
+        toChoice : List Choosable -> Control ( String, List { label : String, value : Choosable } )
+        toChoice choosables =
+            ( "[" ++ String.join ", " (List.map (toOptionString choosableToString) choosables) ++ "]"
+            , List.map (toOption choosableToString) choosables
             )
                 |> Control.value
-          )
-        , ( "Overflowing text choices"
-          , ( """
-        [ { label = "Look at me, I design coastlines, I got an award for Norway. Where's the sense in that? My mistress' eyes are nothing like the sun. Coral be far more red than her lips red.", value = Hitchhiker Zaphod }
-        ]"""
-            , [ { label = "Look at me, I design coastlines, I got an award for Norway. Where's the sense in that? My mistress' eyes are nothing like the sun. Coral be far more red than her lips red.", value = Hitchhiker Zaphod }
-              ]
-            )
-                |> Control.value
-          )
+
+        toValue : ( String, List Choosable ) -> ( String, Control ( String, List { label : String, value : Choosable } ) )
+        toValue =
+            Tuple.mapSecond toChoice
+    in
+    List.map toValue
+        [ ( "Tex-Mex", allTexMex )
+        , ( "81 Kg 2020 Olympic Weightlifters", all81kg2020OlympicWeightlifters )
+        , ( "Unselectable list with only one item", [ TragicSingleton ] )
         ]
+        |> Control.choice
 
 
 {-| -}
 type Msg
     = UpdateSettings (Control Settings)
-    | ChangedTheSelectorValue GetABetterName
+    | ChangedTheSelectorValue Choosable
 
 
 {-| -}
@@ -258,7 +376,7 @@ update : Msg -> State -> ( State, Cmd Msg )
 update msg state =
     case msg of
         ChangedTheSelectorValue newValue ->
-            ( { state | selectedValue = newValue }, Cmd.none )
+            ( { state | selectedValue = Just newValue }, Cmd.none )
 
         UpdateSettings settings ->
             ( { state | control = settings }, Cmd.none )

--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -1,4 +1,5 @@
 Nri.Ui.Block.V3,upgrade to V4
 Nri.Ui.QuestionBox.V2,upgrade to V3
 Nri.Ui.QuestionBox.V3,upgrade to V4
+Nri.Ui.Select.V8,upgrade to V9
 Nri.Ui.Tabs.V6,upgrade to V7

--- a/src/Nri/Ui/Select/V9.elm
+++ b/src/Nri/Ui/Select/V9.elm
@@ -392,7 +392,7 @@ viewSelect config_ config =
         valueLookup =
             optionStringChoices
                 ++ groupStringChoices
-                |> List.map (\x -> ( x.id, x.value ))
+                |> List.map (\x -> ( x.strValue, x.value ))
                 |> Dict.fromList
 
         decodeValue string =
@@ -535,7 +535,7 @@ viewChoice current choice =
 -}
 generateId : String -> String
 generateId x =
-    "nri-select-" ++ Nri.Ui.Util.dashify (Nri.Ui.Util.removePunctuation x)
+    "nri-select-" ++ String.toLower (Nri.Ui.Util.dashify (Nri.Ui.Util.removePunctuation x))
 
 
 selectArrowsCss : { config | disabled : Bool } -> Css.Style

--- a/src/Nri/Ui/Select/V9.elm
+++ b/src/Nri/Ui/Select/V9.elm
@@ -9,6 +9,7 @@ module Nri.Ui.Select.V9 exposing
     , custom, nriDescription, id, testId
     , icon
     , containerCss, noMargin
+    , batch
     )
 
 {-| Build a select input with a label, optional guidance, and error messaging.
@@ -43,6 +44,7 @@ module Nri.Ui.Select.V9 exposing
 @docs custom, nriDescription, id, testId
 @docs icon
 @docs containerCss, noMargin
+@docs batch
 
 -}
 
@@ -110,6 +112,13 @@ and the given error message will be shown.
 errorMessage : Maybe String -> Attribute value
 errorMessage =
     Attribute << InputErrorAndGuidanceInternal.setErrorMessage
+
+
+{-| Combine several attributes into one. A nice way to do nothing via batch []
+-}
+batch : List (Attribute value) -> Attribute value
+batch attrs =
+    List.foldl (\(Attribute update) composition -> composition >> update) identity attrs |> Attribute
 
 
 {-| A guidance message shows below the input, unless an error message is showing instead.

--- a/tests/Spec/Nri/Ui/Select.elm
+++ b/tests/Spec/Nri/Ui/Select.elm
@@ -15,9 +15,23 @@ spec =
             \() ->
                 start
                     -- first option is selected automatically
-                    |> ensureViewHas [ selected True, attribute (Attributes.value "Cat") ]
+                    |> ensureViewHas
+                        [ id "nri-select-cat"
+                        , selected True
+                        , attribute (Attributes.value "Cat")
+                        ]
                     |> selectAnimal Dog
-                    |> ensureViewHas [ selected True, attribute (Attributes.value "Dog") ]
+                    |> ensureViewHas
+                        [ id "nri-select-dog"
+                        , selected True
+                        , attribute (Attributes.value "Dog")
+                        ]
+                    |> selectAnimal Other
+                    |> ensureViewHas
+                        [ id "nri-select-my-favorite-animal-is-something-else"
+                        , selected True
+                        , attribute (Attributes.value "My favorite animal is something else")
+                        ]
                     |> done
         ]
 
@@ -30,7 +44,7 @@ start =
         , view =
             \model ->
                 Select.view "Favorite type of animal"
-                    [ Select.choices (toString >> String.toLower)
+                    [ Select.choices toString
                         (List.map
                             (\animal ->
                                 { label = toString animal
@@ -83,7 +97,7 @@ toString animal =
             "Pig"
 
         Other ->
-            "Other"
+            "My favorite animal is something else"
 
 
 type alias Model =

--- a/tests/Spec/Nri/Ui/Select.elm
+++ b/tests/Spec/Nri/Ui/Select.elm
@@ -1,0 +1,80 @@
+module Spec.Nri.Ui.Select exposing (spec)
+
+import Html.Styled
+import Nri.Ui.Select.V8 as Select
+import ProgramTest exposing (..)
+import Test exposing (..)
+
+
+spec : Test
+spec =
+    describe "Nri.Ui.Select.V9"
+        []
+
+
+program : ProgramTest Model Msg ()
+program =
+    ProgramTest.createSandbox
+        { init = { favoriteAnimal = Nothing }
+        , update = update
+        , view =
+            \model ->
+                Select.view "Favorite type of animal"
+                    [ Select.choices (toString >> String.toLower)
+                        (List.map
+                            (\animal ->
+                                { label = toString animal
+                                , value = animal
+                                }
+                            )
+                            allAnimals
+                        )
+                    , Select.value model.favoriteAnimal
+                    ]
+                    |> Html.Styled.map SelectFavorite
+                    |> Html.Styled.toUnstyled
+        }
+        |> ProgramTest.start ()
+
+
+allAnimals : List Animal
+allAnimals =
+    [ Cat, Dog, Pig, Other ]
+
+
+type Animal
+    = Cat
+    | Dog
+    | Pig
+    | Other
+
+
+toString : Animal -> String
+toString animal =
+    case animal of
+        Cat ->
+            "Cat"
+
+        Dog ->
+            "Dog"
+
+        Pig ->
+            "Pig"
+
+        Other ->
+            "Other"
+
+
+type alias Model =
+    { favoriteAnimal : Maybe Animal }
+
+
+type Msg
+    = SelectFavorite Animal
+
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        SelectFavorite animal ->
+            { model | favoriteAnimal = Just animal }

--- a/tests/Spec/Nri/Ui/Select.elm
+++ b/tests/Spec/Nri/Ui/Select.elm
@@ -11,9 +11,9 @@ import Test.Html.Selector exposing (..)
 spec : Test
 spec =
     describe "Nri.Ui.Select.V9"
-        [ test "allows selection" <|
+        [ test "allows selection when no grouping and default value" <|
             \() ->
-                start
+                ungrouped
                     -- first option is selected automatically
                     |> ensureViewHas
                         [ id "nri-select-cat"
@@ -33,11 +33,39 @@ spec =
                         , attribute (Attributes.value "My favorite animal is something else")
                         ]
                     |> done
+        , test "allows selection when grouping" <|
+            \() ->
+                grouped
+                    -- first option is selected automatically
+                    |> ensureViewHas
+                        [ id "nri-select-cat"
+                        , selected True
+                        , attribute (Attributes.value "Cat")
+                        ]
+                    |> selectAnimal Dog
+                    |> ensureViewHas
+                        [ id "nri-select-dog"
+                        , selected True
+                        , attribute (Attributes.value "Dog")
+                        ]
+                    |> selectAnimal Axolotl
+                    |> ensureViewHas
+                        [ id "nri-select-axolotl"
+                        , selected True
+                        , attribute (Attributes.value "Axolotl")
+                        ]
+                    |> selectAnimal Other
+                    |> ensureViewHas
+                        [ id "nri-select-my-favorite-animal-is-something-else"
+                        , selected True
+                        , attribute (Attributes.value "My favorite animal is something else")
+                        ]
+                    |> done
         ]
 
 
-start : ProgramTest Model Msg ()
-start =
+ungrouped : ProgramTest Model Msg ()
+ungrouped =
     ProgramTest.createSandbox
         { init = { favoriteAnimal = Nothing }
         , update = update
@@ -51,8 +79,37 @@ start =
                                 , value = animal
                                 }
                             )
-                            allAnimals
+                            (mammals ++ amphibians ++ [ Other ])
                         )
+                    , Select.value model.favoriteAnimal
+                    , Select.id selectId
+                    ]
+                    |> Html.Styled.map SelectFavorite
+                    |> Html.Styled.toUnstyled
+        }
+        |> ProgramTest.start ()
+
+
+grouped : ProgramTest Model Msg ()
+grouped =
+    let
+        toOption =
+            \animal ->
+                { label = toString animal
+                , value = animal
+                }
+    in
+    ProgramTest.createSandbox
+        { init = { favoriteAnimal = Nothing }
+        , update = update
+        , view =
+            \model ->
+                Select.view "Favorite type of animal even slimy ones"
+                    [ Select.choices toString [ toOption Other ]
+                    , Select.groupedChoices toString
+                        [ { label = "Mammals", choices = List.map toOption mammals }
+                        , { label = "Amphibians", choices = List.map toOption amphibians }
+                        ]
                     , Select.value model.favoriteAnimal
                     , Select.id selectId
                     ]
@@ -72,15 +129,23 @@ selectId =
     "favorite-animal-selector"
 
 
-allAnimals : List Animal
-allAnimals =
-    [ Cat, Dog, Pig, Other ]
+mammals : List Animal
+mammals =
+    [ Cat, Dog, Pig ]
+
+
+amphibians : List Animal
+amphibians =
+    [ Axolotl, Toad, Frog ]
 
 
 type Animal
     = Cat
     | Dog
     | Pig
+    | Axolotl
+    | Toad
+    | Frog
     | Other
 
 
@@ -95,6 +160,15 @@ toString animal =
 
         Pig ->
             "Pig"
+
+        Axolotl ->
+            "Axolotl"
+
+        Toad ->
+            "Toad"
+
+        Frog ->
+            "Frog"
 
         Other ->
             "My favorite animal is something else"

--- a/tests/Spec/Nri/Ui/Select.elm
+++ b/tests/Spec/Nri/Ui/Select.elm
@@ -1,19 +1,29 @@
 module Spec.Nri.Ui.Select exposing (spec)
 
+import Html.Attributes as Attributes
 import Html.Styled
-import Nri.Ui.Select.V8 as Select
+import Nri.Ui.Select.V9 as Select
 import ProgramTest exposing (..)
 import Test exposing (..)
+import Test.Html.Selector exposing (..)
 
 
 spec : Test
 spec =
     describe "Nri.Ui.Select.V9"
-        []
+        [ test "allows selection" <|
+            \() ->
+                start
+                    -- first option is selected automatically
+                    |> ensureViewHas [ selected True, attribute (Attributes.value "Cat") ]
+                    |> selectAnimal Dog
+                    |> ensureViewHas [ selected True, attribute (Attributes.value "Dog") ]
+                    |> done
+        ]
 
 
-program : ProgramTest Model Msg ()
-program =
+start : ProgramTest Model Msg ()
+start =
     ProgramTest.createSandbox
         { init = { favoriteAnimal = Nothing }
         , update = update
@@ -30,11 +40,22 @@ program =
                             allAnimals
                         )
                     , Select.value model.favoriteAnimal
+                    , Select.id selectId
                     ]
                     |> Html.Styled.map SelectFavorite
                     |> Html.Styled.toUnstyled
         }
         |> ProgramTest.start ()
+
+
+selectAnimal : Animal -> ProgramTest a b c -> ProgramTest a b c
+selectAnimal animal =
+    selectOption selectId "Favorite type of animal" (toString animal) (toString animal)
+
+
+selectId : String
+selectId =
+    "favorite-animal-selector"
 
 
 allAnimals : List Animal


### PR DESCRIPTION
Hey @caseyWebb ! I saw your PR (https://github.com/NoRedInk/noredink-ui/pull/1279) cause you tagged me, and I think there's an issue with the decoder lookup.

```
valueLookup =
            optionStringChoices
                ++ groupStringChoices
                |> List.map (\x -> ( x.id, x.value ))
                |> Dict.fromList

        decodeValue string =
            Dict.get string valueLookup
                |> Maybe.map Json.Decode.succeed
                |> Maybe.withDefault
                    -- At present, elm/virtual-dom throws this failure away.
                    (Json.Decode.fail
                        ("Nri.Select: could not decode the value: "
                            ++ string
                            ++ "\nexpected one of: "
                            ++ String.join ", " (Dict.keys valueLookup)
                        )
                    )

        onSelectHandler =
            Events.on "change" (Events.targetValue |> Json.Decode.andThen decodeValue)
```

I think we're using the look-up table as `Dict Id Value`, but the value that we decode is actually the event's target value, which I think is the `value`.

I wrote a test that hopefully explains what I'm seeing.