### PR TITLE
add Tabs v8: stickiness and background color

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -58,7 +58,7 @@ Please link to any relevant context and stories.
         - if you want to test the component directly, add tests under `tests/Spec`. Historically, this has been the more popular Elm testing strategy for noredink-ui.
 - [ ] Component API follows standard patterns in noredink-ui
     - e.g., as a dev, I can conveniently add an `nriDescription`
-    - and adding a new feature to the component will _not_ require major API changes to the comopnent
+    - and adding a new feature to the component will _not_ require major API changes to the component
 - [ ] Please assign [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) as a reviewer in addition to assigning a reviewer from your team
 
 
@@ -94,4 +94,4 @@ Please link to any relevant context and stories.
 - [ ] Changes to the component are tested/the new version of the component is tested
 - [ ] Component API follows standard patterns in noredink-ui
     - e.g., as a dev, I can conveniently add an `nriDescription`
-    - and adding a new feature to the component will _not_ require major API changes to the comopnent
+    - and adding a new feature to the component will _not_ require major API changes to the component

--- a/component-catalog-app/Code.elm
+++ b/component-catalog-app/Code.elm
@@ -1,7 +1,6 @@
 module Code exposing
     ( string, stringMultiline, maybeString
     , maybe
-    , maybeFloat
     , bool
     , commentInline
     , list, listMultiline
@@ -20,7 +19,6 @@ module Code exposing
 
 @docs string, stringMultiline, maybeString
 @docs maybe
-@docs maybeFloat
 @docs bool
 @docs commentInline
 @docs list, listMultiline
@@ -64,12 +62,6 @@ maybe =
 maybeString : Maybe String -> String
 maybeString =
     maybe << Maybe.map string
-
-
-{-| -}
-maybeFloat : Maybe Float -> String
-maybeFloat =
-    maybe << Maybe.map String.fromFloat
 
 
 {-| -}

--- a/component-catalog-app/Debug/Control/Extra.elm
+++ b/component-catalog-app/Debug/Control/Extra.elm
@@ -1,6 +1,6 @@
 module Debug.Control.Extra exposing
     ( float, int
-    , list, listItem, optionalListItem, optionalListItemDefaultChecked
+    , values, list, listItem, optionalListItem, optionalListItemDefaultChecked
     , optionalBoolListItem
     , bool
     , rotatedChoice, specificChoice
@@ -9,7 +9,7 @@ module Debug.Control.Extra exposing
 {-|
 
 @docs float, int
-@docs list, listItem, optionalListItem, optionalListItemDefaultChecked
+@docs values, list, listItem, optionalListItem, optionalListItemDefaultChecked
 @docs optionalBoolListItem
 @docs bool
 @docs rotatedChoice, specificChoice
@@ -33,6 +33,13 @@ int : Int -> Control Int
 int default =
     Control.map (String.toInt >> Maybe.withDefault default)
         (Control.string (String.fromInt default))
+
+{-| -}
+values : (a -> String) -> List a -> Control a
+values toString nums =
+    nums
+        |> List.map (\n -> ( toString n, Control.value n ))
+        |> Control.choice
 
 
 {-| Use with `listItem` and `optionalListItem`

--- a/component-catalog-app/Debug/Control/Extra.elm
+++ b/component-catalog-app/Debug/Control/Extra.elm
@@ -34,6 +34,7 @@ int default =
     Control.map (String.toInt >> Maybe.withDefault default)
         (Control.string (String.fromInt default))
 
+
 {-| -}
 values : (a -> String) -> List a -> Control a
 values toString nums =

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -132,7 +132,6 @@ example =
                                         , Maybe.map (\title -> moduleName ++ ".title " ++ Code.string title) settings.title
                                         , Maybe.map (\spacing -> moduleName ++ ".spacing " ++ String.fromFloat spacing) settings.customSpacing
                                         , Maybe.map (\color -> moduleName ++ ".pageBackgroundColor" ++ colorToCode color) settings.pageBackgroundColor
-                                        , Maybe.map (\color -> moduleName ++ ".highContrastPageBackgroundColor" ++ colorToCode color) settings.highContrastPageBackgroundColor
                                         , Maybe.map
                                             (\sticky ->
                                                 case sticky of
@@ -170,7 +169,6 @@ example =
                     , Maybe.map Tabs.title settings.title
                     , Maybe.map Tabs.spacing settings.customSpacing
                     , Maybe.map (Tabs.pageBackgroundColor << colorToCss) settings.pageBackgroundColor
-                    , Maybe.map (Tabs.highContrastPageBackgroundColor << colorToCss) settings.highContrastPageBackgroundColor
                     , Maybe.map
                         (\stickiness ->
                             case stickiness of

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -144,7 +144,6 @@ example =
                                                             ++ Code.recordMultiline
                                                                 [ ( "topOffset", String.fromFloat stickyConfig.topOffset )
                                                                 , ( "zIndex", String.fromInt stickyConfig.zIndex )
-                                                                , ( "includeMobile", Code.bool stickyConfig.includeMobile )
                                                                 ]
                                                                 2
                                             )
@@ -338,7 +337,6 @@ initSettings =
                       , Control.record Tabs.TabListStickyConfig
                             |> Control.field "topOffset" (values [ 0, 10, 50 ])
                             |> Control.field "zIndex" (values [ 0, 1, 5, 10 ])
-                            |> Control.field "includeMobile" (Control.bool False)
                             |> Control.map Custom
                       )
                     ]

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -122,13 +122,18 @@ example =
                         let
                             code =
                                 [ moduleName ++ ".view"
-                                , "    { title = " ++ Code.maybeString settings.title
-                                , "    , alignment = " ++ moduleName ++ "." ++ Debug.toString settings.alignment
-                                , "    , customSpacing = " ++ Code.maybeFloat settings.customSpacing
-                                , "    , focusAndSelect = identity"
+                                , "    { focusAndSelect = identity"
                                 , "    , selected = " ++ String.fromInt model.selected
-                                , "    , tabs = " ++ Code.listMultiline (List.map Tuple.first tabs) 2
                                 , "    }"
+                                , Code.listMultiline
+                                    (List.filterMap identity
+                                        [ Just (moduleName ++ ".alignment " ++ moduleName ++ "." ++ Debug.toString settings.alignment)
+                                        , Maybe.map (\title -> moduleName ++ ".title " ++ Code.string title) settings.title
+                                        , Maybe.map (\spacing -> moduleName ++ ".spacing " ++ String.fromFloat spacing) settings.customSpacing
+                                        ]
+                                    )
+                                    1
+                                , Code.listMultiline (List.map Tuple.first tabs) 1
                                 ]
                                     |> String.join "\n"
                         in

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -229,7 +229,13 @@ buildTooltip openTooltipId withTooltips id =
         ]
     , Tabs.build { id = id, idString = tabIdString }
         ([ Tabs.tabString tabName
-         , Tabs.panelHtml (Html.text panelName)
+         , panelName
+            |> List.repeat 50
+            |> String.join "\n"
+            |> Html.text
+            |> List.singleton
+            |> Html.pre []
+            |> Tabs.panelHtml
          ]
             ++ (if withTooltips then
                     [ Tabs.withTooltip

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -15,6 +15,7 @@ import Category exposing (Category(..))
 import Code
 import Css
 import Debug.Control as Control exposing (Control)
+import Debug.Control.Extra exposing (values)
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled as Html
@@ -325,7 +326,7 @@ initSettings =
                 , ( "Right", Control.value Right )
                 ]
             )
-        |> Control.field "customSpacing" (Control.maybe False (values [ 2, 3, 4, 8, 16 ]))
+        |> Control.field "customSpacing" (Control.maybe False (values String.fromFloat [ 2, 3, 4, 8, 16 ]))
         |> Control.field "withTooltips" (Control.bool True)
         |> Control.field "tabListBackgroundColor" (Control.maybe False colorChoices)
         |> Control.field "highContrastTabListBackgroundColor" (Control.maybe False colorChoices)
@@ -335,20 +336,13 @@ initSettings =
                     [ ( "Default", Control.value Default )
                     , ( "Custom"
                       , Control.record Tabs.TabListStickyConfig
-                            |> Control.field "topOffset" (values [ 0, 10, 50 ])
-                            |> Control.field "zIndex" (values [ 0, 1, 5, 10 ])
+                            |> Control.field "topOffset" (values String.fromFloat [ 0, 10, 50 ])
+                            |> Control.field "zIndex" (values String.fromInt [ 0, 1, 5, 10 ])
                             |> Control.map Custom
                       )
                     ]
                 )
             )
-
-
-values : List a -> Control a
-values nums =
-    nums
-        |> List.map (\n -> ( Debug.toString n, Control.value n ))
-        |> Control.choice
 
 
 type Msg

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -21,7 +21,7 @@ import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.Tabs.V7 as Tabs exposing (Alignment(..), Tab)
+import Nri.Ui.Tabs.V8 as Tabs exposing (Alignment(..), Tab)
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.Tooltip.V3 as Tooltip
 import Task
@@ -34,7 +34,7 @@ moduleName =
 
 version : Int
 version =
-    7
+    8
 
 
 example : Example State Msg
@@ -138,13 +138,16 @@ example =
                         ]
                 }
             , Tabs.view
