### PR TITLE
[PHX-594] Eliminate the jitter of QB positioning.

### DIFF
--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -91,11 +91,6 @@ describe("UI tests", function () {
     const [button] = await page.$x("//button[contains(., 'Measure & render')]");
     await button.click();
 
-    await page.waitForXPath(
-      '//div[@data-nri-description="pointing-to-balloon"]',
-      200
-    );
-
     await percySnapshot(page, name);
 
     const results = await new AxePuppeteer(page)

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -93,7 +93,7 @@ describe("UI tests", function () {
 
     await page.waitForXPath(
       '//div[@data-nri-description="pointing-to-balloon"]',
-      200  
+      200
     );
 
     await percySnapshot(page, name);

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -91,6 +91,11 @@ describe("UI tests", function () {
     const [button] = await page.$x("//button[contains(., 'Measure & render')]");
     await button.click();
 
+    await page.waitForXPath(
+      '//div[@data-nri-description="pointing-to-balloon"]',
+      200  
+    );
+
     await percySnapshot(page, name);
 
     const results = await new AxePuppeteer(page)

--- a/src/Nri/Ui/QuestionBox/V4.elm
+++ b/src/Nri/Ui/QuestionBox/V4.elm
@@ -9,6 +9,11 @@ module Nri.Ui.QuestionBox.V4 exposing
 
 {-|
 
+
+## Patch Changes
+
+  - Modified `viewPointingTo` to be hidden when measurements are `Nothing` to reduce the jitter of the question box moving to its correct position.
+
 @docs view, Attribute
 
 @docs id, markdown, actions, character
@@ -132,7 +137,9 @@ calculate the offset from the viewport.
 
 Pass in the id for the block the QuestionBox should point to.
 
-You will need to pass 4 measurements, taken using Dom.Browser, in order for the question box to be positioned correctly.
+You will need to pass 4 measurements, taken using Dom.Browser, in order for the question box to be positioned correctly. The question box
+will be hidden the first time when you pass `Nothing` for the measurements to reduce the jitter of the question box moving to its correct
+position.
 
 -}
 pointingTo :

--- a/src/Nri/Ui/QuestionBox/V4.elm
+++ b/src/Nri/Ui/QuestionBox/V4.elm
@@ -256,7 +256,16 @@ viewPointingTo config blockId measurements =
     in
     viewBalloon config
         (Just blockId)
-        [ Balloon.containerCss [ Css.marginTop (Css.px 8) ]
+        [ Balloon.containerCss
+            [ Css.marginTop (Css.px 8)
+            , case measurements of
+                Just _ ->
+                    Css.opacity (Css.int 1)
+
+                Nothing ->
+                    -- Avoid the "jitter" of the balloon appearing in the wrong place by hiding it until we have measurements
+                    Css.opacity (Css.int 0)
+            ]
         , Balloon.nriDescription "pointing-to-balloon"
         , case config.id of
             Just id_ ->


### PR DESCRIPTION
This PR makes the QB invisible for the brief bit of time while we calculate measurements. This eliminates the jitter that has been throwing some students off when the QuestionBox moves around. 

🎩 to Tessa for the idea. 

# :wrench: Modifying a component

## Context

[PHX-594](https://linear.app/noredink/issue/PHX-594/scaffolding-container-jumps-when-step-changes)

## :framed_picture: What does this change look like?


https://user-images.githubusercontent.com/12899207/227378960-55eb7256-b3dd-478e-9119-77f9be85a148.mov

- [x] Follow the the [Guidelines for an optimal design ping](https://paper.dropbox.com/doc/Guidelines-for-Sharing-User-Facing-Changes-with-Design--BpL8hpJLMugy6033aT5m0JdaAg-bdKGQtYH9qO9I00hUkA6k) to add helpful screenshots/videos for design.
- [x] ~@ mention the design team on this PR to request approval on your changes. A designer will "thumbs up" react to your PR if they approve it, or will leave comments if it's not quite approved yet.~ Design didn't change, simply a bugfix

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the comopnent
