### PR TITLE
Remove internal padding

### DIFF
--- a/src/Nri/Ui/Header/V1.elm
+++ b/src/Nri/Ui/Header/V1.elm
@@ -173,7 +173,7 @@ view attrs { breadCrumbs, isCurrentRoute } =
         ]
         [ Html.div
             (css
-                [ Spacing.centeredContent
+                [ Spacing.centeredContentWithCustomWidth config.pageWidth
                 , Css.alignItems Css.center
                 , Css.displayFlex
                 , Media.withMedia [ MediaQuery.mobile ] [ Css.flexDirection Css.column ]

--- a/src/Nri/Ui/Header/V1.elm
+++ b/src/Nri/Ui/Header/V1.elm
@@ -173,7 +173,7 @@ view attrs { breadCrumbs, isCurrentRoute } =
         ]
         [ Html.div
             (css
-                [ Spacing.centeredContentWithSidePaddingAndCustomWidth config.pageWidth
+                [ Spacing.centeredContent
                 , Css.alignItems Css.center
                 , Css.displayFlex
                 , Media.withMedia [ MediaQuery.mobile ] [ Css.flexDirection Css.column ]


### PR DESCRIPTION
Removes redundant padding for the content of Header

<img width="1552" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/13528834/4f0ee912-f677-472e-b3f7-af66d2b66f10">