-                { title = settings.title
-                , alignment = settings.alignment
-                , customSpacing = settings.customSpacing
-                , focusAndSelect = FocusAndSelectTab
+                { focusAndSelect = FocusAndSelectTab
                 , selected = model.selected
-                , tabs = List.map Tuple.second tabs
                 }
+                (List.filterMap identity
+                    [ Just (Tabs.alignment settings.alignment)
+                    , Maybe.map Tabs.title settings.title
+                    , Maybe.map Tabs.spacing settings.customSpacing
+                    ]
+                )
+                (List.map Tuple.second tabs)
             ]
     }
 

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -241,6 +241,7 @@ type alias Settings =
     , withTooltips : Bool
     , tabListBackgroundColor : Maybe Color
     , highContrastTabListBackgroundColor : Maybe Color
+    , stickiness : Maybe Stickiness
     }
 
 
@@ -269,6 +270,11 @@ colorToCode color =
             "Colors.gray92"
 
 
+type Stickiness
+    = Default
+    | Custom Tabs.TabListStickyConfig
+
+
 initSettings : Control Settings
 initSettings =
     let
@@ -287,20 +293,31 @@ initSettings =
                 , ( "Right", Control.value Right )
                 ]
             )
-        |> Control.field "customSpacing"
-            (Control.maybe False
-                (Control.choice
-                    [ ( "2", Control.value 2 )
-                    , ( "3", Control.value 3 )
-                    , ( "4", Control.value 4 )
-                    , ( "8", Control.value 8 )
-                    , ( "16", Control.value 16 )
-                    ]
-                )
-            )
+        |> Control.field "customSpacing" (Control.maybe False (values [ 2, 3, 4, 8, 16 ]))
         |> Control.field "withTooltips" (Control.bool True)
         |> Control.field "tabListBackgroundColor" (Control.maybe False colorChoices)
         |> Control.field "highContrastTabListBackgroundColor" (Control.maybe False colorChoices)
