### PR TITLE
adds `hoverZIndex` to SortableTable.StickyConfig

### DIFF
--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -154,6 +154,14 @@ example =
                                                         [ ( "topOffset", String.fromFloat stickyConfig.topOffset )
                                                         , ( "zIndex", String.fromInt stickyConfig.zIndex )
                                                         , ( "pageBackgroundColor", "Css.hex \"" ++ stickyConfig.pageBackgroundColor.value ++ "\"" )
+                                                        , ( "customZIndex"
+                                                          , case stickyConfig.hoverZIndex of
+                                                                Nothing ->
+                                                                    "Nothing"
+
+                                                                Just zIndex ->
+                                                                    "Just " ++ String.fromInt zIndex
+                                                          )
                                                         ]
                                                         2
                                     )

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -358,6 +358,7 @@ controlSettings =
                                     , ( "gray", Control.value Colors.gray92 )
                                     ]
                                 )
+                            |> Control.field "hoverZIndex" (Control.maybe False (values String.fromInt [ 0, 1, 5, 10 ]))
                             |> Control.map Custom
                       )
                     ]

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -93,6 +93,7 @@ type alias StickyConfig =
     { topOffset : Float
     , zIndex : Int
     , pageBackgroundColor : Css.Color
+    , hoverZIndex : Maybe Int
     }
 
 
@@ -101,20 +102,33 @@ defaultStickyConfig =
     { topOffset = 0
     , zIndex = 0
     , pageBackgroundColor = Nri.Ui.Colors.V1.white
+    , hoverZIndex = Nothing
     }
 
 
+consJust : Maybe a -> List a -> List a
+consJust maybe_ list =
+    case maybe_ of
+        Just value ->
+            value :: list
+
+        Nothing ->
+            list
+
+
 stickyConfigStyles : StickyConfig -> List Style
-stickyConfigStyles { topOffset, zIndex, pageBackgroundColor } =
+stickyConfigStyles { topOffset, zIndex, pageBackgroundColor, hoverZIndex } =
     [ Css.Media.withMedia
         [ MediaQuery.notMobile ]
         [ Css.Global.children
             [ Css.Global.thead
-                [ Css.position Css.sticky
-                , Css.top (Css.px topOffset)
-                , Css.zIndex (Css.int zIndex)
-                , Css.backgroundColor pageBackgroundColor
-                ]
+                (consJust (Maybe.map (\index -> Css.hover [ Css.zIndex (Css.int index) ]) hoverZIndex)
+                    [ Css.position Css.sticky
+                    , Css.top (Css.px topOffset)
+                    , Css.zIndex (Css.int zIndex)
+                    , Css.backgroundColor pageBackgroundColor
+                    ]
+                )
             ]
         ]
     ]

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -10,6 +10,7 @@ module Nri.Ui.SortableTable.V4 exposing
 
   - Change to an HTML-like API
   - Allow the table header to be sticky
+  - Adds an optional hover z-index for sticky table headers
 
 @docs Column, Sorter, State
 @docs init, initDescending


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

We need a tooltip inside a tab header to be displayed over a tab bar.
The suggestion @tesk9 gave us was lowering the tab bar zIndex, which worked quite well, except now the tab header is being displayed [_over_ the tab bar](https://github.com/NoRedInk/NoRedInk/pull/43950#issuecomment-1534852849). One solution we thought about was lifting the tab header z-index only when it's being hovered, since that would put it in a stacking context above the tab bar, while allowing it to be under it when the user is scrolling.

## :framed_picture: What does this change look like?

![image](https://user-images.githubusercontent.com/12688694/236285006-d48487b6-eec4-4773-becb-57b7983aeb5b.png)
![image](https://user-images.githubusercontent.com/12688694/236285051-8d7fc818-3d7f-415a-9584-eb50bf8612e5.png)


## Component completion checklist

- [X] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [X] Changes are clearly documented
    - [X] Component docs include a changelog
    - [X] Any new exposed functions or properties have docs
- [X] Changes extend to the Component Catalog
    - [X] The Component Catalog is updated to use the newest version, if appropriate
    - [X] The Component Catalog example version number is updated, if appropriate
    - [X] Any new customizations are available from the Component Catalog
    - [X] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [X] Changes to the component are tested/the new version of the component is tested
- [X] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
