### PR TITLE
Tessa/adjust keyboard support view

### DIFF
--- a/component-catalog-app/KeyboardSupport.elm
+++ b/component-catalog-app/KeyboardSupport.elm
@@ -15,6 +15,8 @@ module KeyboardSupport exposing
 import Css exposing (..)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
+import Nri.Ui.Container.V2 as Container
+import Nri.Ui.Heading.V3 as Heading
 
 
 {-| -}
@@ -32,12 +34,14 @@ view keyboardSupport =
             text ""
 
         _ ->
-            details []
-                [ summary [] [ text "Keyboard Support" ]
-                , ul
-                    [ css [ listStyle none, margin2 (px 10) zero, padding zero ]
+            Container.view
+                [ Container.html
+                    [ Heading.h2 [ Heading.plaintext "Keyboard Support" ]
+                    , ul
+                        [ css [ listStyle none, margin2 (px 10) zero, padding zero ]
+                        ]
+                        (List.map viewKeyboardActions keyboardSupport)
                     ]
-                    (List.map viewKeyboardActions keyboardSupport)
                 ]
                 |> List.singleton
                 |> aside []

--- a/component-catalog-app/KeyboardSupport.elm
+++ b/component-catalog-app/KeyboardSupport.elm
@@ -16,6 +16,7 @@ import Css exposing (..)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Container.V2 as Container
+import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 
 
@@ -37,22 +38,21 @@ view keyboardSupport =
             Container.view
                 [ Container.html
                     [ Heading.h2 [ Heading.plaintext "Keyboard Support" ]
-                    , ul
-                        [ css [ listStyle none, margin2 (px 10) zero, padding zero ]
+                    , dl
+                        [ css [ listStyle none, margin2 (px 10) zero, padding zero, Fonts.baseFont ]
                         ]
-                        (List.map viewKeyboardActions keyboardSupport)
+                        (List.concatMap viewKeyboardActions keyboardSupport)
                     ]
                 ]
                 |> List.singleton
                 |> aside []
 
 
-viewKeyboardActions : KeyboardSupport -> Html msg
+viewKeyboardActions : KeyboardSupport -> List (Html msg)
 viewKeyboardActions { keys, result } =
-    li []
-        [ strong [] [ text (String.join "+" (List.map keyToString keys) ++ ": ") ]
-        , text result
-        ]
+    [ dt [ css [ Css.fontWeight Css.bold ] ] [ text (String.join "+" (List.map keyToString keys) ++ ": ") ]
+    , dd [ css [ Css.margin Css.zero, Css.marginBottom (Css.px 8) ] ] [ text result ]
+    ]
 
 
 {-| -}


### PR DESCRIPTION
Adjust the visuals of the Component Catalog to show the Keyboard Information at all times, instead of behind a details element. (Hoping this will make the keyboard behavior more top of mind for folks!)

<img width="1473" alt="image" src="https://user-images.githubusercontent.com/8811312/226014452-9016bb72-1395-41ab-b5d1-eac1f590d2fc.png">

cc @NoRedInk/design (I'm definitely accepting "scrap it" level critical feedback here 😅)