### PR TITLE
:wrench: supporting different width behaviors for breakpoints

### DIFF
--- a/component-catalog-app/Examples/Button.elm
+++ b/component-catalog-app/Examples/Button.elm
@@ -170,6 +170,15 @@ initDebugControls =
                         , ( "fillContainerWidth", Button.fillContainerWidth )
                         ]
                     )
+                |> ControlExtra.optionalListItem "mobile width"
+                    (CommonControls.choice moduleName
+                        [ ( "exactWidthForMobile 120", Button.exactWidthForMobile 120 )
+                        , ( "exactWidthForMobile 70", Button.exactWidthForMobile 70 )
+                        , ( "boundedWidthForMobile 100 180", Button.boundedWidthForMobile { min = 100, max = 180 } )
+                        , ( "unboundedWidthForMobile", Button.unboundedWidthForMobile )
+                        , ( "fillContainerWidthForMobile", Button.fillContainerWidthForMobile )
+                        ]
+                    )
                 |> ControlExtra.optionalBoolListItem "disabled" ( "disabled", Button.disabled )
                 |> ControlExtra.optionalListItem "state (button only)"
                     (CommonControls.choice moduleName

--- a/component-catalog-app/Examples/Button.elm
+++ b/component-catalog-app/Examples/Button.elm
@@ -17,9 +17,11 @@ import Debug.Control.View as ControlView
 import EllieLink
 import Example exposing (Example)
 import Html.Styled exposing (..)
-import Html.Styled.Attributes exposing (css)
+import Html.Styled.Attributes as Attributes exposing (css)
 import Nri.Ui.Button.V10 as Button
+import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Set exposing (Set)
 
@@ -237,6 +239,14 @@ viewButtonExamples ellieLinkConfig state =
                   }
                 ]
         }
+    , Heading.h2
+        [ Heading.plaintext "Interactive examples"
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+        ]
+    , Heading.h2
+        [ Heading.plaintext "Non-interactive examples"
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+        ]
     , buttons model
     , toggleButtons state.pressedToggleButtons
     , Button.link "linkExternalWithTracking"
@@ -255,57 +265,59 @@ buttons : Model -> Html Msg
 buttons model =
     let
         sizes =
