### PR TITLE
Support icon in Select

### DIFF
--- a/component-catalog-app/Examples/Select.elm
+++ b/component-catalog-app/Examples/Select.elm
@@ -164,6 +164,7 @@ initControls =
             (Control.value ( "Select.disabled", Select.disabled ))
         |> ControlExtra.optionalListItem "loading"
             (Control.value ( "Select.loading", Select.loading ))
+        |> CommonControls.icon moduleName Select.icon
 
 
 initChoices : Control ( String, List (Choice String) )

--- a/component-catalog-app/Examples/Select.elm
+++ b/component-catalog-app/Examples/Select.elm
@@ -28,7 +28,7 @@ moduleName =
 
 version : Int
 version =
-    8
+    9
 
 
 {-| -}

--- a/src/Nri/Ui/Select/V9.elm
+++ b/src/Nri/Ui/Select/V9.elm
@@ -61,6 +61,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.CssVendorPrefix.V1 as VendorPrefixed
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
+import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.InputStyles.V4 as InputStyles
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Util
@@ -316,6 +317,7 @@ view label attributes =
             , disabled = disabled_
             }
             config
+         , viewJust viewIcon config.icon
          , InputLabelInternal.view
             { for = id_
             , label = label
@@ -325,6 +327,19 @@ view label attributes =
          ]
             ++ InputErrorAndGuidanceInternal.view id_ InputErrorAndGuidanceInternal.smallMargin config
         )
+
+
+viewIcon : Svg.Svg -> Html a
+viewIcon =
+    Svg.withWidth (Css.px 15)
+        >> Svg.withHeight (Css.px 15)
+        >> Svg.withCss
+            [ Css.position Css.absolute
+            , Css.top (Css.px 23)
+            , Css.left (Css.px 15)
+            , Css.pointerEvents Css.none
+            ]
+        >> Svg.toHtml
 
 
 viewSelect : { id : String, disabled : Bool } -> Config a -> Html a
@@ -449,7 +464,12 @@ viewSelect config_ config =
             -- Size and spacing
             , Css.height (Css.px 45)
             , Css.width (Css.pct 100)
-            , Css.paddingLeft (Css.px 15)
+            , case config.icon of
+                Just _ ->
+                    Css.paddingLeft (Css.px 36)
+
+                Nothing ->
+                    Css.paddingLeft (Css.px 15)
             , Css.paddingRight (Css.px 30)
 
             -- Icons

--- a/src/Nri/Ui/Select/V9.elm
+++ b/src/Nri/Ui/Select/V9.elm
@@ -308,6 +308,7 @@ view label attributes =
 
                else
                 Css.paddingTop (Css.px InputStyles.defaultMarginTop)
+             , Css.color Colors.gray20
              ]
                 ++ config.containerCss
             )
@@ -464,8 +465,7 @@ viewSelect config_ config =
                 , Css.borderRadius (Css.px 8) |> Css.important
                 ]
 
-            -- Font and color
-            , Css.color Colors.gray20
+            -- Font and text
             , Fonts.baseFont
             , Css.fontSize (Css.px 15)
             , Css.fontWeight (Css.int 600)

--- a/src/Nri/Ui/Select/V9.elm
+++ b/src/Nri/Ui/Select/V9.elm
@@ -329,25 +329,36 @@ view label attributes =
         )
 
 
-viewIcon : { config | noMarginTop : Bool } -> Svg.Svg -> Html a
+viewIcon : { config | noMarginTop : Bool, disabled : Bool } -> Svg.Svg -> Html a
 viewIcon config =
+    let
+        topPx =
+            15
+                + (if config.noMarginTop then
+                    0
+
+                   else
+                    InputStyles.defaultMarginTop
+                  )
+                + (if config.disabled then
+                    1
+
+                   else
+                    0
+                  )
+    in
     Svg.withWidth (Css.px 15)
         >> Svg.withHeight (Css.px 15)
         >> Svg.withCss
             [ Css.position Css.absolute
-            , Css.top
-                (Css.px
-                    (15
-                        + (if config.noMarginTop then
-                            0
-
-                           else
-                            InputStyles.defaultMarginTop
-                          )
-                    )
-                )
+            , Css.top (Css.px topPx)
             , Css.left (Css.px 15)
             , Css.pointerEvents Css.none
+            , if config.disabled then
+                Css.color Colors.gray45
+
+              else
+                Css.batch []
             ]
         >> Svg.toHtml
 

--- a/src/Nri/Ui/Select/V9.elm
+++ b/src/Nri/Ui/Select/V9.elm
@@ -317,7 +317,7 @@ view label attributes =
             , disabled = disabled_
             }
             config
