### PR TITLE
Growth/un dogfood id generator

### DIFF
--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -65,6 +65,7 @@ import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.Svg.V1 exposing (Svg)
+import Nri.Ui.Util as Util
 
 
 {-| This disables the input
@@ -232,7 +233,7 @@ view { label, selected } attributes =
                     specificId
 
                 Nothing ->
-                    Extra.safeIdWithPrefix "checkbox-v7" label
+                    "checkbox-v7-" ++ Util.safeIdString label
 
         config_ =
             { identifier = idValue

--- a/src/Nri/Ui/Html/Attributes/V2.elm
+++ b/src/Nri/Ui/Html/Attributes/V2.elm
@@ -141,12 +141,26 @@ safeId unsafe =
                 |> Regex.fromString
                 |> Maybe.withDefault Regex.never
 
-        hyphenMinus : any -> String
-        hyphenMinus _ =
+        alphaAtStart : Regex
+        alphaAtStart =
+            "^[a-zA-Z]"
+                |> Regex.fromString
+                |> Maybe.withDefault Regex.never
+
+        prefix : String
+        prefix =
+            if Regex.contains alphaAtStart unsafe then
+                ""
+
+            else
+                "id-"
+
+        replaceWithHyphenMinus : any -> String
+        replaceWithHyphenMinus _ =
             "-"
     in
-    "id-"
+    prefix
         ++ Regex.replace
             nonAlphaNumUnderscoreHyphenAnywhere
-            hyphenMinus
+            replaceWithHyphenMinus
             unsafe

--- a/src/Nri/Ui/Html/Attributes/V2.elm
+++ b/src/Nri/Ui/Html/Attributes/V2.elm
@@ -164,3 +164,4 @@ safeId unsafe =
             nonAlphaNumUnderscoreHyphenAnywhere
             replaceWithHyphenMinus
             unsafe
+        |> String.toLower

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -53,6 +53,9 @@ import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.Pennant.V2 exposing (premiumFlag)
 import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.Util exposing (removePunctuation)
+import String exposing (toLower)
+import String.Extra exposing (dasherize)
 
 
 {-| Set a custom ID for this checkbox and label. If you don't set this,
@@ -202,7 +205,7 @@ view { label, onChange } attributes =
                     specificId
 
                 Nothing ->
-                    Extra.safeIdWithPrefix "checkbox" label
+                    "checkbox-" ++ dasherize (removePunctuation (toLower label))
 
         isPremium =
             config.premiumDisplay /= PremiumDisplay.Free

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -63,6 +63,7 @@ import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.Pennant.V2 as Pennant
 import Nri.Ui.Svg.V1 exposing (Svg)
+import Nri.Ui.Util as Util
 import Svg.Styled as Svg
 import Svg.Styled.Attributes as SvgAttributes
 
@@ -276,7 +277,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
                     specificId
 
                 Nothing ->
-                    Extra.safeId (name ++ "-" ++ stringValue)
+                    name ++ "-" ++ Util.safeIdString stringValue
 
         isChecked =
             selectedValue == Just value

--- a/src/Nri/Ui/SegmentedControl/V14.elm
+++ b/src/Nri/Ui/SegmentedControl/V14.elm
@@ -31,9 +31,9 @@ import Nri.Ui.Colors.Extra as ColorsExtra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Fonts.V1 as Fonts
-import Nri.Ui.Html.Attributes.V2 exposing (safeId)
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Tooltip.V3 as Tooltip
+import Nri.Ui.Util exposing (dashify)
 import TabsInternal.V2 as TabsInternal
 
 
@@ -132,7 +132,7 @@ viewRadioGroup config =
                         )
 
         name =
-            safeId config.legend
+            dashify (String.toLower config.legend)
 
         legendId =
             "legend-" ++ name

--- a/src/Nri/Ui/Select/V8.elm
+++ b/src/Nri/Ui/Select/V8.elm
@@ -59,6 +59,7 @@ import Nri.Ui.CssVendorPrefix.V1 as VendorPrefixed
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.InputStyles.V4 as InputStyles
+import Nri.Ui.Util
 import SolidColor
 
 
@@ -474,8 +475,8 @@ viewChoice current choice =
 {-| Pass in the label to generate the default DOM element id used by a `Select.view` with the given label.
 -}
 generateId : String -> String
-generateId =
-    Extra.safeIdWithPrefix "nri-select"
+generateId x =
+    "nri-select-" ++ Nri.Ui.Util.dashify (Nri.Ui.Util.removePunctuation x)
 
 
 selectArrowsCss : { config | disabled : Bool } -> Css.Style

--- a/src/Nri/Ui/Select/V9.elm
+++ b/src/Nri/Ui/Select/V9.elm
@@ -66,6 +66,7 @@ import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.InputStyles.V4 as InputStyles
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
+import Nri.Ui.Util
 import SolidColor
 
 
@@ -543,7 +544,7 @@ viewChoice current choice =
 -}
 generateId : String -> String
 generateId x =
-    Extra.safeIdWithPrefix "nri-select-" x
+    "nri-select-" ++ String.toLower (Nri.Ui.Util.dashify (Nri.Ui.Util.removePunctuation x))
 
 
 selectArrowsCss : { config | disabled : Bool } -> Css.Style

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -92,6 +92,7 @@ import InputLabelInternal
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.InputStyles.V4 as InputStyles exposing (Theme(..))
+import Nri.Ui.Util exposing (dashify, removePunctuation)
 
 
 {-| This is private. The public API only exposes `Attribute`.
@@ -457,5 +458,5 @@ writingSingleLineHeight =
 
 {-| -}
 generateId : String -> String
-generateId =
-    Extra.safeIdWithPrefix "nri-ui-text-area"
+generateId labelText =
+    "nri-ui-text-area-" ++ (dashify <| removePunctuation labelText)

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -72,6 +72,7 @@ import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.InputStyles.V4 as InputStyles exposing (defaultMarginTop)
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.UiIcon.V1 as UiIcon
+import Nri.Ui.Util exposing (dashify)
 import Time
 
 
@@ -981,8 +982,8 @@ view label attributes =
 This is for use when you need the DOM element id for use in javascript (such as trigger an event to focus a particular text input)
 -}
 generateId : String -> String
-generateId =
-    Extra.safeIdWithPrefix "Nri-Ui-TextInput"
+generateId labelText =
+    "Nri-Ui-TextInput-" ++ dashify labelText
 
 
 type alias FloatingContentConfig msg =

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -96,6 +96,7 @@ import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
 import Nri.Ui.MediaQuery.V1 as MediaQuery exposing (mobileBreakpoint, narrowMobileBreakpoint, quizEngineBreakpoint)
 import Nri.Ui.Shadows.V1 as Shadows
 import Nri.Ui.UiIcon.V1 as UiIcon
+import Nri.Ui.Util as Util
 import Nri.Ui.WhenFocusLeaves.V1 as WhenFocusLeaves
 
 
@@ -882,7 +883,7 @@ viewToggleTip : { label : String, lastId : Maybe String } -> List (Attribute msg
 viewToggleTip { label, lastId } attributes_ =
     let
         id =
-            ExtraAttributes.safeId label
+            Util.safeIdString label
 
         triggerId =
             "tooltip-trigger__" ++ id

--- a/src/Nri/Ui/Util.elm
+++ b/src/Nri/Ui/Util.elm
@@ -1,0 +1,89 @@
+module Nri.Ui.Util exposing (dashify, removePunctuation, safeIdString)
+
+import Regex exposing (Regex)
+
+
+{-| Convenience method for going from a string with spaces to a string with dashes.
+-}
+dashify : String -> String
+dashify =
+    let
+        regex =
+            Regex.fromString " "
+                |> Maybe.withDefault Regex.never
+    in
+    Regex.replace regex (always "-")
+
+
+{-| Convenience method for removing punctuation
+(removes everything that isn't whitespace, alphanumeric, or an underscore).
+-}
+removePunctuation : String -> String
+removePunctuation =
+    let
+        regex =
+            Regex.fromString "[^A-Za-z0-9\\w\\s]"
+                |> Maybe.withDefault Regex.never
+    in
+    Regex.replace regex (always "")
+
+
+{-| Creates a lowercased string that is safe to use for HTML IDs.
+Ensures that nonletter characters are cut from the front and replaces bad characters with a dash
+-}
+safeIdString : String -> String
+safeIdString =
+    let
+        nonAlphaAtStart =
+            -- From the start of the string, match the contiguous block of
+            -- not ASCII letters at the start of the String.
+            -- Why [a-zA-Z] and not [A-z]?
+            -- There are punctuation characters in that range: [\]^_` all come after Z and before a
+            "^[^a-zA-Z]+"
+
+        nonAlphaNumUnderscoreHyphenAnywhere =
+            -- any contiguous block of characters that aren't any of
+            -- + ASCII letters
+            -- + numbers
+            -- + underscore
+            -- + the hyphen-minus character commonly called "dash" (seen in between "hyphen" and "minus" on this line)
+            -- This does not need the + at the end; Regex.replace is global by default
+            -- but we pay a penalty for calling the replacement function, so
+            -- calling it once per contiguous group is an easy way to cut down on that.
+            "[^a-zA-Z0-9_-]+"
+
+        anyOfThese strs =
+            "(" ++ String.join "|" strs ++ ")"
+
+        unsafeChar =
+            [ nonAlphaAtStart
+            , nonAlphaNumUnderscoreHyphenAnywhere
+            ]
+                |> anyOfThese
+                |> regexFromString
+
+        nonAlphaNumAtEnd =
+            -- any contiguous block of letters that aren't any of
+            -- + ASCII letters
+            -- + numbers
+            regexFromString "[^a-zA-Z0-9]+$"
+
+        collapsePunctuationToOne =
+            regexFromString "[_-]+"
+    in
+    Regex.replace nonAlphaNumAtEnd (always "")
+        >> Regex.replace unsafeChar
+            (\{ index } ->
+                if index == 0 then
+                    ""
+
+                else
+                    "-"
+            )
+        >> Regex.replace collapsePunctuationToOne (always "-")
+        >> String.toLower
+
+
+regexFromString : String -> Regex
+regexFromString =
+    Regex.fromString >> Maybe.withDefault Regex.never

--- a/src/TabsInternal.elm
+++ b/src/TabsInternal.elm
@@ -16,6 +16,7 @@ import Html.Styled.Events as Events
 import Html.Styled.Keyed as Keyed
 import Json.Decode
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
+import Nri.Ui.Util exposing (dashify)
 
 
 {-| -}
@@ -52,7 +53,7 @@ viewTabs : Config id msg -> Html msg
 viewTabs config =
     Html.div
         [ Role.tabList
-        , Aria.owns (List.map (AttributesExtra.safeId << .idString) config.tabs)
+        , Aria.owns (List.map (tabToId << .idString) config.tabs)
         , Attributes.css config.tabListStyles
         ]
         (List.map (viewTab_ config) config.tabs)
@@ -102,7 +103,7 @@ viewTab_ config tab =
                , Aria.selected isSelected
                , Role.tab
                , Aria.controls [ tabToBodyId tab.idString ]
-               , Attributes.id (AttributesExtra.safeId tab.idString)
+               , Attributes.id (tabToId tab.idString)
                , Events.onFocus (config.onSelect tab.id)
                , Events.on "keyup" <|
                     Json.Decode.andThen (keyEvents config tab) Events.keyCode
@@ -120,7 +121,7 @@ keyEvents { onFocus, tabs } thisTab keyCode =
                     acc
 
                 ( True, Nothing ) ->
-                    ( True, Just (AttributesExtra.safeId tab.idString) )
+                    ( True, Just (tabToId tab.idString) )
 
                 ( False, Nothing ) ->
                     ( tab.id == thisTab.id, Nothing )
@@ -172,7 +173,7 @@ viewTabPanel : Tab id msg -> Bool -> Html msg
 viewTabPanel tab selected =
     Html.div
         ([ Role.tabPanel
-         , Aria.labelledBy (AttributesExtra.safeId tab.idString)
+         , Aria.labelledBy (tabToId tab.idString)
          , Attributes.id (tabToBodyId tab.idString)
          ]
             ++ (if selected then
@@ -190,11 +191,16 @@ viewTabPanel tab selected =
         [ tab.panelView ]
 
 
+tabToId : String -> String
+tabToId tab =
+    dashify (String.toLower tab)
+
+
 tabToBodyId : String -> String
-tabToBodyId =
-    AttributesExtra.safeIdWithPrefix "tab-body"
+tabToBodyId tab =
+    "tab-body-" ++ tabToId tab
 
 
 tabToKeyedNode : String -> String
-tabToKeyedNode =
-    AttributesExtra.safeIdWithPrefix "tabs-internal-keyed-node"
+tabToKeyedNode tab =
+    "tabs-internal-keyed-node-" ++ tabToId tab

--- a/src/TabsInternal/V2.elm
+++ b/src/TabsInternal/V2.elm
@@ -20,8 +20,9 @@ import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Html.Styled.Keyed as Keyed
 import Nri.Ui.FocusRing.V1 as FocusRing
-import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (safeId, safeIdWithPrefix)
+import Nri.Ui.Html.Attributes.V2 as AttributesExtra
 import Nri.Ui.Tooltip.V3 as Tooltip
+import Nri.Ui.Util exposing (dashify)
 
 
 {-| -}
@@ -92,7 +93,7 @@ viewTabs config =
         Html.div []
             [ Html.div
                 [ Role.tabList
-                , Aria.owns (List.map (safeId << .idString) config.tabs)
+                , Aria.owns (List.map (tabToId << .idString) config.tabs)
                 ]
                 []
             , Html.div [ Attributes.css config.tabListStyles ]
@@ -160,7 +161,7 @@ viewTab_ config index tab =
                        , Aria.selected isSelected
                        , Role.tab
                        , Aria.controls [ tabToBodyId tab.idString ]
-                       , Attributes.id (safeId tab.idString)
+                       , Attributes.id (tabToId tab.idString)
                        , Key.onKeyUpPreventDefault (keyEvents config tab)
                        ]
                     ++ (case tab.labelledBy of
@@ -192,7 +193,7 @@ viewTab_ config index tab =
 
         ( Nothing, tooltipAttributes ) ->
             Tooltip.view
-                { id = safeIdWithPrefix "tab-tooltip" tab.idString
+                { id = "tab-tooltip__" ++ tabToId tab.idString
                 , trigger = \eventHandlers -> buttonOrLink eventHandlers
                 }
                 ([ Tooltip.smallPadding
@@ -208,7 +209,7 @@ keyEvents { focusAndSelect, tabs } thisTab =
     let
         onFocus : Tab id msg -> msg
         onFocus tab =
-            focusAndSelect { select = tab.id, focus = Just (safeId tab.idString) }
+            focusAndSelect { select = tab.id, focus = Just (tabToId tab.idString) }
 
         findAdjacentTab : Tab id msg -> ( Bool, Maybe msg ) -> ( Bool, Maybe msg )
         findAdjacentTab tab ( isAdjacentTab, acc ) =
@@ -264,7 +265,7 @@ viewTabPanel : Tab id msg -> Bool -> Html msg
 viewTabPanel tab selected =
     Html.div
         ([ Role.tabPanel
-         , Aria.labelledBy (safeId tab.idString)
+         , Aria.labelledBy (tabToId tab.idString)
          , Attributes.id (tabToBodyId tab.idString)
          , Attributes.tabindex 0
          , Attributes.class FocusRing.customClass
@@ -286,11 +287,16 @@ viewTabPanel tab selected =
         [ tab.panelView ]
 
 
+tabToId : String -> String
+tabToId tab =
+    dashify (String.toLower tab)
+
+
 tabToBodyId : String -> String
-tabToBodyId =
-    safeIdWithPrefix "tab-body"
+tabToBodyId tab =
+    "tab-body-" ++ tabToId tab
 
 
 tabToKeyedNode : String -> String
-tabToKeyedNode =
-    safeIdWithPrefix "tabs-internal-keyed-node"
+tabToKeyedNode tab =
+    "tabs-internal-keyed-node-" ++ tabToId tab

--- a/tests/Spec/Nri/Ui/Html/Attributes.elm
+++ b/tests/Spec/Nri/Ui/Html/Attributes.elm
@@ -12,8 +12,8 @@ spec =
             [ test "with an apostrophe and multiple spaces" <|
                 \() ->
                     Attributes.safeId "Enable text-to-speech for  \t     Angela's account"
-                        |> Expect.equal "id-Enable-text-to-speech-for-Angela-s-account"
-            , test "lotsa hyphens and dashes" <|
+                        |> Expect.equal "Enable-text-to-speech-for-Angela-s-account"
+            , test "lotsa hyphens and dashes leading with a non-letter" <|
                 \() ->
                     Attributes.safeId "--__--hellO----_______---HOw----___---____--ArE------___You___--__--__Today"
                         |> Expect.equal "id---__--hellO----_______---HOw----___---____--ArE------___You___--__--__Today"
@@ -25,5 +25,11 @@ spec =
                         "000321 ¡¡VERY!! unsafe  "
                         "0--__--hellO----___!?[]____---HOw----___---____--ArE------___You___--__--__Today?"
                         |> Expect.equal "id-000321-VERY-unsafe--0--__--hellO----___-____---HOw----___---____--ArE------___You___--__--__Today-"
+            , test "test everything at once except the prefix" <|
+                \() ->
+                    Attributes.safeIdWithPrefix
+                        "safe_000321 ¡¡VERY!! unsafe  "
+                        "0--__--hellO----___!?[]____---HOw----___---____--ArE------___You___--__--__Today?"
+                        |> Expect.equal "safe_000321-VERY-unsafe--0--__--hellO----___-____---HOw----___---____--ArE------___You___--__--__Today-"
             ]
         ]

--- a/tests/Spec/Nri/Ui/Html/Attributes.elm
+++ b/tests/Spec/Nri/Ui/Html/Attributes.elm
@@ -12,11 +12,11 @@ spec =
             [ test "with an apostrophe and multiple spaces" <|
                 \() ->
                     Attributes.safeId "Enable text-to-speech for  \t     Angela's account"
-                        |> Expect.equal "Enable-text-to-speech-for-Angela-s-account"
+                        |> Expect.equal "enable-text-to-speech-for-angela-s-account"
             , test "lotsa hyphens and dashes leading with a non-letter" <|
                 \() ->
                     Attributes.safeId "--__--hellO----_______---HOw----___---____--ArE------___You___--__--__Today"
-                        |> Expect.equal "id---__--hellO----_______---HOw----___---____--ArE------___You___--__--__Today"
+                        |> Expect.equal "id---__--hello----_______---how----___---____--are------___you___--__--__today"
             ]
         , describe "safeIdWithPrefix"
             [ test "test everything at once" <|
@@ -24,12 +24,12 @@ spec =
                     Attributes.safeIdWithPrefix
                         "000321 ¡¡VERY!! unsafe  "
                         "0--__--hellO----___!?[]____---HOw----___---____--ArE------___You___--__--__Today?"
-                        |> Expect.equal "id-000321-VERY-unsafe--0--__--hellO----___-____---HOw----___---____--ArE------___You___--__--__Today-"
+                        |> Expect.equal "id-000321-very-unsafe--0--__--hello----___-____---how----___---____--are------___you___--__--__today-"
             , test "test everything at once except the prefix" <|
                 \() ->
                     Attributes.safeIdWithPrefix
                         "safe_000321 ¡¡VERY!! unsafe  "
                         "0--__--hellO----___!?[]____---HOw----___---____--ArE------___You___--__--__Today?"
-                        |> Expect.equal "safe_000321-VERY-unsafe--0--__--hellO----___-____---HOw----___---____--ArE------___You___--__--__Today-"
+                        |> Expect.equal "safe_000321-very-unsafe--0--__--hello----___-____---how----___---____--are------___you___--__--__today-"
             ]
         ]

--- a/tests/Spec/Nri/Ui/Select.elm
+++ b/tests/Spec/Nri/Ui/Select.elm
@@ -16,19 +16,19 @@ spec =
                 ungrouped
                     -- first option is selected automatically
                     |> ensureViewHas
-                        [ id "id-nri-select--Cat"
+                        [ id "nri-select-cat"
                         , selected True
                         , attribute (Attributes.value "Cat")
                         ]
                     |> selectAnimal Dog
                     |> ensureViewHas
-                        [ id "id-nri-select--Dog"
+                        [ id "nri-select-dog"
                         , selected True
                         , attribute (Attributes.value "Dog")
                         ]
                     |> selectAnimal Other
                     |> ensureViewHas
-                        [ id "id-nri-select--My-favorite-animal-is-something-else"
+                        [ id "nri-select-my-favorite-animal-is-something-else"
                         , selected True
                         , attribute (Attributes.value "My favorite animal is something else")
                         ]
@@ -38,25 +38,25 @@ spec =
                 grouped
                     -- first option is selected automatically
                     |> ensureViewHas
-                        [ id "id-nri-select--Cat"
+                        [ id "nri-select-cat"
                         , selected True
                         , attribute (Attributes.value "Cat")
                         ]
                     |> selectAnimal Dog
                     |> ensureViewHas
-                        [ id "id-nri-select--Dog"
+                        [ id "nri-select-dog"
                         , selected True
                         , attribute (Attributes.value "Dog")
                         ]
                     |> selectAnimal Axolotl
                     |> ensureViewHas
-                        [ id "id-nri-select--Axolotl"
+                        [ id "nri-select-axolotl"
                         , selected True
                         , attribute (Attributes.value "Axolotl")
                         ]
                     |> selectAnimal Other
                     |> ensureViewHas
-                        [ id "id-nri-select--My-favorite-animal-is-something-else"
+                        [ id "nri-select-my-favorite-animal-is-something-else"
                         , selected True
                         , attribute (Attributes.value "My favorite animal is something else")
                         ]


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Last hackday I created Nri.Ui.Html.Attributes.V2.safeId and safeIdWithPrefix. This was fine except I used it internally in a lot of our components. This broke way too many cypress tests and also verifiably broke the Guided Drafts intro tour. In order to un-block adoption of newer NRI-UI I have done three things in this PR:

1. stop using this ID generator anywhere in the UI and just exports it for gradual adoption here and in the monolith
1. lowercase the generated ID since most of our tests assume that will happen
1. only add the "id-" prefix when the leading character of the ID is not an ASCII letter

The monolith revert PR in question: https://github.com/NoRedInk/NoRedInk/pull/44536

## :framed_picture: What does this change look like?

No visual changes

## Component completion checklist

* there are no visual or API changes to any components
