### PR TITLE
Bump to 23.0.1 to include Block line breaking fixes

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "23.0.0",
+    "version": "23.0.1",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Ui",


### PR DESCRIPTION
# :label: Bump for version `23.0.1`

## What changes does this release include?

- https://github.com/NoRedInk/noredink-ui/pull/1382
- https://github.com/NoRedInk/noredink-ui/pull/1388
- https://github.com/NoRedInk/noredink-ui/pull/1395

## How has the API changed?

```
No API changes detected, so this is a PATCH change.
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).