-            [ ( Button.small, "small" )
-            , ( Button.medium, "medium" )
-            , ( Button.large, "large" )
+            [ ( Button.small, "Button.small" )
+            , ( Button.medium, "Button.medium" )
+            , ( Button.large, "Button.large" )
             ]
 
         styles =
-            [ ( Button.primary, "primary" )
-            , ( Button.secondary, "secondary" )
-            , ( Button.tertiary, "tertiary" )
-            , ( Button.danger, "danger" )
-            , ( Button.premium, "premium" )
+            [ ( Button.primary, "Button.primary" )
+            , ( Button.secondary, "Button.secondary" )
+            , ( Button.tertiary, "Button.tertiary" )
+            , ( Button.danger, "Button.danger" )
+            , ( Button.premium, "Button.premium" )
             ]
 
         exampleRow ( style, styleName ) =
-            List.concat
-                [ [ td
-                        [ css
-                            [ verticalAlign middle
-                            ]
-                        ]
-                        [ text styleName ]
-                  ]
-                , List.map (Tuple.first >> exampleCell style) sizes
-                ]
-                |> tr []
-
-        buttonOrLink =
-            case model.buttonType of
-                Link ->
-                    Button.link
-
-                Button ->
-                    Button.button
-
-        exampleCell setStyle setSize =
-            buttonOrLink model.label
-                (setSize :: setStyle :: List.map Tuple.second model.attributes)
-                |> List.singleton
-                |> td
-                    [ css
-                        [ verticalAlign middle
-                        , Css.width (Css.px 200)
-                        ]
+            [ tr []
+                (td
+                    [ css [ verticalAlign middle ]
+                    , Attributes.rowspan 2
                     ]
+                    [ code [] [ text styleName ] ]
+                    :: List.map (Tuple.first >> exampleCell Button.button style) sizes
+                    ++ [ td [ css [ verticalAlign middle ] ]
+                            [ code [] [ text "Button.button" ] ]
+                       ]
+                )
+            , tr []
+                (List.map (Tuple.first >> exampleCell Button.link style) sizes
+                    ++ [ td [ css [ verticalAlign middle ] ]
+                            [ code [] [ text "Button.link" ] ]
+                       ]
+                )
+            ]
+
+        exampleCell view setStyle setSize =
+            inCell <|
+                view model.label
+                    (setSize :: setStyle :: List.map Tuple.second model.attributes)
+
+        inCell content =
+            td
+                [ css
+                    [ verticalAlign middle
+                    , Css.width (Css.px 200)
+                    ]
+                ]
+                [ content ]
     in
     List.concat
         [ [ sizes
-                |> List.map (\( _, sizeName ) -> th [] [ text sizeName ])
+                |> List.map (\( _, sizeName ) -> th [] [ code [] [ text sizeName ] ])
                 |> (\cells -> tr [] (th [] [] :: cells))
           ]
-        , List.map exampleRow styles
+        , List.concatMap exampleRow styles
         ]
         |> table []
 
@@ -313,7 +325,10 @@ buttons model =
 toggleButtons : Set Int -> Html Msg
 toggleButtons pressedToggleButtons =
     div []
-        [ Heading.h3 [ Heading.plaintext "Button toggle" ]
+        [ Heading.h2
+            [ Heading.plaintext "Button toggle"
+            , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+            ]
         , div [ css [ Css.displayFlex, Css.marginBottom (Css.px 20) ] ]
             [ Button.toggleButton
                 { onDeselect = ToggleToggleButton 0

--- a/component-catalog-app/Examples/Button.elm
+++ b/component-catalog-app/Examples/Button.elm
@@ -272,8 +272,7 @@ viewButtonExamples ellieLinkConfig state =
                             ++ fName
                             ++ " "
                             ++ Code.string label
-                            ++ " "
-                            ++ Code.list (List.map Tuple.first attributes)
+                            ++ Code.listMultiline (List.map Tuple.first attributes) 1
                 in
                 [ { sectionName = "Button"
                   , code = toCode "button"

--- a/component-catalog-app/Examples/Button.elm
+++ b/component-catalog-app/Examples/Button.elm
@@ -188,6 +188,15 @@ initDebugControls =
                         , ( "fillContainerWidthForQuizEngineMobile", Button.fillContainerWidthForQuizEngineMobile )
                         ]
                     )
+                |> ControlExtra.optionalListItem "narrow mobile width"
+                    (CommonControls.choice moduleName
+                        [ ( "exactWidthForNarrowMobile 120", Button.exactWidthForNarrowMobile 120 )
+                        , ( "exactWidthForNarrowMobile 70", Button.exactWidthForNarrowMobile 70 )
+                        , ( "boundedWidthForNarrowMobile 100 180", Button.boundedWidthForNarrowMobile { min = 100, max = 180 } )
+                        , ( "unboundedWidthForNarrowMobile", Button.unboundedWidthForNarrowMobile )
+                        , ( "fillContainerWidthForNarrowMobile", Button.fillContainerWidthForNarrowMobile )
+                        ]
+                    )
                 |> ControlExtra.optionalBoolListItem "disabled" ( "disabled", Button.disabled )
                 |> ControlExtra.optionalListItem "state (button only)"
                     (CommonControls.choice moduleName

--- a/component-catalog-app/Examples/Button.elm
+++ b/component-catalog-app/Examples/Button.elm
@@ -247,7 +247,7 @@ viewButtonExamples ellieLinkConfig state =
         [ Heading.plaintext "Non-interactive examples"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
-    , buttons model
+    , buttonsTable
     , toggleButtons state.pressedToggleButtons
     , Button.link "linkExternalWithTracking"
         [ Button.unboundedWidth
@@ -261,65 +261,77 @@ viewButtonExamples ellieLinkConfig state =
         |> div []
 
 
-buttons : Model -> Html Msg
-buttons model =
+buttonsTable : Html msg
+buttonsTable =
     let
         sizes =
-            [ ( Button.small, "Button.small" )
-            , ( Button.medium, "Button.medium" )
-            , ( Button.large, "Button.large" )
+            [ ( Button.small, "small" )
+            , ( Button.medium, "medium" )
+            , ( Button.large, "large" )
             ]
 
         styles =
-            [ ( Button.primary, "Button.primary" )
-            , ( Button.secondary, "Button.secondary" )
-            , ( Button.tertiary, "Button.tertiary" )
-            , ( Button.danger, "Button.danger" )
-            , ( Button.premium, "Button.premium" )
+            [ ( Button.primary, "primary" )
+            , ( Button.secondary, "secondary" )
+            , ( Button.tertiary, "tertiary" )
+            , ( Button.danger, "danger" )
+            , ( Button.premium, "premium" )
             ]
 
-        exampleRow ( style, styleName ) =
+        exampleRow styleTuple =
             [ tr []
                 (td
-                    [ css [ verticalAlign middle ]
+                    [ css [ verticalAlign middle, Css.borderTop3 (Css.px 1) Css.solid Colors.gray85 ]
                     , Attributes.rowspan 2
                     ]
-                    [ code [] [ text styleName ] ]
-                    :: List.map (Tuple.first >> exampleCell Button.button style) sizes
-                    ++ [ td [ css [ verticalAlign middle ] ]
+                    [ code [] [ text (Code.fromModule moduleName (Tuple.second styleTuple)) ] ]
+                    :: List.map
+                        (exampleCell
+                            [ Css.borderTop3 (Css.px 1) Css.solid Colors.gray85
+                            , Css.paddingBottom Css.zero |> Css.important
+                            ]
+                            ( Button.button, "button" )
+                            styleTuple
+                        )
+                        sizes
+                    ++ [ td [ css [ verticalAlign middle, Css.borderTop3 (Css.px 1) Css.solid Colors.gray85 ] ]
                             [ code [] [ text "Button.button" ] ]
                        ]
                 )
             , tr []
-                (List.map (Tuple.first >> exampleCell Button.link style) sizes
+                (List.map (exampleCell [] ( Button.link, "link" ) styleTuple) sizes
                     ++ [ td [ css [ verticalAlign middle ] ]
                             [ code [] [ text "Button.link" ] ]
                        ]
                 )
             ]
 
-        exampleCell view setStyle setSize =
-            inCell <|
-                view model.label
-                    (setSize :: setStyle :: List.map Tuple.second model.attributes)
+        exampleCell cellStyle ( view, viewName ) ( style, styleName ) ( setSize, sizeName ) =
+            inCell cellStyle <| view (sizeName ++ " " ++ styleName ++ " " ++ viewName) [ setSize, style ]
 
-        inCell content =
+        inCell style content =
             td
                 [ css
                     [ verticalAlign middle
-                    , Css.width (Css.px 200)
+                    , Css.batch style
+                    , Css.padding (Css.px 10)
                     ]
                 ]
                 [ content ]
     in
     List.concat
         [ [ sizes
-                |> List.map (\( _, sizeName ) -> th [] [ code [] [ text sizeName ] ])
+                |> List.map
+                    (\( _, sizeName ) ->
+                        th [ css [ Css.padding2 (Css.px 25) Css.zero ] ]
+                            [ code [] [ text (Code.fromModule moduleName sizeName) ]
+                            ]
+                    )
                 |> (\cells -> tr [] (th [] [] :: cells))
           ]
         , List.concatMap exampleRow styles
         ]
-        |> table []
+        |> table [ css [ Css.borderCollapse Css.collapse ] ]
 
 
 toggleButtons : Set Int -> Html Msg

--- a/component-catalog-app/Examples/Button.elm
+++ b/component-catalog-app/Examples/Button.elm
@@ -179,6 +179,15 @@ initDebugControls =
                         , ( "fillContainerWidthForMobile", Button.fillContainerWidthForMobile )
                         ]
                     )
+                |> ControlExtra.optionalListItem "quiz engine mobile width"
+                    (CommonControls.choice moduleName
+                        [ ( "exactWidthForQuizEngineMobile 120", Button.exactWidthForQuizEngineMobile 120 )
+                        , ( "exactWidthForQuizEngineMobile 70", Button.exactWidthForQuizEngineMobile 70 )
+                        , ( "boundedWidthForQuizEngineMobile 100 180", Button.boundedWidthForQuizEngineMobile { min = 100, max = 180 } )
+                        , ( "unboundedWidthForQuizEngineMobile", Button.unboundedWidthForQuizEngineMobile )
+                        , ( "fillContainerWidthForQuizEngineMobile", Button.fillContainerWidthForQuizEngineMobile )
+                        ]
+                    )
                 |> ControlExtra.optionalBoolListItem "disabled" ( "disabled", Button.disabled )
                 |> ControlExtra.optionalListItem "state (button only)"
                     (CommonControls.choice moduleName

--- a/component-catalog-app/Examples/Button.elm
+++ b/component-catalog-app/Examples/Button.elm
@@ -240,9 +240,10 @@ viewButtonExamples ellieLinkConfig state =
                 ]
         }
     , Heading.h2
-        [ Heading.plaintext "Interactive examples"
-        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+        [ Heading.plaintext "Interactive example"
+        , Heading.css [ Css.margin2 Spacing.verticalSpacerPx Css.zero ]
         ]
+    , viewCustomizableExample model
     , Heading.h2
         [ Heading.plaintext "Non-interactive examples"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
@@ -259,6 +260,21 @@ viewButtonExamples ellieLinkConfig state =
         ]
     ]
         |> div []
+
+
+viewCustomizableExample : Model -> Html Msg
+viewCustomizableExample model =
+    let
+        buttonOrLink =
+            case model.buttonType of
+                Link ->
+                    Button.link
+
+                Button ->
+                    Button.button
+    in
+    buttonOrLink model.label
+        (List.map Tuple.second model.attributes)
 
 
 buttonsTable : Html msg

--- a/component-catalog-app/Examples/Button.elm
+++ b/component-catalog-app/Examples/Button.elm
@@ -161,6 +161,14 @@ initDebugControls =
             (ControlExtra.list
                 |> CommonControls.icon moduleName Button.icon
                 |> CommonControls.rightIcon moduleName Button.rightIcon
+                |> ControlExtra.optionalListItem "size"
+                    (CommonControls.choice moduleName
+                        [ ( "small", Button.small )
+                        , ( "medium", Button.medium )
+                        , ( "large", Button.large )
+                        , ( "modal", Button.modal )
+                        ]
+                    )
                 |> ControlExtra.optionalListItem "width"
                     (CommonControls.choice moduleName
                         [ ( "exactWidth 120", Button.exactWidth 120 )
@@ -195,6 +203,15 @@ initDebugControls =
                         , ( "boundedWidthForNarrowMobile 100 180", Button.boundedWidthForNarrowMobile { min = 100, max = 180 } )
                         , ( "unboundedWidthForNarrowMobile", Button.unboundedWidthForNarrowMobile )
                         , ( "fillContainerWidthForNarrowMobile", Button.fillContainerWidthForNarrowMobile )
+                        ]
+                    )
+                |> ControlExtra.optionalListItem "theme"
+                    (CommonControls.choice moduleName
+                        [ ( "primary", Button.primary )
+                        , ( "secondary", Button.secondary )
+                        , ( "tertiary", Button.tertiary )
+                        , ( "danger", Button.danger )
+                        , ( "premium", Button.premium )
                         ]
                     )
                 |> ControlExtra.optionalBoolListItem "disabled" ( "disabled", Button.disabled )

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -6,6 +6,7 @@ module Nri.Ui.Button.V10 exposing
     , small, medium, large, modal
     , exactWidth, boundedWidth, unboundedWidth, fillContainerWidth
     , exactWidthForMobile, boundedWidthForMobile, unboundedWidthForMobile, fillContainerWidthForMobile
+    , exactWidthForQuizEngineMobile, boundedWidthForQuizEngineMobile, unboundedWidthForQuizEngineMobile, fillContainerWidthForQuizEngineMobile
     , primary, secondary, tertiary, danger, premium
     , enabled, unfulfilled, disabled, error, loading, success
     , icon, rightIcon
@@ -58,6 +59,7 @@ adding a span around the text could potentially lead to regressions.
 @docs small, medium, large, modal
 @docs exactWidth, boundedWidth, unboundedWidth, fillContainerWidth
 @docs exactWidthForMobile, boundedWidthForMobile, unboundedWidthForMobile, fillContainerWidthForMobile
+@docs exactWidthForQuizEngineMobile, boundedWidthForQuizEngineMobile, unboundedWidthForQuizEngineMobile, fillContainerWidthForQuizEngineMobile
 
 
 ## Change the color scheme
@@ -462,6 +464,40 @@ fillContainerWidthForMobile =
     setMobileWidth WidthFillContainer
 
 
+setQuizEngineMobileWidth : ButtonWidth -> Attribute msg
+setQuizEngineMobileWidth w =
+    set (\attributes -> { attributes | quizEngineMobileWidth = Just w })
+
+
+{-| For the quiz engine mobile breakpoint, define a size in `px` for the button's total width.
+-}
+exactWidthForQuizEngineMobile : Int -> Attribute msg
+exactWidthForQuizEngineMobile inPx =
+    setQuizEngineMobileWidth (WidthExact inPx)
+
+
+{-| For the quiz engine mobile breakpoint, Leave the maxiumum width unbounded (there is a minimum width).
+-}
+unboundedWidthForQuizEngineMobile : Attribute msg
+unboundedWidthForQuizEngineMobile =
+    setQuizEngineMobileWidth WidthUnbounded
+
+
+{-| For the quiz engine mobile breakpoint, make a button that is at least `min` large, and which will grow with
+its content up to `max`. Both bounds are inclusive (`min <= actual value <=
+max`.)
+-}
+boundedWidthForQuizEngineMobile : { min : Int, max : Int } -> Attribute msg
+boundedWidthForQuizEngineMobile bounds =
+    setQuizEngineMobileWidth (WidthBounded bounds)
+
+
+{-| -}
+fillContainerWidthForQuizEngineMobile : Attribute msg
+fillContainerWidthForQuizEngineMobile =
+    setQuizEngineMobileWidth WidthFillContainer
+
+
 
 -- COLOR SCHEMES
 
@@ -623,6 +659,7 @@ build =
         , style = primaryColors
         , width = WidthUnbounded
         , mobileWidth = Nothing
+        , quizEngineMobileWidth = Nothing
         , label = ""
         , state = Enabled
         , icon = Nothing
@@ -643,6 +680,7 @@ type alias ButtonOrLinkAttributes msg =
     , style : ColorPalette
     , width : ButtonWidth
     , mobileWidth : Maybe ButtonWidth
+    , quizEngineMobileWidth : Maybe ButtonWidth
     , label : String
     , state : ButtonState
     , icon : Maybe Svg

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -27,6 +27,7 @@ adding a span around the text could potentially lead to regressions.
 
 # Patch changes:
 
+  - adds width helpers for Mobile breakpoint, Quiz Engine breakpoint, and Narrow Mobile breakpoint
   - uses ClickableAttributes
   - adds `nriDescription`, `testId`, and `id` helpers
   - adds `modal` helper, an alias for `large` size

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -5,6 +5,7 @@ module Nri.Ui.Button.V10 exposing
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
     , small, medium, large, modal
     , exactWidth, boundedWidth, unboundedWidth, fillContainerWidth
+    , exactWidthForMobile, boundedWidthForMobile, unboundedWidthForMobile, fillContainerWidthForMobile
     , primary, secondary, tertiary, danger, premium
     , enabled, unfulfilled, disabled, error, loading, success
     , icon, rightIcon
@@ -56,6 +57,7 @@ adding a span around the text could potentially lead to regressions.
 
 @docs small, medium, large, modal
 @docs exactWidth, boundedWidth, unboundedWidth, fillContainerWidth
+@docs exactWidthForMobile, boundedWidthForMobile, unboundedWidthForMobile, fillContainerWidthForMobile
 
 
 ## Change the color scheme
@@ -392,18 +394,23 @@ type ButtonSize
     | Large
 
 
+setWidth : ButtonWidth -> Attribute msg
+setWidth w =
+    set (\attributes -> { attributes | width = w })
+
+
 {-| Define a size in `px` for the button's total width.
 -}
 exactWidth : Int -> Attribute msg
 exactWidth inPx =
-    set (\attributes -> { attributes | width = WidthExact inPx })
+    setWidth (WidthExact inPx)
 
 
 {-| Leave the maxiumum width unbounded (there is a minimum width).
 -}
 unboundedWidth : Attribute msg
 unboundedWidth =
-    set (\attributes -> { attributes | width = WidthUnbounded })
+    setWidth WidthUnbounded
 
 
 {-| Make a button that is at least `min` large, and which will grow with
@@ -412,13 +419,47 @@ max`.)
 -}
 boundedWidth : { min : Int, max : Int } -> Attribute msg
 boundedWidth bounds =
-    set (\attributes -> { attributes | width = WidthBounded bounds })
+    setWidth (WidthBounded bounds)
 
 
 {-| -}
 fillContainerWidth : Attribute msg
 fillContainerWidth =
-    set (\attributes -> { attributes | width = WidthFillContainer })
+    setWidth WidthFillContainer
+
+
+setMobileWidth : ButtonWidth -> Attribute msg
+setMobileWidth w =
+    set (\attributes -> { attributes | mobileWidth = Just w })
+
+
+{-| For the mobile breakpoint, define a size in `px` for the button's total width.
+-}
+exactWidthForMobile : Int -> Attribute msg
+exactWidthForMobile inPx =
+    setMobileWidth (WidthExact inPx)
+
+
+{-| For the mobile breakpoint, Leave the maxiumum width unbounded (there is a minimum width).
+-}
+unboundedWidthForMobile : Attribute msg
+unboundedWidthForMobile =
+    setMobileWidth WidthUnbounded
+
+
+{-| For the mobile breakpoint, make a button that is at least `min` large, and which will grow with
+its content up to `max`. Both bounds are inclusive (`min <= actual value <=
+max`.)
+-}
+boundedWidthForMobile : { min : Int, max : Int } -> Attribute msg
+boundedWidthForMobile bounds =
+    setMobileWidth (WidthBounded bounds)
+
+
+{-| -}
+fillContainerWidthForMobile : Attribute msg
+fillContainerWidthForMobile =
+    setMobileWidth WidthFillContainer
 
 
 
@@ -581,6 +622,7 @@ build =
         , size = Medium
         , style = primaryColors
         , width = WidthUnbounded
+        , mobileWidth = Nothing
         , label = ""
         , state = Enabled
         , icon = Nothing
@@ -600,6 +642,7 @@ type alias ButtonOrLinkAttributes msg =
     , size : ButtonSize
     , style : ColorPalette
     , width : ButtonWidth
+    , mobileWidth : Maybe ButtonWidth
     , label : String
     , state : ButtonState
     , icon : Maybe Svg

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -7,6 +7,7 @@ module Nri.Ui.Button.V10 exposing
     , exactWidth, boundedWidth, unboundedWidth, fillContainerWidth
     , exactWidthForMobile, boundedWidthForMobile, unboundedWidthForMobile, fillContainerWidthForMobile
     , exactWidthForQuizEngineMobile, boundedWidthForQuizEngineMobile, unboundedWidthForQuizEngineMobile, fillContainerWidthForQuizEngineMobile
+    , exactWidthForNarrowMobile, boundedWidthForNarrowMobile, unboundedWidthForNarrowMobile, fillContainerWidthForNarrowMobile
     , primary, secondary, tertiary, danger, premium
     , enabled, unfulfilled, disabled, error, loading, success
     , icon, rightIcon
@@ -60,6 +61,7 @@ adding a span around the text could potentially lead to regressions.
 @docs exactWidth, boundedWidth, unboundedWidth, fillContainerWidth
 @docs exactWidthForMobile, boundedWidthForMobile, unboundedWidthForMobile, fillContainerWidthForMobile
 @docs exactWidthForQuizEngineMobile, boundedWidthForQuizEngineMobile, unboundedWidthForQuizEngineMobile, fillContainerWidthForQuizEngineMobile
+@docs exactWidthForNarrowMobile, boundedWidthForNarrowMobile, unboundedWidthForNarrowMobile, fillContainerWidthForNarrowMobile
 
 
 ## Change the color scheme
@@ -498,6 +500,40 @@ fillContainerWidthForQuizEngineMobile =
     setQuizEngineMobileWidth WidthFillContainer
 
 
+setNarrowMobileWidth : ButtonWidth -> Attribute msg
+setNarrowMobileWidth w =
+    set (\attributes -> { attributes | narrowMobileWidth = Just w })
+
+
+{-| For the quiz engine mobile breakpoint, define a size in `px` for the button's total width.
+-}
+exactWidthForNarrowMobile : Int -> Attribute msg
+exactWidthForNarrowMobile inPx =
+    setNarrowMobileWidth (WidthExact inPx)
+
+
+{-| For the quiz engine mobile breakpoint, Leave the maxiumum width unbounded (there is a minimum width).
+-}
+unboundedWidthForNarrowMobile : Attribute msg
+unboundedWidthForNarrowMobile =
+    setNarrowMobileWidth WidthUnbounded
+
+
+{-| For the quiz engine mobile breakpoint, make a button that is at least `min` large, and which will grow with
+its content up to `max`. Both bounds are inclusive (`min <= actual value <=
+max`.)
+-}
+boundedWidthForNarrowMobile : { min : Int, max : Int } -> Attribute msg
+boundedWidthForNarrowMobile bounds =
+    setNarrowMobileWidth (WidthBounded bounds)
+
+
+{-| -}
+fillContainerWidthForNarrowMobile : Attribute msg
+fillContainerWidthForNarrowMobile =
+    setNarrowMobileWidth WidthFillContainer
+
+
 
 -- COLOR SCHEMES
 
@@ -660,6 +696,7 @@ build =
         , width = WidthUnbounded
         , mobileWidth = Nothing
         , quizEngineMobileWidth = Nothing
+        , narrowMobileWidth = Nothing
         , label = ""
         , state = Enabled
         , icon = Nothing
@@ -681,6 +718,7 @@ type alias ButtonOrLinkAttributes msg =
     , width : ButtonWidth
     , mobileWidth : Maybe ButtonWidth
     , quizEngineMobileWidth : Maybe ButtonWidth
+    , narrowMobileWidth : Maybe ButtonWidth
     , label : String
     , state : ButtonState
     , icon : Maybe Svg

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -1219,35 +1219,6 @@ sizeStyle { size, width } =
             , Css.paddingBottom (Css.px verticalPaddingPx)
             ]
 
-        widthAttributes =
-            case width of
-                WidthExact pxWidth ->
-                    [ Css.maxWidth (Css.pct 100)
-                    , Css.width (Css.px <| toFloat pxWidth)
-                    , Css.paddingRight (Css.px 4)
-                    , Css.paddingLeft (Css.px 4)
-                    ]
-
-                WidthUnbounded ->
-                    [ Css.paddingLeft (Css.px 16)
-                    , Css.paddingRight (Css.px 16)
-                    , Css.minWidth (Css.px config.minWidth)
-                    ]
-
-                WidthFillContainer ->
-                    [ Css.paddingLeft (Css.px 16)
-                    , Css.paddingRight (Css.px 16)
-                    , Css.minWidth (Css.px config.minWidth)
-                    , Css.width (Css.pct 100)
-                    ]
-
-                WidthBounded { min, max } ->
-                    [ Css.maxWidth (Css.px (toFloat max))
-                    , Css.minWidth (Css.px (toFloat min))
-                    , Css.paddingRight (Css.px 16)
-                    , Css.paddingLeft (Css.px 16)
-                    ]
-
         lineHeightPx =
             case size of
                 Small ->
@@ -1267,5 +1238,36 @@ sizeStyle { size, width } =
         , Css.borderWidth (Css.px 1)
         , Css.borderBottomWidth (Css.px config.shadowHeight)
         , Css.batch sizingAttributes
-        , Css.batch widthAttributes
+        , Css.batch (buttonWidthToStyle width config)
         ]
+
+
+buttonWidthToStyle : ButtonWidth -> { a | minWidth : Float } -> List Style
+buttonWidthToStyle width config =
+    case width of
+        WidthExact pxWidth ->
+            [ Css.maxWidth (Css.pct 100)
+            , Css.width (Css.px <| toFloat pxWidth)
+            , Css.paddingRight (Css.px 4)
+            , Css.paddingLeft (Css.px 4)
+            ]
+
+        WidthUnbounded ->
+            [ Css.paddingLeft (Css.px 16)
+            , Css.paddingRight (Css.px 16)
+            , Css.minWidth (Css.px config.minWidth)
+            ]
+
+        WidthFillContainer ->
+            [ Css.paddingLeft (Css.px 16)
+            , Css.paddingRight (Css.px 16)
+            , Css.minWidth (Css.px config.minWidth)
+            , Css.width (Css.pct 100)
+            ]
+
+        WidthBounded { min, max } ->
+            [ Css.maxWidth (Css.px (toFloat max))
+            , Css.minWidth (Css.px (toFloat min))
+            , Css.paddingRight (Css.px 16)
+            , Css.paddingLeft (Css.px 16)
+            ]

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -867,6 +867,9 @@ toggleButton config =
         [ buttonStyles
             { size = Medium
             , width = WidthUnbounded
+            , mobileWidth = Nothing
+            , quizEngineMobileWidth = Nothing
+            , narrowMobileWidth = Nothing
             , style = secondaryColors
             , state = Enabled
             , customStyles = [ Css.hover [ Css.color Colors.navy ] ]
@@ -907,14 +910,17 @@ buttonStyles :
         | size : ButtonSize
         , style : ColorPalette
         , width : ButtonWidth
+        , mobileWidth : Maybe ButtonWidth
+        , quizEngineMobileWidth : Maybe ButtonWidth
+        , narrowMobileWidth : Maybe ButtonWidth
         , state : ButtonState
         , customStyles : List Style
     }
     -> Style
-buttonStyles { size, width, style, state, customStyles } =
+buttonStyles ({ style, state, customStyles } as config) =
     Css.batch
         [ buttonStyle
-        , sizeStyle size width
+        , sizeStyle config
         , colorStyle style state
         , Css.batch customStyles
         ]
@@ -1189,8 +1195,16 @@ sizeConfig size =
             }
 
 
-sizeStyle : ButtonSize -> ButtonWidth -> Style
-sizeStyle size width =
+sizeStyle :
+    { config
+        | size : ButtonSize
+        , width : ButtonWidth
+        , mobileWidth : Maybe ButtonWidth
+        , quizEngineMobileWidth : Maybe ButtonWidth
+        , narrowMobileWidth : Maybe ButtonWidth
+    }
+    -> Style
+sizeStyle { size, width } =
     let
         config =
             sizeConfig size


### PR DESCRIPTION
Fixes A11-2309

## Context

The goal is to be able to specify how the Menu trigger width should behave at different breakpoints, so that we don't have nice-looking desktop views and janky-looking mobile views. See https://github.com/NoRedInk/noredink-ui/issues/1265 for some example screenshots.

Since Menu now integrates directly with Button and the other clickables, I'm addressing this need by adding per-viewport width support to Button. 

I don't think we'll want clickable texts to expand to take up tons of horizontal space, so I'm not making changes the ClickableText component.

I also think the width behavior of clickable svgs is a _bit_ less complicated? And it makes sense to let the user use mobileCss directly. Example of doing this is here: https://github.com/NoRedInk/NoRedInk/pull/42777.

Additionally, I wanted the width behavior to be easy to test and observe, so I split out an interactive example from the Button table, and made the Button table entirely non-interactive.

## :framed_picture: What does this change look like?

### Width behavior by breakpoint demo

https://user-images.githubusercontent.com/8811312/220441598-81b384b2-7534-412e-bc84-3f9512d822fe.mov

### Examples Table Before

<img width="695" alt="image" src="https://user-images.githubusercontent.com/8811312/220441948-9b591b3b-dcd5-43b3-a178-392b7ff26626.png">

### Examples Table After

<img width="1014" alt="image" src="https://user-images.githubusercontent.com/8811312/220441892-f936153f-c597-4da4-aed1-147feb250a70.png">

cc @NoRedInk/design 

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the comopnent