+        |> Control.field "tabListSticky"
+            (Control.maybe False
+                (Control.choice
+                    [ ( "Default", Control.value Default )
+                    , ( "Custom"
+                      , Control.record Tabs.TabListStickyConfig
+                            |> Control.field "topOffset" (values [ 0, 10, 50 ])
+                            |> Control.field "zIndex" (values [ 0, 1, 5, 10 ])
+                            |> Control.field "includeMobile" (Control.bool False)
+                            |> Control.map Custom
+                      )
+                    ]
+                )
+            )
+
+
+values : List a -> Control a
+values nums =
+    nums
+        |> List.map (\n -> ( Debug.toString n, Control.value n ))
+        |> Control.choice
 
 
 type Msg

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -131,8 +131,8 @@ example =
                                         [ Just (moduleName ++ ".alignment " ++ moduleName ++ "." ++ Debug.toString settings.alignment)
                                         , Maybe.map (\title -> moduleName ++ ".title " ++ Code.string title) settings.title
                                         , Maybe.map (\spacing -> moduleName ++ ".spacing " ++ String.fromFloat spacing) settings.customSpacing
-                                        , Maybe.map (\color -> moduleName ++ ".tabListBackgroundColor" ++ colorToCode color) settings.tabListBackgroundColor
-                                        , Maybe.map (\color -> moduleName ++ ".highContrastTabListBackgroundColor" ++ colorToCode color) settings.highContrastTabListBackgroundColor
+                                        , Maybe.map (\color -> moduleName ++ ".pageBackgroundColor" ++ colorToCode color) settings.pageBackgroundColor
+                                        , Maybe.map (\color -> moduleName ++ ".highContrastPageBackgroundColor" ++ colorToCode color) settings.highContrastPageBackgroundColor
                                         , Maybe.map
                                             (\sticky ->
                                                 case sticky of
@@ -169,8 +169,8 @@ example =
                     [ Just (Tabs.alignment settings.alignment)
                     , Maybe.map Tabs.title settings.title
                     , Maybe.map Tabs.spacing settings.customSpacing
-                    , Maybe.map (Tabs.tabListBackgroundColor << colorToCss) settings.tabListBackgroundColor
-                    , Maybe.map (Tabs.highContrastTabListBackgroundColor << colorToCss) settings.highContrastTabListBackgroundColor
+                    , Maybe.map (Tabs.pageBackgroundColor << colorToCss) settings.pageBackgroundColor
+                    , Maybe.map (Tabs.highContrastPageBackgroundColor << colorToCss) settings.highContrastPageBackgroundColor
                     , Maybe.map
                         (\stickiness ->
                             case stickiness of
@@ -272,8 +272,8 @@ type alias Settings =
     , alignment : Alignment
     , customSpacing : Maybe Float
     , withTooltips : Bool
-    , tabListBackgroundColor : Maybe Color
-    , highContrastTabListBackgroundColor : Maybe Color
+    , pageBackgroundColor : Maybe Color
+    , highContrastPageBackgroundColor : Maybe Color
     , stickiness : Maybe Stickiness
     }
 
@@ -328,8 +328,8 @@ initSettings =
             )
         |> Control.field "customSpacing" (Control.maybe False (values String.fromFloat [ 2, 3, 4, 8, 16 ]))
         |> Control.field "withTooltips" (Control.bool True)
-        |> Control.field "tabListBackgroundColor" (Control.maybe False colorChoices)
-        |> Control.field "highContrastTabListBackgroundColor" (Control.maybe False colorChoices)
+        |> Control.field "pageBackgroundColor" (Control.maybe False colorChoices)
+        |> Control.field "highContrastPageBackgroundColor" (Control.maybe False colorChoices)
         |> Control.field "tabListSticky"
             (Control.maybe False
                 (Control.choice

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -130,6 +130,8 @@ example =
                                         [ Just (moduleName ++ ".alignment " ++ moduleName ++ "." ++ Debug.toString settings.alignment)
                                         , Maybe.map (\title -> moduleName ++ ".title " ++ Code.string title) settings.title
                                         , Maybe.map (\spacing -> moduleName ++ ".spacing " ++ String.fromFloat spacing) settings.customSpacing
+                                        , Maybe.map (\color -> moduleName ++ ".tabListBackgroundColor" ++ colorToCode color) settings.tabListBackgroundColor
+                                        , Maybe.map (\color -> moduleName ++ ".highContrastTabListBackgroundColor" ++ colorToCode color) settings.highContrastTabListBackgroundColor
                                         ]
                                     )
                                     1
@@ -150,6 +152,8 @@ example =
                     [ Just (Tabs.alignment settings.alignment)
                     , Maybe.map Tabs.title settings.title
                     , Maybe.map Tabs.spacing settings.customSpacing
+                    , Maybe.map (Tabs.tabListBackgroundColor << colorToCss) settings.tabListBackgroundColor
+                    , Maybe.map (Tabs.highContrastTabListBackgroundColor << colorToCss) settings.highContrastTabListBackgroundColor
                     ]
                 )
                 (List.map Tuple.second tabs)
@@ -235,11 +239,45 @@ type alias Settings =
     , alignment : Alignment
     , customSpacing : Maybe Float
     , withTooltips : Bool
+    , tabListBackgroundColor : Maybe Color
+    , highContrastTabListBackgroundColor : Maybe Color
     }
+
+
+type Color
+    = White
+    | Gray
+
+
+colorToCss : Color -> Css.Color
+colorToCss color =
+    case color of
+        White ->
+            Colors.white
+
+        Gray ->
+            Colors.gray92
+
+
+colorToCode : Color -> String
+colorToCode color =
+    case color of
+        White ->
+            "Colors.white"
+
+        Gray ->
+            "Colors.gray92"
 
 
 initSettings : Control Settings
 initSettings =
+    let
+        colorChoices =
+            Control.choice
+                [ ( "Gray", Control.value Gray )
+                , ( "White", Control.value White )
+                ]
+    in
     Control.record Settings
         |> Control.field "title" (Control.maybe False (Control.string "Title"))
         |> Control.field "alignment"
@@ -261,6 +299,8 @@ initSettings =
                 )
             )
         |> Control.field "withTooltips" (Control.bool True)
+        |> Control.field "tabListBackgroundColor" (Control.maybe False colorChoices)
+        |> Control.field "highContrastTabListBackgroundColor" (Control.maybe False colorChoices)
 
 
 type Msg

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -132,6 +132,23 @@ example =
                                         , Maybe.map (\spacing -> moduleName ++ ".spacing " ++ String.fromFloat spacing) settings.customSpacing
                                         , Maybe.map (\color -> moduleName ++ ".tabListBackgroundColor" ++ colorToCode color) settings.tabListBackgroundColor
                                         , Maybe.map (\color -> moduleName ++ ".highContrastTabListBackgroundColor" ++ colorToCode color) settings.highContrastTabListBackgroundColor
+                                        , Maybe.map
+                                            (\sticky ->
+                                                case sticky of
+                                                    Default ->
+                                                        moduleName ++ ".tabsListSticky"
+
+                                                    Custom stickyConfig ->
+                                                        moduleName
+                                                            ++ ".tabsListStickyCustom "
+                                                            ++ Code.recordMultiline
+                                                                [ ( "topOffset", String.fromFloat stickyConfig.topOffset )
+                                                                , ( "zIndex", String.fromInt stickyConfig.zIndex )
+                                                                , ( "includeMobile", Code.bool stickyConfig.includeMobile )
+                                                                ]
+                                                                2
+                                            )
+                                            settings.stickiness
                                         ]
                                     )
                                     1
@@ -154,6 +171,16 @@ example =
                     , Maybe.map Tabs.spacing settings.customSpacing
                     , Maybe.map (Tabs.tabListBackgroundColor << colorToCss) settings.tabListBackgroundColor
                     , Maybe.map (Tabs.highContrastTabListBackgroundColor << colorToCss) settings.highContrastTabListBackgroundColor
+                    , Maybe.map
+                        (\stickiness ->
+                            case stickiness of
+                                Default ->
+                                    Tabs.tabListSticky
+
+                                Custom stickyConfig ->
+                                    Tabs.tabListStickyCustom stickyConfig
+                        )
+                        settings.stickiness
                     ]
                 )
                 (List.map Tuple.second tabs)

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -271,7 +271,6 @@ type alias Settings =
     , customSpacing : Maybe Float
     , withTooltips : Bool
     , pageBackgroundColor : Maybe Color
-    , highContrastPageBackgroundColor : Maybe Color
     , stickiness : Maybe Stickiness
     }
 
@@ -327,7 +326,6 @@ initSettings =
         |> Control.field "customSpacing" (Control.maybe False (values String.fromFloat [ 2, 3, 4, 8, 16 ]))
         |> Control.field "withTooltips" (Control.bool True)
         |> Control.field "pageBackgroundColor" (Control.maybe False colorChoices)
