### PR TITLE
[PHX-675] Version bump to fix occasionally overlapping labels on scaffolding

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "22.12.0",
+    "version": "22.12.1",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Ui",


### PR DESCRIPTION
# :label: Bump for version `22.12.1`

## What changes does this release include?

- #1373

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```
No API changes detected, so this is a PATCH change.
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).