### PR TITLE
Bat/fix highlightable spaces

### DIFF
--- a/src/Nri/Ui/Highlighter/V3.elm
+++ b/src/Nri/Ui/Highlighter/V3.elm
@@ -652,15 +652,6 @@ trimHighlightableGroups highlightables =
         |> List.reverse
 
 
-killOnlyStaticHighlights : List (Highlightable marker) -> List (Highlightable marker)
-killOnlyStaticHighlights highlightables =
-    if List.all (\h -> h.type_ == Highlightable.Static) highlightables then
-        removeHighlights_ highlightables
-
-    else
-        highlightables
-
-
 {-| Finds the group indexes of the groups which are in the same highlighting as the group index
 passed in the first argument.
 -}

--- a/src/Nri/Ui/Highlighter/V3.elm
+++ b/src/Nri/Ui/Highlighter/V3.elm
@@ -9,7 +9,11 @@ module Nri.Ui.Highlighter.V3 exposing
     , clickedHighlightable, hoveredHighlightable
     )
 
-{-| Changes from V2:
+{-| Patch changes:
+
+  - fixed :bug: where clicking on a static space would cause the space to be marked
+
+Changes from V2:
 
   - support overlapping highlights (by way of removing the underlying mark element)
   - move asFragmentTuples, usedMarkers, and text to the Highlightable module

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -20,11 +20,32 @@ import Test.Html.Selector as Selector exposing (Selector)
 spec : Test
 spec =
     describe "Nri.Ui.Highlighter"
-        [ describe "keyboard behavior" keyboardTests
+        [ describe "mouse behavior" mouseTests
+        , describe "keyboard behavior" keyboardTests
         , describe "markdown behavior" markdownTests
         , describe "joinAdjacentInteractiveHighlights" joinAdjacentInteractiveHighlightsTests
         , describe "overlapping highlights" overlappingHighlightTests
         ]
+
+
+mouseTests : List Test
+mouseTests =
+    [ test "clicking on a static element does nothing" <|
+        \() ->
+            [ Highlightable.initStatic [] 0 "Pothos", Highlightable.initInteractive [] 1 "Philodendron" ]
+                |> program { markerName = Nothing, joinAdjacentInteractiveHighlights = False }
+                |> click "Pothos"
+                |> ensureViewHasNot [ Selector.tag "mark" ]
+                |> done
+    , test "starting a highlight from a static element works" <|
+        \() ->
+            [ Highlightable.initStatic [] 0 "Pothos", Highlightable.initInteractive [] 1 "Philodendron" ]
+                |> program { markerName = Nothing, joinAdjacentInteractiveHighlights = False }
+                |> mouseDown "Philodendron"
+                |> mouseUp "Pothos"
+                |> ensureMarked [ "Philodendron" ]
+                |> done
+    ]
 
 
 keyboardTests : List Test

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -32,14 +32,18 @@ mouseTests : List Test
 mouseTests =
     [ test "clicking on a static element does nothing" <|
         \() ->
-            [ Highlightable.initStatic [] 0 "Pothos", Highlightable.initInteractive [] 1 "Philodendron" ]
+            [ Highlightable.init Highlightable.Static [] 0 ( [], "Pothos" )
+            , Highlightable.init Highlightable.Interactive [] 1 ( [], "Philodendron" )
+            ]
                 |> program { markerName = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> click "Pothos"
                 |> ensureViewHasNot [ Selector.tag "mark" ]
                 |> done
     , test "starting a highlight from a static element works" <|
         \() ->
-            [ Highlightable.initStatic [] 0 "Pothos", Highlightable.initInteractive [] 1 "Philodendron" ]
+            [ Highlightable.init Highlightable.Static [] 0 ( [], "Pothos" )
+            , Highlightable.init Highlightable.Interactive [] 1 ( [], "Philodendron" )
+            ]
                 |> program { markerName = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> mouseDown "Philodendron"
                 |> mouseUp "Pothos"


### PR DESCRIPTION
## Context

Clicking a static space in a highlighter should _not_ cause the highlight status to change.

Fixes A11-2619

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
