### PR TITLE
Adds `dangerSecondary` to button themes

### DIFF
--- a/component-catalog-app/Examples/Button.elm
+++ b/component-catalog-app/Examples/Button.elm
@@ -211,6 +211,7 @@ initDebugControls =
                         , ( "secondary", Button.secondary )
                         , ( "tertiary", Button.tertiary )
                         , ( "danger", Button.danger )
+                        , ( "dangerSecondary", Button.dangerSecondary )
                         , ( "premium", Button.premium )
                         ]
                     )
@@ -334,6 +335,7 @@ buttonsTable =
             , ( Button.secondary, "secondary" )
             , ( Button.tertiary, "tertiary" )
             , ( Button.danger, "danger" )
+            , ( Button.dangerSecondary, "dangerSecondary" )
             , ( Button.premium, "premium" )
             ]
 

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -8,7 +8,7 @@ module Nri.Ui.Button.V10 exposing
     , exactWidthForMobile, boundedWidthForMobile, unboundedWidthForMobile, fillContainerWidthForMobile
     , exactWidthForQuizEngineMobile, boundedWidthForQuizEngineMobile, unboundedWidthForQuizEngineMobile, fillContainerWidthForQuizEngineMobile
     , exactWidthForNarrowMobile, boundedWidthForNarrowMobile, unboundedWidthForNarrowMobile, fillContainerWidthForNarrowMobile
-    , primary, secondary, tertiary, danger, premium
+    , primary, secondary, tertiary, danger, dangerSecondary, premium
     , enabled, unfulfilled, disabled, error, loading, success
     , icon, rightIcon
     , hideIconForMobile, hideIconFor
@@ -36,6 +36,7 @@ adding a span around the text could potentially lead to regressions.
   - support 'disabled' links according to [Scott O'Hara's disabled links](https://www.scottohara.me/blog/2021/05/28/disabled-links.html) article
   - adds `tertiary` style
   - adds `submit` and `opensModal`
+  - adds `secondaryDanger` style
 
 
 # Changes from V9:
@@ -67,7 +68,7 @@ adding a span around the text could potentially lead to regressions.
 
 ## Change the color scheme
 
-@docs primary, secondary, tertiary, danger, premium
+@docs primary, secondary, tertiary, danger, dangerSecondary, premium
 
 
 ## Change the state (buttons only)
@@ -576,6 +577,15 @@ danger =
 
 
 {-| -}
+dangerSecondary : Attribute msg
+dangerSecondary =
+    set
+        (\attributes ->
+            { attributes | style = dangerSecondaryColors }
+        )
+
+
+{-| -}
 premium : Attribute msg
 premium =
     set
@@ -1064,6 +1074,17 @@ tertiaryColors =
     , hoverText = Colors.navy
     , border = Just <| Colors.gray75
     , shadow = Colors.gray75
+    }
+
+
+dangerSecondaryColors : ColorPalette
+dangerSecondaryColors =
+    { background = Colors.white
+    , hoverBackground = Colors.redLight
+    , text = Colors.red
+    , hoverText = Colors.redDark
+    , border = Just <| Colors.red
+    , shadow = Colors.red
     }
 
 


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Please link to any relevant context and stories.

## :framed_picture: What does this change look like?

![image](https://user-images.githubusercontent.com/12688694/227223168-ebf0438b-870f-4856-a3c5-820b7936bb34.png)

- [X] Follow the the [Guidelines for an optimal design ping](https://paper.dropbox.com/doc/Guidelines-for-Sharing-User-Facing-Changes-with-Design--BpL8hpJLMugy6033aT5m0JdaAg-bdKGQtYH9qO9I00hUkA6k) to add helpful screenshots/videos for design.
- [X] @ mention the design team on this PR to request approval on your changes. A designer will "thumbs up" react to your PR if they approve it, or will leave comments if it's not quite approved yet.

## Component completion checklist

- [X] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [X] Changes are clearly documented
    - [X] Component docs include a changelog
    - [X] Any new exposed functions or properties have docs
- [X] Changes extend to the Component Catalog
    - [X] The Component Catalog is updated to use the newest version, if appropriate
    - [X] The Component Catalog example version number is updated, if appropriate
    - [X] Any new customizations are available from the Component Catalog
    - [X] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [X] Changes to the component are tested/the new version of the component is tested
- [X] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the comopnent
