### PR TITLE
Deprecate vertical and horizontal spacers and add preview

### DIFF
--- a/component-catalog-app/Examples/Spacing.elm
+++ b/component-catalog-app/Examples/Spacing.elm
@@ -119,6 +119,27 @@ view ellieLinkConfig state =
         , { name = "centeredContentWithSidePaddingAndCustomWidth", alignment = "Centered", maxWidth = "(customizable)", sidePadding = "when viewport <= (custom breakpoint value - 30)" }
         , { name = "centeredContentWithCustomWidth", alignment = "Centered", maxWidth = "(customizable)", sidePadding = "0px" }
         ]
+    , Heading.h2 [ Heading.plaintext "Constants", Heading.css [ Css.marginTop Spacing.verticalSpacerPx ] ]
+    , Table.view
+        [ Table.string
+            { header = "Name"
+            , value = .name
+            , width = Css.pct 10
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+            , sort = Nothing
+            }
+        , Table.string
+            { header = "Value"
+            , value = .value
+            , width = Css.pct 10
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+            , sort = Nothing
+            }
+        ]
+        [ { name = "pageTopWhitespacePx", value = "30px" }
+        , { name = "pageBottomWhitespacePx", value = "50px" }
+        , { name = "pageSideWhitespacePx", value = "15px" }
+        ]
     ]
 
 

--- a/component-catalog-app/Examples/Spacing.elm
+++ b/component-catalog-app/Examples/Spacing.elm
@@ -17,6 +17,7 @@ import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
 
@@ -60,7 +61,6 @@ view ellieLinkConfig state =
                     , settings.bottomContainerStyle
                     ]
                 )
-                (List.repeat settings.childCount child)
     in
     [ ControlView.view
         { ellieLinkConfig = ellieLinkConfig
@@ -93,53 +93,16 @@ fakePage =
         ]
 
 
-container : List ( String, Css.Style ) -> List ( String, Html msg ) -> ( String, Html msg )
-container styles children =
-    ( [ "div"
-      , "[ css"
-      , "    [ Css.border3 (Css.px 2) Css.dashed Colors.greenDarkest"
-      , "    , Css.backgroundColor Colors.greenLightest"
-      , "    , Css.property " ++ Code.string "display" ++ " " ++ Code.string "grid"
-      , "    , Css.property " ++ Code.string "grid-template-columns" ++ " " ++ Code.string "1fr 1fr 1fr 1fr 1fr"
-      , "    , Css.batch " ++ Code.listMultiline (List.map Tuple.first styles) 3
-      , "    ]"
+container : List ( String, Css.Style ) -> ( String, Html msg )
+container styles =
+    ( [ "div [ css " ++ Code.listMultiline (List.map Tuple.first styles) 2
       , "]"
-      , Code.list (List.map Tuple.first children)
+      , "[ Container.view [ Container.paragraph \"Content...\" ]"
       ]
         |> String.join (Code.newlineWithIndent 1)
-    , div
-        [ css
-            [ Css.border3 (Css.px 2) Css.dashed Colors.greenDarkest
-            , Css.backgroundColor Colors.greenLightest
-            , Css.property "display" "grid"
-            , Css.property "grid-template-columns" "1fr 1fr 1fr 1fr 1fr"
-            , Css.batch (List.map Tuple.second styles)
-            ]
+    , div [ css (List.map Tuple.second styles) ]
+        [ Container.view [ Container.paragraph "Content..." ]
         ]
-        (List.map Tuple.second children)
-    )
-
-
-child : ( String, Html msg )
-child =
-    ( [ "div"
-      , "[ css"
-      , "    [ Css.border3 (Css.px 1) Css.solid Colors.ochreDark"
-      , "    , Css.backgroundColor Colors.sunshine"
-      , "    , Css.height (Css.px 150)"
-      , "    ]"
-      , "]"
-      , "[]"
-      ]
-        |> String.join (Code.newlineWithIndent 2)
-    , div
-        [ css
-            [ Css.border3 (Css.px 1) Css.solid Colors.ochreDark
-            , Css.backgroundColor Colors.sunshine
-            , Css.height (Css.px 150)
-            ]
-        ]
-        []
     )
 
 
@@ -157,7 +120,6 @@ type alias Settings =
     { topContainerStyle : Maybe ( String, Style )
     , horizontalContainerStyle : Maybe ( String, Style )
     , bottomContainerStyle : Maybe ( String, Style )
-    , childCount : Int
     }
 
 
@@ -218,7 +180,6 @@ controlSettings =
                     )
                 )
             )
-        |> Control.field "Child count" (ControlExtra.int 10)
 
 
 asChoice : ( String, Style ) -> ( String, Control ( String, Style ) )

--- a/component-catalog-app/Examples/Spacing.elm
+++ b/component-catalog-app/Examples/Spacing.elm
@@ -58,22 +58,6 @@ view ellieLinkConfig state =
                     [ settings.topContainerStyle
                     , settings.horizontalContainerStyle
                     , settings.bottomContainerStyle
-                    , if settings.childVerticalSpace then
-                        Just
-                            ( "Css.property \"row-gap\" (.value Spacing.verticalSpacerPx)"
-                            , Css.property "row-gap" (.value Spacing.verticalSpacerPx)
-                            )
-
-                      else
-                        Nothing
-                    , if settings.childHorizontalSpace then
-                        Just
-                            ( "Css.property \"column-gap\" (.value Spacing.horizontalSpacerPx"
-                            , Css.property "column-gap" (.value Spacing.horizontalSpacerPx)
-                            )
-
-                      else
-                        Nothing
                     ]
                 )
                 (List.repeat settings.childCount child)
