### PR TITLE
A11-2824 fix checkbox guidance alignment

### DIFF
--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -274,7 +274,7 @@ view { label, selected } attributes =
                 ( enabledLabelCss, icon )
             )
          ]
-            ++ InputErrorAndGuidanceInternal.view config_.identifier (Css.marginTop Css.zero) config_
+            ++ [ div [ css [ paddingLeft (px 40) ] ] (InputErrorAndGuidanceInternal.view config_.identifier (Css.marginTop Css.zero) config_) ]
         )
 
 


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Fixes checkbox guidance alignment.

## :framed_picture: What does this change look like?

### Before 
![guidance misaligned](https://github.com/NoRedInk/noredink-ui/assets/5647344/fc727d75-b7be-444f-93d1-a93e505def6e)

### After

![guidance aligned](https://github.com/NoRedInk/noredink-ui/assets/5647344/b0e124be-e15e-4e5d-91d7-87378fcaeb0e)

@NoRedInk/design 

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
