### PR TITLE
test with elm-test in buck2

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -86,6 +86,6 @@ genrule(
 
 prettier_diffs(
     name = "prettier_diffs",
-    srcs = glob(["**/*.md"]),
+    srcs = glob(["**/*.md", "script/**/*.js"]),
     prettier = "//:prettier",
 )

--- a/BUCK
+++ b/BUCK
@@ -14,6 +14,7 @@ elm_docs(
 elm_test(
     name = "elm_test",
     test_srcs = glob(["test/**/*.elm"]),
+    elm_test = ":elm_test_binary",
 )
 
 filegroup(
@@ -45,6 +46,13 @@ npm_bin(
         "//lib:prettier_diffs",
         "//component-catalog:prettier_diffs",
     ],
+)
+
+npm_bin(
+    name = "elm_test_binary",
+    bin_name = "elm-test",
+    node_modules = ":node_modules",
+    visibility = ["//component-catalog:elm_test"],
 )
 
 export_file(

--- a/BUCK
+++ b/BUCK
@@ -1,11 +1,19 @@
 # A list of available rules and their signatures can be found here: https://buck2.build/docs/api/rules/
-load("@prelude-nri//:elm.bzl", "elm_docs", "elm_format_diffs")
+load("@prelude-nri//:elm.bzl", "elm_docs", "elm_format_diffs", "elm_test")
 load("@prelude-nri//:node.bzl", "node_modules", "npm_bin", "npm_script_test", "prettier_diffs")
 
 elm_docs(
     name = "docs.json",
     elm_json = "elm.json",
     src = "src",
+    tests = [
+        ":elm_test",
+    ],
+)
+
+elm_test(
+    name = "elm_test",
+    test_srcs = glob(["test/**/*.elm"]),
 )
 
 filegroup(

--- a/BUCK
+++ b/BUCK
@@ -13,7 +13,7 @@ elm_docs(
 
 elm_test(
     name = "elm_test",
-    test_srcs = glob(["test/**/*.elm"]),
+    test_srcs = glob(["tests/**/*.elm"]),
     elm_test = ":elm_test_binary",
 )
 

--- a/BUCK
+++ b/BUCK
@@ -63,10 +63,11 @@ export_file(
 npm_script_test(
     name = "puppeteer",
     node_modules = ":node_modules",
-    args = ["default", "$(location //component-catalog:public)"],
+    args = ["default", "public"],
     extra_files = {
         "script/puppeteer-tests.sh": "script/puppeteer-tests.sh",
         "script/puppeteer-tests.js": "script/puppeteer-tests.js",
+        "public": "//component-catalog:public",
     },
 )
 

--- a/component-catalog/BUCK
+++ b/component-catalog/BUCK
@@ -1,4 +1,4 @@
-load("@prelude-nri//:elm.bzl", "elm_app", "elm_format_diffs")
+load("@prelude-nri//:elm.bzl", "elm_app", "elm_format_diffs", "elm_test")
 load("@prelude-nri//:node.bzl", "prettier_diffs")
 
 elm_app(
@@ -10,6 +10,14 @@ elm_app(
         "../src": "//:src",
         "src": "src",
     },
+    tests = [
+        ":elm_test",
+    ],
+)
+
+elm_test(
+    name = "elm_test",
+    test_srcs = glob(["tests/**/*.elm"]),
 )
 
 filegroup(

--- a/component-catalog/BUCK
+++ b/component-catalog/BUCK
@@ -18,6 +18,7 @@ elm_app(
 elm_test(
     name = "elm_test",
     test_srcs = glob(["tests/**/*.elm"]),
+    elm_test = "//:elm_test_binary",
 )
 
 filegroup(

--- a/component-catalog/review/elm.json
+++ b/component-catalog/review/elm.json
@@ -9,7 +9,7 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.12.2",
+            "jfmengels/elm-review": "2.13.0",
             "jfmengels/elm-review-unused": "1.1.29",
             "stil4m/elm-syntax": "7.2.9"
         },

--- a/elm.json
+++ b/elm.json
@@ -113,9 +113,9 @@
         "tesk9/palette": "3.0.1 <= v < 4.0.0"
     },
     "test-dependencies": {
-        "avh4/elm-program-test": "3.3.0 <= v < 4.0.0",
+        "avh4/elm-program-test": "4.0.0 <= v < 5.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
-        "elm-explorations/test": "1.2.2 <= v < 2.0.0",
+        "elm-explorations/test": "2.0.0 <= v < 3.0.0",
         "tesk9/accessible-html": "5.0.0 <= v < 6.0.0"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,10 +11,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "82e5cd1ad3c387863f0545d7591512e76ab0fc41",
-        "sha256": "090l219mzc0gi33i3psgph6s2pwsc8qy4lyrqjdj4qzkvmaj65a7",
+        "rev": "7225521219f64df00de86c3b946a26f608f3b4dc",
+        "sha256": "04w9c06f70n0k9c4xhma4nfrkxxg7d039xd3v9dak8xd7avjb7v0",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/82e5cd1ad3c387863f0545d7591512e76ab0fc41.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/7225521219f64df00de86c3b946a26f608f3b4dc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -23,10 +23,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2b34f0f11ed8ad83d9ec9c14260192c3bcccb0d",
-        "sha256": "1n9lhqprqnsiv4nw59mh5ab7hchx7lhvq43kkv64473jwz1xv7ki",
+        "rev": "7e0743a5aea1dc755d4b761daf75b20aa486fdad",
+        "sha256": "1zs1l3aivfwxmdrjvkiwqqj50z4yww5rx41m5b3qi6jv9pd9185r",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e2b34f0f11ed8ad83d9ec9c14260192c3bcccb0d.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/7e0743a5aea1dc755d4b761daf75b20aa486fdad.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@percy/puppeteer": "^2.0.2",
         "axe-core": "^4.7.0",
         "browserify": "^17.0.0",
+        "elm-test": "0.19.1-revision12",
         "expect": "29.5.0",
         "mocha": "^10.2.0",
         "prettier": "^2.7.1",
@@ -1266,6 +1267,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1641,6 +1651,76 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true
+    },
+    "node_modules/elm-solve-deps-wasm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/elm-solve-deps-wasm/-/elm-solve-deps-wasm-1.0.2.tgz",
+      "integrity": "sha512-qnwo7RO9IO7jd9SLHvIy0rSOEIlc/tNMTE9Cras0kl+b161PVidW4FvXo0MtXU8GAKi/2s/HYvhcnpR/NNQ1zw==",
+      "dev": true
+    },
+    "node_modules/elm-test": {
+      "version": "0.19.1-revision12",
+      "resolved": "https://registry.npmjs.org/elm-test/-/elm-test-0.19.1-revision12.tgz",
+      "integrity": "sha512-5GV3WkJ8R/faOP1hwElQdNuCt8tKx2+1lsMrdeIYWSFz01Kp9gJl/R6zGtp4QUyrUtO8KnHsxjHrQNUf2CHkrg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "commander": "^9.4.1",
+        "cross-spawn": "^7.0.3",
+        "elm-solve-deps-wasm": "^1.0.2",
+        "glob": "^8.0.3",
+        "graceful-fs": "^4.2.10",
+        "split": "^1.0.1",
+        "which": "^2.0.2",
+        "xmlbuilder": "^15.1.1"
+      },
+      "bin": {
+        "elm-test": "bin/elm-test"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/elm-test/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/elm-test/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/elm-test/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3998,6 +4078,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/sshpk": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
@@ -4592,6 +4684,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/xtend": {
@@ -5695,6 +5796,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6013,6 +6120,63 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
           "dev": true
+        }
+      }
+    },
+    "elm-solve-deps-wasm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/elm-solve-deps-wasm/-/elm-solve-deps-wasm-1.0.2.tgz",
+      "integrity": "sha512-qnwo7RO9IO7jd9SLHvIy0rSOEIlc/tNMTE9Cras0kl+b161PVidW4FvXo0MtXU8GAKi/2s/HYvhcnpR/NNQ1zw==",
+      "dev": true
+    },
+    "elm-test": {
+      "version": "0.19.1-revision12",
+      "resolved": "https://registry.npmjs.org/elm-test/-/elm-test-0.19.1-revision12.tgz",
+      "integrity": "sha512-5GV3WkJ8R/faOP1hwElQdNuCt8tKx2+1lsMrdeIYWSFz01Kp9gJl/R6zGtp4QUyrUtO8KnHsxjHrQNUf2CHkrg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "commander": "^9.4.1",
+        "cross-spawn": "^7.0.3",
+        "elm-solve-deps-wasm": "^1.0.2",
+        "glob": "^8.0.3",
+        "graceful-fs": "^4.2.10",
+        "split": "^1.0.1",
+        "which": "^2.0.2",
+        "xmlbuilder": "^15.1.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
         }
       }
     },
@@ -7797,6 +7961,15 @@
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "dev": true
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
     "sshpk": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
@@ -8292,6 +8465,12 @@
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "dev": true,
       "requires": {}
+    },
+    "xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@percy/puppeteer": "^2.0.2",
     "axe-core": "^4.7.0",
     "browserify": "^17.0.0",
