### PR TITLE
Adjust sidenav mobile behavior

### DIFF
--- a/component-catalog-app/App.elm
+++ b/component-catalog-app/App.elm
@@ -127,7 +127,11 @@ update action model =
                 route =
                     Routes.fromLocation model.moduleStates location
             in
-            ( { model | route = route, previousRoute = Just model.route }
+            ( { model
+                | route = route
+                , previousRoute = Just model.route
+                , isSideNavOpen = False
+              }
             , Maybe.map FocusOn (Routes.headerId route)
                 |> Maybe.withDefault None
             )

--- a/src/Nri/Ui/MediaQuery/V1.elm
+++ b/src/Nri/Ui/MediaQuery/V1.elm
@@ -15,6 +15,7 @@ module Nri.Ui.MediaQuery.V1 exposing
   - remove min-width:1 from media queries in order to support better composibility
   - adds narrowMobileBreakpoint and deprecates narrowMobileBreakPoint
   - adds withViewport for convenience when matching specific viewport size ranges
+  - fix `not` queries to not overlap with the regular breakpoint queries
 
 Standard media queries for responsive pages.
 
@@ -112,7 +113,7 @@ mobile =
 -}
 notMobile : MediaQuery
 notMobile =
-    only screen [ minWidth mobileBreakpoint ]
+    Css.Media.not screen [ maxWidth mobileBreakpoint ]
 
 
 {-| 1000px
@@ -133,7 +134,7 @@ quizEngineMobile =
 -}
 notQuizEngineMobile : MediaQuery
 notQuizEngineMobile =
-    only screen [ minWidth quizEngineBreakpoint ]
+    Css.Media.not screen [ maxWidth quizEngineBreakpoint ]
 
 
 {-| 750px
@@ -154,7 +155,7 @@ narrowMobile =
 -}
 notNarrowMobile : MediaQuery
 notNarrowMobile =
-    only screen [ minWidth narrowMobileBreakpoint ]
+    Css.Media.not screen [ maxWidth narrowMobileBreakpoint ]
 
 
 {-| 500px

--- a/src/Nri/Ui/SideNav/V4.elm
+++ b/src/Nri/Ui/SideNav/V4.elm
@@ -19,6 +19,7 @@ module Nri.Ui.SideNav.V4 exposing
 
   - add missing aria-current=page attribute
   - don't render an empty nav when there are no entries
+  - adjust closed sidenav toggle button styles
 
 
 ### Changes from V3
@@ -246,6 +247,12 @@ view config navAttributes entries =
                 , marginRight Css.zero
                 , marginBottom (Css.px 20)
                 , width (pct 100)
+                , case Maybe.map .isOpen appliedNavAttributes.collapsible of
+                    Just False ->
+                        Css.padding2 (Css.px 25) (Css.px 20)
+
+                    _ ->
+                        Css.batch []
                 ]
             ]
     in

--- a/src/Nri/Ui/SideNav/V4.elm
+++ b/src/Nri/Ui/SideNav/V4.elm
@@ -249,10 +249,10 @@ view config navAttributes entries =
                 , marginBottom (Css.px 20)
                 , width (pct 100)
                 , case Maybe.map .isOpen appliedNavAttributes.collapsible of
-                    Just False ->
-                        Css.padding2 (Css.px 25) (Css.px 20)
+                    Just _ ->
+                        Css.padding (Css.px 10)
 
-                    _ ->
+                    Nothing ->
                         Css.batch []
                 ]
             ]

--- a/src/Nri/Ui/SideNav/V4.elm
+++ b/src/Nri/Ui/SideNav/V4.elm
@@ -291,47 +291,70 @@ viewOpenCloseButton sidenavId navLabel_ { isOpen, toggle, isTooltipOpen, toggleT
                     |> Svg.withCss [ Css.transform (rotate (deg 180)) ]
                 )
 
-        trigger tooltipAttributes =
+        trigger attributes =
             ClickableSvg.button action
                 icon_
