### PR TITLE
only make table headers sticky on desktop

### DIFF
--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -22,6 +22,7 @@ module Nri.Ui.SortableTable.V4 exposing
 import Accessibility.Styled.Aria as Aria
 import Css exposing (..)
 import Css.Global
+import Css.Media
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events
@@ -30,6 +31,7 @@ import Nri.Ui.CssVendorPrefix.V1 as CssVendorPrefix
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 exposing (maybe)
 import Nri.Ui.Html.V3 exposing (viewJust)
+import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Nri.Ui.Svg.V1
 import Nri.Ui.Table.V7 as Table exposing (SortDirection(..))
 import Nri.Ui.UiIcon.V1
@@ -104,12 +106,15 @@ defaultStickyConfig =
 
 stickyConfigStyles : StickyConfig -> List Style
 stickyConfigStyles { topOffset, zIndex, pageBackgroundColor } =
-    [ Css.Global.children
-        [ Css.Global.thead
-            [ Css.position Css.sticky
-            , Css.top (Css.px topOffset)
-            , Css.zIndex (Css.int zIndex)
-            , Css.backgroundColor pageBackgroundColor
+    [ Css.Media.withMedia
+        [ MediaQuery.notMobile ]
+        [ Css.Global.children
+            [ Css.Global.thead
+                [ Css.position Css.sticky
+                , Css.top (Css.px topOffset)
+                , Css.zIndex (Css.int zIndex)
+                , Css.backgroundColor pageBackgroundColor
+                ]
             ]
         ]
     ]


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

As part of ADM-705, I made it possible for the tables to be sticky. I didn't intend for them to be sticky on mobile, but forgot the media query. This adds it!

## :framed_picture: What does this change look like?

No visual change; just that the table headers will not be sticky on a narrow viewport.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
