### PR TITLE
apply the box shadow to the inner <th> instead of the <tr>

### DIFF
--- a/src/Nri/Ui/Table/V7.elm
+++ b/src/Nri/Ui/Table/V7.elm
@@ -23,6 +23,7 @@ module Nri.Ui.Table.V7 exposing
 import Accessibility.Styled.Style as Style
 import Css exposing (..)
 import Css.Animations
+import Css.Global
 import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes as Attributes exposing (css)
 import Nri.Ui.Colors.V1 exposing (..)
@@ -241,11 +242,15 @@ tableBody toRow items =
 
 headersStyles : List Style
 headersStyles =
-    [ -- We use a inset box shadown for a bottom border instead of an actual
+    [ -- We use a inset box shadow for a bottom border instead of an actual
       -- border because with our use of `border-collapse: collapse`, the bottom
       -- gray border sticks to the table instead of traveling with the header
       -- when the header has `position: sticky` applied.
-      boxShadow4 inset (px 0) (px -3) gray75
+      --
+      -- We add the style on the children instead of on the parent because
+      -- `<tr>` tags do not display box shadows in Safari (although by the time
+      -- you read this, they may have fixed it. Feel free to try again!)
+      Css.Global.children [ Css.Global.th [ boxShadow4 inset (px 0) (px -3) gray75 ] ]
     , height (px 45)
     , fontSize (px 15)
     ]


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

First step of ADM-754

## :framed_picture: What does this change look like?

This restores the underline to sortable tables in Safari (already visible in other browsers.)

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
