### PR TITLE
:wrench: Add missing aria-current=page attribute

### DIFF
--- a/src/Nri/Ui/SideNav/V4.elm
+++ b/src/Nri/Ui/SideNav/V4.elm
@@ -246,7 +246,12 @@ view config navAttributes entries =
     div [ Attributes.css (defaultCss ++ appliedNavAttributes.css) ]
         [ viewSkipLink config.onSkipNav
         , viewJust (viewOpenCloseButton sidenavId appliedNavAttributes.navLabel) appliedNavAttributes.collapsible
-        , viewNav sidenavId config appliedNavAttributes entries showNav
+        , case entries of
+            [] ->
+                text ""
+
+            _ ->
+                viewNav sidenavId config appliedNavAttributes entries showNav
         ]
 
 

--- a/src/Nri/Ui/SideNav/V4.elm
+++ b/src/Nri/Ui/SideNav/V4.elm
@@ -66,7 +66,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Data.PremiumDisplay as PremiumDisplay exposing (PremiumDisplay)
 import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Fonts.V1 as Fonts
-import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
+import Nri.Ui.Html.Attributes.V2 as AttributesExtra
 import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
@@ -417,12 +417,15 @@ viewSidebarLeaf config extraStyles entryConfig =
                 , isDisabled = False
                 }
                 entryConfig.clickableAttributes
+
+        isCurrent =
+            isCurrentRoute config entryConfig
     in
     Nri.Ui.styled Html.Styled.a
         ("Nri-Ui-SideNav-" ++ linkFunctionName)
         (sharedEntryStyles
             ++ extraStyles
-            ++ (if isCurrentRoute config entryConfig then
+            ++ (if isCurrent then
                     [ backgroundColor Colors.glacier
                     , color Colors.navy
                     , fontWeight bold
@@ -435,6 +438,7 @@ viewSidebarLeaf config extraStyles entryConfig =
             ++ entryConfig.customStyles
         )
         (Attributes.class FocusRing.customClass
+            :: AttributesExtra.includeIf isCurrent Aria.currentPage
             :: attributes
             ++ entryConfig.customAttributes
         )
@@ -590,13 +594,13 @@ custom attributes =
 {-| -}
 nriDescription : String -> Attribute route msg
 nriDescription description =
-    custom [ ExtraAttributes.nriDescription description ]
+    custom [ AttributesExtra.nriDescription description ]
 
 
 {-| -}
 testId : String -> Attribute route msg
 testId id_ =
-    custom [ ExtraAttributes.testId id_ ]
+    custom [ AttributesExtra.testId id_ ]
 
 
 {-| -}

--- a/src/Nri/Ui/SideNav/V4.elm
+++ b/src/Nri/Ui/SideNav/V4.elm
@@ -15,7 +15,13 @@ module Nri.Ui.SideNav.V4 exposing
 {-|
 
 
-# Changes from V3
+### Patch changes
+
+  - add missing aria-current=page attribute
+  - don't render an empty nav when there are no entries
+
+
+### Changes from V3
 
   - make the nav configurably collapsible
 

--- a/tests/Spec/Nri/Ui/SideNav.elm
+++ b/tests/Spec/Nri/Ui/SideNav.elm
@@ -1,7 +1,7 @@
 module Spec.Nri.Ui.SideNav exposing (spec)
 
 import Accessibility.Aria as Aria
-import Expect
+import Expect exposing (Expectation)
 import Html.Attributes as Attributes
 import Html.Styled exposing (toUnstyled)
 import Nri.Ui.SideNav.V4 as SideNav exposing (Entry, NavAttribute)
@@ -38,14 +38,14 @@ currentPageTests =
         \() ->
             [ SideNav.entry "Cactus" [ SideNav.href "cactus" ] ]
                 |> viewQuery { currentRoute = "cactus" } []
-                |> Query.has [ currentPage "Cactus" "cactus" ]
+                |> expectCurrentPage "Cactus" "cactus"
     , test "with multiple entries, one of which is current" <|
         \() ->
             [ SideNav.entry "Cactus" [ SideNav.href "cactus" ]
             , SideNav.entry "Epiphyllum" [ SideNav.href "epiphyllum" ]
             ]
                 |> viewQuery { currentRoute = "cactus" } []
-                |> Query.has [ currentPage "Cactus" "cactus" ]
+                |> expectCurrentPage "Cactus" "cactus"
     , test "with a currently-selected entry with children" <|
         \() ->
             [ SideNav.entryWithChildren "Cactus"
@@ -53,7 +53,7 @@ currentPageTests =
                 [ SideNav.entry "Epiphyllum" [ SideNav.href "epiphyllum" ] ]
             ]
                 |> viewQuery { currentRoute = "cactus" } []
-                |> Query.has [ currentPage "Cactus" "cactus" ]
+                |> expectCurrentPage "Cactus" "cactus"
     , test "with a currently-selected child entry" <|
         \() ->
             [ SideNav.entryWithChildren "Cactus"
@@ -61,8 +61,17 @@ currentPageTests =
                 [ SideNav.entry "Epiphyllum" [ SideNav.href "epiphyllum" ] ]
             ]
                 |> viewQuery { currentRoute = "epiphyllum" } []
-                |> Query.has [ currentPage "Epiphyllum" "epiphyllum" ]
+                |> expectCurrentPage "Epiphyllum" "epiphyllum"
     ]
+
+
+expectCurrentPage : String -> String -> Query.Single msg -> Expectation
+expectCurrentPage name href_ =
+    Expect.all
+        [ Query.findAll [ attribute Aria.currentPage ]
+            >> Query.count (Expect.equal 1)
+        , Query.has [ currentPage name href_ ]
+        ]
 
 
 currentPage : String -> String -> Selector

--- a/tests/Spec/Nri/Ui/SideNav.elm
+++ b/tests/Spec/Nri/Ui/SideNav.elm
@@ -1,0 +1,36 @@
+module Spec.Nri.Ui.SideNav exposing (spec)
+
+import Expect
+import Html.Styled exposing (toUnstyled)
+import Nri.Ui.SideNav.V4 as SideNav exposing (Entry, NavAttribute)
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (..)
+
+
+spec : Test
+spec =
+    describe "SideNav"
+        [ test "without entries" <|
+            \() ->
+                { currentRoute = "some-route" }
+                    |> viewQuery [] []
+                    |> Query.hasNot [ tag "nav" ]
+        ]
+
+
+viewQuery :
+    List (NavAttribute ())
+    -> List (Entry String ())
+    -> { currentRoute : String }
+    -> Query.Single ()
+viewQuery navAttributes entries { currentRoute } =
+    SideNav.view
+        { isCurrentRoute = (==) currentRoute
+        , routeToString = identity
+        , onSkipNav = ()
+        }
+        navAttributes
+        entries
+        |> toUnstyled
+        |> Query.fromHtml


### PR DESCRIPTION
## Context

Fixes A11-2336

## :framed_picture: What does this change look like?

<img width="1029" alt="Screen Shot 2023-02-24 at 3 36 12 PM" src="https://user-images.githubusercontent.com/8811312/221309547-4f0fe137-64fe-4fd4-b225-2737d972ba89.png">
<img width="1013" alt="Screen Shot 2023-02-24 at 3 38 47 PM" src="https://user-images.githubusercontent.com/8811312/221309560-2f18c631-ab81-453b-908b-2d5eb426e882.png">

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the comopnent
