### PR TITLE
[PHX-709] Borders are not getting blended when markdown is directly underneath emphasis

### DIFF
--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -210,6 +210,13 @@ example =
                     , Block.labelId editorsNoteId
                     , Block.labelPosition (Dict.get editorsNoteId offsets)
                     ]
+                , Block.view 
+                    [ Block.plaintext " "
+                    ]
+                , Block.view
+                    [ Block.content [ Block.italic (Block.phrase "Emphasized Italics.") ]
+                    , Block.emphasize
+                    ]
                 ]
             , p
                 [ css

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -210,7 +210,7 @@ example =
                     , Block.labelId editorsNoteId
                     , Block.labelPosition (Dict.get editorsNoteId offsets)
                     ]
-                , Block.view 
+                , Block.view
                     [ Block.plaintext " "
                     ]
                 , Block.view

--- a/src/Nri/Ui/Block/V4.elm
+++ b/src/Nri/Ui/Block/V4.elm
@@ -278,13 +278,13 @@ renderContent content_ styles =
                 tag =
                     case markdown of
                         Bold ->
-                            strong []
+                            strong [ css styles ]
 
                         Italic ->
-                            em []
+                            em [ css styles ]
             in
             contents
-                |> List.map (\c -> renderContent c styles)
+                |> List.map (\c -> renderContent c [])
                 |> tag
 
 


### PR DESCRIPTION
This PR fixes a bug that was introduced in where markdown **inside** of an emphasis block would have left + right borders between each element if it was at the start or the end of the emphasis.

- https://github.com/NoRedInk/noredink-ui/pull/1254

@tesk9 I'm not sure that just applying the styles on the the parent element is ideal - while there are no visual differences, the styling for individual words is different than for other words not in markdown.  But the API between Block and Mark didn't give me much wiggle room to do anything else.  

I considered extending the type of `viewWithBalloonTags` `renderSegment` function from

```elm
renderSegment : c -> List Style -> Html msg
```

to

```elm
renderSegment : c ->  { startStyles : List Style, styles : List Style, endStyles : List Style }  -> Html msg
```

which gives the caller the power to delegate which descendant node should receive the `startStyles` / `endStyles`.  But there are a handful of `renderSegment` looking functions in the `Mark.V2` module and I didn't want to break the mold. 

# :wrench: Modifying a component

## Context

Please link to any relevant context and stories.

## :framed_picture: What does this change look like?

| Before | After |
| --- | --- |
| <img width="1365" alt="image" src="https://user-images.githubusercontent.com/12899207/235508008-a4cd4313-a462-43dd-9f16-fc9064fd3f1f.png"> | <img width="1428" alt="image" src="https://user-images.githubusercontent.com/12899207/235517581-b912eb76-b187-49b0-9d77-400bfc80d704.png"> |

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