-        |> Control.field "highContrastPageBackgroundColor" (Control.maybe False colorChoices)
         |> Control.field "tabListSticky"
             (Control.maybe False
                 (Control.choice

--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -5,4 +5,5 @@ Nri.Ui.HighlighterToolbar.V1,upgrade to V2
 Nri.Ui.QuestionBox.V2,upgrade to V4
 Nri.Ui.QuestionBox.V3,upgrade to V4
 Nri.Ui.Select.V8,upgrade to V9
-Nri.Ui.Tabs.V6,upgrade to V7
+Nri.Ui.Tabs.V6,upgrade to V8
+Nri.Ui.Tabs.V7,upgrade to V8

--- a/elm.json
+++ b/elm.json
@@ -76,6 +76,7 @@
         "Nri.Ui.Table.V6",
         "Nri.Ui.Tabs.V6",
         "Nri.Ui.Tabs.V7",
+        "Nri.Ui.Tabs.V8",
         "Nri.Ui.Text.V6",
         "Nri.Ui.Text.Writing.V1",
         "Nri.Ui.TextArea.V5",

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -195,7 +195,10 @@ hint = 'upgrade to V5'
 hint = 'upgrade to V6'
 
 [forbidden."Nri.Ui.Tabs.V6"]
-hint = 'upgrade to V7'
+hint = 'upgrade to V8'
+
+[forbidden."Nri.Ui.Tabs.V7"]
+hint = 'upgrade to V8'
 
 [forbidden."Nri.Ui.Text.V2"]
 hint = 'upgrade to V5'

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -309,6 +309,22 @@ view { focusAndSelect, selected } attrs tabs =
             , Css.borderBottomStyle Css.solid
             , Css.borderBottomColor Colors.navy
             , Fonts.baseFont
+            , maybeStyle
+                (\{ topOffset, zIndex, includeMobile } ->
+                    let
+                        styles =
+                            [ Css.position Css.sticky
+                            , Css.top (Css.px topOffset)
+                            , Css.zIndex (Css.int zIndex)
+                            ]
+                    in
+                    if includeMobile then
+                        Css.batch styles
+
+                    else
+                        Css.Media.withMedia [ MediaQuery.notMobile ] styles
+                )
+                config.tabListStickyConfig
             ]
             []
             [ config.title
@@ -372,22 +388,6 @@ stylesTabsAligned config =
     , maybeStyle
         (\color -> MediaQuery.highContrastMode [ Css.backgroundColor color ])
         config.highContrastTabListBackgroundColor
-    , maybeStyle
-        (\{ topOffset, zIndex, includeMobile } ->
-            let
-                styles =
-                    [ Css.position Css.sticky
-                    , Css.top (Css.px topOffset)
-                    , Css.zIndex (Css.int zIndex)
-                    ]
-            in
-            if includeMobile then
-                Css.batch styles
-
-            else
-                Css.Media.withMedia [ MediaQuery.notMobile ] styles
-        )
-        config.tabListStickyConfig
     ]
 
 

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -29,6 +29,7 @@ import Nri.Ui.Colors.Extra exposing (withAlpha)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Nri.Ui.Tooltip.V3 as Tooltip
 import TabsInternal.V2 as TabsInternal
 
@@ -218,7 +219,7 @@ view { focusAndSelect, selected } attrs tabs =
                 , selected = selected
                 , tabs = List.map (\(Tab t) -> t) tabs
                 , tabStyles = tabStyles config.spacing
-                , tabListStyles = stylesTabsAligned config.alignment
+                , tabListStyles = stylesTabsAligned config
                 }
     in
     Nri.Ui.styled Html.div
@@ -271,11 +272,11 @@ viewTitle tabTitle =
 -- STYLES
 
 
-stylesTabsAligned : Alignment -> List Style
-stylesTabsAligned tabAlignment =
+stylesTabsAligned : Config -> List Style
+stylesTabsAligned config =
     let
         alignmentStyles =
-            case tabAlignment of
+            case config.alignment of
                 Left ->
                     Css.justifyContent Css.flexStart
 
@@ -291,7 +292,21 @@ stylesTabsAligned tabAlignment =
     , Css.displayFlex
     , Css.flexGrow (Css.int 1)
     , Css.padding Css.zero
+    , maybeStyle Css.backgroundColor config.headerBackgroundColor
+    , maybeStyle
+        (\color -> MediaQuery.highContrastMode [ Css.backgroundColor color ])
+        config.highContrastHeaderBackgroundColor
     ]
+
+
+maybeStyle : (a -> Style) -> Maybe a -> Style
+maybeStyle styler maybeValue =
+    case maybeValue of
+        Just value ->
+            styler value
+
+        Nothing ->
+            Css.batch []
 
 
 tabStyles : Maybe Float -> Int -> Bool -> List Style

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -129,6 +129,8 @@ type Alignment
     | Right
 
 
+{-| Ways to adapt the appearance of the tabs to your application.
+-}
 type Attribute id msg
     = Title String
     | Alignment Alignment
@@ -137,26 +139,38 @@ type Attribute id msg
     | HighContrasttabListBackgroundColor Css.Color
 
 
+{-| Set a title in the tab list.
+-}
 title : String -> Attribute id msg
 title =
     Title
 
 
+{-| Set the alignment of the tab list.
+-}
 alignment : Alignment -> Attribute id msg
 alignment =
     Alignment
 
 
+{-| Set the spacing between tabs in the tab list.
+-}
 spacing : Float -> Attribute id msg
 spacing =
     Spacing
 
 
+{-| Set the background color of the tab list. Mostly useful to set an explicit
+background color with sticky tabs.
+-}
 tabListBackgroundColor : Css.Color -> Attribute id msg
 tabListBackgroundColor =
     TabListBackgroundColor
 
 
+{-| Set the background color of the tab list in high-contrast mode. Mostly
+useful to set an explicit background color with sticky tabs.
+-}
 highContrastTabListBackgroundColor : Css.Color -> Attribute id msg
 highContrastTabListBackgroundColor =
     HighContrasttabListBackgroundColor

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -1,7 +1,7 @@
 module Nri.Ui.Tabs.V8 exposing
     ( Attribute, title, spacing
     , Alignment(..), alignment
-    , pageBackgroundColor, highContrastPageBackgroundColor
+    , pageBackgroundColor
     , tabListSticky, TabListStickyConfig, tabListStickyCustom
     , view
     , Tab, TabAttribute, build
@@ -21,7 +21,7 @@ module Nri.Ui.Tabs.V8 exposing
 
 @docs Attribute, title, spacing
 @docs Alignment, alignment
-@docs pageBackgroundColor, highContrastPageBackgroundColor
+@docs pageBackgroundColor
 @docs tabListSticky, TabListStickyConfig, tabListStickyCustom
 @docs view
 
@@ -180,14 +180,6 @@ pageBackgroundColor color =
     Attribute (\config -> { config | pageBackgroundColor = Just color })
 
 
-{-| Set the background color of the tab list in high-contrast mode. Mostly
-useful to set an explicit background color with sticky tabs.
--}
-highContrastPageBackgroundColor : Css.Color -> Attribute id msg
-highContrastPageBackgroundColor color =
-    Attribute (\config -> { config | highContrastPageBackgroundColor = Just color })
-
-
 {-| Make the tab list sticky. You probably want to set an explicit background
 color along with this!
 -}
@@ -209,7 +201,6 @@ type alias Config =
     , alignment : Alignment
     , spacing : Maybe Float
     , pageBackgroundColor : Maybe Css.Color
-    , highContrastPageBackgroundColor : Maybe Css.Color
     , tabListStickyConfig : Maybe TabListStickyConfig
     }
 
@@ -220,7 +211,6 @@ defaultConfig =
     , alignment = Left
     , spacing = Nothing
     , pageBackgroundColor = Nothing
