### PR TITLE
Font anti pattern examples

### DIFF
--- a/component-catalog-app/Examples/Fonts.elm
+++ b/component-catalog-app/Examples/Fonts.elm
@@ -102,12 +102,12 @@ viewFontFailurePatterns =
             { header = "Info"
             , value = .info
             , width = Css.pct 30
-            , cellStyles = always [ Fonts.baseFont, Css.padding2 (Css.px 8) Css.zero ]
+            , cellStyles = always [ Fonts.baseFont, Css.padding2 (Css.px 8) Css.zero, Css.whiteSpace Css.preLine ]
             , sort = Nothing
             }
         ]
         [ { example = "Alphabet", text = "AaBbCcDdEeFfGg\nHhIiJjKkLlMmNn\nOoPpQqRrSsTtUu\nVvWwXxYyZz", info = "" }
-        , { example = "Imposter letters", text = "Il1 ecoa", info = "Note that capital i and lowercase l can look near-identical in some fonts. e, c, o, and a can also be difficult to distinguish from each other in some fonts." }
+        , { example = "Imposter letters", text = "Il1 ecoa", info = "Capital i and lowercase l can look near-identical in some fonts.\ne, c, o, and a can also be difficult to distinguish from each other in some fonts." }
         , { example = "Mirrored letters", text = "db\nqp", info = "Mirrored letters are not unique, and can make reading more difficult, particularly for some people with dyslexia." }
         , { example = "Letter spacing", text = "rn vv", info = "r and n next to each other can smoosh into an m shape and v and v into a w in some fonts." }
         ]

--- a/component-catalog-app/Examples/Fonts.elm
+++ b/component-catalog-app/Examples/Fonts.elm
@@ -13,7 +13,6 @@ import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Fonts.V1 as Fonts
-import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Table.V6 as Table
 import Nri.Ui.Text.V6 as Text
 

--- a/component-catalog-app/Examples/Fonts.elm
+++ b/component-catalog-app/Examples/Fonts.elm
@@ -13,6 +13,7 @@ import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Table.V6 as Table
 
 
 {-| -}
@@ -41,19 +42,54 @@ example =
         , ( "ugFont", Fonts.ugFont )
         ]
             |> List.map viewPreview
-    , view =
-        \ellieLinkConfig _ ->
-            [ Heading.h2 [ Heading.plaintext "baseFont" ]
-            , Html.p [ css [ Fonts.baseFont ] ]
-                [ Html.text "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz" ]
-            , Heading.h2 [ Heading.plaintext "quizFont" ]
-            , Html.p [ css [ Fonts.quizFont ] ]
-                [ Html.text "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz" ]
-            , Heading.h2 [ Heading.plaintext "ugFont" ]
-            , Html.p [ css [ Fonts.ugFont ] ]
-                [ Html.text "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz" ]
-            ]
+    , view = \ellieLinkConfig _ -> [ view ]
     }
+
+
+view : Html msg
+view =
+    let
+        fontStyle font _ =
+            [ font
+            , Css.whiteSpace Css.pre
+            , Css.textAlign Css.center
+            ]
+    in
+    Table.view
+        [ Table.rowHeader
+            { header = Html.text "Example"
+            , view = Html.text << .example
+            , width = Css.pct 10
+            , cellStyles = always [ Fonts.baseFont, Css.textAlign Css.left ]
+            , sort = Nothing
+            }
+        , Table.string
+            { header = "baseFont"
+            , value = .text
+            , width = Css.pct 10
+            , cellStyles = fontStyle Fonts.baseFont
+            , sort = Nothing
+            }
+        , Table.string
+            { header = "quizFont/ugFont"
+            , value = .text
+            , width = Css.pct 10
+            , cellStyles = fontStyle Fonts.quizFont
+            , sort = Nothing
+            }
+        , Table.string
+            { header = "Info"
+            , value = .info
+            , width = Css.pct 30
+            , cellStyles = always [ Fonts.baseFont, Css.padding2 (Css.px 8) Css.zero ]
+            , sort = Nothing
+            }
+        ]
+        [ { example = "Alphabet", text = "AaBbCcDdEeFfGg\nHhIiJjKkLlMmNn\nOoPpQqRrSsTtUu\nVvWwXxYyZz", info = "" }
+        , { example = "Imposter letters", text = "Il1 ecoa", info = "Note that capital i and lowercase l can look near-identical in some fonts. e, c, o, and a can also be difficult to distinguish from each other in some fonts." }
+        , { example = "Mirrored letters", text = "db\nqp", info = "Mirrored letters are not unique, and can make reading more difficult, particularly for some people with dyslexia." }
+        , { example = "Letter spacing", text = "rn vv", info = "r and n next to each other can smoosh into an m shape and v and v into a w in some fonts." }
+        ]
 
 
 viewPreview : ( String, Style ) -> Html msg

