### PR TITLE
bump to version 22.6.1 to fix hash issues in 22.6

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "22.6.0",
+    "version": "22.6.1",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Ui",


### PR DESCRIPTION
# :label: Bump for version `VERSION_NUMBER`

## What changes does this release include?
I made a mistake during publishing `22.6.0` and deleted the `22.6.0` tag and pushed it again. That ended up creating issues with hashes.
Publishing a `22.6.1` version should fix these.

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```
No API changes detected, so this is a PATCH change.
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).



