### PR TITLE
:wrench: Use radio inputs under the hood in HighlighterToolbar

### DIFF
--- a/component-catalog-app/Examples/HighlighterToolbar.elm
+++ b/component-catalog-app/Examples/HighlighterToolbar.elm
@@ -18,7 +18,7 @@ import Html.Styled.Attributes exposing (css, id)
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
-import Nri.Ui.HighlighterToolbar.V2 as HighlighterToolbar
+import Nri.Ui.HighlighterToolbar.V3 as HighlighterToolbar
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -32,7 +32,7 @@ moduleName =
 
 version : Int
 version =
-    2
+    3
 
 
 {-| -}

--- a/component-catalog-app/Examples/HighlighterToolbar.elm
+++ b/component-catalog-app/Examples/HighlighterToolbar.elm
@@ -65,8 +65,7 @@ example =
                                 Code.fromModule moduleName "view"
                                     ++ Code.recordMultiline
                                         [ ( "onSelect", "identity -- msg for selecting the tag or eraser" )
-                                        , ( "getColor", "\\tag -> { colorSolid = tag.colorSolid, colorLight = tag.colorLight }" )
-                                        , ( "getName", ".name" )
+                                        , ( "getNameAndColor", "identity" )
                                         , ( "highlighterId", Code.string "highlighter-id" )
                                         ]
                                         2
@@ -81,8 +80,7 @@ example =
             , Heading.h2 [ Heading.plaintext "Example" ]
             , HighlighterToolbar.view
                 { onSelect = SelectTag
-                , getColor = getColor
-                , getName = getName
+                , getNameAndColor = identity
                 , highlighterId = "highlighter"
                 }
                 { currentTool = state.currentTool
@@ -127,47 +125,28 @@ toolPreview color border icon name =
         ]
 
 
-type Tag
-    = Claim
-    | Evidence
-    | Reasoning
+type alias Tag =
+    { name : String
+    , colorSolid : Css.Color
+    , colorLight : Css.Color
+    }
 
 
 tags : List Tag
 tags =
-    [ Claim, Evidence, Reasoning ]
-
-
-getName : Tag -> String
-getName tag =
-    case tag of
-        Claim ->
-            "Claim"
-
-        Evidence ->
-            "Evidence"
-
-        Reasoning ->
-            "Reasoning"
-
-
-getColor : Tag -> { colorSolid : Color, colorLight : Color }
-getColor tag =
-    case tag of
-        Claim ->
-            { colorSolid = Colors.mustard
-            , colorLight = Colors.highlightYellow
-            }
-
-        Evidence ->
-            { colorSolid = Colors.magenta
-            , colorLight = Colors.highlightMagenta
-            }
-
-        Reasoning ->
-            { colorSolid = Colors.cyan
-            , colorLight = Colors.highlightCyan
-            }
+    [ { name = "Claim"
+      , colorSolid = Colors.mustard
+      , colorLight = Colors.highlightYellow
+      }
+    , { name = "Evidence"
+      , colorSolid = Colors.magenta
+      , colorLight = Colors.highlightMagenta
+      }
+    , { name = "Reasoning"
+      , colorSolid = Colors.cyan
+      , colorLight = Colors.highlightCyan
+      }
+    ]
 
 
 {-| -}

--- a/component-catalog-app/Examples/HighlighterToolbar.elm
+++ b/component-catalog-app/Examples/HighlighterToolbar.elm
@@ -6,7 +6,6 @@ module Examples.HighlighterToolbar exposing (Msg, State, example)
 
 -}
 
-import Browser.Dom as Dom
 import Category exposing (Category(..))
 import Code
 import Css exposing (Color)
@@ -22,7 +21,6 @@ import Nri.Ui.HighlighterToolbar.V3 as HighlighterToolbar
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
-import Task
 
 
 moduleName : String
@@ -64,7 +62,7 @@ example =
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
             , HighlighterToolbar.view
