### PR TITLE
Adjust CharacterIcon and Confetti previews

### DIFF
--- a/component-catalog/src/Examples/CharacterIcon.elm
+++ b/component-catalog/src/Examples/CharacterIcon.elm
@@ -40,7 +40,13 @@ example =
     -- We need to start off with a blank example image to avoid axe violations for having duplicated ids
     , icon = Nri.Ui.Svg.V1.init "0 0 480 600" []
     , renderSvgCode = \name -> Code.fromModule moduleName name
-    , preview = IconExamples.preview [ CharacterIcon.lindyInstructive, CharacterIcon.lindySupportive, CharacterIcon.salInstructive, CharacterIcon.salSupportive, CharacterIcon.redInstructive, CharacterIcon.redSupportive ]
+    , preview =
+        IconExamples.previewCustomSize ( Just 70, Just 80 )
+            [ CharacterIcon.lindyInstructive
+            , CharacterIcon.salInstructive
+            , CharacterIcon.redInstructive
+            , CharacterIcon.redSupportive
+            ]
     , all = all
     }
         |> IconExamples.example

--- a/component-catalog/src/Examples/Confetti.elm
+++ b/component-catalog/src/Examples/Confetti.elm
@@ -15,7 +15,6 @@ import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
-import Html.Styled.Attributes exposing (attribute)
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.Extra as ColorsExtra
 import Nri.Ui.Colors.V1 as Colors
@@ -123,7 +122,7 @@ preview =
     [ Svg.svg
         [ SvgAttrs.viewBox "0 0 100 100"
         , SvgAttrs.width "100%"
-        , SvgAttrs.height "100%"
+        , SvgAttrs.height "120px"
         , SvgAttrs.fill (ColorsExtra.toCssString Colors.white)
         , Role.img
         ]

--- a/component-catalog/src/Examples/Confetti.elm
+++ b/component-catalog/src/Examples/Confetti.elm
@@ -6,16 +6,23 @@ module Examples.Confetti exposing (example, State, Msg)
 
 -}
 
+import Accessibility.Styled.Role as Role
 import Browser.Events
 import Category exposing (Category(..))
 import Code
+import Css exposing (Color)
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
+import Html.Styled.Attributes exposing (attribute)
 import Nri.Ui.Button.V10 as Button
+import Nri.Ui.Colors.Extra as ColorsExtra
+import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Confetti.V2 as Confetti
 import Nri.Ui.Html.V3 exposing (viewJust)
+import Svg.Styled as Svg exposing (Svg)
+import Svg.Styled.Attributes as SvgAttrs
 
 
 moduleName : String
@@ -48,7 +55,7 @@ example =
 
                 Nothing ->
                     Sub.none
-    , preview = []
+    , preview = preview
     , view =
         \ellieLinkConfig state ->
             [ viewJust Confetti.view state.model
@@ -109,6 +116,89 @@ example =
                 ]
             ]
     }
+
+
+preview : List (Svg msg)
+preview =
+    [ Svg.svg
+        [ SvgAttrs.viewBox "0 0 100 100"
+        , SvgAttrs.width "100%"
+        , SvgAttrs.height "100%"
+        , SvgAttrs.fill (ColorsExtra.toCssString Colors.white)
+        , Role.img
+        ]
+        (Svg.rect
+            [ SvgAttrs.x "0"
+            , SvgAttrs.y "0"
+            , SvgAttrs.width "100"
+            , SvgAttrs.height "100"
+            ]
+            []
+            :: List.map3
+                (\( x, y ) index color ->
+                    Svg.rect
+                        [ SvgAttrs.x (String.fromInt x)
+                        , SvgAttrs.y (String.fromInt y)
+                        , SvgAttrs.width "8"
+                        , SvgAttrs.height "8"
+                        , SvgAttrs.fill (ColorsExtra.toCssString color)
+                        , SvgAttrs.transform <|
+                            "rotate("
+                                ++ ((if modBy 3 index == 0 then
+                                        "45"
+
+                                     else if modBy 2 index == 0 then
+                                        "20"
+
+                                     else
+                                        "0"
+                                    )
+                                        ++ ","
+                                        ++ String.fromInt x
+                                        ++ ","
+                                        ++ String.fromInt y
+                                        ++ ")"
+                                   )
+                        ]
+                        []
+                )
+                confettiPositions
+                (List.range 0 10)
+                confettiColors
+        )
+    ]
+
+
+confettiPositions : List ( Int, Int )
+confettiPositions =
+    [ ( 40, 10 )
+    , ( 7, 15 )
+    , ( 80, 30 )
+    , ( 4, 80 )
+    , ( 23, 70 )
+    , ( 50, 69 )
+    , ( 19, 52 )
+    , ( 70, 90 )
+    , ( 60, 90 )
+    , ( 94, 60 )
+    , ( 80, 5 )
+    ]
+
+
+confettiColors : List Color
+confettiColors =
+    [ Colors.highlightMagentaDark
+    , Colors.highlightCyan
+    , Colors.highlightGreen
+    , Colors.highlightYellowDark
+    , Colors.highlightBlue
+    , Colors.highlightGreenDark
+    , Colors.highlightBlueDark
+    , Colors.highlightYellow
+    , Colors.highlightCyanDark
+    , Colors.highlightCyan
+    , Colors.highlightMagenta
+    ]
 
 
 {-| -}

