### PR TITLE
[PHX-675] Fix occasionally overlapping labels

### DIFF
--- a/src/Nri/Ui/Block/V3.elm
+++ b/src/Nri/Ui/Block/V3.elm
@@ -196,7 +196,9 @@ splitByOverlaps =
     -- consider the elements from top to bottom
     groupWithSort (\( _, a ) -> a.label.element.y + a.label.element.height)
         (\( _, a ) ( _, b ) ->
-            (a.label.element.y + a.label.element.height) == (b.label.element.y + b.label.element.height)
+            isRangeOverlapping
+                ( a.label.element.y, a.label.element.y + a.label.element.height )
+                ( b.label.element.y, b.label.element.y + b.label.element.height )
         )
         >> List.concatMap
             -- consider the elements from left to right
@@ -205,6 +207,11 @@ splitByOverlaps =
                     (a.label.element.x + xOffsetPx a.label + a.label.element.width) >= (b.label.element.x + xOffsetPx b.label)
                 )
             )
+
+
+isRangeOverlapping : ( Float, Float ) -> ( Float, Float ) -> Bool
+isRangeOverlapping ( a1, a2 ) ( b1, b2 ) =
+    (a1 <= b2 && a2 >= b1) || (a1 <= b2 && a2 >= b1)
 
 
 groupWithSort : (a -> comparable) -> (a -> a -> Bool) -> List a -> List (List a)

--- a/src/Nri/Ui/Block/V4.elm
+++ b/src/Nri/Ui/Block/V4.elm
@@ -185,7 +185,9 @@ splitByOverlaps =
     -- consider the elements from top to bottom
     groupWithSort (\( _, a ) -> a.label.element.y + a.label.element.height)
         (\( _, a ) ( _, b ) ->
-            (a.label.element.y + a.label.element.height) == (b.label.element.y + b.label.element.height)
+            isRangeOverlapping
+                ( a.label.element.y, a.label.element.y + a.label.element.height )
+                ( b.label.element.y, b.label.element.y + b.label.element.height )
         )
         >> List.concatMap
             -- consider the elements from left to right
@@ -194,6 +196,11 @@ splitByOverlaps =
                     (a.label.element.x + xOffsetPx a.label + a.label.element.width) >= (b.label.element.x + xOffsetPx b.label)
                 )
             )
+
+
+isRangeOverlapping : ( Float, Float ) -> ( Float, Float ) -> Bool
+isRangeOverlapping ( a1, a2 ) ( b1, b2 ) =
+    (a1 <= b2 && a2 >= b1) || (a1 <= b2 && a2 >= b1)
 
 
 groupWithSort : (a -> comparable) -> (a -> a -> Bool) -> List a -> List (List a)

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -616,6 +616,28 @@ getLabelPositionsSpec =
                      ]
                         |> Dict.fromList
                     )
+    , test "regression test - apparently impossible label top should not prevent identifying lables as being on same line" <|
+        \() ->
+            Block.getLabelPositions
+                (Dict.fromList
+                    [ ( "173-display-element-labeled-2-5"
+                      , { label = dummyElement { x = 350.984375, y = 212.5, width = 150, height = 53 }
+                        , labelContent = dummyElement { x = 350.984375, y = 261.5, width = 150, height = 45 }
+                        }
+                      )
+                    , ( "173-display-element-labeled-6-12"
+                      , { label = dummyElement { x = 477.2421875, y = 212.5, width = 150, height = 102 }
+                        , labelContent = dummyElement { x = 477.2421875, y = 212.5, width = 150, height = 45 }
+                        }
+                      )
+                    ]
+                )
+                |> Expect.equal
+                    ([ ( "173-display-element-labeled-2-5", { arrowHeight = 8, totalHeight = 53, xOffset = 0, zIndex = 1 } )
+                     , ( "173-display-element-labeled-6-12", { arrowHeight = 57, totalHeight = 102, xOffset = 0, zIndex = 0 } )
+                     ]
+                        |> Dict.fromList
+                    )
     ]
 
 

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -428,7 +428,7 @@ getLabelPositionsSpec =
                      }
                    )
                  , ( "b"
-                   , { label = dummyElement { x = 0, y = 20, width = 100, height = 100 }
+                   , { label = dummyElement { x = 0, y = 150, width = 100, height = 100 }
                      , labelContent = dummyElement { x = 0, y = 0, width = 100, height = startingHeight }
                      }
                    )
@@ -474,7 +474,7 @@ getLabelPositionsSpec =
                    )
                  , -- C is the widest element and it is also on a new line by itself
                    ( "c"
-                   , { label = dummyElement { x = 0, y = 20, width = 300, height = 100 }
+                   , { label = dummyElement { x = 0, y = 150, width = 300, height = 100 }
                      , labelContent = dummyElement { x = 0, y = 0, width = 300, height = startingHeight }
                      }
                    )
@@ -532,7 +532,7 @@ getLabelPositionsSpec =
                    )
                  , -- C is the widest element and it is also on a new line by itself
                    ( "c"
-                   , { label = dummyElement { x = 0, y = 20, width = 300, height = 100 }
+                   , { label = dummyElement { x = 0, y = 150, width = 300, height = 100 }
                      , labelContent = dummyElement { x = 0, y = 0, width = 300, height = startingHeight }
                      }
                    )


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

We've had many many reports from curriculum that labels were overlapping in places where they shouldn't be, but it was almost impossible to reproduce!  Sometimes it would happen in previews, other times only when debugging the QE.  

Finally I made the connection while looking into this that the "flicker" I see while resizing the QE shouldn't be there! I though it was due to labels temporarily overlapping while calculations were being made - but that's not the case.  @tesk9 's code should never temporarily produce an overlap. 

I think this is flaky due to floating point inconsistencies and weird measurement behavior.  The fix is simple - instead of grouping by exact `element.y + element.height`, we use a much more forgiving test to see if any of the range from `(element.y, element.y + element.height)` is overlapping with other labels. We can do this because our labels are grouped into different bands of vertical space that are separated by the sentence.

## :framed_picture: What does this change look like?

### Before

https://user-images.githubusercontent.com/12899207/235009505-248ddd5c-1ee2-4b0a-8568-7d377df2f4bf.mov

### After

https://user-images.githubusercontent.com/12899207/235009519-791c4f46-995a-4996-b315-461a1f801fd7.mov

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
