### PR TITLE
Adjust tooltip example

### DIFF
--- a/component-catalog-app/Examples/Tooltip.elm
+++ b/component-catalog-app/Examples/Tooltip.elm
@@ -272,11 +272,10 @@ viewAuxillaryDescriptionToolip openTooltip =
                 ClickableText.link "Tooltips & Toggletips"
                     [ ClickableText.custom eventHandlers
                     , ClickableText.small
-                    , ClickableText.icon UiIcon.openInNewTab
                     , ClickableText.linkExternal "https://inclusive-components.design/tooltips-toggletips/"
                     ]
         }
-        [ Tooltip.plaintext "Opens in a new window"
+        [ Tooltip.plaintext "Leave noredink-ui"
         , Tooltip.auxiliaryDescription
         , Tooltip.onToggle (ToggleTooltip AuxillaryDescription)
         , Tooltip.open (openTooltip == Just AuxillaryDescription)

--- a/component-catalog-app/Examples/Tooltip.elm
+++ b/component-catalog-app/Examples/Tooltip.elm
@@ -275,7 +275,7 @@ viewAuxillaryDescriptionToolip openTooltip =
                     , ClickableText.linkExternal "https://inclusive-components.design/tooltips-toggletips/"
                     ]
         }
-        [ Tooltip.plaintext "Leave noredink-ui"
+        [ Tooltip.plaintext "Opens in a new tab"
         , Tooltip.auxiliaryDescription
         , Tooltip.onToggle (ToggleTooltip AuxillaryDescription)
         , Tooltip.open (openTooltip == Just AuxillaryDescription)


### PR DESCRIPTION
ClickableText now automatically adds external link visual indication, so it doesn't make sense to add the icon twice 😅 

Fixes A11-2616

<img width="197" alt="image" src="https://user-images.githubusercontent.com/8811312/231012075-a7b87dd3-7c65-47e0-89bd-6c5d08cb6aff.png">

Also, adjusts the copy a bit to give different information than the information that is already conveyed by the SVG.