--- a/component-catalog-app/Examples/Fonts.elm
+++ b/component-catalog-app/Examples/Fonts.elm
@@ -11,9 +11,11 @@ import Css exposing (Style)
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
+import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Table.V6 as Table
+import Nri.Ui.Text.V6 as Text
 
 
 {-| -}
@@ -42,12 +44,31 @@ example =
         , ( "ugFont", Fonts.ugFont )
         ]
             |> List.map viewPreview
-    , view = \ellieLinkConfig _ -> [ view ]
+    , view =
+        \ellieLinkConfig _ ->
+            [ viewFontFailurePatterns
+            , Text.mediumBody
+                [ Text.css [ Css.marginTop (Css.px 30) |> Css.important ]
+                , Text.html
+                    [ Html.text "Learn more about kid-friendly and accessible fonts starting at 24:40 in "
+                    , ClickableText.link "Kids Websites: Where Fun and Accessibility Come to Play"
+                        [ ClickableText.linkExternal "https://www.deque.com/axe-con/sessions/kids-websites-where-fun-and-accessibility-come-to-play/"
+                        , ClickableText.appearsInline
+                        ]
+                    , Html.text " and in "
+                    , ClickableText.link "Accessible fonts and readability: the basics"
+                        [ ClickableText.linkExternal "https://business.scope.org.uk/article/font-accessibility-and-readability-the-basics#:~:text=This%20can%20affect%20reading%20speed,does%20this%20is%20Gill%20Sans."
+                        , ClickableText.appearsInline
+                        ]
+                    , Html.text "."
+                    ]
+                ]
+            ]
     }
 
 
-view : Html msg
-view =
+viewFontFailurePatterns : Html msg
+viewFontFailurePatterns =
     let
         fontStyle font _ =
             [ font

--- a/component-catalog-app/Examples/Fonts.elm
+++ b/component-catalog-app/Examples/Fonts.elm
@@ -46,7 +46,22 @@ example =
             |> List.map viewPreview
     , view =
         \ellieLinkConfig _ ->
-            [ viewFontFailurePatterns
+            let
+                dt =
+                    Html.dt [ css [ Css.fontWeight Css.bold ] ]
+
+                dd =
+                    Html.dd [ css [ Css.marginLeft Css.zero, Css.marginBottom (Css.px 8) ] ]
+            in
+            [ Html.dl [ css [ Fonts.baseFont ] ]
+                [ dt [ Html.text "quizFont" ]
+                , dd [ Html.text "Use for exercise content. Georgia" ]
+                , dt [ Html.text "ugFont" ]
+                , dd [ Html.text "Use for user-generated content. Georgia" ]
+                , dt [ Html.text "baseFont" ]
+                , dd [ Html.text "Use  for everything else! Mulish" ]
+                ]
+            , viewFontFailurePatterns
             , Text.mediumBody
                 [ Text.css [ Css.marginTop (Css.px 30) |> Css.important ]
                 , Text.html


### PR DESCRIPTION
Updates the examples page for Fonts to include guidance around which font to use when and also to illustrate some common issues with fonts that we should be aware of.

## Before

<img width="1503" alt="Screen Shot 2023-03-14 at 6 35 58 PM" src="https://user-images.githubusercontent.com/8811312/225173338-86f4af75-5ed5-4801-b663-14096acda63b.png">


## After

<img width="1519" alt="Screen Shot 2023-03-14 at 6 35 51 PM" src="https://user-images.githubusercontent.com/8811312/225173344-defccd46-336e-4ebc-b3d6-40613503c6e6.png">

cc @NoRedInk/design 
