### PR TITLE
use the column header in the non-interactive case

### DIFF
--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -355,7 +355,7 @@ buildTableColumn maybeUpdateMsg maybeState (Column column) =
                     viewSortHeader (column.sorter /= Nothing) column.header maybeUpdateMsg state_ column.id
 
                 Nothing ->
-                    Debug.todo "non-sorted header"
+                    column.header
         , view = column.view
         , width = Css.px (toFloat column.width)
         , cellStyles = column.cellStyles


### PR DESCRIPTION
Get rid of a `Debug.todo`