### PR TITLE
A11-2851 Bat/improve highlighter performance

### DIFF
--- a/src/Nri/Ui/Highlighter/V4.elm
+++ b/src/Nri/Ui/Highlighter/V4.elm
@@ -924,7 +924,6 @@ static config =
                 , renderMarkdown = False
                 , sorter = Nothing
                 , overlaps = False
-                , highlightables = config.highlightables
                 }
         , id = config.id
         , highlightables = config.highlightables
@@ -960,7 +959,6 @@ staticMarkdown config =
                 , renderMarkdown = True
                 , sorter = Nothing
                 , overlaps = False
-                , highlightables = config.highlightables
                 }
         , id = config.id
         , highlightables = config.highlightables
@@ -985,7 +983,6 @@ staticWithTags config =
                 , renderMarkdown = False
                 , sorter = Nothing
                 , overlaps = False
-                , highlightables = config.highlightables
                 }
     in
     view_
@@ -1025,7 +1022,6 @@ staticMarkdownWithTags config =
                 , renderMarkdown = True
                 , sorter = Nothing
                 , overlaps = False
-                , highlightables = config.highlightables
                 }
     in
     view_
@@ -1205,7 +1201,6 @@ viewHighlightable { renderMarkdown, overlaps } config highlightable =
                 , hintingIndices = config.hintingIndices
                 , sorter = Just config.sorter
                 , overlaps = overlaps
-                , highlightables = config.highlightables
                 }
                 highlightable
 
@@ -1232,7 +1227,6 @@ viewHighlightable { renderMarkdown, overlaps } config highlightable =
                 , hintingIndices = config.hintingIndices
                 , sorter = Just config.sorter
                 , overlaps = overlaps
-                , highlightables = config.highlightables
                 }
                 highlightable
 
@@ -1248,7 +1242,6 @@ viewHighlightableSegment :
     , renderMarkdown : Bool
     , sorter : Maybe (Sorter marker)
     , overlaps : Bool
-    , highlightables : List (Highlightable marker)
     }
     -> Highlightable marker
     -> List Css.Style

--- a/src/Nri/Ui/Highlighter/V4.elm
+++ b/src/Nri/Ui/Highlighter/V4.elm
@@ -1424,31 +1424,33 @@ unmarkedHighlightableStyles config highlightable =
                     isHovered =
                         directlyHoveringInteractiveSegment config highlightable
                 in
-                case tool of
-                    Tool.Marker marker ->
-                        if isHinted_ then
-                            marker.hintClass
+                Css.property "user-select" "none"
+                    :: (case tool of
+                            Tool.Marker marker ->
+                                if isHinted_ then
+                                    marker.hintClass
 
-                        else if isHovered then
-                            -- When hovered, but not marked
-                            List.concat
-                                [ marker.hoverClass
-                                , marker.startGroupClass
-                                , marker.endGroupClass
-                                ]
+                                else if isHovered then
+                                    -- When hovered, but not marked
+                                    List.concat
+                                        [ marker.hoverClass
+                                        , marker.startGroupClass
+                                        , marker.endGroupClass
+                                        ]
 
-                        else
-                            []
+                                else
+                                    []
 
-                    Tool.Eraser eraser_ ->
-                        if isHinted_ then
-                            eraser_.hintClass
+                            Tool.Eraser eraser_ ->
+                                if isHinted_ then
+                                    eraser_.hintClass
 
-                        else if isHovered then
-                            eraser_.hoverClass
+                                else if isHovered then
+                                    eraser_.hoverClass
 
-                        else
-                            []
+                                else
+                                    []
+                       )
 
 
 markedHighlightableStyles :

--- a/src/Nri/Ui/Highlighter/V4.elm
+++ b/src/Nri/Ui/Highlighter/V4.elm
@@ -702,22 +702,28 @@ isHovered_ :
         , highlightables : List (Highlightable marker)
         , overlaps : Bool
         , sorter : Maybe (Sorter marker)
+        , maybeTool : Maybe tool
     }
     -> Highlightable marker
     -> Bool
 isHovered_ config highlightable =
-    directlyHoveringInteractiveSegment config highlightable
-        || (if config.overlaps then
-                case config.sorter of
-                    Just sorter ->
-                        inHoveredGroupForOverlaps config sorter highlightable
+    case config.maybeTool of
+        Nothing ->
+            False
 
-                    _ ->
-                        False
+        Just _ ->
+            directlyHoveringInteractiveSegment config highlightable
+                || (if config.overlaps then
+                        case config.sorter of
+                            Just sorter ->
+                                inHoveredGroupForOverlaps config sorter highlightable
 
-            else
-                inHoveredGroupWithoutOverlaps config highlightable
-           )
+                            _ ->
+                                False
+
+                    else
+                        inHoveredGroupWithoutOverlaps config highlightable
+                   )
 
 
 directlyHoveringInteractiveSegment : { config | mouseOverIndex : Maybe Int } -> Highlightable m -> Bool

--- a/src/Nri/Ui/Mark/V2.elm
+++ b/src/Nri/Ui/Mark/V2.elm
@@ -91,10 +91,8 @@ viewWithOverlaps viewSegment segments =
                             [ tagBeforeContent before
                             , tagAfterContent after
                             , Css.batch startingStyles
-                            , Css.batch
-                                (List.concatMap (\markedWith -> markedWith.styles ++ markedWith.endStyles)
-                                    after
-                                )
+                            , Css.batch (List.concatMap .styles marks)
+                            , Css.batch (List.concatMap .endStyles after)
                             ]
 
                     startStyles =


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

This improves the performance of the highlighter and intends to fix [A11-2851 : Highlighter.V4 is causing severe performance degradations for this sample](https://linear.app/noredink/issue/A11-2851/highlighterv4-is-causing-severe-performance-degradations-for-this)

## :framed_picture: What does this change look like?

There should not be any visual changes.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
