### PR TITLE
:wrench: Animating the block labels

### DIFF
--- a/src/Nri/Ui/Mark/V2.elm
+++ b/src/Nri/Ui/Mark/V2.elm
@@ -24,6 +24,7 @@ import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Style exposing (invisibleStyle)
 import Content
 import Css exposing (Color, Style)
+import Css.Animations
 import Css.Global
 import Html.Styled as Html exposing (Html, span)
 import Html.Styled.Attributes exposing (class, css)
@@ -506,6 +507,19 @@ viewBalloon config label =
 
                 Nothing ->
                     Css.batch []
+            , case config.labelPosition of
+                Nothing ->
+                    Css.opacity Css.zero
+
+                Just _ ->
+                    Css.batch
+                        [ Css.property "animation-delay" "2s"
+                        , Css.property "animation-duration" "0.5s"
+                        , Css.property "animation-fill-mode" "forwards"
+                        , Css.animationName balloonFadeInKeyframes
+                        , Css.property "animation-timing-function" "linear"
+                        , Css.opacity Css.zero
+                        ]
             ]
         , Balloon.css
             [ Css.padding3 Css.zero (Css.px 6) (Css.px 1)
@@ -562,6 +576,14 @@ viewBalloon config label =
 
             Nothing ->
                 Balloon.css []
+        ]
+
+
+balloonFadeInKeyframes : Css.Animations.Keyframes {}
+balloonFadeInKeyframes =
+    Css.Animations.keyframes
+        [ ( 0, [ Css.Animations.opacity Css.zero ] )
+        , ( 100, [ Css.Animations.opacity (Css.num 1) ] )
         ]
 
 

--- a/src/Nri/Ui/Mark/V2.elm
+++ b/src/Nri/Ui/Mark/V2.elm
@@ -570,6 +570,7 @@ viewBalloonSpacer config =
     span
         [ css
             [ Css.display Css.inlineBlock
+            , Css.property "transition" "padding 2s ease"
             , config.labelPosition
                 |> Maybe.map
                     (\{ totalHeight } ->


### PR DESCRIPTION
## Context

Fixes PHX-895

## :framed_picture: What does this change look like?


https://github.com/NoRedInk/noredink-ui/assets/8811312/a793a743-2bee-48c2-af3d-1d2d50272500

Current animations are:
0-2s - height of the lines changes, using `ease`
2s-2.5s - balloon fades in, using `linear`

I didn't play with these at all. I'm sure there are nicer easing functions and timings to use. It might make sense to not delay the fade-in indefinitely too.

@ravi-morbia, without getting your dev env set up, you _could_ play with these directly if you edit this PR on GitHub and then use the netlify preview.

## Component completion checklist

- [ ] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [ ] Changes are clearly documented
    - [ ] Component docs include a changelog
    - [ ] Any new exposed functions or properties have docs
- [ ] Changes extend to the Component Catalog
    - [ ] The Component Catalog is updated to use the newest version, if appropriate
    - [ ] The Component Catalog example version number is updated, if appropriate
    - [ ] Any new customizations are available from the Component Catalog
    - [ ] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [ ] Changes to the component are tested/the new version of the component is tested
- [ ] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
