### PR TITLE
A11-2529 Remove on-click and on-focus outline from Radio

### DIFF
--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -312,7 +312,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
             , css
                 [ position relative
                 , Css.marginLeft (Css.px -2)
-                , Css.paddingLeft (Css.px 38)
+                , Css.paddingLeft (Css.px 30)
                 , Css.paddingTop (px 6)
                 , Css.paddingBottom (px 4)
                 , display inlineBlock
@@ -383,6 +383,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
                     , Css.property "font-weight" "600"
                     , display inlineBlock
                     , Css.property "transition" "all 0.4s ease"
+                    , paddingLeft (px 8)
                     ]
                 ]
                 [ radioInputIcon
@@ -555,9 +556,6 @@ radioInputIcon config =
             , displayFlex
             , justifyContent center
             , alignItems center
-            , -- this padding creates a hit area "bridge" between the
-              -- absolutely-positioned icon SVG and the label text
-              paddingRight (Css.px 8)
             ]
         ]
         [ image


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

This expands the label instead of expanding the radio button. It maintains the clickable area while fixing the outline shape.

## :framed_picture: What does this change look like?

### Before

<img width="81" alt="" src="https://user-images.githubusercontent.com/5647344/229607003-f9fdc4d7-c37c-4ba6-89a6-bf4a981533b3.png">

### After 
<img width="83" alt="" src="https://user-images.githubusercontent.com/5647344/229607006-7dbbee57-9ceb-4acb-8f1a-4762d23500b9.png">

@NoRedInk/design 

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
