### PR TITLE
add sticky headers to sortable tables

### DIFF
--- a/component-catalog-app/Examples/AnimatedIcon.elm
+++ b/component-catalog-app/Examples/AnimatedIcon.elm
@@ -88,7 +88,7 @@ example =
                         ]
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
-            , Table.view
+            , Table.view []
                 [ Table.custom
                     { header = text "Rendered"
                     , view =

--- a/component-catalog-app/Examples/AnimatedIcon.elm
+++ b/component-catalog-app/Examples/AnimatedIcon.elm
@@ -19,7 +19,7 @@ import Nri.Ui.AnimatedIcon.V1 as AnimatedIcon
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Svg.V1 as Svg
-import Nri.Ui.Table.V6 as Table
+import Nri.Ui.Table.V7 as Table
 
 
 moduleName : String

--- a/component-catalog-app/Examples/Block.elm
+++ b/component-catalog-app/Examples/Block.elm
@@ -251,7 +251,7 @@ example =
                     , Block.labelPosition (Dict.get longId offsets)
                     ]
                 ]
-            , Table.view
+            , Table.view []
                 [ Table.custom
                     { header = text "Pattern name & description"
                     , view = .description >> Markdown.toHtml Nothing >> List.map fromUnstyled >> div []

--- a/component-catalog-app/Examples/Block.elm
+++ b/component-catalog-app/Examples/Block.elm
@@ -26,7 +26,7 @@ import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
-import Nri.Ui.Table.V6 as Table
+import Nri.Ui.Table.V7 as Table
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Task

--- a/component-catalog-app/Examples/BreadCrumbs.elm
+++ b/component-catalog-app/Examples/BreadCrumbs.elm
@@ -23,7 +23,7 @@ import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
-import Nri.Ui.Table.V6 as Table
+import Nri.Ui.Table.V7 as Table
 import Nri.Ui.UiIcon.V1 as UiIcon
 
 

--- a/component-catalog-app/Examples/BreadCrumbs.elm
+++ b/component-catalog-app/Examples/BreadCrumbs.elm
@@ -173,7 +173,7 @@ example =
                 [ Heading.h2 [ Heading.plaintext "viewSecondary Example" ]
                 , viewJust (Tuple.second >> viewSecondaryExample settings.currentRoute) breadCrumbs
                 ]
-            , Table.view
+            , Table.view []
                 [ Table.string
                     { header = "Name"
                     , value = .name

--- a/component-catalog-app/Examples/Checkbox.elm
+++ b/component-catalog-app/Examples/Checkbox.elm
@@ -21,7 +21,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Svg.V1 as Svg
-import Nri.Ui.Table.V6 as Table
+import Nri.Ui.Table.V7 as Table
 
 
 moduleName : String

--- a/component-catalog-app/Examples/Checkbox.elm
+++ b/component-catalog-app/Examples/Checkbox.elm
@@ -66,7 +66,7 @@ example =
             , Heading.h2 [ Heading.plaintext "Customizable example" ]
             , exampleView
             , Heading.h2 [ Heading.plaintext "Examples" ]
-            , Table.view
+            , Table.view []
                 [ Table.string
                     { header = "State"
                     , value = .state

--- a/component-catalog-app/Examples/Fonts.elm
+++ b/component-catalog-app/Examples/Fonts.elm
@@ -13,7 +13,7 @@ import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Fonts.V1 as Fonts
-import Nri.Ui.Table.V6 as Table
+import Nri.Ui.Table.V7 as Table
 import Nri.Ui.Text.V6 as Text
 
 

--- a/component-catalog-app/Examples/Fonts.elm
+++ b/component-catalog-app/Examples/Fonts.elm
@@ -90,7 +90,7 @@ viewFontFailurePatterns =
             , Css.textAlign Css.center
             ]
     in
-    Table.view
+    Table.view []
         [ Table.rowHeader
             { header = Html.text "Example"
             , view = Html.text << .example

--- a/component-catalog-app/Examples/Highlighter.elm
+++ b/component-catalog-app/Examples/Highlighter.elm
@@ -25,7 +25,7 @@ import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Highlightable.V2 as Highlightable exposing (Highlightable)
 import Nri.Ui.Highlighter.V3 as Highlighter
 import Nri.Ui.HighlighterTool.V1 as Tool
-import Nri.Ui.Table.V6 as Table
+import Nri.Ui.Table.V7 as Table
 import String.Extra
 
 

--- a/component-catalog-app/Examples/Highlighter.elm
+++ b/component-catalog-app/Examples/Highlighter.elm
@@ -113,7 +113,7 @@ example =
                 ]
             , Heading.h2 [ Heading.plaintext "Non-interactive examples" ]
             , Heading.h3 [ Heading.plaintext "These are examples of some different ways the highlighter can appear to users." ]
-            , Table.view
+            , Table.view []
                 [ Table.rowHeader
                     { header = text "Highlighter."
                     , view = .viewName >> text

--- a/component-catalog-app/Examples/Menu.elm
+++ b/component-catalog-app/Examples/Menu.elm
@@ -29,7 +29,7 @@ import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Menu.V4 as Menu
 import Nri.Ui.Spacing.V1 as Spacing
-import Nri.Ui.Table.V6 as Table
+import Nri.Ui.Table.V7 as Table
 import Nri.Ui.TextInput.V7 as TextInput
 import Nri.Ui.Tooltip.V3 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon

--- a/component-catalog-app/Examples/Menu.elm
+++ b/component-catalog-app/Examples/Menu.elm
@@ -230,7 +230,7 @@ view ellieLinkConfig state =
         [ Heading.plaintext "Menu types"
         , Heading.css [ Css.margin2 Spacing.verticalSpacerPx Css.zero ]
         ]
-    , Table.view
+    , Table.view []
         [ Table.string
             { header = "Menu type"
             , value = .menu

--- a/component-catalog-app/Examples/QuestionBox.elm
+++ b/component-catalog-app/Examples/QuestionBox.elm
@@ -33,7 +33,7 @@ import Nri.Ui.MediaQuery.V1 exposing (..)
 import Nri.Ui.QuestionBox.V4 as QuestionBox
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
-import Nri.Ui.Table.V6 as Table
+import Nri.Ui.Table.V7 as Table
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Task

--- a/component-catalog-app/Examples/QuestionBox.elm
+++ b/component-catalog-app/Examples/QuestionBox.elm
@@ -238,7 +238,7 @@ While these visions did appear.
                 ]
             ]
         ]
-    , Table.view
+    , Table.view []
         [ Table.custom
             { header = text "Pattern name & description"
             , view = .description >> Markdown.toHtml Nothing >> List.map fromUnstyled >> div []

--- a/component-catalog-app/Examples/RingGauge.elm
+++ b/component-catalog-app/Examples/RingGauge.elm
@@ -103,7 +103,7 @@ example =
                 |> Svg.withWidth (Css.px 200)
                 |> Svg.withHeight (Css.px 200)
                 |> Svg.toHtml
-            , Table.view
+            , Table.view []
                 [ Table.string
                     { header = "Color contrast against"
                     , value = .name

--- a/component-catalog-app/Examples/RingGauge.elm
+++ b/component-catalog-app/Examples/RingGauge.elm
@@ -20,7 +20,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.RingGauge.V1 as RingGauge
 import Nri.Ui.Svg.V1 as Svg
-import Nri.Ui.Table.V6 as Table
+import Nri.Ui.Table.V7 as Table
 import Round
 import SolidColor.Accessibility
 

--- a/component-catalog-app/Examples/SortableTable.elm
+++ b/component-catalog-app/Examples/SortableTable.elm
@@ -74,7 +74,7 @@ example =
                     |> Svg.withHeight (Css.px 12)
                     |> Svg.toHtml
         in
-        [ Table.view
+        [ Table.view []
             [ Table.custom
                 { header = header "X"
                 , view = .x >> Html.text

--- a/component-catalog-app/Examples/SortableTable.elm
+++ b/component-catalog-app/Examples/SortableTable.elm
@@ -351,6 +351,12 @@ controlSettings =
                       , Control.record SortableTable.StickyConfig
                             |> Control.field "topOffset" (values String.fromFloat [ 0, 10, 50 ])
                             |> Control.field "zIndex" (values String.fromInt [ 0, 1, 5, 10 ])
+                            |> Control.field "pageBackgroundColor"
+                                (Control.choice
+                                    [ ( "white", Control.value Colors.white)
+                                    , ( "gray", Control.value Colors.gray92)
+                                    ]
+                                )
                             |> Control.map Custom
                       )
                     ]

--- a/component-catalog-app/Examples/SortableTable.elm
+++ b/component-catalog-app/Examples/SortableTable.elm
@@ -154,6 +154,7 @@ example =
                                                     ++ Code.recordMultiline
                                                         [ ( "topOffset", String.fromFloat stickyConfig.topOffset )
                                                         , ( "zIndex", String.fromInt stickyConfig.zIndex )
+                                                        , ( "pageBackgroundColor", "Css.hex \"" ++ stickyConfig.pageBackgroundColor.value ++ "\"")
                                                         ]
                                                         2
                                     )

--- a/component-catalog-app/Examples/SortableTable.elm
+++ b/component-catalog-app/Examples/SortableTable.elm
@@ -17,7 +17,7 @@ import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
-import Nri.Ui.SortableTable.V3 as SortableTable exposing (Column)
+import Nri.Ui.SortableTable.V4 as SortableTable exposing (Column)
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Table.V6 as Table
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -30,7 +30,7 @@ moduleName =
 
 version : Int
 version =
-    3
+    4
 
 
 {-| -}

--- a/component-catalog-app/Examples/SortableTable.elm
+++ b/component-catalog-app/Examples/SortableTable.elm
@@ -105,7 +105,7 @@ example =
                     Control.currentValue model.settings
 
                 config =
-                    { updateMsg = SetSortState
+                    { updateMsg = Just SetSortState
                     , state = Just sortState
                     }
 

--- a/component-catalog-app/Examples/SortableTable.elm
+++ b/component-catalog-app/Examples/SortableTable.elm
@@ -107,6 +107,7 @@ example =
                 config =
                     { updateMsg = SetSortState
                     , columns = columns
+                    , state = Just sortState
                     }
 
                 ( dataCode, data ) =
@@ -149,10 +150,10 @@ example =
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
             , if settings.loading then
-                SortableTable.viewLoading config sortState
+                SortableTable.viewLoading config
 
               else
-                SortableTable.view config sortState data
+                SortableTable.view config data
             ]
     }
 

--- a/component-catalog-app/Examples/SortableTable.elm
+++ b/component-catalog-app/Examples/SortableTable.elm
@@ -104,10 +104,10 @@ example =
                 settings =
                     Control.currentValue model.settings
 
-                config =
-                    { updateMsg = Just SetSortState
-                    , state = Just sortState
-                    }
+                attrs =
+                    [ SortableTable.updateMsg SetSortState
+                    , SortableTable.state sortState
+                    ]
 
                 ( dataCode, data ) =
                     List.unzip dataWithCode
@@ -149,10 +149,10 @@ example =
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
             , if settings.loading then
-                SortableTable.viewLoading config columns
+                SortableTable.viewLoading attrs columns
 
               else
-                SortableTable.view config columns data
+                SortableTable.view attrs columns data
             ]
     }
 

--- a/component-catalog-app/Examples/SortableTable.elm
+++ b/component-catalog-app/Examples/SortableTable.elm
@@ -19,7 +19,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.SortableTable.V4 as SortableTable exposing (Column)
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
-import Nri.Ui.Table.V6 as Table
+import Nri.Ui.Table.V7 as Table
 import Nri.Ui.UiIcon.V1 as UiIcon
 
 

--- a/component-catalog-app/Examples/SortableTable.elm
+++ b/component-catalog-app/Examples/SortableTable.elm
@@ -106,7 +106,6 @@ example =
 
                 config =
                     { updateMsg = SetSortState
-                    , columns = columns
                     , state = Just sortState
                     }
 
@@ -150,10 +149,10 @@ example =
                 }
             , Heading.h2 [ Heading.plaintext "Example" ]
             , if settings.loading then
-                SortableTable.viewLoading config
+                SortableTable.viewLoading config columns
 
               else
-                SortableTable.view config data
+                SortableTable.view config columns data
             ]
     }
 

--- a/component-catalog-app/Examples/SortableTable.elm
+++ b/component-catalog-app/Examples/SortableTable.elm
@@ -119,15 +119,16 @@ example =
                     { sectionName = viewName
                     , code =
                         [ moduleName ++ "." ++ viewName
-                        , Code.recordMultiline
-                            [ ( "updateMsg", "SetSortState" )
-                            , ( "columns", Code.listMultiline columnsCode 2 )
+                        , Code.listMultiline
+                            [ "SortableTable.updateMsg SetSortState"
+                            , "-- The SortableTable's state should be stored on the model, rather than initialized in the view"
+                                ++ "\n      "
+                                ++ "SortableTable.state (SortableTable.init "
+                                ++ Debug.toString model.sortState.column
+                                ++ ")"
                             ]
                             1
-                        , Code.newlineWithIndent 1
-                        , Code.commentInline "The SortableTable's state should be stored on the model, rather than initialized in the view"
-                        , Code.newlineWithIndent 1
-                        , Code.withParens ("SortableTable.init " ++ Debug.toString model.sortState.column)
+                        , Code.listMultiline columnsCode 1
                         , finalArgs
                         ]
                             |> String.join ""

--- a/component-catalog-app/Examples/SortableTable.elm
+++ b/component-catalog-app/Examples/SortableTable.elm
@@ -10,8 +10,7 @@ import Category exposing (Category(..))
 import Code
 import Css exposing (..)
 import Debug.Control as Control exposing (Control)
-import Debug.Control.Extra as ControlExtra
-import Debug.Control.Extra exposing (values)
+import Debug.Control.Extra as ControlExtra exposing (values)
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled as Html exposing (..)
@@ -154,7 +153,7 @@ example =
                                                     ++ Code.recordMultiline
                                                         [ ( "topOffset", String.fromFloat stickyConfig.topOffset )
                                                         , ( "zIndex", String.fromInt stickyConfig.zIndex )
-                                                        , ( "pageBackgroundColor", "Css.hex \"" ++ stickyConfig.pageBackgroundColor.value ++ "\"")
+                                                        , ( "pageBackgroundColor", "Css.hex \"" ++ stickyConfig.pageBackgroundColor.value ++ "\"" )
                                                         ]
                                                         2
                                     )
@@ -187,7 +186,8 @@ example =
                 SortableTable.viewLoading attrs columns
 
               else
-                SortableTable.view attrs columns
+                SortableTable.view attrs
+                    columns
                     (if isStickyAtAll then
                         data
                             |> List.repeat 10
@@ -354,8 +354,8 @@ controlSettings =
                             |> Control.field "zIndex" (values String.fromInt [ 0, 1, 5, 10 ])
                             |> Control.field "pageBackgroundColor"
                                 (Control.choice
-                                    [ ( "white", Control.value Colors.white)
-                                    , ( "gray", Control.value Colors.gray92)
+                                    [ ( "white", Control.value Colors.white )
+                                    , ( "gray", Control.value Colors.gray92 )
                                     ]
                                 )
                             |> Control.map Custom

--- a/component-catalog-app/Examples/Spacing.elm
+++ b/component-catalog-app/Examples/Spacing.elm
@@ -21,7 +21,7 @@ import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
-import Nri.Ui.Table.V6 as Table
+import Nri.Ui.Table.V7 as Table
 import Svg.Styled
 import Svg.Styled.Attributes
 

--- a/component-catalog-app/Examples/Spacing.elm
+++ b/component-catalog-app/Examples/Spacing.elm
@@ -237,7 +237,7 @@ view ellieLinkConfig state =
     , Heading.h2 [ Heading.plaintext "Example", Heading.css [ Css.marginTop Spacing.verticalSpacerPx ] ]
     , fakePage [ exampleView ]
     , Heading.h2 [ Heading.plaintext "Content alignment", Heading.css [ Css.marginTop Spacing.verticalSpacerPx ] ]
-    , Table.view
+    , Table.view []
         [ Table.string
             { header = "Name"
             , value = .name
@@ -275,7 +275,7 @@ view ellieLinkConfig state =
         , { name = "centeredContentWithCustomWidth", alignment = "Centered", maxWidth = "(customizable)", sidePadding = "0px" }
         ]
     , Heading.h2 [ Heading.plaintext "Constants", Heading.css [ Css.marginTop Spacing.verticalSpacerPx ] ]
-    , Table.view
+    , Table.view []
         [ Table.string
             { header = "Name"
             , value = .name

--- a/component-catalog-app/Examples/Table.elm
+++ b/component-catalog-app/Examples/Table.elm
@@ -44,7 +44,7 @@ example =
     , categories = [ Layout ]
     , keyboardSupport = []
     , preview =
-        [ Table.view
+        [ Table.view []
             [ Table.string
                 { header = "A"
                 , value = .a
@@ -98,6 +98,7 @@ example =
                                 { sectionName = moduleName ++ "." ++ viewName
                                 , code =
                                     (moduleName ++ "." ++ viewName)
+                                        ++ " [] "
                                         ++ Code.list columnsCode
                                         ++ dataStr
                                 }
@@ -111,16 +112,16 @@ example =
             , Heading.h2 [ Heading.plaintext "Example" ]
             , case ( showHeader, isLoading ) of
                 ( True, False ) ->
-                    Table.view columns data
+                    Table.view [] columns data
 
                 ( False, False ) ->
-                    Table.viewWithoutHeader columns data
+                    Table.viewWithoutHeader [] columns data
 
                 ( True, True ) ->
-                    Table.viewLoading columns
+                    Table.viewLoading [] columns
 
                 ( False, True ) ->
-                    Table.viewLoadingWithoutHeader columns
+                    Table.viewLoadingWithoutHeader [] columns
             ]
     }
 

--- a/component-catalog-app/Examples/Table.elm
+++ b/component-catalog-app/Examples/Table.elm
@@ -15,7 +15,7 @@ import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Heading.V3 as Heading
-import Nri.Ui.Table.V6 as Table exposing (Column)
+import Nri.Ui.Table.V7 as Table exposing (Column)
 
 
 {-| -}
@@ -30,7 +30,7 @@ moduleName =
 
 version : Int
 version =
-    6
+    7
 
 
 {-| -}

--- a/component-catalog-app/Examples/Tooltip.elm
+++ b/component-catalog-app/Examples/Tooltip.elm
@@ -136,7 +136,7 @@ view : EllieLink.Config -> State -> List (Html Msg)
 view ellieLinkConfig model =
     [ viewCustomizableExample ellieLinkConfig model.staticExampleSettings
     , Heading.h2 [ Heading.plaintext "What type of tooltip should I use?" ]
-    , Table.view
+    , Table.view []
         [ Table.string
             { header = "Type"
             , value = .name

--- a/component-catalog-app/Examples/Tooltip.elm
+++ b/component-catalog-app/Examples/Tooltip.elm
@@ -25,7 +25,7 @@ import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Svg.V1 as Svg
-import Nri.Ui.Table.V6 as Table
+import Nri.Ui.Table.V7 as Table
 import Nri.Ui.Tooltip.V3 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon
 

--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -7,5 +7,6 @@ Nri.Ui.QuestionBox.V2,upgrade to V4
 Nri.Ui.QuestionBox.V3,upgrade to V4
 Nri.Ui.Select.V8,upgrade to V9
 Nri.Ui.SortableTable.V3,upgrade to V4
+Nri.Ui.Table.V6,upgrade to V7
 Nri.Ui.Tabs.V6,upgrade to V8
 Nri.Ui.Tabs.V7,upgrade to V8

--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -6,5 +6,6 @@ Nri.Ui.HighlighterToolbar.V2,upgrade to V3
 Nri.Ui.QuestionBox.V2,upgrade to V4
 Nri.Ui.QuestionBox.V3,upgrade to V4
 Nri.Ui.Select.V8,upgrade to V9
+Nri.Ui.SortableTable.V3,upgrade to V4
 Nri.Ui.Tabs.V6,upgrade to V8
 Nri.Ui.Tabs.V7,upgrade to V8

--- a/elm.json
+++ b/elm.json
@@ -76,6 +76,7 @@
         "Nri.Ui.Svg.V1",
         "Nri.Ui.Switch.V2",
         "Nri.Ui.Table.V6",
+        "Nri.Ui.Table.V7",
         "Nri.Ui.Tabs.V6",
         "Nri.Ui.Tabs.V7",
         "Nri.Ui.Tabs.V8",

--- a/elm.json
+++ b/elm.json
@@ -70,6 +70,7 @@
         "Nri.Ui.Shadows.V1",
         "Nri.Ui.SideNav.V4",
         "Nri.Ui.SortableTable.V3",
+        "Nri.Ui.SortableTable.V4",
         "Nri.Ui.Spacing.V1",
         "Nri.Ui.Sprite.V1",
         "Nri.Ui.Svg.V1",

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -188,6 +188,9 @@ hint = 'upgrade to V4'
 [forbidden."Nri.Ui.SortableTable.V2"]
 hint = 'upgrade to V3'
 
+[forbidden."Nri.Ui.SortableTable.V3"]
+hint = 'upgrade to V4'
+
 [forbidden."Nri.Ui.Switch.V1"]
 hint = 'upgrade to V2'
 

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -200,6 +200,9 @@ hint = 'upgrade to V5'
 [forbidden."Nri.Ui.Table.V5"]
 hint = 'upgrade to V6'
 
+[forbidden."Nri.Ui.Table.V6"]
+hint = 'upgrade to V7'
+
 [forbidden."Nri.Ui.Tabs.V6"]
 hint = 'upgrade to V8'
 

--- a/src/Nri/Ui/SortableTable/V3.elm
+++ b/src/Nri/Ui/SortableTable/V3.elm
@@ -189,8 +189,7 @@ viewLoading config state =
         tableColumns =
             List.map (buildTableColumn config.updateMsg state) config.columns
     in
-    Table.viewLoading
-        tableColumns
+    Table.viewLoading [] tableColumns
 
 
 {-| -}
@@ -203,7 +202,7 @@ view config state entries =
         sorter =
             findSorter config.columns state.column
     in
-    Table.view
+    Table.view []
         tableColumns
         (List.sortWith (sorter state.sortDirection) entries)
 

--- a/src/Nri/Ui/SortableTable/V3.elm
+++ b/src/Nri/Ui/SortableTable/V3.elm
@@ -32,7 +32,7 @@ import Nri.Ui.Colors.V1
 import Nri.Ui.CssVendorPrefix.V1 as CssVendorPrefix
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Svg.V1
-import Nri.Ui.Table.V6 as Table exposing (SortDirection(..))
+import Nri.Ui.Table.V7 as Table exposing (SortDirection(..))
 import Nri.Ui.UiIcon.V1
 
 

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -59,15 +59,14 @@ type alias State id =
 
 
 {-| -}
-type alias Config id entry msg =
+type alias Config id msg =
     { updateMsg : State id -> msg
-    , columns : List (Column id entry msg)
     , state : Maybe (State id)
     }
 
 
 type Attribute id entry msg
-    = Attribute (Config id entry msg -> Config id entry msg)
+    = Attribute (Config id msg -> Config id msg)
 
 
 state : State id -> Attribute id entry msg
@@ -191,17 +190,17 @@ combineSorters sorters =
 
 
 {-| -}
-view : Config id entry msg -> List entry -> Html msg
-view config entries =
+view : Config id msg -> List (Column id entry msg) -> List entry -> Html msg
+view config columns entries =
     let
         tableColumns =
-            List.map (buildTableColumn config.updateMsg config.state) config.columns
+            List.map (buildTableColumn config.updateMsg config.state) columns
     in
     case config.state of
         Just state_ ->
             let
                 sorter =
-                    findSorter config.columns state_.column
+                    findSorter columns state_.column
             in
             Table.view
                 tableColumns
@@ -212,11 +211,11 @@ view config entries =
 
 
 {-| -}
-viewLoading : Config id entry msg -> Html msg
-viewLoading config =
+viewLoading : Config id msg -> List (Column id entry msg) -> Html msg
+viewLoading config columns =
     let
         tableColumns =
-            List.map (buildTableColumn config.updateMsg config.state) config.columns
+            List.map (buildTableColumn config.updateMsg config.state) columns
     in
     Table.viewLoading
         tableColumns

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -139,7 +139,7 @@ entries by name, no matter of the sort direction set on the table.
 -}
 invariantSort : (entry -> comparable) -> Sorter entry
 invariantSort mapper =
-    \sortDirection elem1 elem2 ->
+    \_ elem1 elem2 ->
         compare (mapper elem1) (mapper elem2)
 
 
@@ -249,7 +249,7 @@ listExtraFind predicate list =
 
 identitySorter : Sorter a
 identitySorter =
-    \sortDirection item1 item2 ->
+    \_ _ _ ->
         EQ
 
 

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -21,6 +21,7 @@ module Nri.Ui.SortableTable.V4 exposing
 
 import Accessibility.Styled.Aria as Aria
 import Css exposing (..)
+import Css.Global
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events
@@ -97,6 +98,18 @@ defaultStickyConfig =
     { topOffset = 0
     , zIndex = 0
     }
+
+
+stickyConfigStyles : StickyConfig -> List Style
+stickyConfigStyles { topOffset, zIndex } =
+    [ Css.Global.children
+        [ Css.Global.thead
+            [ Css.position Css.sticky
+            , Css.top (Css.px topOffset)
+            , Css.zIndex (Css.int zIndex)
+            ]
+        ]
+    ]
 
 
 {-| Customize how the table is rendered, for example by adding sorting or
@@ -262,6 +275,10 @@ view attributes columns entries =
         config =
             List.foldl (\(Attribute fn) soFar -> fn soFar) defaultConfig attributes
 
+        stickyStyles =
+            Maybe.map stickyConfigStyles config.stickyHeader
+                |> Maybe.withDefault []
+
         tableColumns =
             List.map (buildTableColumn config.updateMsg config.state) columns
     in
@@ -271,12 +288,12 @@ view attributes columns entries =
                 sorter =
                     findSorter columns state_.column
             in
-            Table.view []
+            Table.view stickyStyles
                 tableColumns
                 (List.sortWith (sorter state_.sortDirection) entries)
 
         Nothing ->
-            Table.view [] tableColumns entries
+            Table.view stickyStyles tableColumns entries
 
 
 {-| -}
@@ -286,10 +303,14 @@ viewLoading attributes columns =
         config =
             List.foldl (\(Attribute fn) soFar -> fn soFar) defaultConfig attributes
 
+        stickyStyles =
+            Maybe.map stickyConfigStyles config.stickyHeader
+                |> Maybe.withDefault []
+
         tableColumns =
             List.map (buildTableColumn config.updateMsg config.state) columns
     in
-    Table.viewLoading [] tableColumns
+    Table.viewLoading stickyStyles tableColumns
 
 
 findSorter : List (Column id entry msg) -> id -> Sorter entry

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -181,17 +181,6 @@ combineSorters sorters =
 
 
 {-| -}
-viewLoading : Config id entry msg -> State id -> Html msg
-viewLoading config state =
-    let
-        tableColumns =
-            List.map (buildTableColumn config.updateMsg state) config.columns
-    in
-    Table.viewLoading
-        tableColumns
-
-
-{-| -}
 view : Config id entry msg -> State id -> List entry -> Html msg
 view config state entries =
     let
@@ -204,6 +193,17 @@ view config state entries =
     Table.view
         tableColumns
         (List.sortWith (sorter state.sortDirection) entries)
+
+
+{-| -}
+viewLoading : Config id entry msg -> State id -> Html msg
+viewLoading config state =
+    let
+        tableColumns =
+            List.map (buildTableColumn config.updateMsg state) config.columns
+    in
+    Table.viewLoading
+        tableColumns
 
 
 findSorter : List (Column id entry msg) -> id -> Sorter entry

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -278,12 +278,12 @@ view attributes columns entries =
                 sorter =
                     findSorter columns state_.column
             in
-            Table.view
+            Table.view []
                 tableColumns
                 (List.sortWith (sorter state_.sortDirection) entries)
 
         Nothing ->
-            Table.view tableColumns entries
+            Table.view [] tableColumns entries
 
 
 {-| -}
@@ -296,8 +296,7 @@ viewLoading attributes columns =
         tableColumns =
             List.map (buildTableColumn config.updateMsg config.state) columns
     in
-    Table.viewLoading
-        tableColumns
+    Table.viewLoading [] tableColumns
 
 
 findSorter : List (Column id entry msg) -> id -> Sorter entry

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -90,6 +90,7 @@ accessibility issues with zooming and panning.
 type alias StickyConfig =
     { topOffset : Float
     , zIndex : Int
+    , pageBackgroundColor : Css.Color
     }
 
 
@@ -97,16 +98,18 @@ defaultStickyConfig : StickyConfig
 defaultStickyConfig =
     { topOffset = 0
     , zIndex = 0
+    , pageBackgroundColor = Nri.Ui.Colors.V1.white
     }
 
 
 stickyConfigStyles : StickyConfig -> List Style
-stickyConfigStyles { topOffset, zIndex } =
+stickyConfigStyles { topOffset, zIndex, pageBackgroundColor } =
     [ Css.Global.children
         [ Css.Global.thead
             [ Css.position Css.sticky
             , Css.top (Css.px topOffset)
             , Css.zIndex (Css.int zIndex)
+            , Css.backgroundColor pageBackgroundColor
             ]
         ]
     ]

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -9,12 +9,10 @@ module Nri.Ui.SortableTable.V4 exposing
 
   - add the possibility to pass Aria.sortAscending and Aria.sortDescending attributes to the <th> tag
 
-Changes from V2:
+Changes from V3:
 
-  - made column non-sortable (e.g. buttons in a column should not be sorted)
-  - use a button instead of a clickable div in headers
-  - use Aria.roleDescription instead of Aria.label in sortable columns headers
-  - use Nri.Ui.UiIcon.V1 sortArrow and Nri.Ui.UiIcon.V1 sortArrowDown icons for the sort indicators
+  - Change to an HTML-like API
+  - Allow the table header to be sticky
 
 @docs Column, Config, Sorter, State
 @docs init, initDescending

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -81,16 +81,14 @@ defaultConfig =
   - `zIndex` controls where in the stacking context the header will end
     up. Useful to prevent elements in rows from appearing over the header.
     (**Defualt value:** 0)
-  - `includeMobile`, if true, will make the header sticky on mobile (narrow)
-    viewports as well as desktop (wider) ones. Be careful about setting this to
-    `True`, as it can make it harder for folks on mobile devices to pinch and
-    zoom, creating accessibility problems. (**Default value:** False)
+
+Headers are never sticky on mobile-sized viewports because doing so causes some
+accessibility issues with zooming and panning.
 
 -}
 type alias StickyConfig =
     { topOffset : Float
     , zIndex : Int
-    , includeMobile : Bool
     }
 
 
@@ -98,7 +96,6 @@ defaultStickyConfig : StickyConfig
 defaultStickyConfig =
     { topOffset = 0
     , zIndex = 0
-    , includeMobile = False
     }
 
 

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -78,6 +78,19 @@ defaultConfig =
     }
 
 
+{-| How the header will be set up to be sticky.
+
+  - `topOffset` controls how far off the top of the viewport the headers will
+    stick, in pixels. (**Default value:** 0)
+  - `zIndex` controls where in the stacking context the header will end
+    up. Useful to prevent elements in rows from appearing over the header.
+    (**Defualt value:** 0)
+  - `includeMobile`, if true, will make the header sticky on mobile (narrow)
+    viewports as well as desktop (wider) ones. Be careful about setting this to
+    `True`, as it can make it harder for folks on mobile devices to pinch and
+    zoom, creating accessibility problems. (**Default value:** False)
+
+-}
 type alias StickyConfig =
     { topOffset : Float
     , zIndex : Int
@@ -93,25 +106,42 @@ defaultStickyConfig =
     }
 
 
+{-| Customize how the table is rendered, for example by adding sorting or
+stickiness.
+-}
 type Attribute id msg
     = Attribute (Config id msg -> Config id msg)
 
 
+{-| Sort a column. You can get an initial state with `init` or `initDescending`.
+If you make this sorting interactive, you should store the state in your model
+and provide it to this function instead of recreating it on every update.
+-}
 state : State id -> Attribute id msg
 state state_ =
     Attribute (\config -> { config | state = Just state_ })
 
 
+{-| Add interactivity in sorting columns. When this attribute is provided and
+sorting is enabled, columns will be sortable by clicking the headers.
+-}
 updateMsg : (State id -> msg) -> Attribute id msg
 updateMsg updateMsg_ =
     Attribute (\config -> { config | updateMsg = Just updateMsg_ })
 
 
+{-| Make the header sticky (that is, it will stick to the top of the viewport
+when it otherwise would have been scrolled off.) You probably will want to set a
+background color on the header as well.
+-}
 stickyHeader : Attribute id msg
 stickyHeader =
     Attribute (\config -> { config | stickyHeader = Just defaultStickyConfig })
 
 
+{-| Does the same thing as `stickyHeader`, but with adaptations for your
+specific use.
+-}
 stickyHeaderCustom : StickyConfig -> Attribute id msg
 stickyHeaderCustom stickyConfig =
     Attribute (\config -> { config | stickyHeader = Just stickyConfig })

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -309,13 +309,13 @@ viewSortHeader isSortable header maybeUpdateMsg state_ id =
                 , Fonts.baseFont
                 , Css.fontSize (Css.em 1)
                 ]
-            , maybe (\updateMsg -> Html.Styled.Events.onClick (updateMsg nextState)) maybeUpdateMsg
+            , maybe (\updateMsg_ -> Html.Styled.Events.onClick (updateMsg_ nextState)) maybeUpdateMsg
 
             -- screen readers should know what clicking this button will do
             , Aria.roleDescription "sort button"
             ]
             [ Html.div [] [ header ]
-            , viewJust (\updateMsg -> viewSortButton updateMsg state_ id) maybeUpdateMsg
+            , viewJust (\_ -> viewSortButton state_ id) maybeUpdateMsg
             ]
 
     else
@@ -325,8 +325,8 @@ viewSortHeader isSortable header maybeUpdateMsg state_ id =
             [ header ]
 
 
-viewSortButton : (State id -> msg) -> State id -> id -> Html msg
-viewSortButton updateMsg state_ id =
+viewSortButton : State id -> id -> Html msg
+viewSortButton state_ id =
     let
         arrows upHighlighted downHighlighted =
             Html.div

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -81,7 +81,7 @@ defaultConfig =
     stick, in pixels. (**Default value:** 0)
   - `zIndex` controls where in the stacking context the header will end
     up. Useful to prevent elements in rows from appearing over the header.
-    (**Defualt value:** 0)
+    (**Default value:** 0)
 
 Headers are never sticky on mobile-sized viewports because doing so causes some
 accessibility issues with zooming and panning.

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -1,0 +1,387 @@
+module Nri.Ui.SortableTable.V4 exposing
+    ( Column, Config, Sorter, State
+    , init, initDescending
+    , custom, string, view, viewLoading
+    , invariantSort, simpleSort, combineSorters
+    )
+
+{-| TODO for next major version:
+
+  - add the possibility to pass Aria.sortAscending and Aria.sortDescending attributes to the <th> tag
+
+Changes from V2:
+
+  - made column non-sortable (e.g. buttons in a column should not be sorted)
+  - use a button instead of a clickable div in headers
+  - use Aria.roleDescription instead of Aria.label in sortable columns headers
+  - use Nri.Ui.UiIcon.V1 sortArrow and Nri.Ui.UiIcon.V1 sortArrowDown icons for the sort indicators
+
+@docs Column, Config, Sorter, State
+@docs init, initDescending
+@docs custom, string, view, viewLoading
+@docs invariantSort, simpleSort, combineSorters
+
+-}
+
+import Accessibility.Styled.Aria as Aria
+import Css exposing (..)
+import Html.Styled as Html exposing (Html)
+import Html.Styled.Attributes exposing (css)
+import Html.Styled.Events
+import Nri.Ui.Colors.V1
+import Nri.Ui.CssVendorPrefix.V1 as CssVendorPrefix
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Svg.V1
+import Nri.Ui.Table.V6 as Table exposing (SortDirection(..))
+import Nri.Ui.UiIcon.V1
+
+
+{-| -}
+type alias Sorter a =
+    SortDirection -> a -> a -> Order
+
+
+{-| -}
+type Column id entry msg
+    = Column
+        { id : id
+        , header : Html msg
+        , view : entry -> Html msg
+        , sorter : Maybe (Sorter entry)
+        , width : Int
+        , cellStyles : entry -> List Style
+        }
+
+
+{-| -}
+type alias State id =
+    { column : id
+    , sortDirection : SortDirection
+    }
+
+
+{-| -}
+type alias Config id entry msg =
+    { updateMsg : State id -> msg
+    , columns : List (Column id entry msg)
+    }
+
+
+{-| -}
+init : id -> State id
+init initialSort =
+    { column = initialSort
+    , sortDirection = Ascending
+    }
+
+
+{-| -}
+initDescending : id -> State id
+initDescending initialSort =
+    { column = initialSort
+    , sortDirection = Descending
+    }
+
+
+{-| -}
+string :
+    { id : id
+    , header : String
+    , value : entry -> String
+    , width : Int
+    , cellStyles : entry -> List Style
+    }
+    -> Column id entry msg
+string { id, header, value, width, cellStyles } =
+    Column
+        { id = id
+        , header = Html.text header
+        , view = value >> Html.text
+        , sorter = Just (simpleSort value)
+        , width = width
+        , cellStyles = cellStyles
+        }
+
+
+{-| -}
+custom :
+    { id : id
+    , header : Html msg
+    , view : entry -> Html msg
+    , sorter : Maybe (Sorter entry)
+    , width : Int
+    , cellStyles : entry -> List Style
+    }
+    -> Column id entry msg
+custom config =
+    Column
+        { id = config.id
+        , header = config.header
+        , view = config.view
+        , sorter = config.sorter
+        , width = config.width
+        , cellStyles = config.cellStyles
+        }
+
+
+{-| Create a sorter function that always orders the entries in the same order.
+For example, this is useful when we want to resolve ties and sort the tied
+entries by name, no matter of the sort direction set on the table.
+-}
+invariantSort : (entry -> comparable) -> Sorter entry
+invariantSort mapper =
+    \sortDirection elem1 elem2 ->
+        compare (mapper elem1) (mapper elem2)
+
+
+{-| Create a simple sorter function that orders entries by mapping a function
+over the collection. It will also reverse it when the sort direction is descending.
+-}
+simpleSort : (entry -> comparable) -> Sorter entry
+simpleSort mapper =
+    \sortDirection elem1 elem2 ->
+        let
+            result =
+                compare (mapper elem1) (mapper elem2)
+        in
+        case sortDirection of
+            Ascending ->
+                result
+
+            Descending ->
+                flipOrder result
+
+
+flipOrder : Order -> Order
+flipOrder order =
+    case order of
+        LT ->
+            GT
+
+        EQ ->
+            EQ
+
+        GT ->
+            LT
+
+
+{-| -}
+combineSorters : List (Sorter entry) -> Sorter entry
+combineSorters sorters =
+    \sortDirection elem1 elem2 ->
+        let
+            folder =
+                \sorter acc ->
+                    case acc of
+                        EQ ->
+                            sorter sortDirection elem1 elem2
+
+                        _ ->
+                            acc
+        in
+        List.foldl folder EQ sorters
+
+
+{-| -}
+viewLoading : Config id entry msg -> State id -> Html msg
+viewLoading config state =
+    let
+        tableColumns =
+            List.map (buildTableColumn config.updateMsg state) config.columns
+    in
+    Table.viewLoading
+        tableColumns
+
+
+{-| -}
+view : Config id entry msg -> State id -> List entry -> Html msg
+view config state entries =
+    let
+        tableColumns =
+            List.map (buildTableColumn config.updateMsg state) config.columns
+
+        sorter =
+            findSorter config.columns state.column
+    in
+    Table.view
+        tableColumns
+        (List.sortWith (sorter state.sortDirection) entries)
+
+
+findSorter : List (Column id entry msg) -> id -> Sorter entry
+findSorter columns columnId =
+    columns
+        |> listExtraFind (\(Column column) -> column.id == columnId)
+        |> Maybe.andThen (\(Column column) -> column.sorter)
+        |> Maybe.withDefault identitySorter
+
+
+{-| Taken from <https://github.com/elm-community/list-extra/blob/8.2.0/src/List/Extra.elm#L556>
+-}
+listExtraFind : (a -> Bool) -> List a -> Maybe a
+listExtraFind predicate list =
+    case list of
+        [] ->
+            Nothing
+
+        first :: rest ->
+            if predicate first then
+                Just first
+
+            else
+                listExtraFind predicate rest
+
+
+identitySorter : Sorter a
+identitySorter =
+    \sortDirection item1 item2 ->
+        EQ
+
+
+buildTableColumn : (State id -> msg) -> State id -> Column id entry msg -> Table.Column entry msg
+buildTableColumn updateMsg state (Column column) =
+    Table.custom
+        { header = viewSortHeader (column.sorter /= Nothing) column.header updateMsg state column.id
+        , view = column.view
+        , width = Css.px (toFloat column.width)
+        , cellStyles = column.cellStyles
+        , sort =
+            if state.column == column.id then
+                Just state.sortDirection
+
+            else
+                Nothing
+        }
+
+
+viewSortHeader : Bool -> Html msg -> (State id -> msg) -> State id -> id -> Html msg
+viewSortHeader isSortable header updateMsg state id =
+    let
+        nextState =
+            nextTableState state id
+    in
+    if isSortable then
+        Html.button
+            [ css
+                [ Css.displayFlex
+                , Css.alignItems Css.center
+                , Css.justifyContent Css.spaceBetween
+                , CssVendorPrefix.property "user-select" "none"
+                , if state.column == id then
+                    fontWeight bold
+
+                  else
+                    fontWeight normal
+                , cursor pointer
+
+                -- make this look less "buttony"
+                , Css.border Css.zero
+                , Css.backgroundColor Css.transparent
+                , Css.width (Css.pct 100)
+                , Css.height (Css.pct 100)
+                , Css.margin Css.zero
+                , Css.padding Css.zero
+                , Fonts.baseFont
+                , Css.fontSize (Css.em 1)
+                ]
+            , Html.Styled.Events.onClick (updateMsg nextState)
+
+            -- screen readers should know what clicking this button will do
+            , Aria.roleDescription "sort button"
+            ]
+            [ Html.div [] [ header ]
+            , viewSortButton updateMsg state id
+            ]
+
+    else
+        Html.div
+            [ css [ fontWeight normal ]
+            ]
+            [ header ]
+
+
+viewSortButton : (State id -> msg) -> State id -> id -> Html msg
+viewSortButton updateMsg state id =
+    let
+        arrows upHighlighted downHighlighted =
+            Html.div
+                [ css
+                    [ Css.displayFlex
+                    , Css.flexDirection Css.column
+                    , Css.alignItems Css.center
+                    , Css.justifyContent Css.center
+                    ]
+                ]
+                [ sortArrow Up upHighlighted
+                , sortArrow Down downHighlighted
+                ]
+
+        buttonContent =
+            case ( state.column == id, state.sortDirection ) of
+                ( True, Ascending ) ->
+                    arrows True False
+
+                ( True, Descending ) ->
+                    arrows False True
+
+                ( False, _ ) ->
+                    arrows False False
+    in
+    Html.div [ css [ padding (px 2) ] ] [ buttonContent ]
+
+
+nextTableState : State id -> id -> State id
+nextTableState state id =
+    if state.column == id then
+        { column = id
+        , sortDirection = flipSortDirection state.sortDirection
+        }
+
+    else
+        { column = id
+        , sortDirection = Ascending
+        }
+
+
+flipSortDirection : SortDirection -> SortDirection
+flipSortDirection order =
+    case order of
+        Ascending ->
+            Descending
+
+        Descending ->
+            Ascending
+
+
+type Direction
+    = Up
+    | Down
+
+
+sortArrow : Direction -> Bool -> Html msg
+sortArrow direction active =
+    let
+        arrow =
+            case direction of
+                Up ->
+                    Nri.Ui.UiIcon.V1.sortArrow
+
+                Down ->
+                    Nri.Ui.UiIcon.V1.sortArrowDown
+
+        color =
+            if active then
+                Nri.Ui.Colors.V1.azure
+
+            else
+                Nri.Ui.Colors.V1.gray75
+    in
+    arrow
+        |> Nri.Ui.Svg.V1.withHeight (px 6)
+        |> Nri.Ui.Svg.V1.withWidth (px 8)
+        |> Nri.Ui.Svg.V1.withColor color
+        |> Nri.Ui.Svg.V1.withCss
+            [ displayFlex
+            , margin2 (px 1) zero
+            ]
+        |> Nri.Ui.Svg.V1.toHtml

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -34,7 +34,7 @@ import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 exposing (maybe)
 import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.Svg.V1
-import Nri.Ui.Table.V6 as Table exposing (SortDirection(..))
+import Nri.Ui.Table.V7 as Table exposing (SortDirection(..))
 import Nri.Ui.UiIcon.V1
 
 

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -2,7 +2,7 @@ module Nri.Ui.SortableTable.V4 exposing
     ( Column, Sorter, State
     , init, initDescending
     , custom, string
-    , Attribute, updateMsg, state, view, viewLoading
+    , Attribute, updateMsg, state, stickyHeader, stickyHeaderCustom, StickyConfig, view, viewLoading
     , invariantSort, simpleSort, combineSorters
     )
 
@@ -18,7 +18,7 @@ Changes from V3:
 @docs Column, Sorter, State
 @docs init, initDescending
 @docs custom, string
-@docs Attribute, updateMsg, state, view, viewLoading
+@docs Attribute, updateMsg, state, stickyHeader, stickyHeaderCustom, StickyConfig, view, viewLoading
 @docs invariantSort, simpleSort, combineSorters
 
 -}
@@ -66,6 +66,7 @@ type alias State id =
 type alias Config id msg =
     { updateMsg : Maybe (State id -> msg)
     , state : Maybe (State id)
+    , stickyHeader : Maybe StickyConfig
     }
 
 
@@ -73,6 +74,22 @@ defaultConfig : Config id msg
 defaultConfig =
     { updateMsg = Nothing
     , state = Nothing
+    , stickyHeader = Nothing
+    }
+
+
+type alias StickyConfig =
+    { topOffset : Float
+    , zIndex : Int
+    , includeMobile : Bool
+    }
+
+
+defaultStickyConfig : StickyConfig
+defaultStickyConfig =
+    { topOffset = 0
+    , zIndex = 0
+    , includeMobile = False
     }
 
 
@@ -88,6 +105,16 @@ state state_ =
 updateMsg : (State id -> msg) -> Attribute id msg
 updateMsg updateMsg_ =
     Attribute (\config -> { config | updateMsg = Just updateMsg_ })
+
+
+stickyHeader : Attribute id msg
+stickyHeader =
+    Attribute (\config -> { config | stickyHeader = Just defaultStickyConfig })
+
+
+stickyHeaderCustom : StickyConfig -> Attribute id msg
+stickyHeaderCustom stickyConfig =
+    Attribute (\config -> { config | stickyHeader = Just stickyConfig })
 
 
 {-| -}

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -6,11 +6,7 @@ module Nri.Ui.SortableTable.V4 exposing
     , invariantSort, simpleSort, combineSorters
     )
 
-{-| TODO for next major version:
-
-  - add the possibility to pass Aria.sortAscending and Aria.sortDescending attributes to the <th> tag
-
-Changes from V3:
+{-| Changes from V3:
 
   - Change to an HTML-like API
   - Allow the table header to be sticky

--- a/src/Nri/Ui/Table/V7.elm
+++ b/src/Nri/Ui/Table/V7.elm
@@ -4,10 +4,13 @@ module Nri.Ui.Table.V7 exposing
     , viewLoading, viewLoadingWithoutHeader
     )
 
-{-| Upgrading from V5:
+{-| Upgrading from V6:
 
-  - The columns take an additional `sort` property that allows
-    you to specify ARIA sorting
+  - If you don't have extra styles for the table, add an empty list to calls
+    to `view`.
+  - Consider moving to `SortableTable`, as in V4 a non-interactive table renders
+    just the same but has additional flexibility in the API and will make future
+    upgrades easier.
 
 @docs Column, SortDirection, custom, string, rowHeader
 
@@ -106,16 +109,16 @@ rowHeader options =
 
 {-| Displays a table of data without a header row
 -}
-viewWithoutHeader : List (Column data msg) -> List data -> Html msg
-viewWithoutHeader columns =
-    tableWithoutHeader [] columns (viewRow columns)
+viewWithoutHeader : List Style -> List (Column data msg) -> List data -> Html msg
+viewWithoutHeader additionalStyles columns =
+    tableWithoutHeader additionalStyles columns (viewRow columns)
 
 
 {-| Displays a table of data based on the provided column definitions
 -}
-view : List (Column data msg) -> List data -> Html msg
-view columns =
-    tableWithHeader [] columns (viewRow columns)
+view : List Style -> List (Column data msg) -> List data -> Html msg
+view additionalStyles columns =
+    tableWithHeader additionalStyles columns (viewRow columns)
 
 
 viewRow : List (Column data msg) -> data -> Html msg
@@ -141,16 +144,16 @@ viewColumn data (Column _ renderer width cellStyles _ cellType) =
 out text with an interesting animation. This view lets the user know that
 data is on its way and what it will look like when it arrives.
 -}
-viewLoading : List (Column data msg) -> Html msg
-viewLoading columns =
-    tableWithHeader loadingTableStyles columns (viewLoadingRow columns) (List.range 0 8)
+viewLoading : List Style -> List (Column data msg) -> Html msg
+viewLoading additionalStyles columns =
+    tableWithHeader (loadingTableStyles ++ additionalStyles) columns (viewLoadingRow columns) (List.range 0 8)
 
 
 {-| Display the loading table without a header row
 -}
-viewLoadingWithoutHeader : List (Column data msg) -> Html msg
-viewLoadingWithoutHeader columns =
-    tableWithoutHeader loadingTableStyles columns (viewLoadingRow columns) (List.range 0 8)
+viewLoadingWithoutHeader : List Style -> List (Column data msg) -> Html msg
+viewLoadingWithoutHeader additionalStyles columns =
+    tableWithoutHeader (loadingTableStyles ++ additionalStyles) columns (viewLoadingRow columns) (List.range 0 8)
 
 
 viewLoadingRow : List (Column data msg) -> Int -> Html msg

--- a/src/Nri/Ui/Table/V7.elm
+++ b/src/Nri/Ui/Table/V7.elm
@@ -253,7 +253,7 @@ headersStyles =
 
 headerStyles : List Style
 headerStyles =
-    [ padding4 (px 15) (px 12) (px 11) (px 12)
+    [ padding4 (px 13) (px 12) (px 14) (px 12)
     , textAlign left
     , fontWeight bold
     ]

--- a/src/Nri/Ui/Table/V7.elm
+++ b/src/Nri/Ui/Table/V7.elm
@@ -246,7 +246,6 @@ headersStyles =
       -- gray border sticks to the table instead of traveling with the header
       -- when the header has `position: sticky` applied.
       boxShadow4 inset (px 0) (px -3) gray75
-    , paddingBottom (px 3)
     , height (px 45)
     , fontSize (px 15)
     ]

--- a/src/Nri/Ui/Table/V7.elm
+++ b/src/Nri/Ui/Table/V7.elm
@@ -1,0 +1,329 @@
+module Nri.Ui.Table.V7 exposing
+    ( Column, SortDirection(..), custom, string, rowHeader
+    , view, viewWithoutHeader
+    , viewLoading, viewLoadingWithoutHeader
+    )
+
+{-| Upgrading from V5:
+
+  - The columns take an additional `sort` property that allows
+    you to specify ARIA sorting
+
+@docs Column, SortDirection, custom, string, rowHeader
+
+@docs view, viewWithoutHeader
+
+@docs viewLoading, viewLoadingWithoutHeader
+
+-}
+
+import Accessibility.Styled.Style as Style
+import Css exposing (..)
+import Css.Animations
+import Html.Styled as Html exposing (..)
+import Html.Styled.Attributes as Attributes exposing (css)
+import Nri.Ui.Colors.V1 exposing (..)
+import Nri.Ui.Fonts.V1 exposing (baseFont)
+
+
+{-| Closed representation of how to render the header and cells of a column
+in the table
+-}
+type Column data msg
+    = Column (Html msg) (data -> Html msg) Style (data -> List Style) (Maybe SortDirection) CellType
+
+
+{-| Which direction is a table column sorted? Only set these on columns that
+actually have an explicit sort!
+-}
+type SortDirection
+    = Ascending
+    | Descending
+
+
+{-| Is this cell a data cell or header cell?
+-}
+type CellType
+    = RowHeaderCell
+    | DataCell
+
+
+cell : CellType -> List (Attribute msg) -> List (Html msg) -> Html msg
+cell cellType attrs =
+    case cellType of
+        RowHeaderCell ->
+            th (Attributes.scope "row" :: attrs)
+
+        DataCell ->
+            td attrs
+
+
+{-| A column that renders some aspect of a value as text
+-}
+string :
+    { header : String
+    , value : data -> String
+    , width : LengthOrAuto compatible
+    , cellStyles : data -> List Style
+    , sort : Maybe SortDirection
+    }
+    -> Column data msg
+string { header, value, width, cellStyles, sort } =
+    Column (Html.text header) (value >> Html.text) (Css.width width) cellStyles sort DataCell
+
+
+{-| A column that renders however you want it to
+-}
+custom :
+    { header : Html msg
+    , view : data -> Html msg
+    , width : LengthOrAuto compatible
+    , cellStyles : data -> List Style
+    , sort : Maybe SortDirection
+    }
+    -> Column data msg
+custom options =
+    Column options.header options.view (Css.width options.width) options.cellStyles options.sort DataCell
+
+
+{-| A column whose cells are row headers
+-}
+rowHeader :
+    { header : Html msg
+    , view : data -> Html msg
+    , width : LengthOrAuto compatible
+    , cellStyles : data -> List Style
+    , sort : Maybe SortDirection
+    }
+    -> Column data msg
+rowHeader options =
+    Column options.header options.view (Css.width options.width) options.cellStyles options.sort RowHeaderCell
+
+
+
+-- VIEW
+
+
+{-| Displays a table of data without a header row
+-}
+viewWithoutHeader : List (Column data msg) -> List data -> Html msg
+viewWithoutHeader columns =
+    tableWithoutHeader [] columns (viewRow columns)
+
+
+{-| Displays a table of data based on the provided column definitions
+-}
+view : List (Column data msg) -> List data -> Html msg
+view columns =
+    tableWithHeader [] columns (viewRow columns)
+
+
+viewRow : List (Column data msg) -> data -> Html msg
+viewRow columns data =
+    tr
+        [ css rowStyles ]
+        (List.map (viewColumn data) columns)
+
+
+viewColumn : data -> Column data msg -> Html msg
+viewColumn data (Column _ renderer width cellStyles _ cellType) =
+    cell cellType
+        [ css ([ width, verticalAlign middle ] ++ cellStyles data)
+        ]
+        [ renderer data ]
+
+
+
+-- VIEW LOADING
+
+
+{-| Display a table with the given columns but instead of data, show blocked
+out text with an interesting animation. This view lets the user know that
+data is on its way and what it will look like when it arrives.
+-}
+viewLoading : List (Column data msg) -> Html msg
+viewLoading columns =
+    tableWithHeader loadingTableStyles columns (viewLoadingRow columns) (List.range 0 8)
+
+
+{-| Display the loading table without a header row
+-}
+viewLoadingWithoutHeader : List (Column data msg) -> Html msg
+viewLoadingWithoutHeader columns =
+    tableWithoutHeader loadingTableStyles columns (viewLoadingRow columns) (List.range 0 8)
+
+
+viewLoadingRow : List (Column data msg) -> Int -> Html msg
+viewLoadingRow columns index =
+    tr
+        [ css rowStyles ]
+        (List.indexedMap (viewLoadingColumn index) columns)
+
+
+viewLoadingColumn : Int -> Int -> Column data msg -> Html msg
+viewLoadingColumn rowIndex colIndex (Column _ _ width _ _ cellType) =
+    cell cellType
+        [ css (stylesLoadingColumn rowIndex colIndex width ++ [ verticalAlign middle ] ++ loadingCellStyles)
+        ]
+        [ span [ css loadingContentStyles ] [] ]
+
+
+stylesLoadingColumn : Int -> Int -> Style -> List Style
+stylesLoadingColumn rowIndex colIndex width =
+    [ width
+    , property "animation-delay" (String.fromFloat (toFloat (rowIndex + colIndex) * 0.1) ++ "s")
+    ]
+
+
+
+-- HELP
+
+
+tableWithoutHeader : List Style -> List (Column data msg) -> (a -> Html msg) -> List a -> Html msg
+tableWithoutHeader styles columns toRow data =
+    table styles
+        [ thead [] [ tr Style.invisible (List.map tableColHeader columns) ]
+        , tableBody toRow data
+        ]
+
+
+tableWithHeader : List Style -> List (Column data msg) -> (a -> Html msg) -> List a -> Html msg
+tableWithHeader styles columns toRow data =
+    table styles
+        [ tableHeader columns
+        , tableBody toRow data
+        ]
+
+
+table : List Style -> List (Html msg) -> Html msg
+table styles =
+    Html.table [ css (styles ++ tableStyles) ]
+
+
+tableHeader : List (Column data msg) -> Html msg
+tableHeader columns =
+    thead []
+        [ tr [ css headersStyles ]
+            (List.map tableColHeader columns)
+        ]
+
+
+tableColHeader : Column data msg -> Html msg
+tableColHeader (Column header _ width _ sort _) =
+    th
+        [ Attributes.scope "col"
+        , css (width :: headerStyles)
+        , Attributes.attribute "aria-sort" <|
+            case sort of
+                Nothing ->
+                    "none"
+
+                Just Ascending ->
+                    "ascending"
+
+                Just Descending ->
+                    "descending"
+        ]
+        [ header ]
+
+
+tableBody : (a -> Html msg) -> List a -> Html msg
+tableBody toRow items =
+    tbody [] (List.map toRow items)
+
+
+
+-- STYLES
+
+
+headersStyles : List Style
+headersStyles =
+    [ borderBottom3 (px 3) solid gray75
+    , height (px 45)
+    , fontSize (px 15)
+    ]
+
+
+headerStyles : List Style
+headerStyles =
+    [ padding4 (px 15) (px 12) (px 11) (px 12)
+    , textAlign left
+    , fontWeight bold
+    ]
+
+
+rowStyles : List Style
+rowStyles =
+    [ height (px 45)
+    , fontSize (px 14)
+    , color gray20
+    , pseudoClass "nth-child(odd)"
+        [ backgroundColor gray96 ]
+    ]
+
+
+loadingContentStyles : List Style
+loadingContentStyles =
+    [ width (pct 100)
+    , display inlineBlock
+    , height (Css.em 1)
+    , borderRadius (Css.em 1)
+    , backgroundColor gray75
+    ]
+
+
+loadingCellStyles : List Style
+loadingCellStyles =
+    [ batch flashAnimation
+    , padding2 (px 14) (px 10)
+    ]
+
+
+loadingTableStyles : List Style
+loadingTableStyles =
+    fadeInAnimation
+
+
+tableStyles : List Style
+tableStyles =
+    [ borderCollapse collapse
+    , baseFont
+    , Css.width (Css.pct 100)
+    ]
+
+
+flash : Css.Animations.Keyframes {}
+flash =
+    Css.Animations.keyframes
+        [ ( 0, [ Css.Animations.opacity (Css.num 0.6) ] )
+        , ( 50, [ Css.Animations.opacity (Css.num 0.2) ] )
+        , ( 100, [ Css.Animations.opacity (Css.num 0.6) ] )
+        ]
+
+
+fadeIn : Css.Animations.Keyframes {}
+fadeIn =
+    Css.Animations.keyframes
+        [ ( 0, [ Css.Animations.opacity (Css.num 0) ] )
+        , ( 100, [ Css.Animations.opacity (Css.num 1) ] )
+        ]
+
+
+flashAnimation : List Css.Style
+flashAnimation =
+    [ animationName flash
+    , property "animation-duration" "2s"
+    , property "animation-iteration-count" "infinite"
+    , opacity (num 0.6)
+    ]
+
+
+fadeInAnimation : List Css.Style
+fadeInAnimation =
+    [ animationName fadeIn
+    , property "animation-duration" "0.4s"
+    , property "animation-delay" "0.2s"
+    , property "animation-fill-mode" "forwards"
+    , animationIterationCount (int 1)
+    , opacity (num 0)
+    ]

--- a/src/Nri/Ui/Table/V7.elm
+++ b/src/Nri/Ui/Table/V7.elm
@@ -241,7 +241,12 @@ tableBody toRow items =
 
 headersStyles : List Style
 headersStyles =
-    [ borderBottom3 (px 3) solid gray75
+    [ -- We use a inset box shadown for a bottom border instead of an actual
+      -- border because with our use of `border-collapse: collapse`, the bottom
+      -- gray border sticks to the table instead of traveling with the header
+      -- when the header has `position: sticky` applied.
+      boxShadow4 inset (px 0) (px -3) gray75
+    , paddingBottom (px 3)
     , height (px 45)
     , fontSize (px 15)
     ]

--- a/src/Nri/Ui/Table/V7.elm
+++ b/src/Nri/Ui/Table/V7.elm
@@ -253,7 +253,7 @@ headersStyles =
 
 headerStyles : List Style
 headerStyles =
-    [ padding4 (px 13) (px 12) (px 14) (px 12)
+    [ padding4 (px 11) (px 12) (px 14) (px 12)
     , textAlign left
     , fontWeight bold
     ]

--- a/tests/Spec/Nri/Ui/SortableTable.elm
+++ b/tests/Spec/Nri/Ui/SortableTable.elm
@@ -3,6 +3,7 @@ module Spec.Nri.Ui.SortableTable exposing (spec)
 import Expect
 import Html.Styled
 import Nri.Ui.SortableTable.V4 as SortableTable
+import Nri.Ui.Table.V6 exposing (SortDirection)
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector
@@ -19,30 +20,23 @@ type alias Person =
     }
 
 
-type Msg
-    = NoOp
-
-
-config : SortableTable.Config Column Person Msg
-config =
-    { updateMsg = \_ -> NoOp
-    , columns =
-        [ SortableTable.string
-            { id = FirstName
-            , header = "First name"
-            , value = .firstName
-            , width = 125
-            , cellStyles = \_ -> []
-            }
-        , SortableTable.string
-            { id = LastName
-            , header = "Last name"
-            , value = .lastName
-            , width = 125
-            , cellStyles = \_ -> []
-            }
-        ]
-    }
+columns : List (SortableTable.Column Column Person msg)
+columns =
+    [ SortableTable.string
+        { id = FirstName
+        , header = "First name"
+        , value = .firstName
+        , width = 125
+        , cellStyles = \_ -> []
+        }
+    , SortableTable.string
+        { id = LastName
+        , header = "Last name"
+        , value = .lastName
+        , width = 125
+        , cellStyles = \_ -> []
+        }
+    ]
 
 
 entries : List Person
@@ -53,9 +47,9 @@ entries =
     ]
 
 
-tableView : SortableTable.State Column -> Query.Single Msg
+tableView : SortableTable.State Column -> Query.Single msg
 tableView sortState =
-    SortableTable.view config sortState entries
+    SortableTable.view [ SortableTable.state sortState ] columns entries
         |> Html.Styled.toUnstyled
         |> Query.fromHtml
 
@@ -70,10 +64,12 @@ sortByDescending field =
     SortableTable.initDescending field
 
 
+ascending : SortDirection
 ascending =
     sortBy FirstName |> .sortDirection
 
 
+descending : SortDirection
 descending =
     sortByDescending FirstName |> .sortDirection
 

--- a/tests/Spec/Nri/Ui/SortableTable.elm
+++ b/tests/Spec/Nri/Ui/SortableTable.elm
@@ -2,7 +2,7 @@ module Spec.Nri.Ui.SortableTable exposing (spec)
 
 import Expect
 import Html.Styled
-import Nri.Ui.SortableTable.V3 as SortableTable
+import Nri.Ui.SortableTable.V4 as SortableTable
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector

--- a/tests/Spec/Nri/Ui/SortableTable.elm
+++ b/tests/Spec/Nri/Ui/SortableTable.elm
@@ -3,7 +3,7 @@ module Spec.Nri.Ui.SortableTable exposing (spec)
 import Expect
 import Html.Styled
 import Nri.Ui.SortableTable.V4 as SortableTable
-import Nri.Ui.Table.V6 exposing (SortDirection)
+import Nri.Ui.Table.V7 exposing (SortDirection)
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -66,6 +66,7 @@
         "Nri.Ui.Shadows.V1",
         "Nri.Ui.SideNav.V4",
         "Nri.Ui.SortableTable.V3",
+        "Nri.Ui.SortableTable.V4",
         "Nri.Ui.Spacing.V1",
         "Nri.Ui.Sprite.V1",
         "Nri.Ui.Svg.V1",

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -72,6 +72,7 @@
         "Nri.Ui.Svg.V1",
         "Nri.Ui.Switch.V2",
         "Nri.Ui.Table.V6",
+        "Nri.Ui.Table.V7",
         "Nri.Ui.Tabs.V6",
         "Nri.Ui.Tabs.V7",
         "Nri.Ui.Tabs.V8",


### PR DESCRIPTION
# :wrench: Modifying a component

API design note: unlike tabs, we don't currently know any use-case aside from stickiness where we'd need to set the page background color separate from stickiness, so I combined them!

## Context

Part of ADM-705

## :framed_picture: What does this change look like?

No changes to the table component except that now the header can be made sticky.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
