### PR TITLE
:wrench: Make the toggle button more flexible

### DIFF
--- a/component-catalog/src/Examples/Button.elm
+++ b/component-catalog/src/Examples/Button.elm
@@ -224,6 +224,15 @@ initDebugControls =
                         , ( "success", Button.success )
                         ]
                     )
+                |> ControlExtra.optionalListItem "toggleButtonPressed"
+                    (Control.map
+                        (\bool ->
+                            ( "toggleButtonPressed " ++ Code.bool bool
+                            , Button.toggleButtonPressed bool
+                            )
+                        )
+                        (Control.bool True)
+                    )
                 |> ControlExtra.optionalBoolListItem "submit (button only)"
                     ( "Button.submit", Button.submit )
                 |> ControlExtra.optionalBoolListItem "opensModal (button only)"

--- a/component-catalog/src/Examples/Button.elm
+++ b/component-catalog/src/Examples/Button.elm
@@ -413,12 +413,12 @@ toggleButtons pressedToggleButtons =
             ]
         , div [ css [ Css.displayFlex, Css.marginBottom (Css.px 20) ] ]
             [ Button.button "5"
-                [ Button.toggleButtonPressed (Set.member 1 pressedToggleButtons)
-                , Button.onClick (ToggleToggleButton 1)
+                [ Button.toggleButtonPressed (Set.member 0 pressedToggleButtons)
+                , Button.onClick (ToggleToggleButton 0)
                 ]
             , Button.button "Kindergarten"
-                [ Button.toggleButtonPressed (Set.member 2 pressedToggleButtons)
-                , Button.onClick (ToggleToggleButton 2)
+                [ Button.toggleButtonPressed (Set.member 1 pressedToggleButtons)
+                , Button.onClick (ToggleToggleButton 1)
                 ]
             ]
         ]

--- a/component-catalog/src/Examples/Button.elm
+++ b/component-catalog/src/Examples/Button.elm
@@ -403,17 +403,13 @@ toggleButtons pressedToggleButtons =
             , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
             ]
         , div [ css [ Css.displayFlex, Css.marginBottom (Css.px 20) ] ]
-            [ Button.toggleButton
-                { onDeselect = ToggleToggleButton 0
-                , onSelect = ToggleToggleButton 0
-                , label = "5"
-                , pressed = Set.member 0 pressedToggleButtons
-                }
-            , Button.toggleButton
-                { onDeselect = ToggleToggleButton 1
-                , onSelect = ToggleToggleButton 1
-                , label = "Kindergarten"
-                , pressed = Set.member 1 pressedToggleButtons
-                }
+            [ Button.button "5"
+                [ Button.toggleButtonPressed (Set.member 1 pressedToggleButtons)
+                , Button.onClick (ToggleToggleButton 1)
+                ]
+            , Button.button "Kindergarten"
+                [ Button.toggleButtonPressed (Set.member 2 pressedToggleButtons)
+                , Button.onClick (ToggleToggleButton 2)
+                ]
             ]
         ]

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -3,6 +3,7 @@ module Nri.Ui.Button.V10 exposing
     , Attribute
     , onClick, submit, opensModal
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
+    , toggleButtonPressed
     , small, medium, large, modal
     , exactWidth, boundedWidth, unboundedWidth, fillContainerWidth
     , exactWidthForMobile, boundedWidthForMobile, unboundedWidthForMobile, fillContainerWidthForMobile
@@ -23,6 +24,7 @@ module Nri.Ui.Button.V10 exposing
 The next version of `Button` should add a `hideTextForMobile` helper.
 This will require adding a selector for the text. We are not making this change in V10, as
 adding a span around the text could potentially lead to regressions.
+The next version of `Button` should also remove `delete` and `toggleButton`
 
 
 # Patch changes:
@@ -55,6 +57,7 @@ adding a span around the text could potentially lead to regressions.
 
 @docs onClick, submit, opensModal
 @docs href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
+@docs toggleButtonPressed
 
 
 ## Sizing
@@ -598,6 +601,13 @@ premium =
 -- BUTTON STATE
 
 
+{-| Mark the button as a toggle button, and pass in its pressed state.
+-}
+toggleButtonPressed : Bool -> Attribute msg
+toggleButtonPressed pressed =
+    set (\attributes -> { attributes | pressed = Just pressed })
+
+
 type ButtonState
     = Enabled
     | Unfulfilled
