### PR TITLE
Tessa/test suggestions

### DIFF
--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -1,11 +1,13 @@
 module Spec.Nri.Ui.Block exposing (spec)
 
+import Accessibility.Aria as Aria
 import Browser.Dom exposing (Element)
 import Dict
 import Expect
 import Html.Attributes as Attributes
 import Html.Styled
 import Nri.Ui.Block.V4 as Block
+import Spec.PseudoElements exposing (hasAfter, hasBefore)
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector
@@ -105,7 +107,31 @@ labelMarkdownSpec =
             , Block.label "This **is** markdown"
             ]
                 |> toQuery
-                |> Query.has [ Selector.text "This is markdown" ]
+                |> Expect.all
+                    [ -- The rendered markdown label content should be in a paragraph tag.
+                      -- It should be hidden from SR users, since the label information
+                      -- is conveyed another way.
+                      Query.has
+                        [ Selector.attribute (Aria.hidden True)
+                        , Selector.containing
+                            [ Selector.tag "p"
+                            , Selector.text "This "
+                            ]
+                        , Selector.containing
+                            [ Selector.tag "p"
+                            , Selector.containing [ Selector.tag "strong" ]
+                            ]
+                        , Selector.containing
+                            [ Selector.tag "p"
+                            , Selector.text " markdown"
+                            ]
+                        ]
+
+                    -- The before and after elements that convey the mark type to AT users
+                    -- should not include markdown (e.g., no asterisks)
+                    , hasBefore "start This is markdown" "Hello"
+                    , hasAfter "end This is markdown" "there"
+                    ]
     ]
 
 

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -131,6 +131,9 @@ labelMarkdownSpec =
                     -- should not include markdown (e.g., no asterisks)
                     , hasBefore "start This is markdown" "Hello"
                     , hasAfter "end This is markdown" "there"
+
+                    -- The roledescription should also not include markdown special characters
+                    , Query.has [ Selector.attribute (Aria.roleDescription "This is markdown highlight") ]
                     ]
     ]
 

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -337,32 +337,23 @@ testRendersMarkdownContent testName view =
 markdownHighlightNameTests : List Test
 markdownHighlightNameTests =
     let
-        model highlightables =
+        model =
             Highlighter.init
                 { id = "test-markdown-highlight-names-rendering"
-                , highlightables = initHighlightables highlightables
+                , highlightables =
+                    [ Highlightable.init Highlightable.Static [ marker (Just "*Markdown label*") ] 0 ( [], "Highlightable" ) ]
                 , marker = markerModel Nothing
                 , joinAdjacentInteractiveHighlights = False
                 }
 
-        initHighlightables : List ( String, List String ) -> List (Highlightable String)
-        initHighlightables =
-            List.indexedMap
-                (\i ( text, marks ) ->
-                    Highlightable.init Highlightable.Static (List.map (Just >> marker) marks) i ( [], text )
-                )
-
         testIt viewName view =
             test viewName <|
                 \() ->
-                    [ ( "Hello", [ "*Markdown label*" ] ), ( "World", [ "*Markdown label*" ] ) ]
-                        |> model
-                        |> view
+                    view model
                         |> toUnstyled
                         |> Query.fromHtml
                         |> Expect.all
-                            [ hasBefore "start Markdown label highlight" "Hello"
-                            , hasNotBefore "start Markdown label highlight" "World"
+                            [ hasBefore "start Markdown label highlight" "Highlightable"
                             ]
     in
     [ testIt "view" Highlighter.view
@@ -371,18 +362,7 @@ markdownHighlightNameTests =
     , testIt "staticMarkdown" Highlighter.staticMarkdown
     , testIt "staticWithTags" Highlighter.staticWithTags
     , testIt "staticMarkdownWithTags" Highlighter.staticMarkdownWithTags
-    , test "viewWithOverlappingHighlights" <|
-        \() ->
-            [ ( "Hello", [ "*A*", "**B**" ] ), ( "World", [ "*A*", "**B**" ] ), ( "!", [ "**B**" ] ) ]
-                |> model
-                |> Highlighter.viewWithOverlappingHighlights
-                |> toUnstyled
-                |> Query.fromHtml
-                |> Expect.all
-                    [ hasBefore "start A and B highlights" "Hello"
-                    , hasNotBefore "start A and B highlights" "World"
-                    , hasNotBefore "start B highlight" "!"
-                    ]
+    , testIt "viewWithOverlappingHighlights" Highlighter.viewWithOverlappingHighlights
     ]
 
 

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -9,9 +9,9 @@ import Nri.Ui.Highlightable.V2 as Highlightable exposing (Highlightable)
 import Nri.Ui.Highlighter.V3 as Highlighter
 import Nri.Ui.HighlighterTool.V1 as Tool exposing (Tool)
 import ProgramTest exposing (..)
-import Regex exposing (Regex)
 import Spec.KeyboardHelpers as KeyboardHelpers
 import Spec.MouseHelpers as MouseHelpers
+import Spec.PseudoElements exposing (..)
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector exposing (Selector)
@@ -347,87 +347,6 @@ startWithoutMarker view highlightables =
         , view = view >> toUnstyled
         }
         |> ProgramTest.start ()
