### PR TITLE
🔧 Replace underlying checkbox input

### DIFF
--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -154,7 +154,7 @@ describe("UI tests", function () {
 
     // visible icon names snapshot
     await page.click("label");
-    await page.waitForSelector(".checkbox-V7__Checked");
+    await page.waitForSelector("[aria-checked=true]");
     await percySnapshot(page, `${name} - display icon names`);
 
     const results = await new AxePuppeteer(page)

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -12,13 +12,18 @@ module Nri.Ui.Checkbox.V7 exposing
 {-|
 
 
-# Changes from V6:
+## Changes from V6:
 
   - Reworked api similar to other components based on Attributes
   - Add support for guidance
   - Dropped checkboxLockOnInside functionality
   - Dropped disabledLabelCss functionality. Use labelCss instead in case when the checkbox is disabled.
   - (breaking-change) By default the label is visible (ie: V6.viewWithLabel), use hiddenLabel to migrate from V6.view.
+
+
+## Patch changes:
+
+  - It turns out that "indeterminate" has to be set from JS -- it doesn't work to add the attribute as part of the HTML. So, instead of using an input under the hood, we're using aria-attributes instead. This also allows us to simplify the styles a bit.
 
 @docs view
 

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -306,21 +306,13 @@ checkboxContainer model =
     Html.span
         [ css
             [ display block
-            , height inherit
-            , position relative
             , marginLeft (px -4)
-            , padding4 (px 13) zero (px 13) (px 40)
+            , paddingTop (px 5)
+            , paddingBottom (px 5)
+            , height inherit
             , pseudoClass "focus-within"
                 [ Css.Global.descendants
                     [ Css.Global.class "checkbox-icon-container" FocusRing.tightStyles
-                    ]
-                ]
-            , Css.Global.descendants
-                [ Css.Global.input
-                    [ position absolute
-                    , top (calc (pct 50) minus (px 10))
-                    , left (px 10)
-                    , boxShadow none |> Css.important
                     ]
                 ]
             , Css.batch model.containerCss
@@ -341,7 +333,8 @@ onCheckMsg selected msg =
 
 enabledLabelCss : List Style
 enabledLabelCss =
-    [ display inlineBlock
+    [ displayFlex
+    , Css.alignItems Css.center
     , textStyle
     , cursor pointer
     ]
@@ -349,7 +342,8 @@ enabledLabelCss =
 
 disabledLabelCss : List Style
 disabledLabelCss =
-    [ display inlineBlock
+    [ displayFlex
+    , Css.alignItems Css.center
     , textStyle
     , Css.outline3 (Css.px 2) Css.solid Css.transparent
     , cursor auto
@@ -412,17 +406,12 @@ viewIcon : List Style -> Svg -> Html msg
 viewIcon styles icon =
     Html.div
         [ css
-            [ position absolute
-            , left zero
-            , top (calc (pct 50) minus (px 18))
-            , border3 (px 2) solid transparent
-            , padding (px 2)
+            [ border3 (px 2) solid transparent
             , borderRadius (px 3)
             , height (Css.px 27)
             , boxSizing contentBox
-            , -- this padding creates a hit area "bridge" between the
-              -- absolutely-positioned icon SVG and the label text
-              paddingRight (Css.px 8)
+            , margin (px 2)
+            , marginRight (px 7)
             ]
         , Attributes.class "checkbox-icon-container"
         ]

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -318,8 +318,6 @@ checkboxContainer model =
             , Css.batch model.containerCss
             ]
         , Attributes.id (model.identifier ++ "-container")
-
-        --, Events.stopPropagationOn "click" (Json.Decode.fail "stop click propagation")
         ]
 
 

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -377,6 +377,7 @@ viewCheckbox config ( styles, icon ) =
         attributes =
             List.filterMap identity
                 [ Just (css (styles ++ config.labelCss))
+                , Just (Attributes.class FocusRing.customClass)
                 , Just Role.checkBox
                 , Just (Key.tabbable True)
                 , Just (Attributes.id config.identifier)

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -367,20 +367,27 @@ viewCheckbox :
 viewCheckbox config ( styles, icon ) =
     let
         attributes =
-            List.filterMap identity
-                [ Just (css (styles ++ config.labelCss))
-                , Just (Attributes.class FocusRing.customClass)
-                , Just Role.checkBox
-                , Just (Key.tabbable True)
-                , Just (Attributes.id config.identifier)
+            List.concat
+                [ [ css (styles ++ config.labelCss)
+                  , Attributes.class FocusRing.customClass
+                  , Role.checkBox
+                  , Key.tabbable True
+                  , Attributes.id config.identifier
+                  , Aria.checked (selectedToMaybe config.selected)
+                  ]
                 , if config.disabled then
-                    Just <| Aria.disabled True
+                    [ Aria.disabled True ]
 
                   else
                     config.onCheck
                         |> Maybe.map (onCheckMsg config.selected)
-                        |> Maybe.map (\msg -> Events.onClick msg)
-                , Just (Aria.checked (selectedToMaybe config.selected))
+                        |> Maybe.map
+                            (\msg ->
+                                [ Events.onClick msg
+                                , Key.onKeyDownPreventDefault [ Key.space msg ]
+                                ]
+                            )
+                        |> Maybe.withDefault []
                 ]
     in
     Html.div attributes

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -241,32 +241,33 @@ view { label, selected } attributes =
             , guidance = config.guidance
             , error = InputErrorAndGuidanceInternal.noError
             }
+
+        ( icon, disabledIcon ) =
+            case selected of
+                Selected ->
+                    ( CheckboxIcons.checked idValue
+                    , CheckboxIcons.checkedDisabled
+                    )
+
+                NotSelected ->
+                    ( CheckboxIcons.unchecked idValue
+                    , CheckboxIcons.uncheckedDisabled
+                    )
+
+                PartiallySelected ->
+                    ( CheckboxIcons.checkedPartially idValue
+                    , CheckboxIcons.checkedPartiallyDisabled
+                    )
     in
     checkboxContainer config_
         ([ viewCheckbox config_
-         , let
-            ( icon, disabledIcon ) =
-                case selected of
-                    Selected ->
-                        ( CheckboxIcons.checked idValue
-                        , CheckboxIcons.checkedDisabled
-                        )
+         , viewLabel config_
+            (if config.isDisabled then
+                ( disabledLabelCss, disabledIcon )
 
-                    NotSelected ->
-                        ( CheckboxIcons.unchecked idValue
-                        , CheckboxIcons.uncheckedDisabled
-                        )
-
-                    PartiallySelected ->
-                        ( CheckboxIcons.checkedPartially idValue
-                        , CheckboxIcons.checkedPartiallyDisabled
-                        )
-           in
-           if config.isDisabled then
-            viewDisabledLabel config_ disabledIcon
-
-           else
-            viewEnabledLabel config_ icon
+             else
+                ( enabledLabelCss, icon )
+            )
          ]
             ++ InputErrorAndGuidanceInternal.view config_.identifier (Css.marginTop Css.zero) config_
         )
@@ -360,7 +361,25 @@ onCheckMsg selected msg =
         |> msg
 
 
-viewEnabledLabel :
+enabledLabelCss : List Style
+enabledLabelCss =
+    [ display inlineBlock
+    , textStyle
+    , cursor pointer
+    ]
+
+
+disabledLabelCss : List Style
+disabledLabelCss =
+    [ display inlineBlock
+    , textStyle
+    , Css.outline3 (Css.px 2) Css.solid Css.transparent
+    , cursor auto
+    , color Colors.gray45
+    ]
+
+
+viewLabel :
     { a
         | identifier : String
         , selected : IsSelected
@@ -368,46 +387,16 @@ viewEnabledLabel :
         , hideLabel : Bool
         , labelCss : List Style
     }
-    -> Svg
+    ->
+        ( List Style
+        , Svg
+        )
     -> Html.Html msg
-viewEnabledLabel config icon =
+viewLabel config ( styles, icon ) =
     Html.label
         [ Attributes.for config.identifier
         , labelClass config.selected
-        , css
-            [ display inlineBlock
-            , textStyle
-            , cursor pointer
-            , Css.batch config.labelCss
-            ]
-        ]
-        [ viewIcon [] icon
-        , labelView config
-        ]
-
-
-viewDisabledLabel :
-    { a
-        | identifier : String
-        , selected : IsSelected
-        , label : String
-        , hideLabel : Bool
-        , labelCss : List Style
-    }
-    -> Svg
-    -> Html.Html msg
-viewDisabledLabel config icon =
-    Html.label
-        [ Attributes.for config.identifier
-        , labelClass config.selected
-        , css
-            [ display inlineBlock
-            , textStyle
-            , Css.outline3 (Css.px 2) Css.solid Css.transparent
-            , cursor auto
-            , color Colors.gray45
-            , Css.batch config.labelCss
-            ]
+        , css (styles ++ config.labelCss)
         ]
         [ viewIcon [] icon
         , labelView config

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -60,7 +60,6 @@ import Html.Styled as Html
 import Html.Styled.Attributes as Attributes exposing (css)
 import Html.Styled.Events as Events
 import InputErrorAndGuidanceInternal exposing (Guidance)
-import Json.Decode
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Fonts.V1 as Fonts


### PR DESCRIPTION
## Context

Switches from using an input with type checkbox under the hood for checkboxes to using Role.checkbox and reimplementing checkbox features.

Fixes A11-2644

Please note for QA for upgrade notes that if there are places where we're styling checkboxes using descendant selectors, those selectors are likely to break now. Worth keeping an eye out/running Percy if it becomes possible again!

## :framed_picture: What does this change look like?

| | Before | After |
| --- | --- | --- |
| Focus ring | <img width="239" alt="Screen Shot 2023-04-18 at 3 35 32 PM" src="https://user-images.githubusercontent.com/8811312/232910780-e92cc540-3e07-4d11-9548-89656fb9a9ed.png"> |  <img width="247" alt="Screen Shot 2023-04-18 at 3 35 25 PM" src="https://user-images.githubusercontent.com/8811312/232910778-12969dc1-7068-46c8-9dbd-84e9d3579aaa.png"> |
| Indeterminate/mixed states w/VO | <img width="673" alt="Screen Shot 2023-04-18 at 3 39 40 PM" src="https://user-images.githubusercontent.com/8811312/232911269-e001d943-d367-4f11-89b1-662f70097d60.png">  |  <img width="655" alt="Screen Shot 2023-04-18 at 3 39 49 PM" src="https://user-images.githubusercontent.com/8811312/232911262-ef01c609-7f6e-4e64-855d-cee39089e95c.png"> |


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
