### PR TITLE
[KRA-913] Align the checkbox as a flex item instead of inline block

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "22.12.2",
+    "version": "22.12.3",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Ui",

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -291,8 +291,8 @@ viewLockedButton { idValue, label, containerCss, onLockedMsg } =
             [ Html.span
                 [ class "premium-checkbox-locked-V8__Label"
                 , css
-                    [ display inlineBlock
-                    , padding4 (px 13) zero (px 13) (px 40)
+                    [ displayFlex
+                    , alignItems center
                     , position relative
                     , Fonts.baseFont
                     , fontSize (px 15)

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -48,7 +48,6 @@ import Css exposing (..)
 import Html.Styled.Attributes as Attributes exposing (class, css)
 import Html.Styled.Events as Events
 import Nri.Ui.Checkbox.V7 as Checkbox
-import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Data.PremiumDisplay as PremiumDisplay exposing (PremiumDisplay)
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -263,6 +263,7 @@ viewLockedButton { idValue, label, containerCss, onLockedMsg } =
             , padding zero
             , cursor pointer
             , Css.batch containerCss
+            , textAlign left
             ]
         , Attributes.id (idValue ++ "-container")
         , case onLockedMsg of
@@ -277,12 +278,10 @@ viewLockedButton { idValue, label, containerCss, onLockedMsg } =
             [ css
                 [ outline Css.none
                 , Fonts.baseFont
-                , color Colors.navy
                 , margin zero
                 , marginLeft (px -4)
                 , padding zero
                 , fontSize (px 15)
-                , Css.property "font-weight" "600"
                 , display inlineBlock
                 , Css.property "transition" "all 0.4s ease"
                 , cursor pointer
@@ -296,8 +295,6 @@ viewLockedButton { idValue, label, containerCss, onLockedMsg } =
                     , position relative
                     , Fonts.baseFont
                     , fontSize (px 15)
-                    , fontWeight (int 600)
-                    , color Colors.navy
                     , Css.outline3 (Css.px 2) Css.solid Css.transparent
                     ]
                 ]


### PR DESCRIPTION
The checkbox was appearing on top of the text, not to the side. This corrects that.

_Update_ I added the version bump to get it released, this was the diff:

```
[nix-shell:~/dev/noredink-ui]$ elm diff
No API changes detected, so this is a PATCH change.
```

# :wrench: Modifying a component

## Context

The premium checkbox is not rendering correctly

<img width="721" alt="image" src="https://user-images.githubusercontent.com/32229300/236061021-f3d93ab5-16a1-4c6c-b928-cca129c8d056.png">

Making the change in this PR addresses this @NoRedInk/design 

<img width="713" alt="image" src="https://user-images.githubusercontent.com/32229300/236061270-d18039c0-2f44-4374-a0f1-032dd770e126.png">


## :framed_picture: What does this change look like?

- [x] Follow the the [Guidelines for an optimal design ping](https://paper.dropbox.com/doc/Guidelines-for-Sharing-User-Facing-Changes-with-Design--BpL8hpJLMugy6033aT5m0JdaAg-bdKGQtYH9qO9I00hUkA6k) to add helpful screenshots/videos for design.
- [x] @ mention the design team on this PR to request approval on your changes. A designer will "thumbs up" react to your PR if they approve it, or will leave comments if it's not quite approved yet.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
