### PR TITLE
Fix line-breaking by going full `whitespace: pre` and using `<wbr/>`

### DIFF
--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -270,6 +270,8 @@ example =
                 , Block.view
                     [ Block.plaintext ", that should not break before this comma!"
                     , Block.label "Dont break"
+                    , Block.labelId dontBreakId
+                    , Block.labelPosition (Dict.get dontBreakId offsets)
                     ]
                 ]
             , Table.view []
@@ -576,6 +578,11 @@ longId =
     "long-label-id"
 
 
+dontBreakId : String
+dontBreakId =
+    "do-not-break-label-id"
+
+
 blocksWithLabelsIds : List String
 blocksWithLabelsIds =
     [ ageId
@@ -591,6 +598,7 @@ blocksWithLabelsIds =
     , goalId
     , shortId
     , longId
+    , dontBreakId
     ]
 
 

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -223,6 +223,7 @@ example =
                     [ Fonts.quizFont
                     , Css.fontSize (Css.px 30)
                     , Css.marginTop (Css.px 60)
+                    , Css.whiteSpace Css.pre
                     ]
                 ]
                 [ Block.view
@@ -262,6 +263,13 @@ example =
                     , Block.blue
                     , Block.labelId longId
                     , Block.labelPosition (Dict.get longId offsets)
+                    ]
+                , Block.view
+                    [ Block.plaintext "This is content"
+                    ]
+                , Block.view
+                    [ Block.plaintext ", that should not break before this comma!"
+                    , Block.label "Dont break"
                     ]
                 ]
             , Table.view []

--- a/src/Nri/Ui/Block/V4.elm
+++ b/src/Nri/Ui/Block/V4.elm
@@ -56,9 +56,15 @@ import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Position exposing (xOffsetPx)
 
 
-{-|
+{-| Create a block element.
 
-    Block.view [ Block.plaintext "Hello, world!" ]
+Note that it is important that a series of Block elements be wrapped in a container with "whitespace; pre" set.
+This will ensure that line breaks only happen at whitespace, and not directly before an emphasis block in
+situations where it would look strange (like if the block started with a comma).
+
+    p
+        [ css [ Css.whitespace Css.pre ] ]
+        [ Block.view [ Block.plaintext "Hello, world!" ] ]
 
 -}
 view : List (Attribute msg) -> Html msg

--- a/src/Nri/Ui/Block/V4.elm
+++ b/src/Nri/Ui/Block/V4.elm
@@ -244,9 +244,17 @@ renderContent :
 renderContent content_ styles =
     case content_ of
         Word str ->
-            blockSegmentContainer Nothing
-                [ text str ]
-                styles
+            let
+                blockContainer =
+                    blockSegmentContainer Nothing
+                        [ text str ]
+                        styles
+            in
+            if str == " " then
+                span [] [ blockContainer, wbr [] [] ]
+
+            else
+                blockContainer
 
         WordWithId wordAndId ->
             blockSegmentContainer (Just wordAndId.id)
@@ -292,7 +300,7 @@ blockSegmentContainer : Maybe String -> List (Html msg) -> List Css.Style -> Htm
 blockSegmentContainer id_ children styles =
     span
         [ css
-            (Css.whiteSpace Css.preWrap
+            (Css.whiteSpace Css.pre
                 :: Css.display Css.inlineBlock
                 :: Css.position Css.relative
                 :: styles

--- a/src/Nri/Ui/Mark/V2.elm
+++ b/src/Nri/Ui/Mark/V2.elm
@@ -516,6 +516,7 @@ viewBalloon config label =
               Css.minWidth (Css.px 30)
             , Css.maxWidth (Css.px 150)
             , Css.textAlign Css.center
+            , Css.whiteSpace Css.normal
             , Css.property "word-break" "break-word"
             , Css.batch <|
                 case config.labelPosition of


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

We've had lots of reports of line breaking that is not ideal - especially when punctuation is emphasized.  I've tried various different approaches to fix this including: 
- Detecting when segments should not have space between them, splitting off the first/last word from plaintext, and wrapping the elements in a "nowrap" span (see https://github.com/NoRedInk/NoRedInk/pull/44103)
- Injectecting zero width joiners (`&NoBreak;`) between the span elements that shouldn't break

Nothing has worked completely. 

I think the only way we can get this breaking behavior exactly correct is to go full `whitespace: pre` on the entire sentence container, and then manually insert break point opportunities (`<wbr/>`) after every space.  Note here that being intentional about putting these **after** spaces means that we fix another annoyance where you can witness a space get bumped to the next line causing it to not line up correctly. 

## :framed_picture: What does this change look like?

https://github.com/NoRedInk/noredink-ui/assets/12899207/6f1eb7eb-b1f2-4ae4-b5dc-e85f82f10326

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
