### PR TITLE
Adds panel heading preview

### DIFF
--- a/component-catalog-app/Examples/Panel.elm
+++ b/component-catalog-app/Examples/Panel.elm
@@ -14,7 +14,10 @@ import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
+import Html.Styled exposing (..)
+import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Panel.V1 as Panel
 
@@ -39,7 +42,30 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview =
+        [ div
+            [ css
+                [ Css.backgroundColor Colors.navy
+                , Css.borderTopLeftRadius (Css.px 8)
+                , Css.borderTopRightRadius (Css.px 8)
+                , Css.width (Css.pct 100)
+                , Css.minHeight (Css.px 20)
+                , Css.fontSize (Css.px 12)
+                , Css.color Colors.white
+                , Fonts.baseFont
+                , Css.padding2 (Css.px 2) (Css.px 8)
+                ]
+            ]
+            [ text "Panel name" ]
+        , div
+            [ css
+                [ Css.backgroundColor Colors.white
+                , Css.width (Css.pct 100)
+                , Css.minHeight (Css.px 50)
+                ]
+            ]
+            []
+        ]
     , view =
         \ellieLinkConfig state ->
             let

--- a/component-catalog-app/Examples/Panel.elm
+++ b/component-catalog-app/Examples/Panel.elm
@@ -43,28 +43,8 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , preview =
-        [ div
-            [ css
-                [ Css.backgroundColor Colors.navy
-                , Css.borderTopLeftRadius (Css.px 8)
-                , Css.borderTopRightRadius (Css.px 8)
-                , Css.width (Css.pct 100)
-                , Css.minHeight (Css.px 20)
-                , Css.fontSize (Css.px 12)
-                , Css.color Colors.white
-                , Fonts.baseFont
-                , Css.padding2 (Css.px 2) (Css.px 8)
-                ]
-            ]
-            [ text "Panel name" ]
-        , div
-            [ css
-                [ Css.backgroundColor Colors.white
-                , Css.width (Css.pct 100)
-                , Css.minHeight (Css.px 50)
-                ]
-            ]
-            []
+        [ panelPreview Colors.navy
+        , panelPreview Colors.gray45
         ]
     , view =
         \ellieLinkConfig state ->
@@ -97,6 +77,34 @@ example =
             , Panel.view attributes
             ]
     }
+
+
+panelPreview : Css.Color -> Html msg
+panelPreview headingColor =
+    div [ css [ Css.marginTop (Css.px 16), Css.firstChild [ Css.marginTop Css.zero ] ] ]
+        [ div
+            [ css
+                [ Css.backgroundColor headingColor
+                , Css.borderTopLeftRadius (Css.px 8)
+                , Css.borderTopRightRadius (Css.px 8)
+                , Css.width (Css.pct 100)
+                , Css.minHeight (Css.px 20)
+                , Css.fontSize (Css.px 12)
+                , Css.color Colors.white
+                , Fonts.baseFont
+                , Css.padding2 (Css.px 2) (Css.px 8)
+                ]
+            ]
+            [ text "Panel name" ]
+        , div
+            [ css
+                [ Css.backgroundColor Colors.white
+                , Css.width (Css.pct 100)
+                , Css.minHeight (Css.px 30)
+                ]
+            ]
+            []
+        ]
 
 
 {-| -}


### PR DESCRIPTION
Adds a Panel preview:

<img width="213" alt="Screen Shot 2023-02-27 at 2 30 10 PM" src="https://user-images.githubusercontent.com/8811312/221690056-0dcb1f79-c9cb-42bb-a374-c30dc0a723f9.png">

cc @NoRedInk/design 