@@ -174,8 +158,6 @@ type alias Settings =
     , horizontalContainerStyle : Maybe ( String, Style )
     , bottomContainerStyle : Maybe ( String, Style )
     , childCount : Int
-    , childVerticalSpace : Bool
-    , childHorizontalSpace : Bool
     }
 
 
@@ -237,8 +219,6 @@ controlSettings =
                 )
             )
         |> Control.field "Child count" (ControlExtra.int 10)
-        |> Control.field "Separate children vertically" (Control.bool True)
-        |> Control.field "Separate children horizontally" (Control.bool True)
 
 
 asChoice : ( String, Style ) -> ( String, Control ( String, Style ) )

--- a/component-catalog-app/Examples/Spacing.elm
+++ b/component-catalog-app/Examples/Spacing.elm
@@ -18,9 +18,12 @@ import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
+import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V6 as Table
+import Svg.Styled
+import Svg.Styled.Attributes
 
 
 moduleName : String
@@ -43,9 +46,161 @@ example =
     , state = init
     , update = update
     , subscriptions = \_ -> Sub.none
-    , preview = []
+    , preview = preview
     , view = view
     }
+
+
+preview : List (Html msg)
+preview =
+    [ Svg.Styled.svg
+        [ Svg.Styled.Attributes.viewBox "0 0 100 100"
+        ]
+        [ Svg.Styled.rect
+            [ Svg.Styled.Attributes.width "100"
+            , Svg.Styled.Attributes.height "100"
+            , Svg.Styled.Attributes.fill Colors.white.value
+            ]
+            []
+        , Svg.Styled.rect
+            [ Svg.Styled.Attributes.x "15"
+            , Svg.Styled.Attributes.y "30"
+            , Svg.Styled.Attributes.width "70"
+            , Svg.Styled.Attributes.height "20"
+            , Svg.Styled.Attributes.fill Colors.gray96.value
+            ]
+            []
+        , Svg.Styled.text_
+            [ Svg.Styled.Attributes.fill Colors.gray20.value
+            , Svg.Styled.Attributes.css [ Fonts.baseFont, Css.fontSize (Css.px 8) ]
+            , Svg.Styled.Attributes.x "20"
+            , Svg.Styled.Attributes.y "43"
+            ]
+            [ Svg.Styled.text "Content" ]
+        , -- Top red line indicator
+          Svg.Styled.g []
+            [ Svg.Styled.line
+                [ Svg.Styled.Attributes.x1 "50"
+                , Svg.Styled.Attributes.x2 "50"
+                , Svg.Styled.Attributes.y1 "1"
+                , Svg.Styled.Attributes.y2 "29"
+                , Svg.Styled.Attributes.stroke Colors.red.value
+                ]
+                []
+            , Svg.Styled.line
+                [ Svg.Styled.Attributes.x1 "45"
+                , Svg.Styled.Attributes.x2 "55"
+                , Svg.Styled.Attributes.y1 "1"
+                , Svg.Styled.Attributes.y2 "1"
+                , Svg.Styled.Attributes.stroke Colors.red.value
+                ]
+                []
+            , Svg.Styled.line
+                [ Svg.Styled.Attributes.x1 "45"
+                , Svg.Styled.Attributes.x2 "55"
+                , Svg.Styled.Attributes.y1 "29"
+                , Svg.Styled.Attributes.y2 "29"
+                , Svg.Styled.Attributes.stroke Colors.red.value
+                ]
+                []
+            , Svg.Styled.text_
+                [ Svg.Styled.Attributes.fill Colors.red.value
+                , Svg.Styled.Attributes.css [ Fonts.baseFont, Css.fontSize (Css.px 8) ]
+                , Svg.Styled.Attributes.x "53"
+                , Svg.Styled.Attributes.y "20"
+                ]
+                [ Svg.Styled.text "30px" ]
+            ]
+        , -- Bottom red line indicator
+          Svg.Styled.g []
+            [ Svg.Styled.line
+                [ Svg.Styled.Attributes.x1 "50"
+                , Svg.Styled.Attributes.x2 "50"
+                , Svg.Styled.Attributes.y1 "51"
+                , Svg.Styled.Attributes.y2 "99"
+                , Svg.Styled.Attributes.stroke Colors.red.value
+                ]
+                []
+            , Svg.Styled.line
+                [ Svg.Styled.Attributes.x1 "45"
+                , Svg.Styled.Attributes.x2 "55"
+                , Svg.Styled.Attributes.y1 "51"
+                , Svg.Styled.Attributes.y2 "51"
+                , Svg.Styled.Attributes.stroke Colors.red.value
+                ]
+                []
+            , Svg.Styled.line
+                [ Svg.Styled.Attributes.x1 "45"
+                , Svg.Styled.Attributes.x2 "55"
+                , Svg.Styled.Attributes.y1 "99"
+                , Svg.Styled.Attributes.y2 "99"
+                , Svg.Styled.Attributes.stroke Colors.red.value
+                ]
+                []
+            , Svg.Styled.text_
+                [ Svg.Styled.Attributes.fill Colors.red.value
+                , Svg.Styled.Attributes.css [ Fonts.baseFont, Css.fontSize (Css.px 8) ]
+                , Svg.Styled.Attributes.x "53"
+                , Svg.Styled.Attributes.y "75"
+                ]
+                [ Svg.Styled.text "50px" ]
+            ]
+        , -- Right red line indicator
+          Svg.Styled.g []
+            [ Svg.Styled.line
+                [ Svg.Styled.Attributes.x1 "86"
+                , Svg.Styled.Attributes.x2 "99"
+                , Svg.Styled.Attributes.y1 "40"
+                , Svg.Styled.Attributes.y2 "40"
+                , Svg.Styled.Attributes.stroke Colors.red.value
+                ]
+                []
+            , Svg.Styled.line
+                [ Svg.Styled.Attributes.x1 "86"
+                , Svg.Styled.Attributes.x2 "86"
+                , Svg.Styled.Attributes.y1 "38"
+                , Svg.Styled.Attributes.y2 "42"
+                , Svg.Styled.Attributes.stroke Colors.red.value
+                ]
+                []
+            , Svg.Styled.line
+                [ Svg.Styled.Attributes.x1 "99"
+                , Svg.Styled.Attributes.x2 "99"
+                , Svg.Styled.Attributes.y1 "38"
+                , Svg.Styled.Attributes.y2 "42"
+                , Svg.Styled.Attributes.stroke Colors.red.value
+                ]
+                []
+            ]
+        , -- Left red line indicator
+          Svg.Styled.g []
+            [ Svg.Styled.line
+                [ Svg.Styled.Attributes.x1 "1"
+                , Svg.Styled.Attributes.x2 "14"
+                , Svg.Styled.Attributes.y1 "40"
+                , Svg.Styled.Attributes.y2 "40"
+                , Svg.Styled.Attributes.stroke Colors.red.value
+                ]
+                []
+            , Svg.Styled.line
+                [ Svg.Styled.Attributes.x1 "1"
+                , Svg.Styled.Attributes.x2 "1"
+                , Svg.Styled.Attributes.y1 "38"
+                , Svg.Styled.Attributes.y2 "42"
+                , Svg.Styled.Attributes.stroke Colors.red.value
+                ]
+                []
+            , Svg.Styled.line
+                [ Svg.Styled.Attributes.x1 "14"
+                , Svg.Styled.Attributes.x2 "14"
+                , Svg.Styled.Attributes.y1 "38"
+                , Svg.Styled.Attributes.y2 "42"
+                , Svg.Styled.Attributes.stroke Colors.red.value
+                ]
+                []
+            ]
+        ]
+    ]
 
 
 view : EllieLink.Config -> State -> List (Html Msg)