-                [ ClickableSvg.custom
+                ([ ClickableSvg.custom
                     [ Aria.controls [ sidenavId ]
                     , Aria.expanded isOpen
                     ]
-                , ClickableSvg.custom tooltipAttributes
-                , ClickableSvg.onClick (toggle (not isOpen))
-                , ClickableSvg.secondary
-                , ClickableSvg.withBorder
-                , ClickableSvg.iconForMobile (AnimatedIcon.mobileOpenClose isOpen)
-                ]
-    in
-    Tooltip.view
-        { trigger = trigger
-        , id = "open-close-sidebar-tooltip"
-        }
-        [ Tooltip.open isTooltipOpen
-        , Tooltip.onToggle toggleTooltip
-        , Tooltip.plaintext action
-        , Tooltip.smallPadding
-        , Tooltip.fitToContent
-        , if isOpen then
-            Tooltip.onLeft
+                 , ClickableSvg.onClick (toggle (not isOpen))
+                 , ClickableSvg.secondary
+                 , ClickableSvg.withBorder
+                 , ClickableSvg.iconForMobile (AnimatedIcon.mobileOpenClose isOpen)
+                 ]
+                    ++ attributes
+                )
 
-          else
-            Tooltip.onRight
-        , Tooltip.onRightForMobile
-        , Tooltip.containerCss
-            (if isOpen then
-                [ Css.Media.withMedia [ MediaQuery.notMobile ]
-                    [ Css.position Css.absolute
-                    , Css.top (Css.px 10)
-                    , Css.right (Css.px 10)
+        nonMobileTooltipView =
+            Tooltip.view
+                { trigger = \tooltipAttributes -> trigger [ ClickableSvg.custom tooltipAttributes ]
+                , id = "open-close-sidebar-tooltip"
+                }
+                [ Tooltip.open isTooltipOpen
+                , Tooltip.onToggle toggleTooltip
+                , Tooltip.plaintext action
+                , Tooltip.smallPadding
+                , Tooltip.fitToContent
+                , if isOpen then
+                    Tooltip.onLeft
+
+                  else
+                    Tooltip.onRight
+                , Tooltip.containerCss
+                    [ -- Hide the tooltip for mobile. We'll display static text instead
+                      Css.Media.withMedia [ MediaQuery.mobile ]
+                        [ Css.display Css.none ]
+                    ]
+                , Tooltip.containerCss
+                    (if isOpen then
+                        [ Css.Media.withMedia [ MediaQuery.notMobile ]
+                            [ Css.position Css.absolute
+                            , Css.top (Css.px 10)
+                            , Css.right (Css.px 10)
+                            ]
+                        ]
+
+                     else
+                        []
+                    )
+                ]
+
+        mobileButtonView =
+            div
+                [ Attributes.css
+                    [ -- Hide the plain button/static text if not on the mobile view
+                      Css.display Css.none
+                    , Css.Media.withMedia [ MediaQuery.mobile ]
+                        [ Css.display Css.block ]
                     ]
                 ]
-
-             else
-                []
-            )
+                [ trigger []
+                ]
+    in
+    div []
+        [ nonMobileTooltipView
+        , mobileButtonView
         ]
 
 

--- a/src/Nri/Ui/SideNav/V4.elm
+++ b/src/Nri/Ui/SideNav/V4.elm
@@ -350,7 +350,7 @@ viewOpenCloseButton sidenavId navLabel_ currentEntry { isOpen, toggle, isTooltip
                     [ -- Hide the plain button/static text if not on the mobile view
                       Css.display Css.none
                     , Css.Media.withMedia [ MediaQuery.mobile ]
-                        [ Css.display Css.block ]
+                        [ Css.displayFlex ]
                     ]
                 ]
                 [ trigger []
@@ -365,9 +365,9 @@ viewOpenCloseButton sidenavId navLabel_ currentEntry { isOpen, toggle, isTooltip
 
 mobileCurrentPage : String -> Html msg
 mobileCurrentPage name =
-    -- TODO: style
-    div
+    span
         [ AttributesExtra.nriDescription "mobile-current-page-name"
+        , Attributes.css (sharedEntryStyles ++ [ Css.display Css.inline, Css.padding (Css.px 8) ])
         ]
         [ text name ]
 

--- a/src/Nri/Ui/SideNav/V4.elm
+++ b/src/Nri/Ui/SideNav/V4.elm
@@ -256,13 +256,9 @@ view config navAttributes entries =
                         Css.batch []
                 ]
             ]
-
-        currentEntry =
-            currentRouteName config.isCurrentRoute entries
     in
     div [ Attributes.css (defaultCss ++ appliedNavAttributes.css) ]
         [ viewSkipLink config.onSkipNav
-        , viewJust (viewOpenCloseButton sidenavId appliedNavAttributes.navLabel currentEntry) appliedNavAttributes.collapsible
         , case entries of
             [] ->
                 text ""
@@ -374,18 +370,26 @@ mobileCurrentPage name =
 
 viewNav : String -> Config route msg -> NavAttributeConfig msg -> List (Entry route msg) -> Bool -> Html msg
 viewNav sidenavId config appliedNavAttributes entries showNav =
+    let
+        currentEntry =
+            currentRouteName config.isCurrentRoute entries
+
+        entryStyles =
+            if showNav then
+                []
+
+            else
+                [ Css.display Css.none ]
+    in
     nav
         ([ Maybe.map Aria.label appliedNavAttributes.navLabel
          , Just (Attributes.id sidenavId)
-         , if showNav then
-            Nothing
-
-           else
-            Just (Attributes.css [ Css.display Css.none ])
          ]
             |> List.filterMap identity
         )
-        (List.map (viewSidebarEntry config []) entries)
+        (viewJust (viewOpenCloseButton sidenavId appliedNavAttributes.navLabel currentEntry) appliedNavAttributes.collapsible
+            :: List.map (viewSidebarEntry config entryStyles) entries
+        )
 
 
 viewSkipLink : msg -> Html msg
@@ -429,7 +433,9 @@ viewSidebarEntry config extraStyles entry_ =
                         )
                         []
                         [ text entryConfig.title ]
-                        :: List.map (viewSidebarEntry config [ marginLeft (px 20) ]) children
+                        :: List.map
+                            (viewSidebarEntry config (marginLeft (px 20) :: extraStyles))
+                            children
                     )
 
             else

--- a/tests/Spec/Nri/Ui/SideNav.elm
+++ b/tests/Spec/Nri/Ui/SideNav.elm
@@ -28,12 +28,12 @@ currentPageTests =
         \() ->
             [ SideNav.entry "Cactus" [] ]
                 |> viewQuery { currentRoute = "a-different-route" } []
-                |> Query.hasNot [ attribute Aria.currentPage ]
+                |> expectNoCurrentPage
     , test "with 1 complete but not current entry" <|
         \() ->
             [ SideNav.entry "Cactus" [ SideNav.href "cactus" ] ]
                 |> viewQuery { currentRoute = "a-different-route" } []
-                |> Query.hasNot [ attribute Aria.currentPage ]
+                |> expectNoCurrentPage
     , test "with 1 current entry" <|
         \() ->
             [ SideNav.entry "Cactus" [ SideNav.href "cactus" ] ]
@@ -65,12 +65,25 @@ currentPageTests =
     ]
 
 
+expectNoCurrentPage : Query.Single msg -> Expectation
+expectNoCurrentPage =
+    Expect.all
+        [ Query.hasNot [ attribute Aria.currentPage ]
+        , Query.hasNot [ mobilePageName ]
+        ]
+
+
 expectCurrentPage : String -> String -> Query.Single msg -> Expectation
 expectCurrentPage name href_ =
     Expect.all
         [ Query.findAll [ attribute Aria.currentPage ]
             >> Query.count (Expect.equal 1)
         , Query.has [ currentPage name href_ ]
+        , -- for mobile, shows the currently-selected route in text
+          Query.has
+            [ mobilePageName
+            , containing [ text name ]
+            ]
         ]
 
 
@@ -82,6 +95,11 @@ currentPage name href_ =
         , attribute Aria.currentPage
         , text name
         ]