-                { focusAndSelect = FocusAndSelectTag
+                { onSelect = SelectTag
                 , getColor = getColor
                 , getName = getName
                 , highlighterId = "highlighter"
@@ -185,8 +183,7 @@ controlSettings =
 {-| -}
 type Msg
     = UpdateControls (Control Settings)
-    | FocusAndSelectTag { select : Maybe Tag, focus : Maybe String }
-    | Focused (Result Dom.Error ())
+    | SelectTag (Maybe Tag)
 
 
 {-| -}
@@ -196,12 +193,7 @@ update msg state =
         UpdateControls settings ->
             ( { state | settings = settings }, Cmd.none )
 
-        FocusAndSelectTag { select, focus } ->
-            ( { state | currentTool = select }
-            , focus
-                |> Maybe.map (Dom.focus >> Task.attempt Focused)
-                |> Maybe.withDefault Cmd.none
+        SelectTag newTool ->
+            ( { state | currentTool = newTool }
+            , Cmd.none
             )
-
-        Focused error ->
-            ( state, Cmd.none )

--- a/component-catalog-app/Examples/HighlighterToolbar.elm
+++ b/component-catalog-app/Examples/HighlighterToolbar.elm
@@ -58,7 +58,25 @@ example =
                 , mainType = Nothing
                 , extraCode = []
                 , renderExample = Code.unstyledView
-                , toExampleCode = \_ -> []
+                , toExampleCode =
+                    \_ ->
+                        [ { sectionName = "Example"
+                          , code =
+                                Code.fromModule moduleName "view"
+                                    ++ Code.recordMultiline
+                                        [ ( "onSelect", "identity -- msg for selecting the tag or eraser" )
+                                        , ( "getColor", "\\tag -> { colorSolid = tag.colorSolid, colorLight = tag.colorLight }" )
+                                        , ( "getName", ".name" )
+                                        , ( "highlighterId", Code.string "highlighter-id" )
+                                        ]
+                                        2
+                                    ++ Code.recordMultiline
+                                        [ ( "currentTool", "Nothing" )
+                                        , ( "tags", "[]" )
+                                        ]
+                                        2
+                          }
+                        ]
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
             , HighlighterToolbar.view

--- a/component-catalog/review/elm.json
+++ b/component-catalog/review/elm.json
@@ -9,26 +9,27 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.7.0",
-            "jfmengels/elm-review-unused": "1.1.20",
+            "jfmengels/elm-review": "2.12.2",
+            "jfmengels/elm-review-unused": "1.1.29",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/time": "1.0.0",
-            "elm/virtual-dom": "1.0.2",
-            "elm-community/list-extra": "8.5.2",
-            "elm-explorations/test": "1.2.2",
-            "miniBill/elm-unicode": "1.0.2",
+            "elm/virtual-dom": "1.0.3",
+            "elm-community/list-extra": "8.7.0",
+            "elm-explorations/test": "2.1.1",
+            "miniBill/elm-unicode": "1.0.3",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2"
+            "elm-explorations/test": "2.1.1"
         },
         "indirect": {}
     }

--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -1,7 +1,8 @@
 Nri.Ui.Block.V3,upgrade to V4
 Nri.Ui.Highlightable.V1,upgrade to V2
 Nri.Ui.Highlighter.V2,upgrade to V3
-Nri.Ui.HighlighterToolbar.V1,upgrade to V2
+Nri.Ui.HighlighterToolbar.V1,upgrade to V3
+Nri.Ui.HighlighterToolbar.V2,upgrade to V3
 Nri.Ui.QuestionBox.V2,upgrade to V4
 Nri.Ui.QuestionBox.V3,upgrade to V4
 Nri.Ui.Select.V8,upgrade to V9

--- a/elm.json
+++ b/elm.json
@@ -41,6 +41,7 @@
         "Nri.Ui.HighlighterTool.V1",
         "Nri.Ui.HighlighterToolbar.V1",
         "Nri.Ui.HighlighterToolbar.V2",
+        "Nri.Ui.HighlighterToolbar.V3",
         "Nri.Ui.Html.Attributes.V2",
         "Nri.Ui.Html.V3",
         "Nri.Ui.InputStyles.V4",

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -88,7 +88,10 @@ hint = 'upgrade to V2'
 hint = 'upgrade to V3'
 
 [forbidden."Nri.Ui.HighlighterToolbar.V1"]
-hint = 'upgrade to V2'
+hint = 'upgrade to V3'
+
+[forbidden."Nri.Ui.HighlighterToolbar.V2"]
+hint = 'upgrade to V3'
 
 [forbidden."Nri.Ui.Icon.V3"]
 hint = 'upgrade to V5'

--- a/review/elm.json
+++ b/review/elm.json
@@ -9,26 +9,27 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.7.0",
-            "jfmengels/elm-review-unused": "1.1.20",
+            "jfmengels/elm-review": "2.12.2",
+            "jfmengels/elm-review-unused": "1.1.29",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/time": "1.0.0",
-            "elm/virtual-dom": "1.0.2",
-            "elm-community/list-extra": "8.5.2",
-            "elm-explorations/test": "1.2.2",
-            "miniBill/elm-unicode": "1.0.2",
+            "elm/virtual-dom": "1.0.3",
+            "elm-community/list-extra": "8.7.0",
+            "elm-explorations/test": "2.1.1",
+            "miniBill/elm-unicode": "1.0.3",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2"
+            "elm-explorations/test": "2.1.1"
         },
         "indirect": {}
     }

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -24,12 +24,10 @@ module Nri.Ui.HighlighterToolbar.V3 exposing (view)
 -}
 
 import Accessibility.Styled.Aria as Aria
-import Accessibility.Styled.Key as Key
 import Accessibility.Styled.Role as Role
 import Css exposing (Color)
-import EventExtras exposing (onClickPreventDefaultAndStopPropagation)
 import Html.Styled exposing (..)
-import Html.Styled.Attributes as Attributes exposing (css, id, tabindex)
+import Html.Styled.Attributes as Attributes exposing (css, id)
 import Html.Styled.Events exposing (onClick)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.FocusRing.V1 as FocusRing
@@ -159,54 +157,6 @@ viewTool name focusAndSelect theme selected tag tools currentTool getName =
             []
         , toolContent name theme tag
         , viewIf (\() -> active theme) selected
-        ]
-
-
-keyEvents : ({ select : Maybe tag, focus : Maybe String } -> msg) -> Maybe tag -> List (Maybe tag) -> (tag -> String) -> List (Key.Event msg)
-keyEvents focusAndSelect tag tools getName =
-    let
-        onFocus tag_ =
-            focusAndSelect
-                { select = tag_
-                , focus =
-                    case tag_ of
-                        Just tag__ ->
-                            Just ("tag-" ++ getName tag__)
-
-                        Nothing ->
-                            Just "tag-Remove highlight"
-                }
-
-        findAdjacentTag tag_ ( isAdjacentTab, acc ) =
-            if isAdjacentTab then
-                ( False, Just (onFocus tag_) )
-
-            else
-                ( tag_ == tag, acc )
-
-        goToNextTag : Maybe msg
-        goToNextTag =
-            List.foldl findAdjacentTag
-                ( False
-                , -- if there is no adjacent tag, default to the first tag
-                  Maybe.map onFocus (List.head tools)
-                )
-                tools
-                |> Tuple.second
-
-        goToPreviousTag : Maybe msg
-        goToPreviousTag =
-            List.foldr findAdjacentTag
-                ( False
-                , -- if there is no adjacent tag, default to the last tag
-                  Maybe.map onFocus (List.head (List.reverse tools))
-                )
-                tools
-                |> Tuple.second
-    in
-    List.filterMap identity
-        [ Maybe.map Key.right goToNextTag
-        , Maybe.map Key.left goToPreviousTag
         ]
 
 

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -52,7 +52,7 @@ view config model =
     let
         viewTagWithConfig : tag -> Html msg
         viewTagWithConfig tag =
