### PR TITLE
Bump version 22.10.1 => 22.11.0 (Add white SSO vendor logos)

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "22.10.1",
+    "version": "22.11.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Ui",


### PR DESCRIPTION
# :label: Bump for version `22.11.0`

## What changes does this release include?
[Adds `cleverCWhite`, `googleGWhite`, and `classLinkWhite` to `Nri.Ui.Logo.V1`](https://github.com/NoRedInk/noredink-ui/pull/1360)

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```
This is a MINOR change.

---- Nri.Ui.Logo.V1 - MINOR ----

    Added:
        classLinkWhite : Nri.Ui.Svg.V1.Svg
        cleverCWhite : Nri.Ui.Svg.V1.Svg
        googleGWhite : Nri.Ui.Svg.V1.Svg
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).