-
-
-hasBefore : String -> String -> Query.Single msg -> Expectation
-hasBefore =
-    hasPseudoElement "::before"
-
-
-hasAfter : String -> String -> Query.Single msg -> Expectation
-hasAfter =
-    hasPseudoElement "::after"
-
-
-hasNotBefore : String -> String -> Query.Single msg -> Expectation
-hasNotBefore =
-    hasNotPseudoElement "::before"
-
-
-hasNotAfter : String -> String -> Query.Single msg -> Expectation
-hasNotAfter =
-    hasNotPseudoElement "::after"
-
-
-hasPseudoElement : String -> String -> String -> Query.Single msg -> Expectation
-hasPseudoElement pseudoElement highlightMarker relevantHighlightableText view =
-    case pseudoElementSelector pseudoElement highlightMarker view of
-        Just className ->
-            Query.has
-                [ className
-                , Selector.containing [ Selector.text relevantHighlightableText ]
-                ]
-                view
-
-        Nothing ->
-            ("Expected to find a class defining a " ++ pseudoElement ++ " element with content: `")
-                ++ highlightMarker
-                ++ "`, but failed to find the class in the styles: \n\n"
-                ++ rawStyles view
-                |> Expect.fail
-
-
-hasNotPseudoElement : String -> String -> String -> Query.Single msg -> Expectation
-hasNotPseudoElement pseudoElement highlightMarker relevantHighlightableText view =
-    case pseudoElementSelector pseudoElement highlightMarker view of
-        Just className ->
-            view
-                |> Query.findAll [ className ]
-                |> Query.each (Query.hasNot [ Selector.containing [ Selector.text relevantHighlightableText ] ])
-
-        Nothing ->
-            Expect.pass
-
-
-pseudoElementSelector : String -> String -> Query.Single msg -> Maybe Selector
-pseudoElementSelector pseudoElement highlightMarker view =
-    let
-        startHighlightClassRegex : Maybe Regex
-        startHighlightClassRegex =
-            ("\\.(\\_[a-zA-Z0-9]+)" ++ pseudoElement ++ "\\{content:\\\\\"\\s*\\s*")
-                ++ highlightMarker
-                |> Regex.fromString
-
-        maybeClassName : Maybe String
-        maybeClassName =
-            startHighlightClassRegex
-                |> Maybe.andThen
-                    (\regex ->
-                        Regex.find regex (rawStyles view)
-                            |> List.head
-                            |> Maybe.andThen (.submatches >> List.head)
-                    )
-                |> Maybe.withDefault Nothing
-    in
-    Maybe.map Selector.class maybeClassName
-
-
-rawStyles : Query.Single msg -> String
-rawStyles view =
-    view
-        |> Query.find [ Selector.tag "style" ]
-        |> Query.children []
-        |> Debug.toString
 
 
 ensureTabbable : String -> TestContext -> TestContext

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -1,5 +1,6 @@
 module Spec.Nri.Ui.Highlighter exposing (spec)
 
+import Accessibility.Aria as Aria
 import Accessibility.Key as Key
 import Expect exposing (Expectation)
 import Html.Styled exposing (Html, toUnstyled)
@@ -353,7 +354,18 @@ markdownHighlightNameTests =
                         |> toUnstyled
                         |> Query.fromHtml
                         |> Expect.all