--- a/component-catalog-app/Examples/Spacing.elm
+++ b/component-catalog-app/Examples/Spacing.elm
@@ -20,6 +20,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
+import Nri.Ui.Table.V6 as Table
 
 
 moduleName : String
@@ -78,8 +79,46 @@ view ellieLinkConfig state =
                   }
                 ]
         }
-    , Heading.h2 [ Heading.plaintext "Example" ]
+    , Heading.h2 [ Heading.plaintext "Example", Heading.css [ Css.marginTop Spacing.verticalSpacerPx ] ]
     , fakePage [ exampleView ]
+    , Heading.h2 [ Heading.plaintext "Content alignment", Heading.css [ Css.marginTop Spacing.verticalSpacerPx ] ]
+    , Table.view
+        [ Table.string
+            { header = "Name"
+            , value = .name
+            , width = Css.pct 10
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+            , sort = Nothing
+            }
+        , Table.string
+            { header = "Content alignment"
+            , value = .alignment
+            , width = Css.pct 10
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+            , sort = Nothing
+            }
+        , Table.string
+            { header = "Content max-width"
+            , value = .maxWidth
+            , width = Css.pct 10
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+            , sort = Nothing
+            }
+        , Table.string
+            { header = "Side padding"
+            , value = .sidePadding
+            , width = Css.pct 10
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+            , sort = Nothing
+            }
+        ]
+        [ { name = "centeredContentWithSidePadding", alignment = "Centered", maxWidth = "1000px", sidePadding = "when viewport <= 970px" }
+        , { name = "centeredContent", alignment = "Centered", maxWidth = "1000px", sidePadding = "0px" }
+        , { name = "centeredQuizEngineContentWithSidePadding", alignment = "Centered", maxWidth = "750px", sidePadding = "when viewport <= 720px" }
+        , { name = "centeredQuizEngineContent", alignment = "Centered", maxWidth = "750px", sidePadding = "0px" }
+        , { name = "centeredContentWithSidePaddingAndCustomWidth", alignment = "Centered", maxWidth = "(customizable)", sidePadding = "when viewport <= (custom breakpoint value - 30)" }
+        , { name = "centeredContentWithCustomWidth", alignment = "Centered", maxWidth = "(customizable)", sidePadding = "0px" }
+        ]
     ]
 
 

