### PR TITLE
:wrench: Adjust highlighter high-contrast styles

### DIFF
--- a/src/Nri/Ui/HighlighterTool/V1.elm
+++ b/src/Nri/Ui/HighlighterTool/V1.elm
@@ -89,8 +89,10 @@ buildMarker { highlightColor, hoverColor, hoverHighlightColor, kind, name } =
 
 startGroupStyles : List Css.Style
 startGroupStyles =
-    [ Css.borderLeftWidth (Css.px 2)
-    , Css.paddingLeft (Css.px 2)
+    [ MediaQuery.highContrastMode
+        [ Css.property "border-left" "2px solid Mark"
+        ]
+    , Css.paddingLeft (Css.px 4)
     , Css.borderTopLeftRadius (Css.px 4)
     , Css.borderBottomLeftRadius (Css.px 4)
     ]
@@ -98,8 +100,10 @@ startGroupStyles =
 
 endGroupStyles : List Css.Style
 endGroupStyles =
-    [ Css.borderRightWidth (Css.px 2)
-    , Css.paddingRight (Css.px 2)
+    [ MediaQuery.highContrastMode
+        [ Css.property "border-right" "2px solid Mark"
+        ]
+    , Css.paddingRight (Css.px 4)
     , Css.borderTopRightRadius (Css.px 4)
     , Css.borderBottomRightRadius (Css.px 4)
     ]
@@ -111,21 +115,19 @@ highlightStyles color =
         sharedStyles
         [ Css.backgroundColor color
         , Css.boxShadow5 Css.zero (Css.px 1) Css.zero Css.zero Colors.gray75
-        , MediaQuery.highContrastMode
-            [ Css.property "border-color" "Mark"
-            , Css.property "color" "CanvasText"
-            ]
         ]
 
 
 sharedStyles : List Css.Style
 sharedStyles =
-    [ Css.borderStyle Css.solid
-    , Css.borderTopWidth (Css.px 2)
-    , Css.paddingTop (Css.px 2)
-    , Css.borderBottomWidth (Css.px 2)
-    , Css.paddingBottom (Css.px 1)
+    [ Css.paddingTop (Css.px 4)
+    , Css.paddingBottom (Css.px 3)
     , Css.property "transition" "background-color 0.4s, box-shadow 0.4s"
+    , MediaQuery.highContrastMode
+        [ Css.property "color" "CanvasText"
+        , Css.property "border-top" "2px solid Mark"
+        , Css.property "border-bottom" "2px solid Mark"
+        ]
     ]
 
 
@@ -136,8 +138,7 @@ hoverStyles color =
         [ Css.boxShadow5 Css.zero Css.zero (Css.px 10) (Css.px 2) color
         , Css.important (Css.backgroundColor color)
         , MediaQuery.highContrastMode
-            [ Css.property "border-color" "Highlight"
-                |> Css.important
+            [ Css.property "border-color" "Highlight" |> Css.important
             ]
 
         -- The Highlighter applies both these styles and the startGroup and

--- a/src/Nri/Ui/HighlighterTool/V1.elm
+++ b/src/Nri/Ui/HighlighterTool/V1.elm
@@ -89,7 +89,8 @@ buildMarker { highlightColor, hoverColor, hoverHighlightColor, kind, name } =
 
 startGroupStyles : List Css.Style
 startGroupStyles =
-    [ Css.paddingLeft (Css.px 4)
+    [ Css.borderLeftWidth (Css.px 2)
+    , Css.paddingLeft (Css.px 2)
     , Css.borderTopLeftRadius (Css.px 4)
     , Css.borderBottomLeftRadius (Css.px 4)
     ]
@@ -97,7 +98,8 @@ startGroupStyles =
 
 endGroupStyles : List Css.Style
 endGroupStyles =
-    [ Css.paddingRight (Css.px 4)
+    [ Css.borderRightWidth (Css.px 2)
+    , Css.paddingRight (Css.px 2)
     , Css.borderTopRightRadius (Css.px 4)
     , Css.borderBottomRightRadius (Css.px 4)
     ]
@@ -110,16 +112,19 @@ highlightStyles color =
         [ Css.backgroundColor color
         , Css.boxShadow5 Css.zero (Css.px 1) Css.zero Css.zero Colors.gray75
         , MediaQuery.highContrastMode
-            [ Css.property "background-color" "Mark"
-            , Css.property "forced-color-adjust" "none"
+            [ Css.property "border-color" "Mark"
+            , Css.property "color" "CanvasText"
             ]
         ]
 
 
 sharedStyles : List Css.Style
 sharedStyles =
-    [ Css.paddingTop (Css.px 4)
-    , Css.paddingBottom (Css.px 3)
+    [ Css.borderStyle Css.solid
+    , Css.borderTopWidth (Css.px 2)
+    , Css.paddingTop (Css.px 2)
+    , Css.borderBottomWidth (Css.px 2)
+    , Css.paddingBottom (Css.px 1)
     , Css.property "transition" "background-color 0.4s, box-shadow 0.4s"
     ]
 
@@ -131,9 +136,8 @@ hoverStyles color =
         [ Css.boxShadow5 Css.zero Css.zero (Css.px 10) (Css.px 2) color
         , Css.important (Css.backgroundColor color)
         , MediaQuery.highContrastMode
-            [ Css.property "background-color" "Highlight" |> Css.important
-            , Css.property "color" "HighlightText"
-            , Css.property "forced-color-adjust" "none"
+            [ Css.property "border-color" "Highlight"
+                |> Css.important
             ]
 
         -- The Highlighter applies both these styles and the startGroup and
@@ -159,8 +163,9 @@ buildMarkerWithBorder { highlightColor, kind, name } =
                 [ Css.padding2 (Css.px 6) Css.zero
                 , Css.lineHeight (Css.em 2.5)
                 , MediaQuery.highContrastMode
-                    [ Css.property "background-color" "Mark" |> Css.important
-                    , Css.property "forced-color-adjust" "none"
+                    [ Css.property "border-color" "Mark"
+                    , Css.property "color" "CanvasText"
+                    , Css.borderWidth (Css.px 2)
                     ]
                 ]
     in

--- a/src/Nri/Ui/HighlighterTool/V1.elm
+++ b/src/Nri/Ui/HighlighterTool/V1.elm
@@ -6,6 +6,11 @@ module Nri.Ui.HighlighterTool.V1 exposing
 
 {-|
 
+
+### Patch changes
+
+  - change the high-contrast styles to be border-based instead of background-color based
+
 @docs Tool
 @docs EraserModel, buildEraser
 @docs MarkerModel, buildMarker, buildMarkerWithBorder

--- a/src/Nri/Ui/Mark/V2.elm
+++ b/src/Nri/Ui/Mark/V2.elm
@@ -219,16 +219,22 @@ viewMarked tagStyle markedWith segments =
                 ]
             ]
         ]
-        (viewStartHighlight tagStyle markedWith :: segments)
+        (case markedWith.name of
+            Just name ->
+                viewStartHighlightTag tagStyle markedWith name :: segments
+
+            Nothing ->
+                segments
+        )
 
 
-viewStartHighlight : TagStyle -> Mark -> Html msg
-viewStartHighlight tagStyle marked =
+viewStartHighlightTag : TagStyle -> Mark -> String -> Html msg
+viewStartHighlightTag tagStyle marked name =
     span
         [ css (marked.styles ++ marked.startStyles)
         , class "highlighter-inline-tag highlighter-inline-tag-highlighted"
         ]
-        [ viewJust (viewTag tagStyle) marked.name ]
+        [ viewTag tagStyle name ]
 
 
 markStyles : Int -> Maybe Mark -> List Css.Style
@@ -237,7 +243,17 @@ markStyles index marked =
         ( True, Just markedWith ) ->
             -- if we're on the first highlighted element, we add
             -- a `before` content saying what kind of highlight we're starting
-            tagBeforeContent markedWith :: markedWith.styles
+            tagBeforeContent markedWith
+                :: markedWith.styles
+                ++ -- if we're on the first element, and the mark has a name,
+                   -- there's an inline tag to show.
+                   -- but if not, we can attach the start styles to the first segment
+                   (if markedWith.name == Nothing then
+                        markedWith.startStyles
+
+                    else
+                        []
+                   )
 
         _ ->
             Maybe.map .styles marked

--- a/src/Nri/Ui/Mark/V2.elm
+++ b/src/Nri/Ui/Mark/V2.elm
@@ -5,6 +5,11 @@ module Nri.Ui.Mark.V2 exposing
 
 {-|
 
+
+### Patch changes
+
+  - change how the start styles are attached when there is not an explicit tag to show in order to reduce how often the starting highlight ends up isolated on its own line
+
 @docs Mark
 @docs view, viewWithInlineTags, viewWithBalloonTags
 


### PR DESCRIPTION
## Context

Fixes A11-2367

## :framed_picture: What does this change look like?


| | Before | After |
| --- | --- | --- |
| single highlighted word |  <img width="308" alt="Screen Shot 2023-03-02 at 11 05 04 AM" src="https://user-images.githubusercontent.com/8811312/222513927-9e517ae8-5004-4b12-9b98-2706efb6ae12.png"> | <img width="325" alt="Screen Shot 2023-03-02 at 11 04 25 AM" src="https://user-images.githubusercontent.com/8811312/222513936-85e10869-3d5d-4124-821c-6c170ba014af.png"> |
| multiple highlighted segments with tags | <img width="574" alt="Screen Shot 2023-03-02 at 11 04 57 AM" src="https://user-images.githubusercontent.com/8811312/222513929-cb8778ce-dfa1-4ff8-8750-42e1b6719305.png"> |  <img width="554" alt="Screen Shot 2023-03-02 at 11 04 17 AM" src="https://user-images.githubusercontent.com/8811312/222513919-259d988f-0fa3-4352-81b5-da85d61fa6bd.png"> |
| hovered segment | <img width="1369" alt="Screen Shot 2023-03-02 at 11 05 11 AM" src="https://user-images.githubusercontent.com/8811312/222513921-b8fb6632-9a75-4778-9350-e5c311c7f12f.png">  | <img width="1283" alt="Screen Shot 2023-03-02 at 11 04 33 AM" src="https://user-images.githubusercontent.com/8811312/222513930-04296519-8c00-4089-9989-0bb7939569f6.png"> |

cc @NoRedInk/design 

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the comopnent
