### PR TITLE
:wrench: Fix long-text handling in radio button

### DIFF
--- a/component-catalog-app/Examples/RadioButton.elm
+++ b/component-catalog-app/Examples/RadioButton.elm
@@ -123,8 +123,8 @@ view ellieLinkConfig state =
             , "toString : Animals -> String"
             , "toString animals ="
                 ++ Code.caseExpression "animals"
-                    [ ( "Dogs", Code.string "Dogs" )
-                    , ( "Cats", Code.string "Cats" )
+                    [ ( "Dogs", Code.string selectionSettings.dogsLabel )
+                    , ( "Cats", Code.string selectionSettings.catsLabel )
                     ]
                     1
             ]
@@ -166,11 +166,11 @@ viewExamplesCode selectionSettings selectedValue =
         toExampleCode ( kind, settings ) =
             Code.fromModule "RadioButton" "view"
                 ++ Code.recordMultiline
-                    [ ( "label", (selectionToString >> Code.string) kind )
+                    [ ( "label", (selectionToString selectionSettings >> Code.string) kind )
                     , ( "name", Code.string "pets" )
-                    , ( "value", selectionToString kind )
+                    , ( "value", selectionToString selectionSettings kind )
                     , ( "selectedValue"
-                      , Code.maybe (Maybe.map selectionToString selectedValue)
+                      , Code.maybe (Maybe.map (selectionToString selectionSettings) selectedValue)
                       )
                     , ( "valueToString", "toString" )
                     ]
@@ -185,11 +185,11 @@ viewExamples selectionSettings selectedValue =
     let
         viewExample_ ( kind, settings ) =
             RadioButton.view
-                { label = selectionToString kind
+                { label = selectionToString selectionSettings kind
                 , name = "pets"
                 , value = kind
                 , selectedValue = selectedValue
-                , valueToString = selectionToString
+                , valueToString = selectionToString selectionSettings
                 }
                 (RadioButton.onSelect Select :: List.map Tuple.second settings)
     in
@@ -211,14 +211,14 @@ type Selection
     | Cats
 
 
-selectionToString : Selection -> String
-selectionToString selection =
+selectionToString : SelectionSettings -> Selection -> String
+selectionToString { dogsLabel, catsLabel } selection =
     case selection of
         Dogs ->
-            "Dogs"
+            dogsLabel
 
         Cats ->
-            "Cats"
+            catsLabel
 
 
 {-| -}
@@ -239,7 +239,9 @@ init =
 
 
 type alias SelectionSettings =
-    { dogs : List ( String, RadioButton.Attribute Selection Msg )
+    { dogsLabel : String
+    , dogs : List ( String, RadioButton.Attribute Selection Msg )
+    , catsLabel : String
     , cats : List ( String, RadioButton.Attribute Selection Msg )
     }
 
@@ -247,7 +249,9 @@ type alias SelectionSettings =
 initSelectionSettings : Control SelectionSettings
 initSelectionSettings =
     Control.record SelectionSettings
+        |> Control.field "Dogs label" (Control.string "Dogs")
         |> Control.field "Dogs" controlAttributes
+        |> Control.field "Cats label" (Control.string "Cats")
         |> Control.field "Cats" controlAttributes
 
 

--- a/component-catalog-app/Examples/RadioButton.elm
+++ b/component-catalog-app/Examples/RadioButton.elm
@@ -271,7 +271,13 @@ controlAttributes =
             )
         |> ControlExtra.optionalListItem "containerCss"
             (Control.choice
-                [ ( "100% width"
+                [ ( "max-width with border"
+                  , Control.value
+                        ( "RadioButton.containerCss [ Css.maxWidth (Css.px 200), Css.border3 (Css.px 1) Css.solid Colors.red ]"
+                        , RadioButton.containerCss [ Css.maxWidth (Css.px 200), Css.border3 (Css.px 1) Css.solid Colors.red ]
+                        )
+                  )
+                , ( "100% width"
                   , Control.value
                         ( "RadioButton.containerCss [ Css.width (Css.pct 100) ]"
                         , RadioButton.containerCss [ Css.width (Css.pct 100) ]

--- a/component-catalog-app/Examples/RadioButton.elm
+++ b/component-catalog-app/Examples/RadioButton.elm
@@ -117,8 +117,17 @@ view ellieLinkConfig state =
         , version = version
         , update = SetSelectionSettings
         , settings = state.selectionSettings
-        , mainType = Just "Html msg"
-        , extraCode = []
+        , mainType = Nothing
+        , extraCode =
+            [ "type Animals = Dogs | Cats\n"
+            , "toString : Animals -> String"
+            , "toString animals ="
+                ++ Code.caseExpression "animals"
+                    [ ( "Dogs", Code.string "Dogs" )
+                    , ( "Cats", Code.string "Cats" )
+                    ]
+                    1
+            ]
         , renderExample = Code.unstyledView
         , toExampleCode =
             \_ ->
@@ -154,26 +163,21 @@ view ellieLinkConfig state =
 viewExamplesCode : SelectionSettings -> Maybe Selection -> String
 viewExamplesCode selectionSettings selectedValue =
     let
-        selectedValueString =
-            case selectedValue of
-                Just value ->
-                    "Just " ++ selectionToString value
-
-                Nothing ->
-                    "Nothing"
-
         toExampleCode ( kind, settings ) =
-            "RadioButton.view"
-                ++ ("\n\t{ label = " ++ selectionToString kind)
-                ++ "\n\t, name = \"pets\""
-                ++ ("\n\t, value = " ++ selectionToString kind)
-                ++ ("\n\t, selectedValue = " ++ selectedValueString)
-                ++ "\n\t, valueToString = toString"
-                ++ "\n\t}\n\t[ "
-                ++ String.join "\n\t, " (List.map Tuple.first settings)
-                ++ "\n\t] "
+            Code.fromModule "RadioButton" "view"
+                ++ Code.recordMultiline
+                    [ ( "label", (selectionToString >> Code.string) kind )
+                    , ( "name", Code.string "pets" )
+                    , ( "value", selectionToString kind )
+                    , ( "selectedValue"
+                      , Code.maybe (Maybe.map selectionToString selectedValue)
+                      )
+                    , ( "valueToString", "toString" )
+                    ]
+                    2
+                ++ Code.listMultiline (List.map Tuple.first settings) 2
     in
-    "  " ++ String.join "\n, " (List.map toExampleCode (examples selectionSettings))
+    "div []" ++ Code.listMultiline (List.map toExampleCode (examples selectionSettings)) 1
 
 
 viewExamples : SelectionSettings -> Maybe Selection -> Html Msg

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -386,6 +386,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
                         [ display inlineFlex
                         , alignItems center
                         , Css.minHeight (px 20)
+                        , Css.property "word-break" "break-word"
                         ]
                     ]
                     [ Html.span

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -9,7 +9,16 @@ module Nri.Ui.RadioButton.V4 exposing
     , disabled, enabled, errorIf, errorMessage, guidance
     )
 
-{-| Changes from V3:
+{-|
+
+
+### Patch changes:
+
+  - replace `height` use with `minHeight` to prevent vertical text overflow issues
+  - use `break-word` to prevent horiztonal text overflow issues
+
+
+### Changes from V3:
 
   - use PremiumDisplay instead of PremiumLevel
   - rename showPennant to onLockedClick since its display depends on premium now

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -385,7 +385,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
                     [ css
                         [ display inlineFlex
                         , alignItems center
-                        , Css.height (px 20)
+                        , Css.minHeight (px 20)
                         ]
                     ]
                     [ Html.span


### PR DESCRIPTION
## Context

Fixes A11-2126
Fixes A11-2125

## :framed_picture: What does this change look like?

| | Before | After |
| --- | --- | --- |
| vertical overflow | <img width="322" alt="Screen Shot 2023-02-27 at 12 19 00 PM" src="https://user-images.githubusercontent.com/8811312/221663284-c2df9167-b4ae-4db1-9f42-fe907081eb10.png">  |  <img width="305" alt="Screen Shot 2023-02-27 at 12 19 22 PM" src="https://user-images.githubusercontent.com/8811312/221663290-f21bd54a-784f-4d74-a136-669ae0cb2811.png"> |
| horizontal overflow |  <img width="429" alt="Screen Shot 2023-02-27 at 12 23 55 PM" src="https://user-images.githubusercontent.com/8811312/221663289-3716c59d-aa63-4ed2-be39-e8ce1ac18b89.png"> | <img width="307" alt="Screen Shot 2023-02-27 at 12 26 25 PM" src="https://user-images.githubusercontent.com/8811312/221663285-04d5de69-53d3-4c0a-9af8-6c9597dda200.png"> |

cc @NoRedInk/design 

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the comopnent