+
+
+mobilePageName : Selector
+mobilePageName =
+    attribute (Attributes.attribute "data-nri-description" "mobile-current-page-name")
 
 
 viewQuery :

--- a/tests/Spec/Nri/Ui/SideNav.elm
+++ b/tests/Spec/Nri/Ui/SideNav.elm
@@ -4,7 +4,7 @@ import Accessibility.Aria as Aria
 import Expect exposing (Expectation)
 import Html.Attributes as Attributes
 import Html.Styled exposing (toUnstyled)
-import Nri.Ui.SideNav.V4 as SideNav exposing (Entry, NavAttribute)
+import Nri.Ui.SideNav.V4 as SideNav exposing (Entry)
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (..)

--- a/tests/Spec/Nri/Ui/SideNav.elm
+++ b/tests/Spec/Nri/Ui/SideNav.elm
@@ -22,29 +22,29 @@ currentPageTests =
     [ test "without entries" <|
         \() ->
             []
-                |> viewQuery { currentRoute = "cactus" } []
+                |> viewQuery { currentRoute = "cactus" }
                 |> Query.hasNot [ tag "nav" ]
     , test "with 1 partial entry" <|
         \() ->
             [ SideNav.entry "Cactus" [] ]
-                |> viewQuery { currentRoute = "a-different-route" } []
+                |> viewQuery { currentRoute = "a-different-route" }
                 |> expectNoCurrentPage
     , test "with 1 complete but not current entry" <|
         \() ->
             [ SideNav.entry "Cactus" [ SideNav.href "cactus" ] ]
-                |> viewQuery { currentRoute = "a-different-route" } []
+                |> viewQuery { currentRoute = "a-different-route" }
                 |> expectNoCurrentPage
     , test "with 1 current entry" <|
         \() ->
             [ SideNav.entry "Cactus" [ SideNav.href "cactus" ] ]
-                |> viewQuery { currentRoute = "cactus" } []
+                |> viewQuery { currentRoute = "cactus" }
                 |> expectCurrentPage "Cactus" "cactus"
     , test "with multiple entries, one of which is current" <|
         \() ->
             [ SideNav.entry "Cactus" [ SideNav.href "cactus" ]
             , SideNav.entry "Epiphyllum" [ SideNav.href "epiphyllum" ]
             ]
-                |> viewQuery { currentRoute = "cactus" } []
+                |> viewQuery { currentRoute = "cactus" }
                 |> expectCurrentPage "Cactus" "cactus"
     , test "with a currently-selected entry with children" <|
         \() ->
@@ -52,7 +52,7 @@ currentPageTests =
                 [ SideNav.href "cactus" ]
                 [ SideNav.entry "Epiphyllum" [ SideNav.href "epiphyllum" ] ]
             ]