-         , viewJust viewIcon config.icon
+         , viewJust (viewIcon config) config.icon
          , InputLabelInternal.view
             { for = id_
             , label = label
@@ -329,13 +329,23 @@ view label attributes =
         )
 
 
-viewIcon : Svg.Svg -> Html a
-viewIcon =
+viewIcon : { config | noMarginTop : Bool } -> Svg.Svg -> Html a
+viewIcon config =
     Svg.withWidth (Css.px 15)
         >> Svg.withHeight (Css.px 15)
         >> Svg.withCss
             [ Css.position Css.absolute
-            , Css.top (Css.px 23)
+            , Css.top
+                (Css.px
+                    (15
+                        + (if config.noMarginTop then
+                            0
+
+                           else
+                            InputStyles.defaultMarginTop
+                          )
+                    )
+                )
             , Css.left (Css.px 15)
             , Css.pointerEvents Css.none
             ]

--- a/src/Nri/Ui/Select/V9.elm
+++ b/src/Nri/Ui/Select/V9.elm
@@ -167,7 +167,8 @@ testId id_ =
     custom [ Extra.testId id_ ]
 
 
-{-| -}
+{-| Add an SVG icon that will render on top of the select by way of absolute positioning.
+-}
 icon : Svg -> Attribute msg
 icon icon_ =
     Attribute <| \attributes -> { attributes | icon = Just icon_ }

--- a/src/Nri/Ui/Select/V9.elm
+++ b/src/Nri/Ui/Select/V9.elm
@@ -7,6 +7,7 @@ module Nri.Ui.Select.V9 exposing
     , hiddenLabel, visibleLabel
     , disabled, loading, errorIf, errorMessage, guidance
     , custom, nriDescription, id, testId
+    , icon
     , containerCss, noMargin
     )
 
@@ -18,6 +19,7 @@ module Nri.Ui.Select.V9 exposing
     - The option `value` attribute is no longer prefixed with `nri-select-`;
       This is not a breaking change to the API, but affects automated tests
       that are looking for this prefix.
+    - adds `icon` support
 
 @docs view, generateId
 
@@ -39,6 +41,7 @@ module Nri.Ui.Select.V9 exposing
 @docs hiddenLabel, visibleLabel
 @docs disabled, loading, errorIf, errorMessage, guidance
 @docs custom, nriDescription, id, testId
+@docs icon
 @docs containerCss, noMargin
 
 -}
@@ -59,6 +62,7 @@ import Nri.Ui.CssVendorPrefix.V1 as VendorPrefixed
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.InputStyles.V4 as InputStyles
+import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Util
 import SolidColor
 
@@ -162,6 +166,12 @@ testId id_ =
     custom [ Extra.testId id_ ]
 
 
+{-| -}
+icon : Svg -> Attribute msg
+icon icon_ =
+    Attribute <| \attributes -> { attributes | icon = Just icon_ }
+
+
 {-| Adds CSS to the element containing the input.
 -}
 containerCss : List Css.Style -> Attribute value
@@ -240,6 +250,7 @@ type alias Config value =
     , loading : Bool
     , guidance : Guidance
     , hideLabel : Bool
+    , icon : Maybe Svg
     , noMarginTop : Bool
     , containerCss : List Css.Style
     , custom : List (Html.Attribute Never)
@@ -259,6 +270,7 @@ defaultConfig =
     , loading = False
     , guidance = InputErrorAndGuidanceInternal.noGuidance
     , hideLabel = False
+    , icon = Nothing
     , noMarginTop = False
     , containerCss = []
     , custom = []

--- a/src/Nri/Ui/Select/V9.elm
+++ b/src/Nri/Ui/Select/V9.elm
@@ -360,7 +360,7 @@ viewIcon config =
                 Css.color Colors.gray45
 
               else
-                Css.batch []
+                Css.color Colors.azure
             ]
         >> Svg.toHtml
 


### PR DESCRIPTION
## Context

Fixes A11-2310
Fixes https://github.com/NoRedInk/noredink-ui/issues/1264

## :framed_picture: What does this change look like?

<img width="324" alt="Screen Shot 2023-02-22 at 2 55 31 PM" src="https://user-images.githubusercontent.com/8811312/220768592-27b2df4d-1d53-492f-bce6-eb498d159ab5.png">

<img width="317" alt="Screen Shot 2023-02-22 at 2 55 02 PM" src="https://user-images.githubusercontent.com/8811312/220768598-6c5e9942-b711-42af-9583-d89579048128.png">

<img width="315" alt="Screen Shot 2023-02-22 at 2 55 13 PM" src="https://user-images.githubusercontent.com/8811312/220768595-2b1fec6e-785d-421b-bc01-94ddecdbd794.png">

cc @NoRedInk/design 

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the comopnent
