### PR TITLE
:star2: FocusLoop

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -30,6 +30,7 @@
         "Nri.Ui.Divider.V2",
         "Nri.Ui.Effects.V1",
         "Nri.Ui.WhenFocusLeaves.V1",
+        "Nri.Ui.FocusLoop.V1",
         "Nri.Ui.FocusRing.V1",
         "Nri.Ui.FocusTrap.V1",
         "Nri.Ui.Fonts.V1",

--- a/src/Nri/Ui/Accordion/V3.elm
+++ b/src/Nri/Ui/Accordion/V3.elm
@@ -274,8 +274,7 @@ view_ { entries, focus, leftId } =
         [ Html.Styled.Keyed.node "div"
             []
             (FocusLoop.addEvents
-                { toId = \(AccordionEntry { headerId } _) -> headerId
-                , focus = focus
+                { focus = \(AccordionEntry { headerId } _) -> focus headerId
                 , leftRight = False
                 , upDown = True
                 }

--- a/src/Nri/Ui/Accordion/V3.elm
+++ b/src/Nri/Ui/Accordion/V3.elm
@@ -69,6 +69,7 @@ import Html.Styled.Events exposing (onClick)
 import Html.Styled.Keyed
 import Nri.Ui.AnimatedIcon.V1 as AnimatedIcon
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.FocusLoop.V1 as FocusLoop
 import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
@@ -269,49 +270,28 @@ view_ :
     }
     -> Html msg
 view_ { entries, focus, leftId } =
-    let
-        headerIds : List String
-        headerIds =
-            List.map getHeaderId entries
-
-        arrowUpIds : List (Maybe String)
-        arrowUpIds =
-            lastHeaderId :: List.map Just headerIds
-
-        firstHeaderId : Maybe String
-        firstHeaderId =
-            List.head headerIds
-
-        lastHeaderId : Maybe String
-        lastHeaderId =
-            List.head (List.reverse headerIds)
-    in
     div [ Attributes.class accordionClass ]
         [ Html.Styled.Keyed.node "div"
             []
-            (entries
-                |> List.map2 (\id nextEntry -> ( id, nextEntry )) arrowUpIds
-                |> List.foldr
-                    (\( previousId, AccordionEntry entry_ children ) ( nextId, acc ) ->
-                        let
-                            node =
-                                ( "keyed-section__" ++ entry_.headerId
-                                , viewEntry focus
-                                    { up = previousId
-                                    , down = nextId
-                                    , right = Maybe.map getHeaderId (List.head children)
-                                    , left = leftId
-                                    }
-                                    entry_
-                                    children
-                                )
-                        in
-                        ( Just entry_.headerId
-                        , node :: acc
+            (FocusLoop.addEvents
+                { toId = \(AccordionEntry { headerId } _) -> headerId
+                , focus = focus
+                , leftRight = False
+                , upDown = True
+                }
+                entries
+                |> List.map
+                    (\( AccordionEntry entry_ children, upDownEvents ) ->
+                        ( "keyed-section__" ++ entry_.headerId
+                        , viewEntry focus
+                            { upDownEvents = upDownEvents
+                            , right = Maybe.map getHeaderId (List.head children)
+                            , left = leftId
+                            }
+                            entry_
+                            children
                         )
                     )
-                    ( firstHeaderId, [] )
-                |> Tuple.second
             )
         ]
 
@@ -319,8 +299,7 @@ view_ { entries, focus, leftId } =
 viewEntry :
     (String -> msg)
     ->
-        { up : Maybe String
-        , down : Maybe String
+        { upDownEvents : List (Key.Event msg)
         , right : Maybe String
         , left : Maybe String
         }
@@ -357,12 +336,11 @@ viewEntry focus arrows ({ headerId, headerLevel, caret, headerContent, entryClas
                     |> Maybe.map (\toggle -> onClick (toggle (not isExpanded)))
                     |> Maybe.withDefault AttributesExtra.none
                 , Key.onKeyDownPreventDefault
-                    ([ Maybe.map (\id -> Key.up (focus id)) arrows.up
-                     , Maybe.map (\id -> Key.down (focus id)) arrows.down
-                     , Maybe.map (\id -> Key.right (focus id)) arrows.right
-                     , Maybe.map (\id -> Key.left (focus id)) arrows.left
-                     ]
-                        |> List.filterMap identity
+                    (arrows.upDownEvents
+                        ++ List.filterMap identity
+                            [ Maybe.map (\id -> Key.right (focus id)) arrows.right
+                            , Maybe.map (\id -> Key.left (focus id)) arrows.left
+                            ]
                     )
                 ]
                 [ caret isExpanded

--- a/src/Nri/Ui/FocusLoop/V1.elm
+++ b/src/Nri/Ui/FocusLoop/V1.elm
@@ -6,7 +6,7 @@ module Nri.Ui.FocusLoop.V1 exposing (addEvents)
 
 -}
 
-import Accessibility.Styled.Key exposing (Event)
+import Accessibility.Styled.Key as Key exposing (Event)
 
 
 {-| -}
@@ -18,4 +18,65 @@ addEvents :
     -> List a
     -> List ( a, List (Event msg) )
 addEvents config items =
-    []
+    case items of
+        [] ->
+            []
+
+        item :: [] ->
+            [ ( item, [] ) ]
+
+        _ ->
+            addEvents_ config items
+
+
+addEvents_ :
+    { toId : a -> String
+    , leftRight : Bool
+    , upDown : Bool
+    }
+    -> List a
+    -> List ( a, List (Event msg) )
+addEvents_ config items =
+    let
+        ids : List String
+        ids =
+            List.map config.toId items
+
+        previousIds : List (Maybe String)
+        previousIds =
+            finalId :: List.map Just ids
+
+        firstId : Maybe String
+        firstId =
+            List.head ids
+
+        finalId : Maybe String
+        finalId =
+            List.head (List.reverse ids)
+    in
+    List.map2 (\id nextItem -> ( id, nextItem )) previousIds items
+        |> List.foldr
+            (\( previousId, item ) ( nextId, acc ) ->
+                let
+                    leftRightEvents =
+                        if config.leftRight then
+                            -- TODO: add actual events
+                            []
+
+                        else
+                            []
+
+                    upDownEvents =
+                        if config.upDown then
+                            -- TODO: add actual events
+                            []
+
+                        else
+                            []
+                in
+                ( Just (config.toId item)
+                , ( item, leftRightEvents ++ upDownEvents ) :: acc
+                )
+            )
+            ( firstId, [] )
+        |> Tuple.second

--- a/src/Nri/Ui/FocusLoop/V1.elm
+++ b/src/Nri/Ui/FocusLoop/V1.elm
@@ -1,19 +1,21 @@
-module Nri.Ui.FocusLoop.V1 exposing (eventListeners)
+module Nri.Ui.FocusLoop.V1 exposing (addEvents)
 
 {-| Sometimes, there are sets of interactive elements that we want users to be able to navigate through with arrow keys rather than with tabs, and we want the final focus change to wrap. This module makes it easier to set up this focus and wrapping behavior.
 
-@docs eventListeners
+@docs addEvents
 
 -}
 
+import Accessibility.Styled.Key exposing (Event)
+
 
 {-| -}
-eventListeners :
+addEvents :
     { toId : a -> String
     , leftRight : Bool
     , upDown : Bool
     }
     -> List a
-    -> List ( a, List (Attribute msg) )
-eventListeners config items =
+    -> List ( a, List (Event msg) )
+addEvents config items =
     []

--- a/src/Nri/Ui/FocusLoop/V1.elm
+++ b/src/Nri/Ui/FocusLoop/V1.elm
@@ -12,6 +12,7 @@ import Accessibility.Styled.Key as Key exposing (Event)
 {-| -}
 addEvents :
     { toId : a -> String
+    , onFocus : String -> msg
     , leftRight : Bool
     , upDown : Bool
     }
@@ -31,6 +32,7 @@ addEvents config items =
 
 addEvents_ :
     { toId : a -> String
+    , onFocus : String -> msg
     , leftRight : Bool
     , upDown : Bool
     }

--- a/src/Nri/Ui/FocusLoop/V1.elm
+++ b/src/Nri/Ui/FocusLoop/V1.elm
@@ -12,7 +12,7 @@ import Accessibility.Styled.Key as Key exposing (Event)
 {-| -}
 addEvents :
     { toId : a -> String
-    , onFocus : String -> msg
+    , focus : String -> msg
     , leftRight : Bool
     , upDown : Bool
     }
@@ -32,7 +32,7 @@ addEvents config items =
 
 addEvents_ :
     { toId : a -> String
-    , onFocus : String -> msg
+    , focus : String -> msg
     , leftRight : Bool
     , upDown : Bool
     }
@@ -62,22 +62,24 @@ addEvents_ config items =
                 let
                     leftRightEvents =
                         if config.leftRight then
-                            -- TODO: add actual events
-                            []
+                            [ Maybe.map (config.focus >> Key.right) nextId
+                            , Maybe.map (config.focus >> Key.left) previousId
+                            ]
 
                         else
                             []
 
                     upDownEvents =
                         if config.upDown then
-                            -- TODO: add actual events
-                            []
+                            [ Maybe.map (config.focus >> Key.down) nextId
+                            , Maybe.map (config.focus >> Key.up) previousId
+                            ]
 
                         else
                             []
                 in
                 ( Just (config.toId item)
-                , ( item, leftRightEvents ++ upDownEvents ) :: acc
+                , ( item, List.filterMap identity (leftRightEvents ++ upDownEvents) ) :: acc
                 )
             )
             ( firstId, [] )

--- a/src/Nri/Ui/FocusLoop/V1.elm
+++ b/src/Nri/Ui/FocusLoop/V1.elm
@@ -11,8 +11,7 @@ import Accessibility.Styled.Key as Key exposing (Event)
 
 {-| -}
 addEvents :
-    { toId : a -> String
-    , focus : String -> msg
+    { focus : a -> msg
     , leftRight : Bool
     , upDown : Bool
     }
@@ -31,8 +30,7 @@ addEvents config items =
 
 
 addEvents_ :
-    { toId : a -> String
-    , focus : String -> msg
+    { focus : a -> msg
     , leftRight : Bool
     , upDown : Bool
     }
@@ -40,21 +38,17 @@ addEvents_ :
     -> List ( a, List (Event msg) )
 addEvents_ config items =
     let
-        ids : List String
-        ids =
-            List.map config.toId items
-
-        previousIds : List (Maybe String)
+        previousIds : List (Maybe a)
         previousIds =
-            finalId :: List.map Just ids
+            finalId :: List.map Just items
 
-        firstId : Maybe String
+        firstId : Maybe a
         firstId =
-            List.head ids
+            List.head items
 
-        finalId : Maybe String
+        finalId : Maybe a
         finalId =
-            List.head (List.reverse ids)
+            List.head (List.reverse items)
     in
     List.map2 (\id nextItem -> ( id, nextItem )) previousIds items
         |> List.foldr
@@ -78,7 +72,7 @@ addEvents_ config items =
                         else
                             []
                 in
-                ( Just (config.toId item)
+                ( Just item
                 , ( item, List.filterMap identity (leftRightEvents ++ upDownEvents) ) :: acc
                 )
             )

--- a/src/Nri/Ui/FocusLoop/V1.elm
+++ b/src/Nri/Ui/FocusLoop/V1.elm
@@ -1,0 +1,19 @@
+module Nri.Ui.FocusLoop.V1 exposing (eventListeners)
+
+{-| Sometimes, there are sets of interactive elements that we want users to be able to navigate through with arrow keys rather than with tabs, and we want the final focus change to wrap. This module makes it easier to set up this focus and wrapping behavior.
+
+@docs eventListeners
+
+-}
+
+
+{-| -}
+eventListeners :
+    { toId : a -> String
+    , leftRight : Bool
+    , upDown : Bool
+    }
+    -> List a
+    -> List ( a, List (Attribute msg) )
+eventListeners config items =
+    []

--- a/src/Nri/Ui/SegmentedControl/V14.elm
+++ b/src/Nri/Ui/SegmentedControl/V14.elm
@@ -203,7 +203,6 @@ view config =
             , tabView = [ viewIcon option.icon, option.label ]
             , panelView = option.content
             , spaHref = Maybe.map (\toUrl -> toUrl option.value) config.toUrl
-            , disabled = False
             , labelledBy = Nothing
             , describedBy = []
             }

--- a/src/Nri/Ui/Tabs/V7.elm
+++ b/src/Nri/Ui/Tabs/V7.elm
@@ -2,7 +2,7 @@ module Nri.Ui.Tabs.V7 exposing
     ( view
     , Alignment(..)
     , Tab, Attribute, build
-    , tabString, tabHtml, withTooltip, disabled, labelledBy, describedBy
+    , tabString, tabHtml, withTooltip, labelledBy, describedBy
     , panelHtml
     , spaHref
     )
@@ -21,7 +21,7 @@ Changes from V6:
 @docs view
 @docs Alignment
 @docs Tab, Attribute, build
-@docs tabString, tabHtml, withTooltip, disabled, labelledBy, describedBy
+@docs tabString, tabHtml, withTooltip, labelledBy, describedBy
 @docs panelHtml
 @docs spaHref
 
@@ -66,13 +66,6 @@ tabHtml content =
 withTooltip : List (Tooltip.Attribute msg) -> Attribute id msg
 withTooltip attributes =
     Attribute (\tab -> { tab | tabTooltip = attributes })
-
-
-{-| Makes it so that the tab can't be clicked or focused via keyboard navigation
--}
-disabled : Bool -> Attribute id msg
-disabled isDisabled =
-    Attribute (\tab -> { tab | disabled = isDisabled })
 
 
 {-| Sets an overriding labelledBy on the tab for an external tooltip.

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -5,7 +5,7 @@ module Nri.Ui.Tabs.V8 exposing
     , tabListSticky, TabListStickyConfig, tabListStickyCustom
     , view
     , Tab, TabAttribute, build
-    , tabString, tabHtml, withTooltip, disabled, labelledBy, describedBy
+    , tabString, tabHtml, withTooltip, labelledBy, describedBy
     , panelHtml
     , spaHref
     )
@@ -30,7 +30,7 @@ module Nri.Ui.Tabs.V8 exposing
 ### Tabs
 
 @docs Tab, TabAttribute, build
-@docs tabString, tabHtml, withTooltip, disabled, labelledBy, describedBy
+@docs tabString, tabHtml, withTooltip, labelledBy, describedBy
 @docs panelHtml
 @docs spaHref
 
@@ -78,13 +78,6 @@ tabHtml content =
 withTooltip : List (Tooltip.Attribute msg) -> TabAttribute id msg
 withTooltip attributes =
     TabAttribute (\tab -> { tab | tabTooltip = attributes })
-
-
-{-| Makes it so that the tab can't be clicked or focused via keyboard navigation
--}
-disabled : Bool -> TabAttribute id msg
-disabled isDisabled =
-    TabAttribute (\tab -> { tab | disabled = isDisabled })
 
 
 {-| Sets an overriding labelledBy on the tab for an external tooltip.

--- a/src/TabsInternal/V2.elm
+++ b/src/TabsInternal/V2.elm
@@ -19,6 +19,7 @@ import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Html.Styled.Keyed as Keyed
+import Nri.Ui.FocusLoop.V1 as FocusLoop
 import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (safeId, safeIdWithPrefix)
 import Nri.Ui.Tooltip.V3 as Tooltip

--- a/src/TabsInternal/V2.elm
+++ b/src/TabsInternal/V2.elm
@@ -44,7 +44,6 @@ type alias Tab id msg =
     , tabView : List (Html msg)
     , panelView : Html msg
     , spaHref : Maybe String
-    , disabled : Bool
     , labelledBy : Maybe String
     , describedBy : List String
     }
@@ -62,7 +61,6 @@ fromList { id, idString } attributes =
             , tabView = []
             , panelView = Html.text ""
             , spaHref = Nothing
-            , disabled = False
             , labelledBy = Nothing
             , describedBy = []
             }
@@ -171,8 +169,7 @@ viewTab_ config index ( tab, keyEvents ) =
                        , -- check for isSelected because otherwise users won't
                          -- be able to focus on the current tab with the
                          -- keyboard.
-                         Attributes.disabled (not isSelected && tab.disabled)
-                       , Aria.selected isSelected
+                         Aria.selected isSelected
                        , Role.tab
                        , Aria.controls [ tabToBodyId tab.idString ]
                        , Attributes.id (safeId tab.idString)

--- a/tests/Spec/Nri/Ui/FocusLoop.elm
+++ b/tests/Spec/Nri/Ui/FocusLoop.elm
@@ -128,8 +128,7 @@ allCases startingList expected =
     [ test "without left/right or up/down events" <|
         \() ->
             FocusLoop.addEvents
-                { toId = identity
-                , focus = identity
+                { focus = identity
                 , leftRight = False
                 , upDown = False
                 }
@@ -138,8 +137,7 @@ allCases startingList expected =
     , test "with left/right and without up/down events" <|
         \() ->
             FocusLoop.addEvents
-                { toId = identity
-                , focus = identity
+                { focus = identity
                 , leftRight = True
                 , upDown = False
                 }
@@ -148,8 +146,7 @@ allCases startingList expected =
     , test "without left/right and with up/down events" <|
         \() ->
             FocusLoop.addEvents
-                { toId = identity
-                , focus = identity
+                { focus = identity
                 , leftRight = False
                 , upDown = True
                 }
@@ -158,8 +155,7 @@ allCases startingList expected =
     , test "with left/right and up/down events" <|
         \() ->
             FocusLoop.addEvents
-                { toId = identity
-                , focus = identity
+                { focus = identity
                 , leftRight = True
                 , upDown = True
                 }

--- a/tests/Spec/Nri/Ui/FocusLoop.elm
+++ b/tests/Spec/Nri/Ui/FocusLoop.elm
@@ -75,10 +75,10 @@ forATwoElementList =
 allCases :
     List String
     ->
-        { noEvents : List ( String, List (Event msg) )
-        , justLeftRight : List ( String, List (Event msg) )
-        , justUpDown : List ( String, List (Event msg) )
-        , allEvents : List ( String, List (Event msg) )
+        { noEvents : List ( String, List (Event String) )
+        , justLeftRight : List ( String, List (Event String) )
+        , justUpDown : List ( String, List (Event String) )
+        , allEvents : List ( String, List (Event String) )
         }
     -> List Test
 allCases startingList expected =
@@ -86,6 +86,7 @@ allCases startingList expected =
         \() ->
             FocusLoop.addEvents
                 { toId = identity
+                , onFocus = identity
                 , leftRight = False
                 , upDown = False
                 }
@@ -95,6 +96,7 @@ allCases startingList expected =
         \() ->
             FocusLoop.addEvents
                 { toId = identity
+                , onFocus = identity
                 , leftRight = True
                 , upDown = False
                 }
@@ -104,6 +106,7 @@ allCases startingList expected =
         \() ->
             FocusLoop.addEvents
                 { toId = identity
+                , onFocus = identity
                 , leftRight = False
                 , upDown = True
                 }
@@ -113,6 +116,7 @@ allCases startingList expected =
         \() ->
             FocusLoop.addEvents
                 { toId = identity
+                , onFocus = identity
                 , leftRight = True
                 , upDown = True
                 }

--- a/tests/Spec/Nri/Ui/FocusLoop.elm
+++ b/tests/Spec/Nri/Ui/FocusLoop.elm
@@ -12,6 +12,7 @@ spec =
         [ forAnEmptyList
         , forASingletonList
         , forATwoElementList
+        , forAThreeElementList
         ]
 
 
@@ -65,6 +66,48 @@ forATwoElementList =
                     , Key.left "a"
                     , Key.down "a"
                     , Key.up "a"
+                    ]
+                  )
+                ]
+            }
+        )
+
+
+forAThreeElementList : Test
+forAThreeElementList =
+    describe "for a three-element list"
+        (allCases [ "a", "b", "c" ]
+            { noEvents = [ ( "a", [] ), ( "b", [] ), ( "c", [] ) ]
+            , justLeftRight =
+                [ ( "a", [ Key.right "b", Key.left "c" ] )
+                , ( "b", [ Key.right "c", Key.left "a" ] )
+                , ( "c", [ Key.right "a", Key.left "b" ] )
+                ]
+            , justUpDown =
+                [ ( "a", [ Key.down "b", Key.up "c" ] )
+                , ( "b", [ Key.down "c", Key.up "a" ] )
+                , ( "c", [ Key.down "a", Key.up "b" ] )
+                ]
+            , allEvents =
+                [ ( "a"
+                  , [ Key.right "b"
+                    , Key.left "c"
+                    , Key.down "b"
+                    , Key.up "c"
+                    ]
+                  )
+                , ( "b"
+                  , [ Key.right "c"
+                    , Key.left "a"
+                    , Key.down "c"
+                    , Key.up "a"
+                    ]
+                  )
+                , ( "c"
+                  , [ Key.right "a"
+                    , Key.left "b"
+                    , Key.down "a"
+                    , Key.up "b"
                     ]
                   )
                 ]

--- a/tests/Spec/Nri/Ui/FocusLoop.elm
+++ b/tests/Spec/Nri/Ui/FocusLoop.elm
@@ -1,0 +1,54 @@
+module Spec.Nri.Ui.FocusLoop exposing (spec)
+
+import Expect
+import Nri.Ui.FocusLoop.V1 as FocusLoop
+import Test exposing (..)
+
+
+spec : Test
+spec =
+    describe "Nri.Ui.FocusLoop"
+        [ forAnEmptyList
+        ]
+
+
+forAnEmptyList : Test
+forAnEmptyList =
+    describe "for an empty list"
+        [ test "without left/right or up/down events" <|
+            \() ->
+                FocusLoop.addEvents
+                    { toId = identity
+                    , leftRight = False
+                    , upDown = False
+                    }
+                    []
+                    |> Expect.equal []
+        , test "with left/right and without up/down events" <|
+            \() ->
+                FocusLoop.addEvents
+                    { toId = identity
+                    , leftRight = True
+                    , upDown = False
+                    }
+                    []
+                    |> Expect.equal []
+        , test "without left/right and with up/down events" <|
+            \() ->
+                FocusLoop.addEvents
+                    { toId = identity
+                    , leftRight = False
+                    , upDown = True
+                    }
+                    []
+                    |> Expect.equal []
+        , test "with left/right and up/down events" <|
+            \() ->
+                FocusLoop.addEvents
+                    { toId = identity
+                    , leftRight = True
+                    , upDown = True
+                    }
+                    []
+                    |> Expect.equal []
+        ]

--- a/tests/Spec/Nri/Ui/FocusLoop.elm
+++ b/tests/Spec/Nri/Ui/FocusLoop.elm
@@ -1,5 +1,6 @@
 module Spec.Nri.Ui.FocusLoop exposing (spec)
 
+import Accessibility.Styled.Key exposing (Event)
 import Expect
 import Nri.Ui.FocusLoop.V1 as FocusLoop
 import Test exposing (..)
@@ -15,40 +16,59 @@ spec =
 forAnEmptyList : Test
 forAnEmptyList =
     describe "for an empty list"
-        [ test "without left/right or up/down events" <|
-            \() ->
-                FocusLoop.addEvents
-                    { toId = identity
-                    , leftRight = False
-                    , upDown = False
-                    }
-                    []
-                    |> Expect.equal []
-        , test "with left/right and without up/down events" <|
-            \() ->
-                FocusLoop.addEvents
-                    { toId = identity
-                    , leftRight = True
-                    , upDown = False
-                    }
-                    []
-                    |> Expect.equal []
-        , test "without left/right and with up/down events" <|
-            \() ->
-                FocusLoop.addEvents
-                    { toId = identity
-                    , leftRight = False
-                    , upDown = True
-                    }
-                    []
-                    |> Expect.equal []
-        , test "with left/right and up/down events" <|
-            \() ->
-                FocusLoop.addEvents
-                    { toId = identity
-                    , leftRight = True
-                    , upDown = True
-                    }
-                    []
-                    |> Expect.equal []
-        ]
+        (allCases []
+            { noEvents = []
+            , justLeftRight = []
+            , justUpDown = []
+            , allEvents = []
+            }
+        )
+
+
+allCases :
+    List String
+    ->
+        { noEvents : List ( String, List (Event msg) )
+        , justLeftRight : List ( String, List (Event msg) )
+        , justUpDown : List ( String, List (Event msg) )
+        , allEvents : List ( String, List (Event msg) )
+        }
+    -> List Test
+allCases startingList expected =
+    [ test "without left/right or up/down events" <|
+        \() ->
+            FocusLoop.addEvents
+                { toId = identity
+                , leftRight = False
+                , upDown = False
+                }
+                startingList
+                |> Expect.equal expected.noEvents
+    , test "with left/right and without up/down events" <|
+        \() ->
+            FocusLoop.addEvents
+                { toId = identity
+                , leftRight = True
+                , upDown = False
+                }
+                startingList
+                |> Expect.equal expected.justLeftRight
+    , test "without left/right and with up/down events" <|
+        \() ->
+            FocusLoop.addEvents
+                { toId = identity
+                , leftRight = False
+                , upDown = True
+                }
+                startingList
+                |> Expect.equal expected.justUpDown
+    , test "with left/right and up/down events" <|
+        \() ->
+            FocusLoop.addEvents
+                { toId = identity
+                , leftRight = True
+                , upDown = True
+                }
+                startingList
+                |> Expect.equal expected.allEvents
+    ]

--- a/tests/Spec/Nri/Ui/FocusLoop.elm
+++ b/tests/Spec/Nri/Ui/FocusLoop.elm
@@ -57,7 +57,7 @@ forATwoElementList =
                   , [ Key.right "b"
                     , Key.left "b"
                     , Key.down "b"
-                    , Key.up "a"
+                    , Key.up "b"
                     ]
                   )
                 , ( "b"
@@ -86,7 +86,7 @@ allCases startingList expected =
         \() ->
             FocusLoop.addEvents
                 { toId = identity
-                , onFocus = identity
+                , focus = identity
                 , leftRight = False
                 , upDown = False
                 }
@@ -96,7 +96,7 @@ allCases startingList expected =
         \() ->
             FocusLoop.addEvents
                 { toId = identity
-                , onFocus = identity
+                , focus = identity
                 , leftRight = True
                 , upDown = False
                 }
@@ -106,7 +106,7 @@ allCases startingList expected =
         \() ->
             FocusLoop.addEvents
                 { toId = identity
-                , onFocus = identity
+                , focus = identity
                 , leftRight = False
                 , upDown = True
                 }
@@ -116,7 +116,7 @@ allCases startingList expected =
         \() ->
             FocusLoop.addEvents
                 { toId = identity
-                , onFocus = identity
+                , focus = identity
                 , leftRight = True
                 , upDown = True
                 }

--- a/tests/Spec/Nri/Ui/FocusLoop.elm
+++ b/tests/Spec/Nri/Ui/FocusLoop.elm
@@ -1,6 +1,6 @@
 module Spec.Nri.Ui.FocusLoop exposing (spec)
 
-import Accessibility.Styled.Key exposing (Event)
+import Accessibility.Styled.Key as Key exposing (Event)
 import Expect
 import Nri.Ui.FocusLoop.V1 as FocusLoop
 import Test exposing (..)
@@ -10,6 +10,8 @@ spec : Test
 spec =
     describe "Nri.Ui.FocusLoop"
         [ forAnEmptyList
+        , forASingletonList
+        , forATwoElementList
         ]
 
 
@@ -21,6 +23,51 @@ forAnEmptyList =
             , justLeftRight = []
             , justUpDown = []
             , allEvents = []
+            }
+        )
+
+
+forASingletonList : Test
+forASingletonList =
+    describe "for a singleton list"
+        (allCases [ "a" ]
+            { noEvents = [ ( "a", [] ) ]
+            , justLeftRight = [ ( "a", [] ) ]
+            , justUpDown = [ ( "a", [] ) ]
+            , allEvents = [ ( "a", [] ) ]
+            }
+        )
+
+
+forATwoElementList : Test
+forATwoElementList =
+    describe "for a two-element list"
+        (allCases [ "a", "b" ]
+            { noEvents = [ ( "a", [] ), ( "b", [] ) ]
+            , justLeftRight =
+                [ ( "a", [ Key.right "b", Key.left "b" ] )
+                , ( "b", [ Key.right "a", Key.left "a" ] )
+                ]
+            , justUpDown =
+                [ ( "a", [ Key.down "b", Key.up "b" ] )
+                , ( "b", [ Key.down "a", Key.up "a" ] )
+                ]
+            , allEvents =
+                [ ( "a"
+                  , [ Key.right "b"
+                    , Key.left "b"
+                    , Key.down "b"
+                    , Key.up "a"
+                    ]
+                  )
+                , ( "b"
+                  , [ Key.right "a"
+                    , Key.left "a"
+                    , Key.down "a"
+                    , Key.up "a"
+                    ]
+                  )
+                ]
             }
         )
 

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -26,6 +26,7 @@
         "Nri.Ui.Divider.V2",
         "Nri.Ui.Effects.V1",
         "Nri.Ui.WhenFocusLeaves.V1",
+        "Nri.Ui.FocusLoop.V1",
         "Nri.Ui.FocusRing.V1",
         "Nri.Ui.FocusTrap.V1",
         "Nri.Ui.Fonts.V1",


### PR DESCRIPTION
Adds a new FocusLoop component that can be used to "loop" focus bidirectionally through a list of elements using up/down and/or left/right arrow keys.

Fixes A11-3191

QA notes: Accordion, Tabs, TabsMinimal, and SegmentedControls should all keep working.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with this component in mind
- [x] Component has clear documentation
- [ ] Component is in the Component Catalog -- **Since this new component is more of a building block than full-fledged component, I'm not adding to the Component Catalog. Perhaps in the future it will make sense to add programatic helpers?**
    - [ ] Component is categorized reasonably (see [Category](https://github.com/NoRedInk/noredink-ui/blob/master/component-catalog-app/Category.elm) for all the currently available categories). The component can be in multiple categories, if appropriate.
    - [ ] Component has a representative preview for the Component Catalog cards (bonus points for making it delightful!)
    - [ ] Component has a customizable example. Aim for having _every_ possible supported version of the component displayable through the configuration on this page. (Protip: This is handy for testing expected behavior!)
    - [ ] The customizable example produces sample code
    - [ ] The component's example page includes keyboard behavior, if any
    - [ ] The component's example page includes guidance around how to use the component, if necessary
- [x] Component is tested
    - axe checks and percy snapshots will be automatically added for every component. However, if you want to customize _when_ the checks and snapshots are made, you will need to make changes to [script/puppeteer-tests.js](https://github.com/NoRedInk/noredink-ui/blob/master/script/puppeteer-tests.js).
    - there are 2 ways to add Elm tests:
        - if you want to test the Component Catalog example directly, add ProgramTest-style tests under `component-catalog/tests`
        - if you want to test the component directly, add tests under `tests/Spec`. Historically, this has been the more popular Elm testing strategy for noredink-ui.
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] Please assign [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) as a reviewer in addition to assigning a reviewer from your team