+    "elm-test": "0.19.1-revision12",
     "expect": "29.5.0",
     "mocha": "^10.2.0",
     "prettier": "^2.7.1",

--- a/prelude-nri/elm.bzl
+++ b/prelude-nri/elm.bzl
@@ -177,7 +177,7 @@ def _elm_test_impl(ctx: "context") -> [[DefaultInfo.type, ExternalRunnerTestInfo
         ExternalRunnerTestInfo(
             type = "elm_test",
             command = command,
-            run_from_project_root = False,
+            use_project_relative_paths = False,
         ),
     ]
 

--- a/prelude-nri/elm.bzl
+++ b/prelude-nri/elm.bzl
@@ -155,3 +155,44 @@ elm_format_diffs = rule(
         ),
     }
 )
+
+def _elm_test_impl(ctx: "context") -> [[DefaultInfo.type, ExternalRunnerTestInfo.type]]:
+    command = [
+        ctx.attrs._python_toolchain[PythonToolchainInfo].interpreter,
+        cmd_args(ctx.attrs._elm_toolchain[ElmToolchainInfo].elm_test_workdir[DefaultInfo].default_outputs),
+        "--elm-test-binary", "elm-test", # TODO parameterize
+        ctx.label.package or '.',
+        cmd_args(ctx.attrs._elm_toolchain.get(ElmToolchainInfo).elm, format="--compiler={}"),
+        cmd_args(str(ctx.attrs.fuzz), format="--fuzz={}"),
+    ]
+
+    if ctx.attrs.seed:
+        command.append(cmd_args(ctx.attrs.seed, format="--seed={}"))
+
+    command.extend(ctx.attrs.test_srcs)
+
+    return [
+        DefaultInfo(),
+        ExternalRunnerTestInfo(
+            type = "elm_test",
+            command = command,
+            run_from_project_root = False,
+        ),
+    ]
+
+elm_test = rule(
+    impl = _elm_test_impl,
+    attrs = {
+        "test_srcs": attrs.list(attrs.source()),
+        "fuzz": attrs.int(default=100),
+        "seed": attrs.option(attrs.string(), default=None),
+        "_elm_toolchain": attrs.toolchain_dep(
+            default = "toolchains//:elm",
+            providers = [ElmToolchainInfo],
+        ),
+        "_python_toolchain": attrs.toolchain_dep(
+            default = "toolchains//:python",
+            providers = [PythonToolchainInfo],
+        ),
+    },
+)