-                            [ hasBefore "start Markdown label highlight" "Highlightable"
+                            [ -- The rendered markdown tag should be hidden from SR users, since the label information
+                              -- is conveyed another way
+                              Query.has
+                                [ Selector.attribute (Aria.hidden True)
+                                , Selector.containing
+                                    [ Selector.tag "strong"
+                                    , Selector.containing [ Selector.text "Markdown label " ]
+                                    ]
+                                ]
+                            , -- The before and after elements that convey the mark type to AT users
+                              -- should not include markdown (e.g., no asterisks)
+                              hasBefore "start Markdown label highlight" "Highlightable"
                             ]
     in
     [ testIt "view" Highlighter.view

--- a/tests/Spec/PseudoElements.elm
+++ b/tests/Spec/PseudoElements.elm
@@ -1,0 +1,97 @@
+module Spec.PseudoElements exposing
+    ( hasBefore, hasAfter
+    , hasNotBefore, hasNotAfter
+    )
+
+{-|
+
+@docs hasBefore, hasAfter
+@docs hasNotBefore, hasNotAfter
+
+-}
+
+import Expect exposing (Expectation)
+import Regex exposing (Regex)
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector exposing (Selector)
+
+
+hasBefore : String -> String -> Query.Single msg -> Expectation
+hasBefore =
+    hasPseudoElement "::before"
+
+
+hasAfter : String -> String -> Query.Single msg -> Expectation
+hasAfter =
+    hasPseudoElement "::after"
+
+
+hasNotBefore : String -> String -> Query.Single msg -> Expectation
+hasNotBefore =
+    hasNotPseudoElement "::before"
+
+
+hasNotAfter : String -> String -> Query.Single msg -> Expectation
+hasNotAfter =
+    hasNotPseudoElement "::after"
+
+
+hasPseudoElement : String -> String -> String -> Query.Single msg -> Expectation
+hasPseudoElement pseudoElement highlightMarker relevantHighlightableText view =
+    case pseudoElementSelector pseudoElement highlightMarker view of
+        Just className ->
+            Query.has
+                [ className
+                , Selector.containing [ Selector.text relevantHighlightableText ]
+                ]
+                view
+
+        Nothing ->
+            ("Expected to find a class defining a " ++ pseudoElement ++ " element with content: `")
+                ++ highlightMarker
+                ++ "`, but failed to find the class in the styles: \n\n"
+                ++ rawStyles view
+                |> Expect.fail
+
+
+hasNotPseudoElement : String -> String -> String -> Query.Single msg -> Expectation
+hasNotPseudoElement pseudoElement highlightMarker relevantHighlightableText view =
+    case pseudoElementSelector pseudoElement highlightMarker view of
+        Just className ->
+            view
+                |> Query.findAll [ className ]
+                |> Query.each (Query.hasNot [ Selector.containing [ Selector.text relevantHighlightableText ] ])
+
+        Nothing ->
+            Expect.pass
+
+
+pseudoElementSelector : String -> String -> Query.Single msg -> Maybe Selector
+pseudoElementSelector pseudoElement highlightMarker view =
+    let
+        startHighlightClassRegex : Maybe Regex
+        startHighlightClassRegex =
+            ("\\.(\\_[a-zA-Z0-9]+)" ++ pseudoElement ++ "\\{content:\\\\\"\\s*\\s*")
+                ++ highlightMarker
+                |> Regex.fromString
+
+        maybeClassName : Maybe String
+        maybeClassName =
+            startHighlightClassRegex
+                |> Maybe.andThen
+                    (\regex ->
+                        Regex.find regex (rawStyles view)
+                            |> List.head
+                            |> Maybe.andThen (.submatches >> List.head)
+                    )
+                |> Maybe.withDefault Nothing
+    in
+    Maybe.map Selector.class maybeClassName
+
+
+rawStyles : Query.Single msg -> String
+rawStyles view =
+    view
+        |> Query.find [ Selector.tag "style" ]
+        |> Query.children []
+        |> Debug.toString


### PR DESCRIPTION
Suggestions for https://github.com/NoRedInk/noredink-ui/pull/1254:

- adds additional assertions for Block tests
- improves test coverage for Highlighter (was only testing overlapping highlighter views, there are 6 other highlighter views that are all more commonly used)
- adds failing assertions for Highlighter rendering the tags visually as markdown correctly

---

> I'm not quite sure I know what you mean by "sometimes-visually-displayed" start tag

If using `Highlighter.staticWithTags` or `Highlighter.staticMarkdownWithTags`, names for the highlights will be displayed (if they exist):

<img width="1353" alt="Screen Shot 2023-04-05 at 3 01 56 PM" src="https://user-images.githubusercontent.com/8811312/230211764-c9e46e2d-2015-4eea-95da-adff3b2ccc4f.png">

(Note that the markdown is being rendered raw in the screenshot -- I adjusted the name in the "claimMarkerWithBorder" helper to get into this state.)

Additionally, if users are in high contrast mode, this tag will **always render** if the name is present for every highlighter view:

<img width="1342" alt="Screen Shot 2023-04-05 at 3 03 45 PM" src="https://user-images.githubusercontent.com/8811312/230211771-ede2e63f-dbd1-4c56-9f61-53bea4acfdf6.png">

<img width="1367" alt="Screen Shot 2023-04-05 at 3 03 57 PM" src="https://user-images.githubusercontent.com/8811312/230211769-aafee0a6-5367-4a04-bef0-3340a8e41e1d.png">

The tag is meaningfully equivalent to the label used in Block.

---

I wasn't thinking about these before, but while adding these tests a couple of points on concern occurred to me:

1. If we add semantics (e.g., strong, em) to the label, that information will not be conveyed to AT users. I'm curious why we need markdown support in the labels? is it mostly for visual affordances or is it going to be meaningful? This is something I will take back to the a11ybats too.
2. Adding the paragraph wrapper to the label content is a bit funky since it introduces a paragraph tag _inside another paragraph tag_. The next version of WCAG is going to remove the HTML parsing validity requirement, so I don't know that it matters a ton. So mostly just a heads up that you can do with what you will.