-    , highContrastPageBackgroundColor = Nothing
     , tabListStickyConfig = Nothing
     }
 
@@ -349,9 +339,6 @@ stylesTabsAligned config =
     , Css.flexGrow (Css.int 1)
     , Css.padding Css.zero
     , maybeStyle Css.backgroundColor config.pageBackgroundColor
-    , maybeStyle
-        (\color -> MediaQuery.highContrastMode [ Css.backgroundColor color ])
-        config.highContrastPageBackgroundColor
     ]
 
 

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -178,8 +178,14 @@ updateConfig attr config =
 
 
 {-| -}
-view : ({ select : id, focus : Maybe String } -> msg) -> id -> List (Attribute id msg) -> List (Tab id msg) -> Html msg
-view focusAndSelect selected attrs tabs =
+view :
+    { focusAndSelect : { select : id, focus : Maybe String } -> msg
+    , selected : id
+    }
+    -> List (Attribute id msg)
+    -> List (Tab id msg)
+    -> Html msg
+view { focusAndSelect, selected } attrs tabs =
     let
         config =
             List.foldl updateConfig defaultConfig attrs

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -14,6 +14,7 @@ module Nri.Ui.Tabs.V8 exposing
 
   - Uses an HTML-like API
   - Adds sticky positioning
+  - Adds background color in the tab list (for use with sticky positioning)
 
 
 ### Attributes

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -230,15 +230,11 @@ defaultConfig =
     stick, in pixels. (**Default value:** 0)
   - `zIndex` controls how high up the z-order the bar will float. (**Default
     value:** 0)
-  - `onMobile` controls whether or not the bar is sticky on mobile. Be careful
-    about setting this to `True`; it can harm accessibility. (**Default value:**
-    `False`.)
 
 -}
 type alias TabListStickyConfig =
     { topOffset : Float
     , zIndex : Int
-    , includeMobile : Bool
     }
 
 
@@ -246,7 +242,6 @@ defaultTabListStickyConfig : TabListStickyConfig
 defaultTabListStickyConfig =
     { topOffset = 0
     , zIndex = 0
-    , includeMobile = False
     }
 
 
@@ -284,19 +279,13 @@ view { focusAndSelect, selected } attrs tabs =
             , Css.borderBottomColor Colors.navy
             , Fonts.baseFont
             , maybeStyle
-                (\{ topOffset, zIndex, includeMobile } ->
-                    let
-                        styles =
-                            [ Css.position Css.sticky
-                            , Css.top (Css.px topOffset)
-                            , Css.zIndex (Css.int zIndex)
-                            ]
-                    in
-                    if includeMobile then
-                        Css.batch styles
-
-                    else
-                        Css.Media.withMedia [ MediaQuery.notMobile ] styles
+                (\{ topOffset, zIndex } ->
+                    Css.Media.withMedia
+                        [ MediaQuery.notMobile ]
+                        [ Css.position Css.sticky
+                        , Css.top (Css.px topOffset)
+                        , Css.zIndex (Css.int zIndex)
+                        ]
                 )
                 config.tabListStickyConfig
             ]

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -279,6 +279,7 @@ view { focusAndSelect, selected } attrs tabs =
                         ]
                 )
                 config.tabListStickyConfig
+            , maybeStyle Css.backgroundColor config.pageBackgroundColor
             ]
             []
             [ config.title
@@ -338,7 +339,6 @@ stylesTabsAligned config =
     , Css.displayFlex
     , Css.flexGrow (Css.int 1)
     , Css.padding Css.zero
-    , maybeStyle Css.backgroundColor config.pageBackgroundColor
     ]
 
 

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -1,5 +1,5 @@
 module Nri.Ui.Tabs.V8 exposing
