### PR TITLE
:wrench: Improve highlighter styles

### DIFF
--- a/src/Nri/Ui/HighlighterTool/V1.elm
+++ b/src/Nri/Ui/HighlighterTool/V1.elm
@@ -11,6 +11,7 @@ module Nri.Ui.HighlighterTool.V1 exposing
 
   - change the high-contrast styles to be border-based instead of background-color based
   - adds buildMarkerWithoutRounding for inline comment styling
+  - changes the 4px of side padding on the marker to 2px of padding+negative margin
 
 @docs Tool
 @docs EraserModel, buildEraser

--- a/src/Nri/Ui/HighlighterTool/V1.elm
+++ b/src/Nri/Ui/HighlighterTool/V1.elm
@@ -99,6 +99,7 @@ startGroupStyles =
         [ Css.property "border-left" "2px solid Mark"
         ]
     , Css.paddingLeft (Css.px 4)
+    , Css.marginLeft (Css.px -4)
     , Css.borderTopLeftRadius (Css.px 4)
     , Css.borderBottomLeftRadius (Css.px 4)
     ]
@@ -110,6 +111,7 @@ endGroupStyles =
         [ Css.property "border-right" "2px solid Mark"
         ]
     , Css.paddingRight (Css.px 4)
+    , Css.marginRight (Css.px -4)
     , Css.borderTopRightRadius (Css.px 4)
     , Css.borderBottomRightRadius (Css.px 4)
     ]
@@ -146,12 +148,6 @@ hoverStyles color =
         , MediaQuery.highContrastMode
             [ Css.property "border-color" "Highlight" |> Css.important
             ]
-
-        -- The Highlighter applies both these styles and the startGroup and
-        -- endGroup styles. Here we disable the left and the right padding
-        -- because otherwise it would cause the text to move around.
-        , Css.important (Css.paddingLeft Css.zero)
-        , Css.important (Css.paddingRight Css.zero)
         ]
 
 

--- a/src/Nri/Ui/HighlighterTool/V1.elm
+++ b/src/Nri/Ui/HighlighterTool/V1.elm
@@ -98,8 +98,8 @@ startGroupStyles =
     [ MediaQuery.highContrastMode
         [ Css.property "border-left" "2px solid Mark"
         ]
-    , Css.paddingLeft (Css.px 4)
-    , Css.marginLeft (Css.px -4)
+    , Css.paddingLeft (Css.px paddingSize)
+    , Css.marginLeft (Css.px -paddingSize)
     , Css.borderTopLeftRadius (Css.px 4)
     , Css.borderBottomLeftRadius (Css.px 4)
     ]
@@ -110,11 +110,16 @@ endGroupStyles =
     [ MediaQuery.highContrastMode
         [ Css.property "border-right" "2px solid Mark"
         ]
-    , Css.paddingRight (Css.px 4)
-    , Css.marginRight (Css.px -4)
+    , Css.paddingRight (Css.px paddingSize)
+    , Css.marginRight (Css.px -paddingSize)
     , Css.borderTopRightRadius (Css.px 4)
     , Css.borderBottomRightRadius (Css.px 4)
     ]
+
+
+paddingSize : Float
+paddingSize =
+    2
 
 
 highlightStyles : Css.Color -> List Css.Style

--- a/src/Nri/Ui/HighlighterTool/V1.elm
+++ b/src/Nri/Ui/HighlighterTool/V1.elm
@@ -220,14 +220,12 @@ buildMarkerWithoutRounding { highlightColor, hoverColor, hoverHighlightColor, ki
     { hoverClass = squareHoverStyles hoverColor
     , hintClass = squareHoverStyles hoverColor
     , startGroupClass =
-        [ Css.paddingLeft (Css.px 4)
-        , MediaQuery.highContrastMode
+        [ MediaQuery.highContrastMode
             [ Css.property "border-left" "2px solid Mark"
             ]
         ]
     , endGroupClass =
-        [ Css.paddingRight (Css.px 4)
-        , MediaQuery.highContrastMode
+        [ MediaQuery.highContrastMode
             [ Css.property "border-right" "2px solid Mark"
             ]
         ]
@@ -261,13 +259,4 @@ squareSharedStyles =
 
 squareHoverStyles : Css.Color -> List Css.Style
 squareHoverStyles color =
-    List.append
-        squareSharedStyles
-        [ Css.important (Css.backgroundColor color)
-
-        -- The Highlighter applies both these styles and the startGroup and
-        -- endGroup styles. Here we disable the left and the right padding
-        -- because otherwise it would cause the text to move around.
-        , Css.important (Css.paddingLeft Css.zero)
-        , Css.important (Css.paddingRight Css.zero)
-        ]
+    List.append squareSharedStyles [ Css.important (Css.backgroundColor color) ]


### PR DESCRIPTION
## Context

Fixes A11-2439 using negative margin and a smaller amount of side padding on the highlight.

Also, adjusts the start styles implementation so that the highlight start should hopefully never be isolated on its own line anymore.

## :framed_picture: What does this change look like?

<img width="237" alt="Screen Shot 2023-04-03 at 11 05 40 AM" src="https://user-images.githubusercontent.com/8811312/229579480-9637ae17-8c71-45e6-b31a-e7d74e59ba29.png">

<img width="470" alt="Screen Shot 2023-04-03 at 11 05 47 AM" src="https://user-images.githubusercontent.com/8811312/229579485-dfe061a6-dea1-47de-a7a0-68ff9f6cceaf.png">

(Approved in [slack](https://noredink.slack.com/archives/C9MEFL3KL/p1680541573061169?thread_ts=1679091965.620369&cid=C9MEFL3KL))

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the comopnent
