### PR TITLE
:wrench: `Page` `h1` focusability

### DIFF
--- a/src/Nri/Ui/Page/V3.elm
+++ b/src/Nri/Ui/Page/V3.elm
@@ -2,6 +2,7 @@ module Nri.Ui.Page.V3 exposing
     ( httpError
     , DefaultPage, broken, blockedV4, blocked, notFound, noPermission, loggedOut, timeOut, networkError
     , RecoveryText(..)
+    , headingId
     )
 
 {-| A styled NRI page!
@@ -9,9 +10,11 @@ module Nri.Ui.Page.V3 exposing
 @docs httpError
 @docs DefaultPage, broken, blockedV4, blocked, notFound, noPermission, loggedOut, timeOut, networkError
 @docs RecoveryText
+@docs headingId
 
 -}
 
+import Accessibility.Styled.Key as Key
 import Css exposing (..)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
@@ -185,6 +188,14 @@ httpError error defaultPage =
             blockedV4 body defaultPage
 
 
+{-| This ID is attached to the `h1` produced by Page.
+This can be useful when you need to move focus to the heading to communicate to AT users that there's been an error.
+-}
+headingId : String
+headingId =
+    "nri-ui-page-heading-h1"
+
+
 
 -- INTERNAL
 
@@ -206,6 +217,8 @@ view config =
         , Heading.h1
             [ Heading.plaintext config.title
             , Heading.css [ Css.textAlign Css.center ]
+            , Heading.id headingId
+            , Heading.custom [ Key.tabbable False ]
             ]
         , Text.mediumBody
             [ Text.plaintext config.subtitle

--- a/src/Nri/Ui/Page/V3.elm
+++ b/src/Nri/Ui/Page/V3.elm
@@ -6,8 +6,9 @@ module Nri.Ui.Page.V3 exposing
     )
 
 {-| Patch changes:
-- added `headingId` as the `id` of the `h1` produced by `Page`
-- made the `h1` produced by `Page` programmatically focusable
+
+  - added `headingId` as the `id` of the `h1` produced by `Page`
+  - made the `h1` produced by `Page` programmatically focusable
 
 A styled NRI error page.
 

--- a/src/Nri/Ui/Page/V3.elm
+++ b/src/Nri/Ui/Page/V3.elm
@@ -5,7 +5,11 @@ module Nri.Ui.Page.V3 exposing
     , headingId
     )
 
-{-| A styled NRI page!
+{-| Patch changes:
+- added `headingId` as the `id` of the `h1` produced by `Page`
+- made the `h1` produced by `Page` programmatically focusable
+
+A styled NRI error page.
 
 @docs httpError
 @docs DefaultPage, broken, blockedV4, blocked, notFound, noPermission, loggedOut, timeOut, networkError

--- a/tests/Spec/Nri/Ui/Page.elm
+++ b/tests/Spec/Nri/Ui/Page.elm
@@ -1,15 +1,12 @@
 module Spec.Nri.Ui.Page exposing (all)
 
+import Accessibility.Key as Key
 import Expect
 import Html.Styled as Html
 import Nri.Ui.Page.V3 as Page
 import Test exposing (..)
 import Test.Html.Query as Query
-import Test.Html.Selector exposing (..)
-
-
-type Msg
-    = NoOp
+import Test.Html.Selector as Selector exposing (..)
 
 
 all : Test
@@ -19,7 +16,7 @@ all =
             [ test "handles recovery text for ReturnTo" <|
                 \() ->
                     Page.notFound
-                        { link = NoOp
+                        { link = ()
                         , recoveryText = Page.ReturnTo "the main page"
                         }
                         |> Html.toUnstyled
@@ -29,7 +26,7 @@ all =
             , test "handles recovery text for Reload" <|
                 \() ->
                     Page.notFound
-                        { link = NoOp
+                        { link = ()
                         , recoveryText = Page.Reload
                         }
                         |> Html.toUnstyled
@@ -39,12 +36,28 @@ all =
             , test "handles recovery text for Custom" <|
                 \() ->
                     Page.notFound
-                        { link = NoOp
+                        { link = ()
                         , recoveryText = Page.Custom "cats"
                         }
                         |> Html.toUnstyled
                         |> Query.fromHtml
                         |> Expect.all
                             [ Query.has [ text "cats" ] ]
+            , test "heading is focusable" <|
+                \() ->
+                    Page.notFound
+                        { link = ()
+                        , recoveryText = Page.Reload
+                        }
+                        |> Html.toUnstyled
+                        |> Query.fromHtml
+                        |> Expect.all
+                            [ Query.has
+                                [ Selector.all
+                                    [ id "nri-ui-page-heading-h1"
+                                    , attribute (Key.tabbable False)
+                                    ]
+                                ]
+                            ]
             ]
         ]

--- a/tests/Spec/Nri/Ui/Page.elm
+++ b/tests/Spec/Nri/Ui/Page.elm
@@ -54,7 +54,7 @@ all =
                         |> Expect.all
                             [ Query.has
                                 [ Selector.all
-                                    [ id "nri-ui-page-heading-h1"
+                                    [ id Page.headingId
                                     , attribute (Key.tabbable False)
                                     ]
                                 ]


### PR DESCRIPTION
## Context

Fixes A11-3182

## :framed_picture: What does this change look like?

<img width="634" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/f878a5c5-d052-42e9-bdcf-c893c3d4b2c0">


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