-                |> viewQuery { currentRoute = "cactus" } []
+                |> viewQuery { currentRoute = "cactus" }
                 |> expectCurrentPage "Cactus" "cactus"
     , test "with a currently-selected child entry" <|
         \() ->
@@ -60,7 +60,7 @@ currentPageTests =
                 [ SideNav.href "cactus" ]
                 [ SideNav.entry "Epiphyllum" [ SideNav.href "epiphyllum" ] ]
             ]
-                |> viewQuery { currentRoute = "epiphyllum" } []
+                |> viewQuery { currentRoute = "epiphyllum" }
                 |> expectCurrentPage "Epiphyllum" "epiphyllum"
     ]
 
@@ -104,16 +104,21 @@ mobilePageName =
 
 viewQuery :
     { currentRoute : String }
-    -> List (NavAttribute ())
     -> List (Entry String ())
     -> Query.Single ()
-viewQuery { currentRoute } navAttributes entries =
+viewQuery { currentRoute } entries =
     SideNav.view
         { isCurrentRoute = (==) currentRoute
         , routeToString = identity
         , onSkipNav = ()
         }
-        navAttributes
+        [ SideNav.collapsible
+            { isOpen = True
+            , toggle = \_ -> ()
+            , isTooltipOpen = False
+            , toggleTooltip = \_ -> ()
+            }
+        ]
         entries
         |> toUnstyled
         |> Query.fromHtml


### PR DESCRIPTION
## Context

Fixes notMobile, notQuizEngineMobile, etc media queries so that there's no overlap when using the query and the notQuery together (for instance, the current version of ClickableSvg has its icon disappear at a 1000 pixel viewport width when the mobileIcon is set -- not great!)

Also, adjusts the sidenav mobile behavior so that there's no tooltips for mobile and the selected category shows without needing to open the category list.

Based on [this antetype](https://cloud.antetype.com/exports/link/ed719e8c-1d8c-44f5-be5b-f1fdde859b7e?screen=id5182589l), although the mobile hamburger isn't pixel-perfect (I didn't want to mess with the general padding on the sidenav container).

## :framed_picture: What does this change look like?

<img width="1089" alt="Screen Shot 2023-03-28 at 1 55 34 PM" src="https://user-images.githubusercontent.com/8811312/228352575-4a8b84c8-2a28-4479-8544-b978748be500.png">
<img width="1105" alt="Screen Shot 2023-03-28 at 1 55 48 PM" src="https://user-images.githubusercontent.com/8811312/228352584-3ea88dc3-2d32-4f55-8082-98311d9018aa.png">

cc @NoRedInk/design 

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the comopnent