-    ( Attribute, title, alignment, spacing, headerBackgroundColor, highContrastHeaderBackgroundColor, view
+    ( Attribute, title, alignment, spacing, tabListBackgroundColor, highContrastTabListBackgroundColor, view
     , Alignment(..)
     , Tab, TabAttribute, build
     , tabString, tabHtml, withTooltip, disabled, labelledBy, describedBy
@@ -12,7 +12,7 @@ module Nri.Ui.Tabs.V8 exposing
   - Uses an HTML-like API
   - Adds sticky positioning
 
-@docs Attribute, title, alignment, spacing, headerBackgroundColor, highContrastHeaderBackgroundColor, view
+@docs Attribute, title, alignment, spacing, tabListBackgroundColor, highContrastTabListBackgroundColor, view
 @docs Alignment
 @docs Tab, TabAttribute, build
 @docs tabString, tabHtml, withTooltip, disabled, labelledBy, describedBy
@@ -133,8 +133,8 @@ type Attribute id msg
     = Title String
     | Alignment Alignment
     | Spacing Float
-    | HeaderBackgroundColor Css.Color
-    | HighContrastHeaderBackgroundColor Css.Color
+    | TabListBackgroundColor Css.Color
+    | HighContrasttabListBackgroundColor Css.Color
 
 
 title : String -> Attribute id msg
@@ -152,22 +152,22 @@ spacing =
     Spacing
 
 
-headerBackgroundColor : Css.Color -> Attribute id msg
-headerBackgroundColor =
-    HeaderBackgroundColor
+tabListBackgroundColor : Css.Color -> Attribute id msg
+tabListBackgroundColor =
+    TabListBackgroundColor
 
 
-highContrastHeaderBackgroundColor : Css.Color -> Attribute id msg
-highContrastHeaderBackgroundColor =
-    HighContrastHeaderBackgroundColor
+highContrastTabListBackgroundColor : Css.Color -> Attribute id msg
+highContrastTabListBackgroundColor =
+    HighContrasttabListBackgroundColor
 
 
 type alias Config =
     { title : Maybe String
     , alignment : Alignment
     , spacing : Maybe Float
-    , headerBackgroundColor : Maybe Css.Color
-    , highContrastHeaderBackgroundColor : Maybe Css.Color
+    , tabListBackgroundColor : Maybe Css.Color
+    , highContrastTabListBackgroundColor : Maybe Css.Color
     }
 
 
@@ -176,8 +176,8 @@ defaultConfig =
     { title = Nothing
     , alignment = Left
     , spacing = Nothing
-    , headerBackgroundColor = Nothing
-    , highContrastHeaderBackgroundColor = Nothing
+    , tabListBackgroundColor = Nothing
+    , highContrastTabListBackgroundColor = Nothing
     }
 
 
@@ -193,11 +193,11 @@ updateConfig attr config =
         Spacing newSpacing ->
             { config | spacing = Just newSpacing }
 
-        HeaderBackgroundColor newColor ->
-            { config | headerBackgroundColor = Just newColor }
+        TabListBackgroundColor newColor ->
+            { config | tabListBackgroundColor = Just newColor }
 
-        HighContrastHeaderBackgroundColor newColor ->
-            { config | highContrastHeaderBackgroundColor = Just newColor }
+        HighContrasttabListBackgroundColor newColor ->
+            { config | highContrastTabListBackgroundColor = Just newColor }
 
 
 {-| -}
@@ -292,10 +292,10 @@ stylesTabsAligned config =
     , Css.displayFlex
     , Css.flexGrow (Css.int 1)
     , Css.padding Css.zero
-    , maybeStyle Css.backgroundColor config.headerBackgroundColor
+    , maybeStyle Css.backgroundColor config.tabListBackgroundColor
     , maybeStyle
         (\color -> MediaQuery.highContrastMode [ Css.backgroundColor color ])
-        config.highContrastHeaderBackgroundColor
+        config.highContrastTabListBackgroundColor
     ]
 
 

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -1,7 +1,7 @@
 module Nri.Ui.Tabs.V8 exposing
     ( view
     , Alignment(..)
-    , Tab, Attribute, build
+    , Tab, TabAttribute, build
     , tabString, tabHtml, withTooltip, disabled, labelledBy, describedBy
     , panelHtml
     , spaHref
@@ -14,7 +14,7 @@ module Nri.Ui.Tabs.V8 exposing
 
 @docs view
 @docs Alignment
-@docs Tab, Attribute, build
+@docs Tab, TabAttribute, build
 @docs tabString, tabHtml, withTooltip, disabled, labelledBy, describedBy
 @docs panelHtml
 @docs spaHref
@@ -39,32 +39,32 @@ type Tab id msg
 
 
 {-| -}
-type Attribute id msg
+type TabAttribute id msg
     = Attribute (TabsInternal.Tab id msg -> TabsInternal.Tab id msg)
 
 
 {-| -}
-tabString : String -> Attribute id msg
+tabString : String -> TabAttribute id msg
 tabString content =
     Attribute (\tab -> { tab | tabView = [ viewTabDefault content ] })
 
 
 {-| -}
-tabHtml : Html Never -> Attribute id msg
+tabHtml : Html Never -> TabAttribute id msg
 tabHtml content =
     Attribute (\tab -> { tab | tabView = [ Html.map never content ] })
 
 
 {-| Tooltip defaults: `[Tooltip.smallPadding, Tooltip.onBottom, Tooltip.fitToContent]`
 -}
-withTooltip : List (Tooltip.Attribute msg) -> Attribute id msg
+withTooltip : List (Tooltip.Attribute msg) -> TabAttribute id msg
 withTooltip attributes =
     Attribute (\tab -> { tab | tabTooltip = attributes })
 
 
 {-| Makes it so that the tab can't be clicked or focused via keyboard navigation
 -}
-disabled : Bool -> Attribute id msg
+disabled : Bool -> TabAttribute id msg
 disabled isDisabled =
     Attribute (\tab -> { tab | disabled = isDisabled })
 
@@ -72,7 +72,7 @@ disabled isDisabled =
 {-| Sets an overriding labelledBy on the tab for an external tooltip.
 This assumes an external tooltip is set and disables any internal tooltip configured.
 -}
-labelledBy : String -> Attribute id msg
+labelledBy : String -> TabAttribute id msg
 labelledBy labelledById =
     Attribute (\tab -> { tab | labelledBy = Just labelledById })
 
@@ -84,31 +84,31 @@ This attribute can be used multiple times if more than one element describes
 this tab.
 
 -}
-describedBy : String -> Attribute id msg
+describedBy : String -> TabAttribute id msg
 describedBy describedById =
     Attribute (\tab -> { tab | describedBy = describedById :: tab.describedBy })
 
 
 {-| -}
-panelHtml : Html msg -> Attribute id msg
+panelHtml : Html msg -> TabAttribute id msg
 panelHtml content =
     Attribute (\tab -> { tab | panelView = content })
 
 
 {-| -}
-spaHref : String -> Attribute id msg
+spaHref : String -> TabAttribute id msg
 spaHref url =
     Attribute (\tab -> { tab | spaHref = Just url })
 
 
 {-| -}
-tabAttributes : List (Html.Attribute msg) -> Attribute id msg
+tabAttributes : List (Html.Attribute msg) -> TabAttribute id msg
 tabAttributes attrs =
     Attribute (\tab -> { tab | tabAttributes = tab.tabAttributes ++ attrs })
 
 
 {-| -}
-build : { id : id, idString : String } -> List (Attribute id msg) -> Tab id msg
+build : { id : id, idString : String } -> List (TabAttribute id msg) -> Tab id msg
 build config attributes =
     Tab
         (TabsInternal.fromList config

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -1,7 +1,7 @@
 module Nri.Ui.Tabs.V8 exposing
     ( Attribute, title, spacing
     , Alignment(..), alignment
-    , tabListBackgroundColor, highContrastTabListBackgroundColor
+    , pageBackgroundColor, highContrastPageBackgroundColor
     , tabListSticky, TabListStickyConfig, tabListStickyCustom
     , view
     , Tab, TabAttribute, build
@@ -21,7 +21,7 @@ module Nri.Ui.Tabs.V8 exposing
 
 @docs Attribute, title, spacing
 @docs Alignment, alignment
-@docs tabListBackgroundColor, highContrastTabListBackgroundColor
+@docs pageBackgroundColor, highContrastPageBackgroundColor
 @docs tabListSticky, TabListStickyConfig, tabListStickyCustom
 @docs view
 
@@ -171,20 +171,21 @@ spacing spacing_ =
     Attribute (\config -> { config | spacing = Just spacing_ })
 
 
-{-| Set the background color of the tab list. Mostly useful to set an explicit
-background color with sticky tabs.
+{-| Tell this tab list about the background color of the page it lievs on. This
+is mostly useful when setting up sticky headers, to prevent page content from
+showing through the background.
 -}
-tabListBackgroundColor : Css.Color -> Attribute id msg
-tabListBackgroundColor color =
-    Attribute (\config -> { config | tabListBackgroundColor = Just color })
+pageBackgroundColor : Css.Color -> Attribute id msg
+pageBackgroundColor color =
+    Attribute (\config -> { config | pageBackgroundColor = Just color })
 
 
 {-| Set the background color of the tab list in high-contrast mode. Mostly
 useful to set an explicit background color with sticky tabs.
 -}
-highContrastTabListBackgroundColor : Css.Color -> Attribute id msg
-highContrastTabListBackgroundColor color =
-    Attribute (\config -> { config | highContrastTabListBackgroundColor = Just color })
+highContrastPageBackgroundColor : Css.Color -> Attribute id msg
+highContrastPageBackgroundColor color =
+    Attribute (\config -> { config | highContrastPageBackgroundColor = Just color })
 
 
 {-| Make the tab list sticky. You probably want to set an explicit background
@@ -207,8 +208,8 @@ type alias Config =
     { title : Maybe String
     , alignment : Alignment
     , spacing : Maybe Float
-    , tabListBackgroundColor : Maybe Css.Color
-    , highContrastTabListBackgroundColor : Maybe Css.Color
+    , pageBackgroundColor : Maybe Css.Color
+    , highContrastPageBackgroundColor : Maybe Css.Color
     , tabListStickyConfig : Maybe TabListStickyConfig
     }
 
@@ -218,8 +219,8 @@ defaultConfig =
     { title = Nothing
     , alignment = Left
     , spacing = Nothing
-    , tabListBackgroundColor = Nothing
-    , highContrastTabListBackgroundColor = Nothing
+    , pageBackgroundColor = Nothing
+    , highContrastPageBackgroundColor = Nothing
     , tabListStickyConfig = Nothing
     }
 
@@ -347,10 +348,10 @@ stylesTabsAligned config =
     , Css.displayFlex
     , Css.flexGrow (Css.int 1)
     , Css.padding Css.zero
-    , maybeStyle Css.backgroundColor config.tabListBackgroundColor
+    , maybeStyle Css.backgroundColor config.pageBackgroundColor
     , maybeStyle
         (\color -> MediaQuery.highContrastMode [ Css.backgroundColor color ])
-        config.highContrastTabListBackgroundColor
+        config.highContrastPageBackgroundColor
     ]
 
 

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -1,5 +1,5 @@
 module Nri.Ui.Tabs.V8 exposing
-    ( Attribute, title, alignment, spacing, view
+    ( Attribute, title, alignment, spacing, headerBackgroundColor, highContrastHeaderBackgroundColor, view
     , Alignment(..)
     , Tab, TabAttribute, build
     , tabString, tabHtml, withTooltip, disabled, labelledBy, describedBy
@@ -12,7 +12,7 @@ module Nri.Ui.Tabs.V8 exposing
   - Uses an HTML-like API
   - Adds sticky positioning
 
-@docs Attribute, title, alignment, spacing, view
+@docs Attribute, title, alignment, spacing, headerBackgroundColor, highContrastHeaderBackgroundColor, view
 @docs Alignment
 @docs Tab, TabAttribute, build
 @docs tabString, tabHtml, withTooltip, disabled, labelledBy, describedBy
@@ -132,6 +132,8 @@ type Attribute id msg
     = Title String
     | Alignment Alignment
     | Spacing Float
+    | HeaderBackgroundColor Css.Color
+    | HighContrastHeaderBackgroundColor Css.Color
 
 
 title : String -> Attribute id msg
@@ -149,10 +151,22 @@ spacing =
     Spacing
 
 
+headerBackgroundColor : Css.Color -> Attribute id msg
+headerBackgroundColor =
+    HeaderBackgroundColor
+
+
+highContrastHeaderBackgroundColor : Css.Color -> Attribute id msg
+highContrastHeaderBackgroundColor =
+    HighContrastHeaderBackgroundColor
+
+
 type alias Config =
     { title : Maybe String
     , alignment : Alignment
     , spacing : Maybe Float
+    , headerBackgroundColor : Maybe Css.Color
+    , highContrastHeaderBackgroundColor : Maybe Css.Color
     }
 
 
@@ -161,6 +175,8 @@ defaultConfig =
     { title = Nothing
     , alignment = Left
     , spacing = Nothing
+    , headerBackgroundColor = Nothing
+    , highContrastHeaderBackgroundColor = Nothing
     }
 
 
@@ -175,6 +191,12 @@ updateConfig attr config =
 
         Spacing newSpacing ->
             { config | spacing = Just newSpacing }
+
+        HeaderBackgroundColor newColor ->
+            { config | headerBackgroundColor = Just newColor }
+
+        HighContrastHeaderBackgroundColor newColor ->
+            { config | highContrastHeaderBackgroundColor = Just newColor }
 
 
 {-| -}

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -1,0 +1,298 @@
+module Nri.Ui.Tabs.V8 exposing
+    ( view
+    , Alignment(..)
+    , Tab, Attribute, build
+    , tabString, tabHtml, withTooltip, disabled, labelledBy, describedBy
+    , panelHtml
+    , spaHref
+    )
+
+{-| Patch changes:
+
+  - use Tooltip.V3 instead of Tooltip.V2
+
+Changes from V7:
+
+  - Changes Tab construction to follow attributes-based approach
+  - Adds tooltip support
+  - combine onFocus and onSelect into focusAndSelect msg handler (for tooltips)
+
+@docs view
+@docs Alignment
+@docs Tab, Attribute, build
+@docs tabString, tabHtml, withTooltip, disabled, labelledBy, describedBy
+@docs panelHtml
+@docs spaHref
+
+-}
+
+import Css exposing (..)
+import Html.Styled as Html exposing (Html)
+import Html.Styled.Attributes as Attributes
+import Nri.Ui
+import Nri.Ui.Colors.Extra exposing (withAlpha)
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.FocusRing.V1 as FocusRing
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Tooltip.V3 as Tooltip
+import TabsInternal.V2 as TabsInternal
+
+
+{-| -}
+type Tab id msg
+    = Tab (TabsInternal.Tab id msg)
+
+
+{-| -}
+type Attribute id msg
+    = Attribute (TabsInternal.Tab id msg -> TabsInternal.Tab id msg)
+
+
+{-| -}
+tabString : String -> Attribute id msg
+tabString content =
+    Attribute (\tab -> { tab | tabView = [ viewTabDefault content ] })
+
+
+{-| -}
+tabHtml : Html Never -> Attribute id msg
+tabHtml content =
+    Attribute (\tab -> { tab | tabView = [ Html.map never content ] })
+
+
+{-| Tooltip defaults: `[Tooltip.smallPadding, Tooltip.onBottom, Tooltip.fitToContent]`
+-}
+withTooltip : List (Tooltip.Attribute msg) -> Attribute id msg
+withTooltip attributes =
+    Attribute (\tab -> { tab | tabTooltip = attributes })
+
+
+{-| Makes it so that the tab can't be clicked or focused via keyboard navigation
+-}
+disabled : Bool -> Attribute id msg
+disabled isDisabled =
+    Attribute (\tab -> { tab | disabled = isDisabled })
+
+
+{-| Sets an overriding labelledBy on the tab for an external tooltip.
+This assumes an external tooltip is set and disables any internal tooltip configured.
+-}
+labelledBy : String -> Attribute id msg
+labelledBy labelledById =
+    Attribute (\tab -> { tab | labelledBy = Just labelledById })
+
+
+{-| Like [`labelledBy`](#labelledBy), but it describes the given element
+instead of labeling it.
+
+This attribute can be used multiple times if more than one element describes
+this tab.
+
+-}
+describedBy : String -> Attribute id msg
+describedBy describedById =
+    Attribute (\tab -> { tab | describedBy = describedById :: tab.describedBy })
+
+
+{-| -}
+panelHtml : Html msg -> Attribute id msg
+panelHtml content =
+    Attribute (\tab -> { tab | panelView = content })
+
+
+{-| -}
+spaHref : String -> Attribute id msg
+spaHref url =
+    Attribute (\tab -> { tab | spaHref = Just url })
+
+
+{-| -}
+tabAttributes : List (Html.Attribute msg) -> Attribute id msg
+tabAttributes attrs =
+    Attribute (\tab -> { tab | tabAttributes = tab.tabAttributes ++ attrs })
+
+
+{-| -}
+build : { id : id, idString : String } -> List (Attribute id msg) -> Tab id msg
+build config attributes =
+    Tab
+        (TabsInternal.fromList config
+            (List.map (\(Attribute f) -> f)
+                (tabAttributes [ Attributes.class FocusRing.customClass ]
+                    :: attributes
+                )
+            )
+        )
+
+
+{-| Determines whether tabs are centered or floating to the left or right.
+-}
+type Alignment
+    = Left
+    | Center
+    | Right
+
+
+{-| -}
+view :
+    { title : Maybe String
+    , alignment : Alignment
+    , customSpacing : Maybe Float
+    , focusAndSelect : { select : id, focus : Maybe String } -> msg
+    , selected : id
+    , tabs : List (Tab id msg)
+    }
+    -> Html msg
+view config =
+    let
+        { tabList, tabPanels } =
+            TabsInternal.views
+                { focusAndSelect = config.focusAndSelect
+                , selected = config.selected
+                , tabs = List.map (\(Tab t) -> t) config.tabs
+                , tabStyles = tabStyles config.customSpacing
+                , tabListStyles = stylesTabsAligned config.alignment
+                }
+    in
+    Nri.Ui.styled Html.div
+        "Nri-Ui-Tabs__container"
+        []
+        []
+        [ Html.styled Html.div
+            [ Css.displayFlex
+            , Css.alignItems Css.flexEnd
+            , Css.borderBottom (Css.px 1)
+            , Css.borderBottomStyle Css.solid
+            , Css.borderBottomColor Colors.navy
+            , Fonts.baseFont
+            ]
+            []
+            [ config.title
+                |> Maybe.map viewTitle
+                |> Maybe.withDefault (Html.text "")
+            , tabList
+            ]
+        , tabPanels
+        ]
+
+
+{-| -}
+viewTabDefault : String -> Html msg
+viewTabDefault title =
+    Html.div
+        [ Attributes.css
+            [ Css.padding4 (Css.px 14) (Css.px 20) (Css.px 12) (Css.px 20)
+            ]
+        ]
+        [ Html.text title ]
+
+
+viewTitle : String -> Html msg
+viewTitle title =
+    Html.styled Html.h1
+        [ Css.flexGrow (Css.int 2)
+        , Css.fontSize (Css.px 20)
+        , Css.fontWeight Css.bold
+        , Css.margin4 (Css.px 5) (Css.px 10) (Css.px 10) Css.zero
+        , Css.color Colors.navy
+        ]
+        []
+        [ Html.text title ]
+
+
+
+-- STYLES
+
+
+stylesTabsAligned : Alignment -> List Style
+stylesTabsAligned alignment =
+    let
+        alignmentStyles =
+            case alignment of
+                Left ->
+                    Css.justifyContent Css.flexStart
+
+                Center ->
+                    Css.justifyContent Css.center
+
+                Right ->
+                    Css.justifyContent Css.flexEnd
+    in
+    alignmentStyles
+        :: [ Css.margin Css.zero
+           , Css.fontSize (Css.px 19)
+           , Css.displayFlex
+           , Css.flexGrow (Css.int 1)
+           , Css.padding Css.zero
+           ]
+
+
+tabStyles : Maybe Float -> Int -> Bool -> List Style
+tabStyles customSpacing index isSelected =
+    let
+        stylesDynamic =
+            if isSelected then
+                [ Css.backgroundColor Colors.white
+                , Css.borderBottom (Css.px 1)
+                , Css.borderBottomStyle Css.solid
+                , Css.borderBottomColor Colors.white
+                ]
+
+            else
+                [ Css.backgroundColor Colors.frost
+                , Css.backgroundImage <|
+                    Css.linearGradient2 Css.toTop
+                        (Css.stop2 (withAlpha 0.25 Colors.azure) (Css.pct 0))
+                        (Css.stop2 (withAlpha 0 Colors.azure) (Css.pct 25))
+                        [ Css.stop2 (withAlpha 0 Colors.azure) (Css.pct 100) ]
+                ]
+
+        baseStyles =
+            [ Css.color Colors.navy
+            , Css.position Css.relative
+
+            -- necessary because bourbon or bootstrap or whatever add underlines when tabs are used as links
+            , Css.textDecoration Css.none |> important
+            , Css.property "background" "none"
+            , Css.fontFamily Css.inherit
+            , Css.fontSize Css.inherit
+            , Css.cursor Css.pointer
+            , Css.border zero
+            , Css.height (Css.pct 100)
+            ]
+
+        stylesTab =
+            [ Css.display Css.inlineBlock
+            , Css.borderTopLeftRadius (Css.px 10)
+            , Css.borderTopRightRadius (Css.px 10)
+            , Css.border3 (Css.px 1) Css.solid Colors.navy
+            , Css.marginTop Css.zero
+            , Css.marginLeft
+                (if index == 0 then
+                    Css.px 0
+
+                 else
+                    Css.px margin
+                )
+            , Css.marginRight (Css.px margin)
+            , Css.padding2 (Css.px 1) (Css.px 6)
+            , Css.marginBottom (Css.px -1)
+            , Css.cursor Css.pointer
+            , property "transition" "background-color 0.2s"
+            , property "transition" "border-color 0.2s"
+            , hover
+                [ backgroundColor Colors.white
+                , borderTopColor Colors.azure
+                , borderRightColor Colors.azure
+                , borderLeftColor Colors.azure
+                ]
+            , pseudoClass "focus-visible"
+                [ FocusRing.outerBoxShadow
+                , Css.outline3 (Css.px 2) Css.solid Css.transparent
+                ]
+            ]
+
+        margin =
+            Maybe.withDefault 10 customSpacing / 2
+    in
+    baseStyles ++ stylesTab ++ stylesDynamic

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -7,15 +7,10 @@ module Nri.Ui.Tabs.V8 exposing
     , spaHref
     )
 
-{-| Patch changes:
+{-| Changes from V7:
 
-  - use Tooltip.V3 instead of Tooltip.V2
-
-Changes from V7:
-
-  - Changes Tab construction to follow attributes-based approach
-  - Adds tooltip support
-  - combine onFocus and onSelect into focusAndSelect msg handler (for tooltips)
+  - Uses an HTML-like API
+  - Adds sticky positioning
 
 @docs view
 @docs Alignment

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -72,6 +72,7 @@
         "Nri.Ui.Table.V6",
         "Nri.Ui.Tabs.V6",
         "Nri.Ui.Tabs.V7",
+        "Nri.Ui.Tabs.V8",
         "Nri.Ui.Text.V6",
         "Nri.Ui.Text.Writing.V1",
         "Nri.Ui.TextArea.V5",


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

For ADM-705, we need to be able to have the tabs and table headers sticky on the screen. This is the first step there!

Note on the last checklist item here: this is true in V8 where it wasn't in V7. I know this is a bigger change but it opens up the possibilities!

## :framed_picture: What does this change look like?

There are no visual changes from V7; only behavior changes.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
