### PR TITLE
add topPadding

### DIFF
--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -143,6 +143,7 @@ example =
                                                             ++ ".tabsListStickyCustom "
                                                             ++ Code.recordMultiline
                                                                 [ ( "topOffset", String.fromFloat stickyConfig.topOffset )
+                                                                , ( "topPadding", String.fromFloat stickyConfig.topPadding )
                                                                 , ( "zIndex", String.fromInt stickyConfig.zIndex )
                                                                 ]
                                                                 2
@@ -333,6 +334,7 @@ initSettings =
                     , ( "Custom"
                       , Control.record Tabs.TabListStickyConfig
                             |> Control.field "topOffset" (values String.fromFloat [ 0, 10, 50 ])
+                            |> Control.field "topPadding" (values String.fromFloat [ 0, 10, 50 ])
                             |> Control.field "zIndex" (values String.fromInt [ 0, 1, 5, 10 ])
                             |> Control.map Custom
                       )

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -218,13 +218,19 @@ defaultConfig =
 {-| Configure how the top bar is sticky.
 
   - `topOffset` controls how far from the top of the viewport the bar will
-    stick, in pixels. (**Default value:** 0)
+    stick, in pixels. Content will be visible below this offset in the z-order.
+    (**Default value:** 0)
+  - `topPadding` controls how far from the top of the viewport the bar will
+    be padded. Unlike `topOffset`, content will _not_ be visible behind the
+    padding. Be aware that this padding will add space in the DOM even when the
+    bar is not sticky. (**Default value:** 0)
   - `zIndex` controls how high up the z-order the bar will float. (**Default
     value:** 0)
 
 -}
 type alias TabListStickyConfig =
     { topOffset : Float
+    , topPadding : Float
     , zIndex : Int
     }
 
@@ -232,6 +238,7 @@ type alias TabListStickyConfig =
 defaultTabListStickyConfig : TabListStickyConfig
 defaultTabListStickyConfig =
     { topOffset = 0
+    , topPadding = 0
     , zIndex = 0
     }
 
@@ -270,11 +277,12 @@ view { focusAndSelect, selected } attrs tabs =
             , Css.borderBottomColor Colors.navy
             , Fonts.baseFont
             , maybeStyle
-                (\{ topOffset, zIndex } ->
+                (\{ topOffset, topPadding, zIndex } ->
                     Css.Media.withMedia
                         [ MediaQuery.notMobile ]
                         [ Css.position Css.sticky
                         , Css.top (Css.px topOffset)
+                        , Css.paddingTop (Css.px topPadding)
                         , Css.zIndex (Css.int zIndex)
                         ]
                 )


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Related to ADM-705

## :framed_picture: What does this change look like?

This is not really screenshotable. Play around with custom padding configs in the tabs page of the catalog to see how this works.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