-            viewTag config tag model
+            viewTool (config.getName tag) config.onSelect (config.getColor tag) (Just tag) model
     in
     toolbar config.highlighterId
         (List.map viewTagWithConfig model.tags
@@ -76,19 +76,6 @@ toolbar highlighterId =
             , Css.flexWrap Css.wrap
             ]
         ]
-
-
-viewTag :
-    { onSelect : Maybe tag -> msg
-    , getColor : tag -> { extras | colorSolid : Color, colorLight : Color }
-    , getName : tag -> String
-    , highlighterId : String
-    }
-    -> tag
-    -> { model | currentTool : Maybe tag }
-    -> Html msg
-viewTag { onSelect, getColor, getName } tag model =
-    viewTool (getName tag) onSelect (getColor tag) (Just tag) model
 
 
 viewEraser :

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -1,0 +1,281 @@
+module Nri.Ui.HighlighterToolbar.V3 exposing (view)
+
+{-| Bar with markers for choosing how text will be highlighted in a highlighter.
+
+@docs view
+
+
+### Patch changes:
+
+  - Ensure selected tool is clear in high contrast mode
+
+
+### Changes from V1:
+
+  - replaces `onChangeTag` and `onSetEraser` with `focusAndSelect`.
+  - adds `highlighterId` to config
+  - adds keyboard navigation
+
+-}
+
+import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Key as Key
+import Accessibility.Styled.Role as Role
+import Css exposing (Color)
+import EventExtras exposing (onClickPreventDefaultAndStopPropagation)
+import Html.Styled exposing (..)
+import Html.Styled.Attributes exposing (css, id, tabindex)
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Html.Attributes.V2 exposing (nriDescription)
+import Nri.Ui.Html.V3 exposing (viewIf)
+import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.UiIcon.V1 as UiIcon
+
+
+toolbar : String -> List (Html msg) -> Html msg
+toolbar highlighterId =
+    div
+        [ nriDescription "tools"
+        , Role.toolBar
+        , Aria.label "Highlighter options"
+        , Aria.controls [ highlighterId ]
+        , css
+            [ Css.displayFlex
+            , Css.listStyle Css.none
+            , Css.padding (Css.px 0)
+            , Css.margin (Css.px 0)
+            , Css.marginTop (Css.px 10)
+            , Css.flexWrap Css.wrap
+            ]
+        ]
+
+
+toolContainer : String -> Html msg -> Html msg
+toolContainer toolName tool =
+    div [ nriDescription toolName ] [ tool ]
+
+
+{-| View renders each marker and an eraser. This is usually used with a Highlighter.
+-}
+view :
+    { focusAndSelect : { select : Maybe tag, focus : Maybe String } -> msg
+    , getColor : tag -> { extras | colorSolid : Color, colorLight : Color }
+    , getName : tag -> String
+    , highlighterId : String
+    }
+    -> { model | currentTool : Maybe tag, tags : List tag }
+    -> Html msg
+view config model =
+    let
+        tools =
+            List.map Just model.tags ++ [ Nothing ]
+
+        viewTagWithConfig : tag -> Html msg
+        viewTagWithConfig tag =
+            viewTag config (model.currentTool == Just tag) tag tools model.currentTool
+
+        eraserSelected : Bool
+        eraserSelected =
+            model.currentTool == Nothing
+    in
+    toolbar config.highlighterId
+        (List.map viewTagWithConfig model.tags
+            ++ [ viewEraser config.focusAndSelect eraserSelected tools model.currentTool config.getName ]
+        )
+
+
+viewTag :
+    { focusAndSelect : { select : Maybe tag, focus : Maybe String } -> msg
+    , getColor : tag -> { extras | colorSolid : Color, colorLight : Color }
+    , getName : tag -> String
+    , highlighterId : String
+    }
+    -> Bool
+    -> tag
+    -> List (Maybe tag)
+    -> Maybe tag
+    -> Html msg
+viewTag { focusAndSelect, getColor, getName } selected tag tools currentTool =
+    toolContainer ("tag-" ++ getName tag)
+        (viewTool (getName tag) focusAndSelect (getColor tag) selected (Just tag) tools currentTool getName)
+
+
+viewEraser :
+    ({ select : Maybe tag, focus : Maybe String } -> msg)
+    -> Bool
+    -> List (Maybe tag)
+    -> Maybe tag
+    -> (tag -> String)
+    -> Html msg
+viewEraser focusAndSelect selected tools currentTool getName =
+    toolContainer "eraser"
+        (viewTool "Remove highlight"
+            focusAndSelect
+            { colorLight = Colors.gray75, colorSolid = Colors.white }
+            selected
+            Nothing
+            tools
+            currentTool
+            getName
+        )
+
+
+viewTool :
+    String
+    -> ({ select : Maybe tag, focus : Maybe String } -> msg)
+    -> { extras | colorSolid : Color, colorLight : Color }
+    -> Bool
+    -> Maybe tag
+    -> List (Maybe tag)
+    -> Maybe tag
+    -> (tag -> String)
+    -> Html msg
+viewTool name focusAndSelect theme selected tag tools currentTool getName =
+    button
+        [ id ("tag-" ++ name)
+        , css
+            [ Css.backgroundColor Css.transparent
+            , Css.borderRadius (Css.px 0)
+            , Css.border (Css.px 0)
+            , Css.active [ Css.outlineStyle Css.none ]
+            , Css.focus [ Css.outlineStyle Css.none ]
+            , Css.cursor Css.pointer
+            ]
+        , onClickPreventDefaultAndStopPropagation (focusAndSelect { select = tag, focus = Nothing })
+        , Aria.pressed (Just selected)
+        , tabindex
+            (if selected then
+                0
+
+             else
+                -1
+            )
+        , Key.onKeyDownPreventDefault (keyEvents focusAndSelect currentTool tools getName)
+        ]
+        [ toolContent name theme tag
+        , viewIf (\() -> active theme) selected
+        ]
+
+
+keyEvents : ({ select : Maybe tag, focus : Maybe String } -> msg) -> Maybe tag -> List (Maybe tag) -> (tag -> String) -> List (Key.Event msg)
+keyEvents focusAndSelect tag tools getName =
+    let
+        onFocus tag_ =
+            focusAndSelect
+                { select = tag_
+                , focus =
+                    case tag_ of
+                        Just tag__ ->
+                            Just ("tag-" ++ getName tag__)
+
+                        Nothing ->
+                            Just "tag-Remove highlight"
+                }
+
+        findAdjacentTag tag_ ( isAdjacentTab, acc ) =
+            if isAdjacentTab then
+                ( False, Just (onFocus tag_) )
+
+            else
+                ( tag_ == tag, acc )
+
+        goToNextTag : Maybe msg
+        goToNextTag =
+            List.foldl findAdjacentTag
+                ( False
+                , -- if there is no adjacent tag, default to the first tag
+                  Maybe.map onFocus (List.head tools)
+                )
+                tools
+                |> Tuple.second
+
+        goToPreviousTag : Maybe msg
+        goToPreviousTag =
+            List.foldr findAdjacentTag
+                ( False
+                , -- if there is no adjacent tag, default to the last tag
+                  Maybe.map onFocus (List.head (List.reverse tools))
+                )
+                tools
+                |> Tuple.second
+    in
+    List.filterMap identity
+        [ Maybe.map Key.right goToNextTag
+        , Maybe.map Key.left goToPreviousTag
+        ]
+
+
+active :
+    { extras | colorLight : Color }
+    -> Html msg
+active palette_ =
+    div
+        [ nriDescription "active-tool"
+        , css
+            [ Css.width (Css.px 38)
+            , Css.border3 (Css.px 2) Css.solid palette_.colorLight
+            ]
+        ]
+        []
+
+
+toolContent :
+    String
+    -> { extras | colorSolid : Color, colorLight : Color }
+    -> Maybe tag
+    -> Html msg
+toolContent name palette_ tool =
+    span
+        [ nriDescription "tool-content"
+        , css
+            [ Css.position Css.relative
+            , Css.height (Css.pct 100)
+            , Css.padding (Css.px 0)
+            , Css.paddingRight (Css.px 15)
+            , Css.display Css.inlineFlex
+            , Css.alignItems Css.center
+            ]
+        ]
+        [ case tool of
+            Just _ ->
+                toolIcon
+                    { background = palette_.colorSolid
+                    , border = palette_.colorSolid
+                    , icon = Svg.withColor Colors.white UiIcon.highlighter
+                    }
+
+            Nothing ->
+                toolIcon
+                    { background = palette_.colorSolid
+                    , border = Colors.gray75
+                    , icon = Svg.withColor Colors.gray20 UiIcon.eraser
+                    }
+        , span
+            [ nriDescription "tool-label"
+            , css
+                [ Css.color Colors.navy
+                , Css.fontSize (Css.px 15)
+                , Css.marginLeft (Css.px 5)
+                , Css.fontWeight (Css.int 600)
+                , Fonts.baseFont
+                ]
+            ]
+            [ text name ]
+        ]
+
+
+toolIcon : { background : Color, border : Color, icon : Svg.Svg } -> Html msg
+toolIcon config =
+    span
+        [ css
+            [ Css.backgroundColor config.background
+            , Css.width (Css.px 38)
+            , Css.height (Css.px 38)
+            , Css.borderRadius (Css.pct 50)
+            , Css.padding (Css.px 7)
+            , Css.border3 (Css.px 1) Css.solid config.border
+            ]
+        ]
+        [ Svg.toHtml config.icon
+        ]

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -5,6 +5,11 @@ module Nri.Ui.HighlighterToolbar.V3 exposing (view)
 @docs view
 
 
