### PR TITLE
:wrench: Fix Switch cursor

### DIFF
--- a/src/Nri/Ui/Switch/V2.elm
+++ b/src/Nri/Ui/Switch/V2.elm
@@ -9,7 +9,12 @@ module Nri.Ui.Switch.V2 exposing
 {-|
 
 
-# Changes from V1:
+### Patch Changes:
+
+    - Fix cursor styles when hovering over the transparent checkbox
+
+
+### Changes from V1:
 
     - Fixes invalid ARIA use, [conformance requirements](https://www.w3.org/TR/html-aria/#docconformance)
     - labels should only support strings (this is the only way they're actually used in practice)

--- a/src/Nri/Ui/Switch/V2.elm
+++ b/src/Nri/Ui/Switch/V2.elm
@@ -149,9 +149,6 @@ view { label, id } attrs =
     let
         config =
             List.foldl (\(Attribute update) -> update) defaultConfig attrs
-
-        notOperable =
-            config.onSwitch == Nothing || config.isDisabled
     in
     Html.label
         ([ Attributes.id (id ++ "-container")
@@ -167,30 +164,19 @@ view { label, id } attrs =
                         ]
                     ]
                 ]
-            , Css.cursor
-                (if notOperable then
-                    Css.notAllowed
-
-                 else
-                    Css.pointer
-                )
+            , cursorStyle config
             , Css.batch config.containerCss
             ]
          , Attributes.for id
          ]
             ++ List.map (Attributes.map never) config.custom
         )
-        [ viewCheckbox
-            { id = id
-            , onCheck = config.onSwitch
-            , isDisabled = config.isDisabled
-            , selected = config.isSelected
-            }
+        [ viewCheckbox id config
         , Nri.Ui.Svg.V1.toHtml
             (viewSwitch
                 { id = id
                 , isSelected = config.isSelected
-                , isDisabled = notOperable
+                , isDisabled = notOperable config
                 }
             )
         , Html.span
@@ -212,32 +198,42 @@ view { label, id } attrs =
         ]
 
 
-viewCheckbox :
-    { id : String
-    , onCheck : Maybe (Bool -> msg)
-    , selected : Bool
-    , isDisabled : Bool
-    }
-    -> Html msg
-viewCheckbox config =
-    Html.checkbox config.id
-        (Just config.selected)
-        [ Attributes.id config.id
+viewCheckbox : String -> Config msg -> Html msg
+viewCheckbox id config =
+    Html.checkbox id
+        (Just config.isSelected)
+        [ Attributes.id id
         , Role.switch
         , Attributes.css
             [ Css.position Css.absolute
             , Css.top (Css.px 10)
             , Css.left (Css.px 10)
-            , Css.zIndex (Css.int 0)
             , Css.opacity (Css.num 0)
+            , cursorStyle config
             ]
-        , case ( config.onCheck, config.isDisabled ) of
-            ( Just onCheck, False ) ->
-                Events.onCheck onCheck
+        , case ( config.onSwitch, config.isDisabled ) of
+            ( Just onSwitch_, False ) ->
+                Events.onCheck onSwitch_
 
             _ ->
                 Aria.disabled True
         ]
+
+
+notOperable : Config msg -> Bool
+notOperable config =
+    config.onSwitch == Nothing || config.isDisabled
+
+
+cursorStyle : Config msg -> Style
+cursorStyle config =
+    Css.cursor
+        (if notOperable config then
+            Css.notAllowed
+
+         else
+            Css.pointer
+        )
 
 
 viewSwitch :


### PR DESCRIPTION
## Context

Fixes A11-2354

- when cursor is disabled, everywhere you hover on the switch will use cursor not-allowed
- when cursor is enabled, everywhere you hover on the switch will use cursor pointer

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the comopnent
