### PR TITLE
Tabs  add fade to panel background color

### DIFF
--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -167,29 +167,31 @@ example =
                           }
                         ]
                 }
-            , Tabs.view
-                { focusAndSelect = FocusAndSelectTab
-                , selected = model.selected
-                }
-                (List.filterMap identity
-                    [ Just (Tabs.alignment settings.alignment)
-                    , Maybe.map Tabs.title settings.title
-                    , Maybe.map Tabs.spacing settings.customSpacing
-                    , Maybe.map (Tabs.pageBackgroundColor << colorToCss) settings.pageBackgroundColor
-                    , Maybe.map (Tabs.fadeToPanelBackgroundColor << colorToCss) settings.fadeToPanelBackgroundColor
-                    , Maybe.map
-                        (\stickiness ->
-                            case stickiness of
-                                Default ->
-                                    Tabs.tabListSticky
+            , Html.div [ css [ Css.padding (Css.px 20) ] ]
+                [ Tabs.view
+                    { focusAndSelect = FocusAndSelectTab
+                    , selected = model.selected
+                    }
+                    (List.filterMap identity
+                        [ Just (Tabs.alignment settings.alignment)
+                        , Maybe.map Tabs.title settings.title
+                        , Maybe.map Tabs.spacing settings.customSpacing
+                        , Maybe.map (Tabs.pageBackgroundColor << colorToCss) settings.pageBackgroundColor
+                        , Maybe.map (Tabs.fadeToPanelBackgroundColor << colorToCss) settings.fadeToPanelBackgroundColor
+                        , Maybe.map
+                            (\stickiness ->
+                                case stickiness of
+                                    Default ->
+                                        Tabs.tabListSticky
 
-                                Custom stickyConfig ->
-                                    Tabs.tabListStickyCustom stickyConfig
-                        )
-                        settings.stickiness
-                    ]
-                )
-                (List.map Tuple.second tabs)
+                                    Custom stickyConfig ->
+                                        Tabs.tabListStickyCustom stickyConfig
+                            )
+                            settings.stickiness
+                        ]
+                    )
+                    (List.map Tuple.second tabs)
+                ]
             ]
     }
 

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -22,6 +22,7 @@ import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Message.V3 as Message
 import Nri.Ui.Tabs.V8 as Tabs exposing (Alignment(..), Tab)
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.Tooltip.V3 as Tooltip
@@ -107,7 +108,11 @@ example =
                     Control.currentValue model.settings
 
                 tabs =
