### PR TITLE
:wrench: Fix HighlighterToolbar high contrast mode appearance

### DIFF
--- a/src/Nri/Ui/HighlighterToolbar/V2.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V2.elm
@@ -4,7 +4,13 @@ module Nri.Ui.HighlighterToolbar.V2 exposing (view)
 
 @docs view
 
-Changes from V1:
+
+### Patch changes:
+
+  - Ensure selected tool is clear in high contrast mode
+
+
+### Changes from V1:
 
   - replaces `onChangeTag` and `onSetEraser` with `focusAndSelect`.
   - adds `highlighterId` to config
@@ -208,8 +214,7 @@ active palette_ =
         [ nriDescription "active-tool"
         , css
             [ Css.width (Css.px 38)
-            , Css.height (Css.px 4)
-            , Css.backgroundColor palette_.colorLight
+            , Css.border3 (Css.px 2) Css.solid palette_.colorLight
             ]
         ]
         []


### PR DESCRIPTION
## Context

Fixes A11-2181

## :framed_picture: What does this change look like?

<img width="593" alt="Screen Shot 2023-03-14 at 1 05 24 PM" src="https://user-images.githubusercontent.com/8811312/225111334-1c48e4e7-eec6-4944-b813-8037ed57b9b6.png">

cc @NoRedInk/design 


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the comopnent