+### Changes from V2:
+
+  - Use radio inputs under the hood
+
+
 ### Patch changes:
 
   - Ensure selected tool is clear in high contrast mode
@@ -33,7 +38,7 @@ import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.UiIcon.V1 as UiIcon
 
 
-{-| View renders each marker and an eraser. This is usually used with a Highlighter.
+{-| View renders each marker and an eraser. This is exclusively used with an interactive Highlighter, whose id you should pass in when initializing the HighlighterToolbar.
 -}
 view :
     { focusAndSelect : { select : Maybe tag, focus : Maybe String } -> msg

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -8,6 +8,7 @@ module Nri.Ui.HighlighterToolbar.V3 exposing (view)
 ### Changes from V2:
 
   - Use radio inputs under the hood
+  - don't arbitrarily complicate API -- match the usecases on the monolith side
 
 
 ### Patch changes:
@@ -42,8 +43,7 @@ import Nri.Ui.UiIcon.V1 as UiIcon
 -}
 view :
     { onSelect : Maybe tag -> msg
-    , getColor : tag -> { extras | colorSolid : Color, colorLight : Color }
-    , getName : tag -> String
+    , getNameAndColor : tag -> { extras | name : String, colorSolid : Color, colorLight : Color }
     , highlighterId : String
     }
     -> { model | currentTool : Maybe tag, tags : List tag }
@@ -52,7 +52,7 @@ view config model =
     let
         viewTagWithConfig : tag -> Html msg
         viewTagWithConfig tag =
-            viewTool (config.getName tag) config.onSelect (config.getColor tag) (Just tag) model
+            viewTool config.onSelect (config.getNameAndColor tag) (Just tag) model
     in
     toolbar config.highlighterId
         (List.map viewTagWithConfig model.tags
@@ -83,21 +83,23 @@ viewEraser :
     -> { model | currentTool : Maybe tag }
     -> Html msg
 viewEraser onSelect model =
-    viewTool "Remove highlight"
+    viewTool
         onSelect
-        { colorLight = Colors.gray75, colorSolid = Colors.white }
+        { name = "Remove highlight"
+        , colorLight = Colors.gray75
+        , colorSolid = Colors.white
+        }
         Nothing
         model
 
 
 viewTool :
-    String
-    -> (Maybe tag -> msg)
-    -> { extras | colorSolid : Color, colorLight : Color }
+    (Maybe tag -> msg)
+    -> { extras | name : String, colorSolid : Color, colorLight : Color }
     -> Maybe tag
     -> { model | currentTool : Maybe tag }
     -> Html msg
-viewTool name onSelect theme tag model =
+viewTool onSelect ({ name } as theme) tag model =
     let
         selected =
             model.currentTool == tag

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -32,6 +32,7 @@ import Html.Styled exposing (..)
 import Html.Styled.Attributes as Attributes exposing (css, id, tabindex)
 import Html.Styled.Events exposing (onClick)
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 exposing (nriDescription)
 import Nri.Ui.Html.V3 exposing (viewIf)
@@ -86,11 +87,6 @@ toolbar highlighterId =
         ]
 
 
-toolContainer : String -> Html msg -> Html msg
-toolContainer toolName tool =
-    div [ nriDescription toolName ] [ tool ]
-
-
 viewTag :
     { focusAndSelect : { select : Maybe tag, focus : Maybe String } -> msg
     , getColor : tag -> { extras | colorSolid : Color, colorLight : Color }
@@ -103,8 +99,7 @@ viewTag :
     -> Maybe tag
     -> Html msg
 viewTag { focusAndSelect, getColor, getName } selected tag tools currentTool =
-    toolContainer ("tag-" ++ getName tag)
-        (viewTool (getName tag) focusAndSelect (getColor tag) selected (Just tag) tools currentTool getName)
+    viewTool (getName tag) focusAndSelect (getColor tag) selected (Just tag) tools currentTool getName
 
 
 viewEraser :
@@ -115,16 +110,14 @@ viewEraser :
     -> (tag -> String)
     -> Html msg
 viewEraser focusAndSelect selected tools currentTool getName =
-    toolContainer "eraser"
-        (viewTool "Remove highlight"
-            focusAndSelect
-            { colorLight = Colors.gray75, colorSolid = Colors.white }
-            selected
-            Nothing
-            tools
-            currentTool
-            getName
-        )
+    viewTool "Remove highlight"
+        focusAndSelect
+        { colorLight = Colors.gray75, colorSolid = Colors.white }
+        selected
+        Nothing
+        tools
+        currentTool
+        getName
 
 
 viewTool :
@@ -141,11 +134,9 @@ viewTool name focusAndSelect theme selected tag tools currentTool getName =
     label
         [ id ("tag-" ++ name)
         , css
-            [ Css.backgroundColor Css.transparent
-            , Css.borderRadius (Css.px 0)
-            , Css.border (Css.px 0)
-            , Css.cursor Css.pointer
+            [ Css.cursor Css.pointer
             , Css.position Css.relative
+            , Css.pseudoClass "focus-within" FocusRing.styles
             ]
         ]
         [ input
@@ -162,6 +153,7 @@ viewTool name focusAndSelect theme selected tag tools currentTool getName =
                 , Css.top (Css.px 4)
                 , Css.left (Css.px 4)
                 ]
+            , Attributes.class FocusRing.customClass
             ]
             []
         , toolContent name theme tag

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -33,29 +33,6 @@ import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.UiIcon.V1 as UiIcon
 
 
-toolbar : String -> List (Html msg) -> Html msg
-toolbar highlighterId =
-    div
-        [ nriDescription "tools"
-        , Role.toolBar
-        , Aria.label "Highlighter options"
-        , Aria.controls [ highlighterId ]
-        , css
-            [ Css.displayFlex
-            , Css.listStyle Css.none
-            , Css.padding (Css.px 0)
-            , Css.margin (Css.px 0)
-            , Css.marginTop (Css.px 10)
-            , Css.flexWrap Css.wrap
-            ]
-        ]
-
-
-toolContainer : String -> Html msg -> Html msg
-toolContainer toolName tool =
-    div [ nriDescription toolName ] [ tool ]
-
-
 {-| View renders each marker and an eraser. This is usually used with a Highlighter.
 -}
 view :
@@ -83,6 +60,29 @@ view config model =
         (List.map viewTagWithConfig model.tags
             ++ [ viewEraser config.focusAndSelect eraserSelected tools model.currentTool config.getName ]
         )
+
+
+toolbar : String -> List (Html msg) -> Html msg
+toolbar highlighterId =
+    div
+        [ nriDescription "tools"
+        , Role.toolBar
+        , Aria.label "Highlighter options"
+        , Aria.controls [ highlighterId ]
+        , css
+            [ Css.displayFlex
+            , Css.listStyle Css.none
+            , Css.padding (Css.px 0)
+            , Css.margin (Css.px 0)
+            , Css.marginTop (Css.px 10)
+            , Css.flexWrap Css.wrap
+            ]
+        ]
+
+
+toolContainer : String -> Html msg -> Html msg
+toolContainer toolName tool =
+    div [ nriDescription toolName ] [ tool ]
 
 
 viewTag :

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -56,7 +56,7 @@ view config model =
     in
     toolbar config.highlighterId
         (List.map viewTagWithConfig model.tags
-            ++ [ viewEraser config.onSelect model config.getName ]
+            ++ [ viewEraser config.onSelect model ]
         )
 
 
@@ -88,21 +88,19 @@ viewTag :
     -> { model | currentTool : Maybe tag }
     -> Html msg
 viewTag { onSelect, getColor, getName } tag model =
-    viewTool (getName tag) onSelect (getColor tag) (Just tag) model getName
+    viewTool (getName tag) onSelect (getColor tag) (Just tag) model
 
 
 viewEraser :
     (Maybe tag -> msg)
     -> { model | currentTool : Maybe tag }
-    -> (tag -> String)
     -> Html msg
-viewEraser onSelect model getName =
+viewEraser onSelect model =
     viewTool "Remove highlight"
         onSelect
         { colorLight = Colors.gray75, colorSolid = Colors.white }
         Nothing
         model
-        getName
 
 
 viewTool :
@@ -111,9 +109,8 @@ viewTool :
     -> { extras | colorSolid : Color, colorLight : Color }
     -> Maybe tag
     -> { model | currentTool : Maybe tag }
-    -> (tag -> String)
     -> Html msg
-viewTool name onSelect theme tag model getName =
+viewTool name onSelect theme tag model =
     let
         selected =
             model.currentTool == tag

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -137,6 +137,7 @@ viewTool name focusAndSelect theme selected tag tools currentTool getName =
             [ Css.cursor Css.pointer
             , Css.position Css.relative
             , Css.pseudoClass "focus-within" FocusRing.styles
+            , Css.paddingBottom (Css.px 2)
             ]
         ]
         [ input

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -29,7 +29,8 @@ import Accessibility.Styled.Role as Role
 import Css exposing (Color)
 import EventExtras exposing (onClickPreventDefaultAndStopPropagation)
 import Html.Styled exposing (..)
-import Html.Styled.Attributes exposing (css, id, tabindex)
+import Html.Styled.Attributes as Attributes exposing (css, id, tabindex)
+import Html.Styled.Events exposing (onClick)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 exposing (nriDescription)
@@ -137,28 +138,33 @@ viewTool :
     -> (tag -> String)
     -> Html msg
 viewTool name focusAndSelect theme selected tag tools currentTool getName =
-    button
+    label
         [ id ("tag-" ++ name)
         , css
             [ Css.backgroundColor Css.transparent
             , Css.borderRadius (Css.px 0)
             , Css.border (Css.px 0)
-            , Css.active [ Css.outlineStyle Css.none ]
-            , Css.focus [ Css.outlineStyle Css.none ]
             , Css.cursor Css.pointer
+            , Css.position Css.relative
             ]
-        , onClickPreventDefaultAndStopPropagation (focusAndSelect { select = tag, focus = Nothing })
-        , Aria.pressed (Just selected)
-        , tabindex
-            (if selected then
-                0
-
-             else
-                -1
-            )
-        , Key.onKeyDownPreventDefault (keyEvents focusAndSelect currentTool tools getName)
         ]
-        [ toolContent name theme tag
+        [ input
+            [ Attributes.value name
+            , Attributes.type_ "radio"
+            , Attributes.name "highlighter-toolbar-tool"
+            , Attributes.checked (currentTool == tag)
+            , onClick (focusAndSelect { select = tag, focus = Nothing })
+            , css
+                [ Css.cursor Css.pointer
+
+                -- position the radio input underneath the tool content
+                , Css.position Css.absolute
+                , Css.top (Css.px 4)
+                , Css.left (Css.px 4)
+                ]
+            ]
+            []
+        , toolContent name theme tag
         , viewIf (\() -> active theme) selected
         ]
 

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -111,6 +111,7 @@ viewTool onSelect ({ name } as theme) tag model =
             , Css.position Css.relative
             , Css.pseudoClass "focus-within" FocusRing.styles
             , Css.paddingBottom (Css.px 2)
+            , Css.marginRight (Css.px 15)
             ]
         ]
         [ input
@@ -161,7 +162,6 @@ toolContent name palette_ tool =
             [ Css.position Css.relative
             , Css.height (Css.pct 100)
             , Css.padding (Css.px 0)
-            , Css.paddingRight (Css.px 15)
             , Css.display Css.inlineFlex
             , Css.alignItems Css.center
             ]

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -55,15 +55,11 @@ view config model =
 
         viewTagWithConfig : tag -> Html msg
         viewTagWithConfig tag =
-            viewTag config (model.currentTool == Just tag) tag tools model.currentTool
-
-        eraserSelected : Bool
-        eraserSelected =
-            model.currentTool == Nothing
+            viewTag config tag tools model
     in
     toolbar config.highlighterId
         (List.map viewTagWithConfig model.tags
-            ++ [ viewEraser config.onSelect eraserSelected tools model.currentTool config.getName ]
+            ++ [ viewEraser config.onSelect tools model config.getName ]
         )
 
 
@@ -91,30 +87,27 @@ viewTag :
     , getName : tag -> String
     , highlighterId : String
     }
-    -> Bool
     -> tag
     -> List (Maybe tag)
-    -> Maybe tag
+    -> { model | currentTool : Maybe tag }
     -> Html msg
-viewTag { onSelect, getColor, getName } selected tag tools currentTool =
-    viewTool (getName tag) onSelect (getColor tag) selected (Just tag) tools currentTool getName
+viewTag { onSelect, getColor, getName } tag tools model =
+    viewTool (getName tag) onSelect (getColor tag) (Just tag) tools model getName
 
 
 viewEraser :
     (Maybe tag -> msg)
-    -> Bool
     -> List (Maybe tag)
-    -> Maybe tag
+    -> { model | currentTool : Maybe tag }
     -> (tag -> String)
     -> Html msg
-viewEraser onSelect selected tools currentTool getName =
+viewEraser onSelect tools model getName =
     viewTool "Remove highlight"
         onSelect
         { colorLight = Colors.gray75, colorSolid = Colors.white }
-        selected
         Nothing
         tools
-        currentTool
+        model
         getName
 
 
@@ -122,13 +115,16 @@ viewTool :
     String
     -> (Maybe tag -> msg)
     -> { extras | colorSolid : Color, colorLight : Color }
-    -> Bool
     -> Maybe tag
     -> List (Maybe tag)
-    -> Maybe tag
+    -> { model | currentTool : Maybe tag }
     -> (tag -> String)
     -> Html msg
-viewTool name onSelect theme selected tag tools currentTool getName =
+viewTool name onSelect theme tag tools model getName =
+    let
+        selected =
+            model.currentTool == tag
+    in
     label
         [ id ("tag-" ++ name)
         , css
@@ -142,7 +138,7 @@ viewTool name onSelect theme selected tag tools currentTool getName =
             [ Attributes.value name
             , Attributes.type_ "radio"
             , Attributes.name "highlighter-toolbar-tool"
-            , Attributes.checked (currentTool == tag)
+            , Attributes.checked selected
             , onClick (onSelect tag)
             , css
                 [ Css.cursor Css.pointer

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -17,7 +17,7 @@ module Nri.Ui.HighlighterToolbar.V3 exposing (view)
 
 ### Changes from V1:
 
-  - replaces `onChangeTag` and `onSetEraser` with `focusAndSelect`.
+  - replaces `onChangeTag` and `onSetEraser` with `onSelect`.
   - adds `highlighterId` to config
   - adds keyboard navigation
 
@@ -41,7 +41,7 @@ import Nri.Ui.UiIcon.V1 as UiIcon
 {-| View renders each marker and an eraser. This is exclusively used with an interactive Highlighter, whose id you should pass in when initializing the HighlighterToolbar.
 -}
 view :
-    { focusAndSelect : { select : Maybe tag, focus : Maybe String } -> msg
+    { onSelect : Maybe tag -> msg
     , getColor : tag -> { extras | colorSolid : Color, colorLight : Color }
     , getName : tag -> String
     , highlighterId : String
@@ -63,7 +63,7 @@ view config model =
     in
     toolbar config.highlighterId
         (List.map viewTagWithConfig model.tags
-            ++ [ viewEraser config.focusAndSelect eraserSelected tools model.currentTool config.getName ]
+            ++ [ viewEraser config.onSelect eraserSelected tools model.currentTool config.getName ]
         )
 
 
@@ -86,7 +86,7 @@ toolbar highlighterId =
 
 
 viewTag :
-    { focusAndSelect : { select : Maybe tag, focus : Maybe String } -> msg
+    { onSelect : Maybe tag -> msg
     , getColor : tag -> { extras | colorSolid : Color, colorLight : Color }
     , getName : tag -> String
     , highlighterId : String
@@ -96,20 +96,20 @@ viewTag :
     -> List (Maybe tag)
     -> Maybe tag
     -> Html msg
-viewTag { focusAndSelect, getColor, getName } selected tag tools currentTool =
-    viewTool (getName tag) focusAndSelect (getColor tag) selected (Just tag) tools currentTool getName
+viewTag { onSelect, getColor, getName } selected tag tools currentTool =
+    viewTool (getName tag) onSelect (getColor tag) selected (Just tag) tools currentTool getName
 
 
 viewEraser :
-    ({ select : Maybe tag, focus : Maybe String } -> msg)
+    (Maybe tag -> msg)
     -> Bool
     -> List (Maybe tag)
     -> Maybe tag
     -> (tag -> String)
     -> Html msg
-viewEraser focusAndSelect selected tools currentTool getName =
+viewEraser onSelect selected tools currentTool getName =
     viewTool "Remove highlight"
-        focusAndSelect
+        onSelect
         { colorLight = Colors.gray75, colorSolid = Colors.white }
         selected
         Nothing
@@ -120,7 +120,7 @@ viewEraser focusAndSelect selected tools currentTool getName =
 
 viewTool :
     String
-    -> ({ select : Maybe tag, focus : Maybe String } -> msg)
+    -> (Maybe tag -> msg)
     -> { extras | colorSolid : Color, colorLight : Color }
     -> Bool
     -> Maybe tag
@@ -128,7 +128,7 @@ viewTool :
     -> Maybe tag
     -> (tag -> String)
     -> Html msg
-viewTool name focusAndSelect theme selected tag tools currentTool getName =
+viewTool name onSelect theme selected tag tools currentTool getName =
     label
         [ id ("tag-" ++ name)
         , css
@@ -143,7 +143,7 @@ viewTool name focusAndSelect theme selected tag tools currentTool getName =
             , Attributes.type_ "radio"
             , Attributes.name "highlighter-toolbar-tool"
             , Attributes.checked (currentTool == tag)
-            , onClick (focusAndSelect { select = tag, focus = Nothing })
+            , onClick (onSelect tag)
             , css
                 [ Css.cursor Css.pointer
 

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -50,16 +50,13 @@ view :
     -> Html msg
 view config model =
     let
-        tools =
-            List.map Just model.tags ++ [ Nothing ]
-
         viewTagWithConfig : tag -> Html msg
         viewTagWithConfig tag =
-            viewTag config tag tools model
+            viewTag config tag model
     in
     toolbar config.highlighterId
         (List.map viewTagWithConfig model.tags
-            ++ [ viewEraser config.onSelect tools model config.getName ]
+            ++ [ viewEraser config.onSelect model config.getName ]
         )
 
 
@@ -88,25 +85,22 @@ viewTag :
     , highlighterId : String
     }
     -> tag
-    -> List (Maybe tag)
     -> { model | currentTool : Maybe tag }
     -> Html msg
-viewTag { onSelect, getColor, getName } tag tools model =
-    viewTool (getName tag) onSelect (getColor tag) (Just tag) tools model getName
+viewTag { onSelect, getColor, getName } tag model =
+    viewTool (getName tag) onSelect (getColor tag) (Just tag) model getName
 
 
 viewEraser :
     (Maybe tag -> msg)
-    -> List (Maybe tag)
     -> { model | currentTool : Maybe tag }
     -> (tag -> String)
     -> Html msg
-viewEraser onSelect tools model getName =
+viewEraser onSelect model getName =
     viewTool "Remove highlight"
         onSelect
         { colorLight = Colors.gray75, colorSolid = Colors.white }
         Nothing
-        tools
         model
         getName
 
@@ -116,11 +110,10 @@ viewTool :
     -> (Maybe tag -> msg)
     -> { extras | colorSolid : Color, colorLight : Color }
     -> Maybe tag
-    -> List (Maybe tag)
     -> { model | currentTool : Maybe tag }
     -> (tag -> String)
     -> Html msg
-viewTool name onSelect theme tag tools model getName =
+viewTool name onSelect theme tag model getName =
     let
         selected =
             model.currentTool == tag

--- a/tests/Spec/Nri/Ui/HighlighterToolbar.elm
+++ b/tests/Spec/Nri/Ui/HighlighterToolbar.elm
@@ -7,7 +7,7 @@ import Expect
 import Html.Attributes as Attributes
 import Html.Styled as Html exposing (..)
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.HighlighterToolbar.V2 as HighlighterToolbar
+import Nri.Ui.HighlighterToolbar.V3 as HighlighterToolbar
 import ProgramTest exposing (..)
 import Spec.KeyboardHelpers as KeyboardHelpers
 import Test exposing (..)
@@ -18,7 +18,7 @@ import Test.Html.Selector as Selector
 
 spec : Test
 spec =
-    describe "Nri.Ui.HighlighterToolbar.V2"
+    describe "Nri.Ui.HighlighterToolbar.V3"
         [ describe "tool selection" selectionTests
         , describe "keyboard behavior" keyboardTests
         ]

--- a/tests/Spec/Nri/Ui/HighlighterToolbar.elm
+++ b/tests/Spec/Nri/Ui/HighlighterToolbar.elm
@@ -1,7 +1,6 @@
 module Spec.Nri.Ui.HighlighterToolbar exposing (..)
 
-import Accessibility.Key as Key
-import Css exposing (Color)
+import Css
 import Expect
 import Html.Attributes as Attributes
 import Html.Styled as Html exposing (..)

--- a/tests/Spec/Nri/Ui/HighlighterToolbar.elm
+++ b/tests/Spec/Nri/Ui/HighlighterToolbar.elm
@@ -70,55 +70,35 @@ ensureActiveToolIs label testContext =
             )
 
 
-type Tag
-    = Claim
-    | Evidence
-    | Reasoning
+type alias Tag =
+    { name : String
+    , colorSolid : Css.Color
+    , colorLight : Css.Color
+    }
 
 
 tags : List Tag
 tags =
-    [ Claim, Evidence, Reasoning ]
-
-
-getName : Tag -> String
-getName tag =
-    case tag of
-        Claim ->
-            "Claim"
-
-        Evidence ->
-            "Evidence"
-
-        Reasoning ->
-            "Reasoning"
-
-
-getColor : Tag -> { colorSolid : Color, colorLight : Color }
-getColor tag =
-    case tag of
-        Claim ->
-            { colorSolid = Colors.mustard
-            , colorLight = Colors.highlightYellow
-            }
-
-        Evidence ->
-            { colorSolid = Colors.magenta
-            , colorLight = Colors.highlightMagenta
-            }
-
-        Reasoning ->
-            { colorSolid = Colors.cyan
-            , colorLight = Colors.highlightCyan
-            }
+    [ { name = "Claim"
+      , colorSolid = Colors.mustard
+      , colorLight = Colors.highlightYellow
+      }
+    , { name = "Evidence"
+      , colorSolid = Colors.magenta
+      , colorLight = Colors.highlightMagenta
+      }
+    , { name = "Reasoning"
+      , colorSolid = Colors.cyan
+      , colorLight = Colors.highlightCyan
+      }
+    ]
 
 
 view : Maybe Tag -> Html (Maybe Tag)
 view model =
     HighlighterToolbar.view
         { onSelect = identity
-        , getColor = getColor
-        , getName = getName
+        , getNameAndColor = identity
         , highlighterId = "highlighter"
         }
         { currentTool = model

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -37,6 +37,7 @@
         "Nri.Ui.HighlighterTool.V1",
         "Nri.Ui.HighlighterToolbar.V1",
         "Nri.Ui.HighlighterToolbar.V2",
+        "Nri.Ui.HighlighterToolbar.V3",
         "Nri.Ui.Html.Attributes.V2",
         "Nri.Ui.Html.V3",
         "Nri.Ui.InputStyles.V4",


### PR DESCRIPTION
## Context

Fixes A11-2436

Instead of managing the keyboard focus manually, use radio inputs for the HighlighterToolbar component so that the browser takes care of focus/keyboard behavior automagically.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the comopnent
