### PR TITLE
Adjust question box style to conform the design

### DIFF
--- a/src/Nri/Ui/QuestionBox/V4.elm
+++ b/src/Nri/Ui/QuestionBox/V4.elm
@@ -188,7 +188,7 @@ viewStandalone : Config msg -> Html msg
 viewStandalone config =
     div
         [ AttributesExtra.maybe Attributes.id config.id
-        , css (config.containerCss ++ [ Css.fontSize (Css.px 18) ])
+        , css config.containerCss
         , nriDescription "standalone-balloon-container"
         ]
         [ viewBalloon config
@@ -293,10 +293,10 @@ viewPointingTo config blockId measurements =
             , css
                 (case measurements of
                     Just { questionBox } ->
-                        [ Css.height (Css.px (questionBox.element.height + 8)), Css.fontSize (Css.px 18) ]
+                        [ Css.height (Css.px (questionBox.element.height + 8)) ]
 
                     Nothing ->
-                        [ Css.fontSize (Css.px 18) ]
+                        []
                 )
             ]
 
@@ -317,7 +317,7 @@ viewBalloon config referencingId attributes =
                 ]
             )
          , Balloon.customTheme { backgroundColor = Colors.glacier, color = Colors.glacier }
-         , Balloon.css [ Css.padding (Css.px 0), Css.boxShadow Css.none ]
+         , Balloon.css [ Css.padding (Css.px 0), Css.boxShadow Css.none, Css.fontSize (Css.px 18) ]
          ]
             ++ attributes
         )
@@ -368,6 +368,7 @@ viewSpeechBubble config referencingId extraAttributes =
             , Css.padding (Css.px 20)
             , Css.boxShadow Css.none
             , Css.Global.children [ Css.Global.p [ Css.margin Css.zero ] ]
+            , Css.fontSize (Css.px 18)
             ]
          , Balloon.custom
             [ AttributesExtra.maybe (guidanceId >> Attributes.id) config.id

--- a/src/Nri/Ui/QuestionBox/V4.elm
+++ b/src/Nri/Ui/QuestionBox/V4.elm
@@ -317,7 +317,7 @@ viewBalloon config referencingId attributes =
                 ]
             )
          , Balloon.customTheme { backgroundColor = Colors.glacier, color = Colors.glacier }
-         , Balloon.css [ Css.padding (Css.px 0), Css.boxShadow Css.none, Css.fontSize (Css.px 18) ]
+         , Balloon.css [ Css.padding (Css.px 0), Css.boxShadow Css.none ]
          ]
             ++ attributes
         )

--- a/src/Nri/Ui/QuestionBox/V4.elm
+++ b/src/Nri/Ui/QuestionBox/V4.elm
@@ -188,7 +188,7 @@ viewStandalone : Config msg -> Html msg
 viewStandalone config =
     div
         [ AttributesExtra.maybe Attributes.id config.id
-        , css config.containerCss
+        , css (config.containerCss ++ [ Css.fontSize (Css.px 18) ])
         , nriDescription "standalone-balloon-container"
         ]
         [ viewBalloon config
@@ -293,10 +293,10 @@ viewPointingTo config blockId measurements =
             , css
                 (case measurements of
                     Just { questionBox } ->
-                        [ Css.height (Css.px (questionBox.element.height + 8)) ]
+                        [ Css.height (Css.px (questionBox.element.height + 8)), Css.fontSize (Css.px 18) ]
 
                     Nothing ->
-                        []
+                        [ Css.fontSize (Css.px 18) ]
                 )
             ]
 
@@ -364,8 +364,8 @@ viewSpeechBubble config referencingId extraAttributes =
         ([ Balloon.nriDescription "guidance-speech-bubble"
          , Balloon.white
          , Balloon.css
-            [ Css.borderRadius (Css.px 16)
-            , Css.padding (Css.px 10)
+            [ Css.borderRadius (Css.px 20)
+            , Css.padding (Css.px 20)
             , Css.boxShadow Css.none
             , Css.Global.children [ Css.Global.p [ Css.margin Css.zero ] ]
             ]


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Requested changes from design, that I forgot to implement on v4. [More context here](https://linear.app/noredink/issue/PHX-481#comment-82b336e6)
## :framed_picture: What does this change look like?
<img width="672" alt="image" src="https://user-images.githubusercontent.com/17324511/221698236-a057647a-2abb-4558-aede-918360447e46.png">

- Follow the the [Guidelines for an optimal design ping](https://paper.dropbox.com/doc/Guidelines-for-Sharing-User-Facing-Changes-with-Design--BpL8hpJLMugy6033aT5m0JdaAg-bdKGQtYH9qO9I00hUkA6k) to add helpful screenshots/videos for design.
- Ping design on this PR to get approval on your changes.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the comopnent