--- a/prelude-nri/elm.bzl
+++ b/prelude-nri/elm.bzl
@@ -160,7 +160,8 @@ def _elm_test_impl(ctx: "context") -> [[DefaultInfo.type, ExternalRunnerTestInfo
     command = [
         ctx.attrs._python_toolchain[PythonToolchainInfo].interpreter,
         cmd_args(ctx.attrs._elm_toolchain[ElmToolchainInfo].elm_test_workdir[DefaultInfo].default_outputs),
-        "--elm-test-binary", "elm-test", # TODO parameterize
+        "--elm-test-binary",
+        ctx.attrs.elm_test[RunInfo] if ctx.attrs.elm_test else "elm-test",
         ctx.label.package or '.',
         cmd_args(ctx.attrs._elm_toolchain.get(ElmToolchainInfo).elm, format="--compiler={}"),
         cmd_args(str(ctx.attrs.fuzz), format="--fuzz={}"),
@@ -186,6 +187,7 @@ elm_test = rule(
         "test_srcs": attrs.list(attrs.source()),
         "fuzz": attrs.int(default=100),
         "seed": attrs.option(attrs.string(), default=None),
+        "elm_test": attrs.option(attrs.exec_dep(), default=None),
         "_elm_toolchain": attrs.toolchain_dep(
             default = "toolchains//:elm",
             providers = [ElmToolchainInfo],

--- a/prelude-nri/elm/BUCK
+++ b/prelude-nri/elm/BUCK
@@ -3,6 +3,11 @@ export_file(
     visibility = ["PUBLIC"],
 )
 
+export_file(
+    name = "elm_test_workdir.py",
+    visibility = ["PUBLIC"],
+)
+
 ELM_COMPILER_URL = select({
     "config//os:linux": "https://github.com/elm/compiler/releases/download/0.19.1/binary-for-linux-64-bit.gz",
     "config//os:macos": "https://github.com/elm/compiler/releases/download/0.19.1/binary-for-mac-64-bit.gz",
@@ -24,6 +29,7 @@ genrule(
     cmd = "gzip --decompress --stdout --keep $(location :elm_compiler_archive) > $OUT && chmod +x $OUT",
     out = "elm",
     executable = True,
+    remote = True,
     visibility = ["PUBLIC"],
 )
 
@@ -54,5 +60,6 @@ genrule(
     out = "elm-format",
     cmd = "cp $(location :elm_format_archive)/elm-format $OUT",
     executable = True,
+    remote = True,
     visibility = ["PUBLIC"],
 )

--- a/prelude-nri/elm/elm_test_workdir.py
+++ b/prelude-nri/elm/elm_test_workdir.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+import argparse
+import subprocess
+import sys
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "root", help="Where to change directory to before running elm-test"
+    )
+    parser.add_argument(
+        "--elm-test-binary",
+        default="elm-test",
+        help="The binary to invoke for elm-test",
+    )
+    parser.add_argument(
+        "elm_test_args",
+        nargs=argparse.REMAINDER,
+        help="Args to be passed on to elm-test",
+    )
+
+    args = parser.parse_args()
+
+    returncode = subprocess.call(
+        [args.elm_test_binary] + args.elm_test_args, cwd=args.root
+    )
+    sys.exit(returncode)

--- a/prelude-nri/elm/toolchain.bzl
+++ b/prelude-nri/elm/toolchain.bzl
@@ -1,7 +1,8 @@
 ElmToolchainInfo = provider(fields = [
     "elm",
-    "isolated_compile",
     "elm_format",
+    "isolated_compile",
+    "elm_test_workdir",
 ])
 
 def _system_elm_toolchain_impl(ctx) -> [[DefaultInfo.type, ElmToolchainInfo.type]]:
@@ -15,6 +16,7 @@ def _system_elm_toolchain_impl(ctx) -> [[DefaultInfo.type, ElmToolchainInfo.type
             elm = RunInfo(args = ["elm"]),
             elm_format = RunInfo(args = ["elm-format"]),
             isolated_compile = ctx.attrs._isolated_compile,
+            elm_test_workdir = ctx.attrs._elm_test_workdir,
         ),
     ]
 
@@ -22,6 +24,7 @@ system_elm_toolchain = rule(
     impl = _system_elm_toolchain_impl,
     attrs = {
         "_isolated_compile": attrs.dep(default = "prelude-nri//elm:isolated_compile.py"),
+        "_elm_test_workdir": attrs.dep(default = "prelude-nri//elm:elm_test_workdir.py"),
     },
     is_toolchain_rule = True,
 )
@@ -37,21 +40,23 @@ def _elm_toolchain_impl(ctx: "context") -> [[DefaultInfo.type, ElmToolchainInfo.
             elm = ctx.attrs.elm[RunInfo],
             elm_format = ctx.attrs.elm_format[RunInfo],
             isolated_compile = ctx.attrs._isolated_compile,
+            elm_test_workdir = ctx.attrs._elm_test_workdir,
         ),
     ]
 
 elm_toolchain = rule(
     impl = _elm_toolchain_impl,
     attrs = {
-        "elm": attrs.dep(
+        "elm": attrs.exec_dep(
             providers = [RunInfo],
             default = "prelude-nri//elm:elm_compiler_binary",
         ),
-        "elm_format": attrs.dep(
+        "elm_format": attrs.exec_dep(
             providers = [RunInfo],
             default = "prelude-nri//elm:elm_format_binary",
         ),
         "_isolated_compile": attrs.dep(default = "prelude-nri//elm:isolated_compile.py"),
+        "_elm_test_workdir": attrs.dep(default = "prelude-nri//elm:elm_test_workdir.py"),
     },
     is_toolchain_rule = True,
 )

--- a/prelude-nri/node.bzl
+++ b/prelude-nri/node.bzl
@@ -127,6 +127,7 @@ def _npm_script_test_impl(ctx: "context") -> [[DefaultInfo.type, ExternalRunnerT
         ExternalRunnerTestInfo(
             type = "npm",
             command = cmd,
+            use_project_relative_paths = False,
         ),
         DefaultInfo(),
     ]

--- a/review/elm.json
+++ b/review/elm.json
@@ -9,7 +9,7 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.12.2",
+            "jfmengels/elm-review": "2.13.0",
             "jfmengels/elm-review-unused": "1.1.29",
             "stil4m/elm-syntax": "7.2.9"
         },

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -18,14 +18,18 @@ describe("UI tests", function () {
   let browser;
 
   before(async () => {
-    let root = process.env.ROOT || `${__dirname}/../public`
+    let root = process.env.ROOT || `${__dirname}/../public`;
 
     if (!fs.existsSync(root)) {
-      assert.fail(`Root was specified as ${root}, but that path does not exist.`)
+      assert.fail(
+        `Root was specified as ${root}, but that path does not exist.`
+      );
     }
 
     if (!fs.existsSync(`${root}/index.html`)) {
-      assert.fail(`Root was specified as ${root}, but does not contain an index.html.`)
+      assert.fail(
+        `Root was specified as ${root}, but does not contain an index.html.`
+      );
     }
 
     server = httpServer.createServer({ root });
@@ -43,10 +47,10 @@ describe("UI tests", function () {
   });
 
   const handlePageErrors = function (page) {
-    page.on('pageerror', (err) => {
+    page.on("pageerror", (err) => {
       console.log("Error from page:", err.toString());
-    })
-  }
+    });
+  };
 
   const handleAxeResults = function (name, results) {
     const violations = results["violations"];
@@ -204,7 +208,7 @@ describe("UI tests", function () {
   it("All", async function () {
     page = await browser.newPage();
     handlePageErrors(page);
-    await page.goto(`http://localhost:${PORT}`);
+    await page.goto(`http://localhost:${PORT}`, { waitUntil: "load" });
     await page.$("#maincontent");
     await percySnapshot(page, this.test.fullTitle());
 

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -1,4 +1,5 @@
 const expect = require("expect");
+const fs = require("fs");
 const puppeteer = require("puppeteer");
 const httpServer = require("http-server");
 const percySnapshot = require("@percy/puppeteer");
@@ -17,9 +18,17 @@ describe("UI tests", function () {
   let browser;
 
   before(async () => {
-    server = httpServer.createServer({
-      root: process.env.ROOT || `${__dirname}/../public`,
-    });
+    let root = process.env.ROOT || `${__dirname}/../public`
+
+    if (!fs.existsSync(root)) {
+      assert.fail(`Root was specified as ${root}, but that path does not exist.`)
+    }
+
+    if (!fs.existsSync(`${root}/index.html`)) {
+      assert.fail(`Root was specified as ${root}, but does not contain an index.html.`)
+    }
+
+    server = httpServer.createServer({ root });
     server.listen(PORT);
 
     browser = await puppeteer.launch({

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -33,6 +33,12 @@ describe("UI tests", function () {
     server.close();
   });
 
+  const handlePageErrors = function (page) {
+    page.on('pageerror', (err) => {
+      console.log("Error from page:", err.toString());
+    })
+  }
+
   const handleAxeResults = function (name, results) {
     const violations = results["violations"];
     if (violations.length > 0) {
@@ -188,6 +194,7 @@ describe("UI tests", function () {
 
   it("All", async function () {
     page = await browser.newPage();
+    handlePageErrors(page);
     await page.goto(`http://localhost:${PORT}`);
     await page.$("#maincontent");
     await percySnapshot(page, this.test.fullTitle());
@@ -208,6 +215,7 @@ describe("UI tests", function () {
 
   it("Doodads", async function () {
     page = await browser.newPage();
+    handlePageErrors(page);
     await page.goto(`http://localhost:${PORT}`);
 
     await page.$("#maincontent");


### PR DESCRIPTION
This tests the package with elm-test in buck2. It temporarily adds elm-test (the package) to Node's package set, just because it probably doesn't make sense to figure out how to grab binaries from Nix at the same time (but WAT-600 will do that.)