@@ -710,6 +720,7 @@ build =
         , narrowMobileWidth = Nothing
         , label = ""
         , state = Enabled
+        , pressed = Nothing
         , icon = Nothing
         , iconStyles = []
         , rightIcon = Nothing
@@ -732,6 +743,7 @@ type alias ButtonOrLinkAttributes msg =
     , narrowMobileWidth : Maybe ButtonWidth
     , label : String
     , state : ButtonState
+    , pressed : Maybe Bool
     , icon : Maybe Svg
     , iconStyles : List Style
     , rightIcon : Maybe Svg
@@ -753,6 +765,7 @@ renderButton ((ButtonOrLink config) as button_) =
         (ClickableAttributes.toButtonAttributes config.clickableAttributes
             { disabled = isDisabled config.state }
             ++ Attributes.class FocusRing.customClass
+            :: ExtraAttributes.maybe (Just >> Aria.pressed) config.pressed
             :: config.customAttributes
         )
         (viewContent button_)
@@ -833,7 +846,10 @@ delete config =
 -- TOGGLE BUTTON
 
 
-{-| A button that can be toggled into a pressed state and back again.
+{-| DEPRECATED - this helper will be removed in Button.V11. Use `toggleButtonPressed` attribute instead.
+
+A button that can be toggled into a pressed state and back again.
+
 -}
 toggleButton :
     { label : String

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -39,6 +39,7 @@ The next version of `Button` should also remove `delete` and `toggleButton`
   - adds `tertiary` style
   - adds `submit` and `opensModal`
   - adds `secondaryDanger` style
+  - marked toggleButton as deprecated and added toggleButtonPressed attribute
 
 
 # Changes from V9:

--- a/tests/Spec/Nri/Ui/Button.elm
+++ b/tests/Spec/Nri/Ui/Button.elm
@@ -1,0 +1,45 @@
+module Spec.Nri.Ui.Button exposing (spec)
+
+import Accessibility.Aria as Aria
+import Html.Styled exposing (Html, toUnstyled)
+import Nri.Ui.Button.V10 as Button
+import ProgramTest exposing (..)
+import Test exposing (..)
+import Test.Html.Selector exposing (..)
+
+
+spec : Test
+spec =
+    describe "Nri.Ui.Button.V10"
+        [ describe "toggleButtonPressed" toggleButtonPressed
+        ]
+
+
+toggleButtonPressed : List Test
+toggleButtonPressed =
+    [ test "can be pressed" <|
+        \() ->
+            program { pressed = False }
+                (\{ pressed } ->
+                    Button.button "Italic"
+                        [ Button.toggleButtonPressed pressed
+                        , Button.onClick { pressed = not pressed }
+                        ]
+                )
+                |> ensureViewHas [ attribute (Aria.pressed (Just False)) ]
+                |> clickButton "Italic"
+                |> ensureViewHas [ attribute (Aria.pressed (Just True)) ]
+                |> clickButton "Italic"
+                |> ensureViewHas [ attribute (Aria.pressed (Just False)) ]
+                |> done
+    ]
+
+
+program : model -> (model -> Html model) -> ProgramTest model model ()
+program init view =
+    ProgramTest.createSandbox
+        { init = init
+        , update = \msg model -> msg
+        , view = \model -> Html.Styled.div [] [ view model ] |> toUnstyled
+        }
+        |> ProgramTest.start ()


### PR DESCRIPTION
## Context

Currently, the formatting tutorial features toggle buttons for setting capitalization, italicization, and quotation marks for selected text.

<img width="213" alt="screenshot of formatting tutorial toggle buttons" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/d43df915-c20c-4e2e-a5a3-9630a99d4b38">

Because the toggle button API differed from the rest of the Button api, and therefore didn't support adding an explicit aria-label, the accessible names of these buttons are literally "CAPS", "I", and "“ ”" -- not helpful and not clear!

This PR marks the current toggle button implementation as deprecated and adds a new Button attribute that fits in to the rest of the nice-and-flexible Button API. This way, it will be straightforward to replace the accessible names for these buttons.

Fixes A11-885 partially

## :framed_picture: What does this change look like?

<img width="268" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/066e2062-8301-4100-9955-db1d4c25d941">

(no change intended in the above screenshot. Including just in case you see something I missed!)


<img width="431" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/86541196-3335-410c-bc43-670c5e18e582">

@NoRedInk/design 

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