--- a/component-catalog/src/Examples/IconExamples.elm
+++ b/component-catalog/src/Examples/IconExamples.elm
@@ -2,7 +2,7 @@ module Examples.IconExamples exposing
     ( example
     , Settings, Msg
     , Group
-    , preview
+    , preview, previewCustomSize
     )
 
 {-|
@@ -10,7 +10,7 @@ module Examples.IconExamples exposing
 @docs example
 @docs Settings, Msg
 @docs Group
-@docs preview
+@docs preview, previewCustomSize
 
 -}
 
@@ -60,7 +60,22 @@ example config =
 
 {-| -}
 preview : List Svg.Svg -> List (Html msg)
-preview icons =
+preview =
+    previewCustomSize ( Just 30, Just 30 )
+
+
+{-| -}
+previewCustomSize : ( Maybe Float, Maybe Float ) -> List Svg.Svg -> List (Html msg)
+previewCustomSize ( width, height ) icons =
+    let
+        setWidth =
+            Maybe.map (Svg.withWidth << Css.px) width
+                |> Maybe.withDefault identity
+
+        setHeight =
+            Maybe.map (Svg.withHeight << Css.px) height
+                |> Maybe.withDefault identity
+    in
     [ Html.div
         [ css
             [ Css.displayFlex
@@ -70,7 +85,7 @@ preview icons =
             ]
         ]
         (List.map
-            (Svg.withWidth (Css.px 30) >> Svg.withHeight (Css.px 30) >> Svg.toHtml)
+            (setWidth >> setHeight >> Svg.toHtml)
             icons
         )
     ]

--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -6,8 +6,9 @@ Nri.Ui.Highlighter.V2,upgrade to V4
 Nri.Ui.Highlighter.V3,upgrade to V4
 Nri.Ui.HighlighterToolbar.V1,upgrade to V3
 Nri.Ui.HighlighterToolbar.V2,upgrade to V3
-Nri.Ui.QuestionBox.V2,upgrade to V4
-Nri.Ui.QuestionBox.V3,upgrade to V4
+Nri.Ui.QuestionBox.V2,upgrade to V5
+Nri.Ui.QuestionBox.V3,upgrade to V5
+Nri.Ui.QuestionBox.V4,upgrade to V5
 Nri.Ui.Select.V8,upgrade to V9
 Nri.Ui.SortableTable.V3,upgrade to V4
 Nri.Ui.Table.V6,upgrade to V7

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -159,11 +159,14 @@ hint = 'upgrade to V8'
 hint = 'upgrade to V3'
 
 [forbidden."Nri.Ui.QuestionBox.V2"]
-hint = 'upgrade to V4'
+hint = 'upgrade to V5'
 usages = ['component-catalog/../src/Nri/Ui/Block/V3.elm']
 
 [forbidden."Nri.Ui.QuestionBox.V3"]
-hint = 'upgrade to V4'
+hint = 'upgrade to V5'
+
+[forbidden."Nri.Ui.QuestionBox.V4"]
+hint = 'upgrade to V5'
 
 [forbidden."Nri.Ui.RadioButton.V1"]
 hint = 'upgrade to V2'


### PR DESCRIPTION
| | Before | After |
| --- | --- | --- |
| CharacterIcon | <img width="212" alt="Screen Shot 2023-06-14 at 1 51 48 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/80f46a82-47b1-405f-9fe2-e653c7d1f8da"> |  <img width="212" alt="Screen Shot 2023-06-14 at 1 51 26 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/45672fcd-a79f-4da7-92fb-f533af7d670f"> |
| Confetti | <img width="211" alt="Screen Shot 2023-06-14 at 1 52 06 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/cb602723-55de-4611-ac53-98e7c258f8d0"> | <img width="214" alt="Screen Shot 2023-06-14 at 1 53 28 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/8a9599bb-91b7-4985-837e-8e5ed8ff57a9"> |