--- a/src/Nri/Ui/Spacing/V1.elm
+++ b/src/Nri/Ui/Spacing/V1.elm
@@ -23,6 +23,10 @@ module Nri.Ui.Spacing.V1 exposing
 @docs pageTopWhitespace, pageTopWhitespacePx
 @docs pageSideWhitespace, pageSideWhitespacePx
 @docs pageBottomWhitespace, pageBottomWhitespacePx
+
+
+## Deprecated:
+
 @docs verticalSpacerPx, horizontalSpacerPx
 
 -}
@@ -168,20 +172,14 @@ pageTopWhitespacePx =
     Css.px 30
 
 
-{-| Most elements should have 20px of whitespace separating them vertically.
-
-See [the UI Style Guide and Caveats' Spacing section](https://paper.dropbox.com/doc/UI-Style-Guide-and-Caveats--BobQllelpdS56NBITiRcrO6gAg-PvOLxeX3oyujYEzdJx5pu#:uid=905917270049954035442315&h2=:under-construction:-Spacing) for more details.
-
+{-| DEPRECATED -- do not use. A future version of noredink-ui will remove.
 -}
 verticalSpacerPx : Css.Px
 verticalSpacerPx =
     Css.px 20
 
 
-{-| Most elements should have 10px of whitespace separating them horizontally.
-
-See [the UI Style Guide and Caveats' Spacing section](https://paper.dropbox.com/doc/UI-Style-Guide-and-Caveats--BobQllelpdS56NBITiRcrO6gAg-PvOLxeX3oyujYEzdJx5pu#:uid=905917270049954035442315&h2=:under-construction:-Spacing) for more details.
-
+{-| DEPRECATED -- do not use. A future version of noredink-ui will remove.
 -}
 horizontalSpacerPx : Css.Px
 horizontalSpacerPx =


### PR DESCRIPTION
Fixes A11-2314

- marks the child spacers as deprecated
- expand the spacing examples
- add a preview


## Preview
<img width="217" alt="Screen Shot 2023-03-08 at 3 57 52 PM" src="https://user-images.githubusercontent.com/8811312/223870477-80b1a54b-d3d8-481a-8e1d-f970f19a9144.png">

## Example

### Before

<img width="1373" alt="Screen Shot 2023-03-08 at 3 58 58 PM" src="https://user-images.githubusercontent.com/8811312/223870598-666c5a2a-9700-4962-a87b-6206297802cc.png">


### After

<img width="1380" alt="Screen Shot 2023-03-08 at 3 58 48 PM" src="https://user-images.githubusercontent.com/8811312/223870595-ff7627aa-e741-469e-87d9-f776433a2cbe.png">

cc @NoRedInk/design 