-                    allTabs model.openTooltip settings.withTooltips
+                    allTabs
+                        { openTooltipId = model.openTooltip
+                        , withTooltips = settings.withTooltips
+                        , fadeToPanelBackgroundColor = settings.fadeToPanelBackgroundColor
+                        }
             in
             [ ControlView.view
                 { ellieLinkConfig = ellieLinkConfig
@@ -189,14 +194,25 @@ example =
     }
 
 
-allTabs : Maybe Int -> Bool -> List ( String, Tab Int Msg )
-allTabs openTooltipId withTooltips =
+allTabs :
+    { openTooltipId : Maybe Int
+    , withTooltips : Bool
+    , fadeToPanelBackgroundColor : Maybe Color
+    }
+    -> List ( String, Tab Int Msg )
+allTabs config =
     List.repeat 4 ()
-        |> List.indexedMap (\i _ -> buildTooltip openTooltipId withTooltips i)
+        |> List.indexedMap (\i _ -> buildTab config i)
 
 
-buildTooltip : Maybe Int -> Bool -> Int -> ( String, Tab Int Msg )
-buildTooltip openTooltipId withTooltips id =
+buildTab :
+    { openTooltipId : Maybe Int
+    , withTooltips : Bool
+    , fadeToPanelBackgroundColor : Maybe Color
+    }
+    -> Int
+    -> ( String, Tab Int Msg )
+buildTab config id =
     let
         idString =
             String.fromInt (id + 1)
@@ -214,13 +230,13 @@ buildTooltip openTooltipId withTooltips id =
         [ "Tabs.build { id = " ++ String.fromInt id ++ ", idString = " ++ Code.string tabIdString ++ " }"
         , "\n\t    [ Tabs.tabString " ++ Code.string tabName
         , "\n\t    , Tabs.panelHtml (text " ++ Code.string panelName ++ ")"
-        , if withTooltips then
+        , if config.withTooltips then
             String.join "\n\t    "
                 [ "\n\t    , Tabs.withTooltip"
                 , "   [ Tooltip.plaintext " ++ Code.string tabName
                 , "    -- You will need to have a tooltip handler"
                 , "    -- , Tooltip.onToggle ToggleTooltip " ++ ""
-                , "   , Tooltip.open " ++ Code.bool (openTooltipId == Just id)
+                , "   , Tooltip.open " ++ Code.bool (config.openTooltipId == Just id)
                 , "   ]"
                 ]
 
@@ -230,19 +246,40 @@ buildTooltip openTooltipId withTooltips id =
         ]
     , Tabs.build { id = id, idString = tabIdString }
         ([ Tabs.tabString tabName
-         , panelName
-            |> List.repeat 50
-            |> String.join "\n"
-            |> Html.text
-            |> List.singleton
-            |> Html.pre []
-            |> Tabs.panelHtml
+         , Tabs.panelHtml
+            (Html.pre
+                [ css
+                    [ Css.marginTop Css.zero
+                    , Css.padding (Css.px 10)
+                    , case config.fadeToPanelBackgroundColor of
+                        Nothing ->
+                            Css.batch []
+
+                        Just color ->
+                            Css.backgroundColor (colorToCss color)
+                    ]
+                ]
+                [ case config.fadeToPanelBackgroundColor of
+                    Nothing ->
+                        Html.text ""
+
+                    Just _ ->
+                        Message.view
+                            [ Message.tip
+                            , Message.plaintext "Panel background adjusted to match fadeToPanelBackgroundColor attribute"
+                            ]
+                , panelName
+                    |> List.repeat 50
+                    |> String.join "\n"
+                    |> Html.text
+                ]
+            )
          ]
-            ++ (if withTooltips then
+            ++ (if config.withTooltips then
                     [ Tabs.withTooltip
                         [ Tooltip.plaintext tabName
                         , Tooltip.onToggle (ToggleTooltip id)
-                        , Tooltip.open (openTooltipId == Just id)
+                        , Tooltip.open (config.openTooltipId == Just id)
                         ]
                     ]
 

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -248,34 +248,7 @@ buildTab config id =
         ]
     , Tabs.build { id = id, idString = tabIdString }
         ([ Tabs.tabString tabName
-         , Tabs.panelHtml
-            (Html.pre
-                [ css
-                    [ Css.marginTop Css.zero
-                    , Css.padding (Css.px 10)
-                    , case config.fadeToPanelBackgroundColor of
-                        Nothing ->
-                            Css.batch []
-
-                        Just color ->
-                            Css.backgroundColor (colorToCss color)
-                    ]
-                ]
-                [ case config.fadeToPanelBackgroundColor of
-                    Nothing ->
-                        Html.text ""
-
-                    Just _ ->
-                        Message.view
-                            [ Message.tip
-                            , Message.plaintext "Panel background adjusted to match fadeToPanelBackgroundColor attribute"
-                            ]
-                , panelName
-                    |> List.repeat 50
-                    |> String.join "\n"
-                    |> Html.text
-                ]
-            )
+         , Tabs.panelHtml (panelContent config.fadeToPanelBackgroundColor panelName)
          ]
             ++ (if config.withTooltips then
                     [ Tabs.withTooltip
@@ -290,6 +263,36 @@ buildTab config id =
                )
         )
     )
+
+
+panelContent : Maybe Color -> String -> Html.Html msg
+panelContent fadeToPanelBackgroundColor_ panelName =
+    Html.pre
+        [ css
+            [ Css.marginTop Css.zero
+            , Css.padding (Css.px 10)
+            , case fadeToPanelBackgroundColor_ of
+                Nothing ->
+                    Css.batch []
+
+                Just color ->
+                    Css.backgroundColor (colorToCss color)
+            ]
+        ]
+        [ case fadeToPanelBackgroundColor_ of
+            Nothing ->
+                Html.text ""
+
+            Just _ ->
+                Message.view
+                    [ Message.tip
+                    , Message.plaintext "Panel background adjusted to match fadeToPanelBackgroundColor attribute"
+                    ]
+        , panelName
+            |> List.repeat 50
+            |> String.join "\n"
+            |> Html.text
+        ]
 
 
 type alias State =

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -307,14 +307,14 @@ panelContent pageBackgroundColor_ id panelName =
                 |> List.Extra.splitAt id
                 |> (\( beforeSplit, afterSplit ) -> afterSplit ++ beforeSplit)
     in
-    Html.div [ css [ Css.padding2 (Css.px 20) (Css.px 10) ] ]
+    Html.div []
         (List.concat
             [ List.map
                 (\( title, content ) ->
                     Panel.view
                         [ Panel.header title
                         , Panel.paragraph content
-                        , Panel.containerCss [ Css.marginBottom (Css.px 30) ]
+                        , Panel.containerCss [ Css.margin2 (Css.px 10) Css.zero ]
                         ]
                 )
                 pangrams

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -169,7 +169,17 @@ example =
                           }
                         ]
                 }
-            , Html.div [ css [ Css.padding (Css.px 20) ] ]
+            , Html.div
+                [ css
+                    [ Css.padding (Css.px 20)
+                    , case settings.pageBackgroundColor of
+                        Nothing ->
+                            Css.batch []
+
+                        Just color ->
+                            Css.backgroundColor (colorToCss color)
+                    ]
+                ]
                 [ Tabs.view
                     { focusAndSelect = FocusAndSelectTab
                     , selected = model.selected

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -328,7 +328,7 @@ colorToCss color =
             Colors.white
 
         Gray ->
-            Colors.gray92
+            Colors.gray96
 
 
 colorToCode : Color -> String
@@ -338,7 +338,7 @@ colorToCode color =
             "Colors.white"
 
         Gray ->
-            "Colors.gray92"
+            "Colors.gray96"
 
 
 type Stickiness

--- a/component-catalog-app/Examples/Tabs.elm
+++ b/component-catalog-app/Examples/Tabs.elm
@@ -131,7 +131,8 @@ example =
                                         [ Just (moduleName ++ ".alignment " ++ moduleName ++ "." ++ Debug.toString settings.alignment)
                                         , Maybe.map (\title -> moduleName ++ ".title " ++ Code.string title) settings.title
                                         , Maybe.map (\spacing -> moduleName ++ ".spacing " ++ String.fromFloat spacing) settings.customSpacing
-                                        , Maybe.map (\color -> moduleName ++ ".pageBackgroundColor" ++ colorToCode color) settings.pageBackgroundColor
+                                        , Maybe.map (\color -> moduleName ++ ".pageBackgroundColor " ++ colorToCode color) settings.pageBackgroundColor
+                                        , Maybe.map (\color -> moduleName ++ ".fadeToPanelBackgroundColor " ++ colorToCode color) settings.fadeToPanelBackgroundColor
                                         , Maybe.map
                                             (\sticky ->
                                                 case sticky of
@@ -170,6 +171,7 @@ example =
                     , Maybe.map Tabs.title settings.title
                     , Maybe.map Tabs.spacing settings.customSpacing
                     , Maybe.map (Tabs.pageBackgroundColor << colorToCss) settings.pageBackgroundColor
+                    , Maybe.map (Tabs.fadeToPanelBackgroundColor << colorToCss) settings.fadeToPanelBackgroundColor
                     , Maybe.map
                         (\stickiness ->
                             case stickiness of
@@ -272,6 +274,7 @@ type alias Settings =
     , customSpacing : Maybe Float
     , withTooltips : Bool
     , pageBackgroundColor : Maybe Color
+    , fadeToPanelBackgroundColor : Maybe Color
     , stickiness : Maybe Stickiness
     }
 
@@ -327,6 +330,7 @@ initSettings =
         |> Control.field "customSpacing" (Control.maybe False (values String.fromFloat [ 2, 3, 4, 8, 16 ]))
         |> Control.field "withTooltips" (Control.bool True)
         |> Control.field "pageBackgroundColor" (Control.maybe False colorChoices)
+        |> Control.field "fadeToPanelBackgroundColor" (Control.maybe False colorChoices)
         |> Control.field "tabListSticky"
             (Control.maybe False
                 (Control.choice

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -182,6 +182,11 @@ pageBackgroundColor color =
     Attribute (\config -> { config | pageBackgroundColor = Just color })
 
 
+{-| The active tab will be white by default, which may look bad if the panel
+below it doesn't have a white background. This attribute lets you make the
+active tab's background fade from white (at the top) to the desired color (at
+the bottom) to make it match the background of the current panel.
+-}
 fadeToPanelBackgroundColor : Css.Color -> Attribute id msg
 fadeToPanelBackgroundColor color =
     Attribute (\config -> { config | fadeToPanelBackgroundColor = color })

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -270,7 +270,7 @@ view { focusAndSelect, selected } attrs tabs =
                 { focusAndSelect = focusAndSelect
                 , selected = selected
                 , tabs = List.map (\(Tab t) -> t) tabs
-                , tabStyles = tabStyles config.spacing
+                , tabStyles = tabStyles config.spacing config.fadeToPanelBackgroundColor
                 , tabListStyles = stylesTabsAligned config
                 }
     in
@@ -369,15 +369,20 @@ maybeStyle styler maybeValue =
             Css.batch []
 
 
-tabStyles : Maybe Float -> Int -> Bool -> List Style
-tabStyles customSpacing index isSelected =
+tabStyles : Maybe Float -> Css.Color -> Int -> Bool -> List Style
+tabStyles customSpacing fadeToPanelBackgroundColor_ index isSelected =
     let
         stylesDynamic =
             if isSelected then
-                [ Css.backgroundColor Colors.white
-                , Css.borderBottom (Css.px 1)
+                [ Css.borderBottom (Css.px 1)
                 , Css.borderBottomStyle Css.solid
-                , Css.borderBottomColor Colors.white
+                , Css.backgroundColor Colors.white
+                , Css.borderBottomColor fadeToPanelBackgroundColor_
+                , Css.backgroundImage <|
+                    Css.linearGradient2 Css.toTop
+                        (Css.stop2 (withAlpha 1 fadeToPanelBackgroundColor_) (Css.pct 0))
+                        (Css.stop2 (withAlpha 0 fadeToPanelBackgroundColor_) (Css.pct 25))
+                        [ Css.stop2 (withAlpha 0 fadeToPanelBackgroundColor_) (Css.pct 100) ]
                 ]
 
             else

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -387,8 +387,8 @@ tabStyles customSpacing fadeToPanelBackgroundColor_ index isSelected =
                 , Css.backgroundImage <|
                     Css.linearGradient2 Css.toTop
                         (Css.stop2 (withAlpha 1 fadeToPanelBackgroundColor_) (Css.pct 0))
-                        (Css.stop2 (withAlpha 0 fadeToPanelBackgroundColor_) (Css.pct 25))
-                        [ Css.stop2 (withAlpha 0 fadeToPanelBackgroundColor_) (Css.pct 100) ]
+                        (Css.stop2 (withAlpha 0 fadeToPanelBackgroundColor_) (Css.pct 100))
+                        []
                 ]
 
             else

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -2,7 +2,6 @@ module Nri.Ui.Tabs.V8 exposing
     ( Attribute, title, spacing
     , Alignment(..), alignment
     , pageBackgroundColor
-    , fadeToPanelBackgroundColor
     , tabListSticky, TabListStickyConfig, tabListStickyCustom
     , view
     , Tab, TabAttribute, build
@@ -24,7 +23,6 @@ module Nri.Ui.Tabs.V8 exposing
 @docs Attribute, title, spacing
 @docs Alignment, alignment
 @docs pageBackgroundColor
-@docs fadeToPanelBackgroundColor
 @docs tabListSticky, TabListStickyConfig, tabListStickyCustom
 @docs view
 
@@ -174,23 +172,20 @@ spacing spacing_ =
     Attribute (\config -> { config | spacing = Just spacing_ })
 
 
-{-| Tell this tab list about the background color of the page it lievs on. This
-is mostly useful when setting up sticky headers, to prevent page content from
-showing through the background.
+{-| Tell this tab list about the background color of the page it lievs on.
+
+You may want to use this if, for example:
+
+  - you are setting up sticky headers, to prevent page content from showing
+    through the background.
+
+  - you are using tabs in a page that has non-white background, so the
+    background of the active tab fades into the panel below it.
+
 -}
 pageBackgroundColor : Css.Color -> Attribute id msg
 pageBackgroundColor color =
     Attribute (\config -> { config | pageBackgroundColor = Just color })
-
-
-{-| The active tab will be white by default, which may look bad if the panel
-below it doesn't have a white background. This attribute lets you make the
-active tab's background fade from white (at the top) to the desired color (at
-the bottom) to make it match the background of the current panel.
--}
-fadeToPanelBackgroundColor : Css.Color -> Attribute id msg
-fadeToPanelBackgroundColor color =
-    Attribute (\config -> { config | fadeToPanelBackgroundColor = color })
 
 
 {-| Make the tab list sticky. You probably want to set an explicit background
@@ -214,7 +209,6 @@ type alias Config =
     , alignment : Alignment
     , spacing : Maybe Float
     , pageBackgroundColor : Maybe Css.Color
-    , fadeToPanelBackgroundColor : Css.Color
     , tabListStickyConfig : Maybe TabListStickyConfig
     }
 
@@ -225,7 +219,6 @@ defaultConfig =
     , alignment = Left
     , spacing = Nothing
     , pageBackgroundColor = Nothing
-    , fadeToPanelBackgroundColor = Colors.white
     , tabListStickyConfig = Nothing
     }
 
@@ -276,7 +269,10 @@ view { focusAndSelect, selected } attrs tabs =
                 { focusAndSelect = focusAndSelect
                 , selected = selected
                 , tabs = List.map (\(Tab t) -> t) tabs
-                , tabStyles = tabStyles config.spacing config.fadeToPanelBackgroundColor
+                , tabStyles =
+                    tabStyles
+                        config.spacing
+                        (Maybe.withDefault Colors.white config.pageBackgroundColor)
                 , tabListStyles = stylesTabsAligned config
                 }
     in
@@ -376,18 +372,18 @@ maybeStyle styler maybeValue =
 
 
 tabStyles : Maybe Float -> Css.Color -> Int -> Bool -> List Style
-tabStyles customSpacing fadeToPanelBackgroundColor_ index isSelected =
+tabStyles customSpacing pageBackgroundColor_ index isSelected =
     let
         stylesDynamic =
             if isSelected then
                 [ Css.borderBottom (Css.px 1)
                 , Css.borderBottomStyle Css.solid
                 , Css.backgroundColor Colors.white
-                , Css.borderBottomColor fadeToPanelBackgroundColor_
+                , Css.borderBottomColor pageBackgroundColor_
                 , Css.backgroundImage <|
                     Css.linearGradient2 Css.toTop
-                        (Css.stop2 (withAlpha 1 fadeToPanelBackgroundColor_) (Css.pct 0))
-                        (Css.stop2 (withAlpha 0 fadeToPanelBackgroundColor_) (Css.pct 100))
+                        (Css.stop2 (withAlpha 1 pageBackgroundColor_) (Css.pct 0))
+                        (Css.stop2 (withAlpha 0 pageBackgroundColor_) (Css.pct 100))
                         []
                 ]
 

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -16,6 +16,7 @@ module Nri.Ui.Tabs.V8 exposing
   - Uses an HTML-like API
   - Adds sticky positioning
   - Adds background color in the tab list (for use with sticky positioning)
+  - Adds the ability to make the background of the active tab fade into the background of the panel below it
 
 
 ### Attributes

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -2,6 +2,7 @@ module Nri.Ui.Tabs.V8 exposing
     ( Attribute, title, spacing
     , Alignment(..), alignment
     , pageBackgroundColor
+    , fadeToPanelBackgroundColor
     , tabListSticky, TabListStickyConfig, tabListStickyCustom
     , view
     , Tab, TabAttribute, build
@@ -22,6 +23,7 @@ module Nri.Ui.Tabs.V8 exposing
 @docs Attribute, title, spacing
 @docs Alignment, alignment
 @docs pageBackgroundColor
+@docs fadeToPanelBackgroundColor
 @docs tabListSticky, TabListStickyConfig, tabListStickyCustom
 @docs view
 
@@ -180,6 +182,11 @@ pageBackgroundColor color =
     Attribute (\config -> { config | pageBackgroundColor = Just color })
 
 
+fadeToPanelBackgroundColor : Css.Color -> Attribute id msg
+fadeToPanelBackgroundColor color =
+    Attribute (\config -> { config | fadeToPanelBackgroundColor = color })
+
+
 {-| Make the tab list sticky. You probably want to set an explicit background
 color along with this!
 -}
@@ -201,6 +208,7 @@ type alias Config =
     , alignment : Alignment
     , spacing : Maybe Float
     , pageBackgroundColor : Maybe Css.Color
+    , fadeToPanelBackgroundColor : Css.Color
     , tabListStickyConfig : Maybe TabListStickyConfig
     }
 
@@ -211,6 +219,7 @@ defaultConfig =
     , alignment = Left
     , spacing = Nothing
     , pageBackgroundColor = Nothing
+    , fadeToPanelBackgroundColor = Colors.white
     , tabListStickyConfig = Nothing
     }
 


### PR DESCRIPTION
## Context

### Summary
  - We recently made content tutorials have a gray background (with one or more white containers for what we call _content groups_).
  - The UI for combined tutorials uses tabs to render multiple tutorials. Until now, the Tabs UI was embedded within the global white container. Once we got rid of this container the tabs looked weird because they kind of assume that the panels below them have a white background (see screenshot below).
  - Design proposed that we fix this by making the background fade from white (top) to whatever color we use in the panel [[slack tread](https://noredink.slack.com/archives/C0395NFHQ3F/p1679691928081669)].

<img width="859" alt="screen_shot_2023-03-24_at_18 03 19" src="https://user-images.githubusercontent.com/753421/229907362-4b9a9e91-06c2-471f-afab-bf39721bf448.png">

### API Design Notes
  - When I first checked with A11ybats, Tessa suggested making this a per-tab attribute because of the extra flexibility (and maybe because at the time we didn't have widget-wide attributes which we now do)
  - I decided to initially make it global though, for two reasons:
    - Design doesn't seem to think we'll want that flexibility [[slack](https://noredink.slack.com/archives/C9MEFL3KL/p1680639855683989)]
    - implementing this per-tab would be a bit hairy, involving:
      - either changing `TabsInternal.Tab` with a new attribute that doesn't make sense for other components or change `TabAttribute` from being a single wrapper to a union type to account for this new attribute.
      - either making the new attribute a parameter of the `tabStyles` callback (making all other components aware of it) or writing something like what I have in the snippet below to pull it out 

Soooo I am totally open to changing this, but figured it made sense to do the simplest thing and put it up for review first.

```elm
-- Example of how the code could look like if we made this a per-tab attribute
TabsInternal.views
    { focusAndSelect = focusAndSelect
    , selected = selected
    , tabs = List.map (\(Tab t) -> t) tabs
    , tabStyles =
        \index isSelected ->
            let
                fadeToPanelBackgroundColor =
                    tabs
                        |> List.Extra.getAt index
                        |> Maybe.map .fadeToPanelBackgroundColor
                        |> Maybe.withDefault Colors.white
            in
            tabStyles config.spacing fadeToPanelBackgroundColor index isSelected
    , tabListStyles = stylesTabsAligned config
    }
```





## :framed_picture: What does this change look like?

- [X] Follow the the [Guidelines for an optimal design ping](https://paper.dropbox.com/doc/Guidelines-for-Sharing-User-Facing-Changes-with-Design--BpL8hpJLMugy6033aT5m0JdaAg-bdKGQtYH9qO9I00hUkA6k) to add helpful screenshots/videos for design.
- [x] @ mention the design team on this PR to request approval on your changes. A designer will "thumbs up" react to your PR if they approve it, or will leave comments if it's not quite approved yet.





https://user-images.githubusercontent.com/753421/230169400-68740a74-edcd-4a1a-85c3-44fbd1e97a0d.mov




## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
