### PR TITLE
A11-3081 Create Message V4

### DIFF
--- a/component-catalog/src/Examples/Message.elm
+++ b/component-catalog/src/Examples/Message.elm
@@ -11,13 +11,13 @@ import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
-import Nri.Ui.Message.V3 as Message
+import Nri.Ui.Message.V4 as Message
 import ViewHelpers exposing (viewExamples)
 
 
 version : Int
 version =
-    3
+    4
 
 
 type alias State =
@@ -111,7 +111,7 @@ controlRole : Control ( String, Message.Attribute msg )
 controlRole =
     CommonControls.choice "Message"
         [ ( "alertRole", Message.alertRole )
-        , ( "alertDialogRole", Message.alertDialogRole )
+        , ( "statusRole", Message.statusRole )
         ]
 
 

--- a/component-catalog/src/Examples/Tabs.elm
+++ b/component-catalog/src/Examples/Tabs.elm
@@ -23,7 +23,7 @@ import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Key(..))
 import List.Extra
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.Message.V3 as Message
+import Nri.Ui.Message.V4 as Message
 import Nri.Ui.Panel.V1 as Panel
 import Nri.Ui.Tabs.V8 as Tabs exposing (Alignment(..), Tab)
 import Nri.Ui.Text.V6 as Text

--- a/elm.json
+++ b/elm.json
@@ -55,6 +55,7 @@
         "Nri.Ui.MediaQuery.V1",
         "Nri.Ui.Menu.V4",
         "Nri.Ui.Message.V3",
+        "Nri.Ui.Message.V4",
         "Nri.Ui.Modal.V11",
         "Nri.Ui.Page.V3",
         "Nri.Ui.Pagination.V1",

--- a/src/InputErrorAndGuidanceInternal.elm
+++ b/src/InputErrorAndGuidanceInternal.elm
@@ -21,7 +21,7 @@ import Accessibility.Styled.Live as Live
 import Css
 import Html.Styled as Html exposing (Html)
 import Nri.Ui.Html.Attributes.V2
-import Nri.Ui.Message.V3 as Message
+import Nri.Ui.Message.V4 as Message
 import Nri.Ui.Text.V6 as Text
 
 

--- a/src/Nri/Ui/Message/V4.elm
+++ b/src/Nri/Ui/Message/V4.elm
@@ -827,8 +827,8 @@ getIcon customIcon size theme =
                     div
                         [ Attributes.css
                             [ borderRadius (pct 50)
-                            , height (px 20)
-                            , width (px 20)
+                            , height (px 18)
+                            , width (px 18)
                             , Css.marginRight (Css.px 5)
                             , backgroundColor Colors.navy
                             , displayFlex

--- a/src/Nri/Ui/Message/V4.elm
+++ b/src/Nri/Ui/Message/V4.elm
@@ -157,7 +157,11 @@ view attributes_ =
                         [ Nri.Ui.styled div
                             "Nri-Ui-Message--icon"
                             []
-                            []
+                            [ Attributes.css
+                                [ displayFlex
+                                , alignItems center
+                                ]
+                            ]
                             [ icon_
                             ]
                         , div [] attributes.content

--- a/src/Nri/Ui/Message/V4.elm
+++ b/src/Nri/Ui/Message/V4.elm
@@ -128,65 +128,54 @@ view attributes_ =
     in
     case attributes.size of
         Tiny ->
-            let
-                tinyMessage =
-                    div
-                        [ ExtraAttributes.nriDescription "Nri-Ui-Message--tiny"
-                        , Attributes.css
-                            (baseStyles
-                                ++ [ displayFlex
-                                   , justifyContent start
-                                   , alignItems center
-                                   , fontSize (px 13)
-                                   , Css.Global.children
-                                        [ Css.Global.div
-                                            [ nthChild "2"
-                                                [ marginTop (px -3)
-                                                , Css.Global.children
-                                                    [ Css.Global.p [ margin zero ] ]
-                                                ]
-                                            ]
-                                        ]
-                                   ]
-                            )
+            div
+                [ ExtraAttributes.nriDescription "Nri-Ui-Message--tiny"
+                , Attributes.css
+                    (baseStyles
+                        ++ [ paddingTop (px 6)
+                           , paddingBottom (px 8)
+                           ]
+                    )
+                ]
+                [ div
+                    [ Attributes.css
+                        [ displayFlex
+                        , alignItems center
                         ]
-                        [ div
-                            ([ Attributes.css
-                                [ displayFlex
-                                , alignItems center
-                                , paddingTop (px 6)
-                                , paddingBottom (px 8)
-                                ]
-                             , tabbable False
-                             ]
-                                ++ role
-                                ++ attributes.customAttributes
-                            )
-                            [ Nri.Ui.styled div
-                                "Nri-Ui-Message--icon"
-                                [ alignSelf flexStart ]
-                                []
-                                [ icon_
-                                ]
-                            , div [] attributes.content
+                    ]
+                    [ div
+                        ([ Attributes.css
+                            [ displayFlex
+                            , alignItems center
+                            , fontSize (px 13)
                             ]
-                        , case attributes.onDismiss of
-                            Nothing ->
-                                text ""
-
-                            Just msg ->
-                                tinyDismissButton msg
+                         , tabbable False
+                         ]
+                            ++ role
+                            ++ attributes.customAttributes
+                        )
+                        [ Nri.Ui.styled div
+                            "Nri-Ui-Message--icon"
+                            []
+                            []
+                            [ icon_
+                            ]
+                        , div [] attributes.content
                         ]
-            in
-            case attributes.codeDetails of
-                Just details ->
-                    div []
-                        [ tinyMessage
-                        , viewCodeDetails details
-                        ]
+                    , case attributes.onDismiss of
+                        Nothing ->
+                            text ""
 
-                Nothing ->
-                    tinyMessage
+                        Just msg ->
+                            tinyDismissButton msg
+                    ]
+                , case attributes.codeDetails of
+                    Just details ->
+                        viewCodeDetails details
+
+                    Nothing ->
+                        text ""
+                ]
 
         Large ->
             div
@@ -201,11 +190,8 @@ view attributes_ =
                     )
                 ]
                 [ div
-                    ([ Attributes.css
-                        [ displayFlex
-                        , property "width" "fit-content"
-                        , alignItems center
-                        , fontSize (px 15)
+                    [ Attributes.css
+                        [ fontSize (px 15)
                         , fontWeight (int 600)
                         , lineHeight (px 21)
                         , padding (px 20)
@@ -214,33 +200,49 @@ view attributes_ =
                             [ padding (px 15)
                             ]
                         ]
-                     , tabbable False
-                     ]
-                        ++ role
-                        ++ attributes.customAttributes
-                    )
-                    [ icon_
-                    , div
+                    ]
+                    [ div
                         [ Attributes.css
-                            [ minWidth (px 100)
-                            , flexBasis (px 100)
-                            , flexGrow (int 1)
+                            [ displayFlex
+                            , alignItems center
                             ]
                         ]
-                        attributes.content
-                    , case attributes.onDismiss of
+                        [ div
+                            ([ Attributes.css
+                                [ displayFlex
+                                , alignItems center
+                                , property "width" "fit-content"
+                                ]
+                             , tabbable False
+                             ]
+                                ++ role
+                                ++ attributes.customAttributes
+                            )
+                            [ icon_
+                            , div
+                                [ Attributes.css
+                                    [ minWidth (px 100)
+                                    , flexBasis (px 100)
+                                    , flexGrow (int 1)
+                                    ]
+                                ]
+                                attributes.content
+                            ]
+                        , div [ Attributes.css [ flexGrow (int 1) ] ] []
+                        , case attributes.onDismiss of
+                            Nothing ->
+                                text ""
+
+                            Just msg ->
+                                largeDismissButton msg
+                        ]
+                    , case attributes.codeDetails of
+                        Just details ->
+                            viewCodeDetails details
+
                         Nothing ->
                             text ""
-
-                        Just msg ->
-                            largeDismissButton msg
                     ]
-                , case attributes.codeDetails of
-                    Just details ->
-                        viewCodeDetails details
-
-                    Nothing ->
-                        text ""
                 ]
 
         Banner ->
@@ -254,65 +256,70 @@ view attributes_ =
                 ]
                 [ div
                     [ Attributes.css
-                        [ alignItems center
-                        , displayFlex
-                        , justifyContent center
+                        [ fontSize (px 20)
+                        , fontWeight (int 700)
+                        , lineHeight (num 1.4)
+                        , padding (px 20)
+                        , Css.Media.withMedia
+                            [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
+                            [ fontSize (px 15)
+                            , fontWeight (int 600)
+                            , padding (px 15)
+                            ]
                         ]
                     ]
                     [ div
-                        ([ Attributes.css
-                            [ alignItems center
-                            , displayFlex
-                            , justifyContent center
-                            , property "width" "fit-content"
-                            , fontSize (px 20)
-                            , fontWeight (int 700)
-                            , lineHeight (num 1.4)
-                            , padding (px 20)
-                            , Css.Media.withMedia
-                                [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
-                                [ fontSize (px 15)
-                                , fontWeight (int 600)
-                                , padding (px 15)
-                                ]
+                        [ Attributes.css
+                            [ displayFlex
+                            , alignItems center
                             ]
-                         , tabbable False
-                         ]
-                            ++ role
-                            ++ attributes.customAttributes
-                        )
-                        [ icon_
-                        , Nri.Ui.styled div
-                            "banner-alert-notification"
-                            [ fontSize (px 20)
-                            , fontWeight (int 700)
-                            , lineHeight (num 1.4)
-                            , maxWidth (px 600)
-                            , minWidth (px 100)
-                            , flexShrink (int 1)
-                            , Fonts.baseFont
-                            , Css.Media.withMedia
-                                [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
-                                [ fontSize (px 15)
-                                , fontWeight (int 600)
-                                ]
-                            ]
-                            []
-                            attributes.content
                         ]
-                    , case attributes.onDismiss of
+                        [ div [ Attributes.css [ flexGrow (int 1) ] ] []
+                        , div
+                            ([ Attributes.css
+                                [ displayFlex
+                                , alignItems center
+                                , property "width" "fit-content"
+                                ]
+                             , tabbable False
+                             ]
+                                ++ role
+                                ++ attributes.customAttributes
+                            )
+                            [ icon_
+                            , Nri.Ui.styled div
+                                "banner-alert-notification"
+                                [ fontSize (px 20)
+                                , fontWeight (int 700)
+                                , lineHeight (num 1.4)
+                                , maxWidth (px 600)
+                                , minWidth (px 100)
+                                , flexShrink (int 1)
+                                , Fonts.baseFont
+                                , Css.Media.withMedia
+                                    [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
+                                    [ fontSize (px 15)
+                                    , fontWeight (int 600)
+                                    ]
+                                ]
+                                []
+                                attributes.content
+                            ]
+                        , div [ Attributes.css [ flexGrow (int 1) ] ] []
+                        , case attributes.onDismiss of
+                            Nothing ->
+                                text ""
+
+                            Just msg ->
+                                bannerDismissButton msg
+                        ]
+                    , case attributes.codeDetails of
+                        Just details ->
+                            viewCodeDetails details
+
                         Nothing ->
                             text ""
-
-                        Just msg ->
-                            bannerDismissButton msg
                     ]
-                , case attributes.codeDetails of
-                    Just details ->
-                        viewCodeDetails details
-
-                    Nothing ->
-                        text ""
                 ]
 
 

--- a/src/Nri/Ui/Message/V4.elm
+++ b/src/Nri/Ui/Message/V4.elm
@@ -1,0 +1,999 @@
+module Nri.Ui.Message.V4 exposing
+    ( somethingWentWrong
+    , view, Attribute
+    , icon, custom, testId, id
+    , hideIconForMobile, hideIconFor
+    , css, notMobileCss, mobileCss, quizEngineMobileCss
+    , tiny, large, banner
+    , paragraph, plaintext, markdown, html, httpError, codeDetails
+    , tip, error, alert, success, customTheme
+    , alertRole, statusRole
+    , onDismiss
+    )
+
+{-| Changes from V3:
+
+  - adds `statusRole`
+  - removes `alertDialogRole`
+  - moves custom attributes and role to a div containing the icon and text
+  - makes this div programmatically focusable
+
+Patch changes:
+
+  - adds `notMobileCss`, `mobileCss`, `quizEngineMobileCss`
+  - adds `hideIconForMobile` and `hideIconFor`
+  - use `Shadows`
+  - use internal `Content` module
+  - make the tiny Message's icon size smaller
+
+Changes from V2:
+
+    - adds helpers: `custom`,`css`,`icon`,`testId`,`id`
+
+
+# View
+
+@docs somethingWentWrong
+@docs view, Attribute
+@docs icon, custom, testId, id
+
+
+# CSS
+
+@docs hideIconForMobile, hideIconFor
+@docs css, notMobileCss, mobileCss, quizEngineMobileCss
+
+
+## Size
+
+@docs tiny, large, banner
+
+
+## Content
+
+@docs paragraph, plaintext, markdown, html, httpError, codeDetails
+
+
+## Theme
+
+@docs tip, error, alert, success, customTheme
+
+
+## Role
+
+@docs alertRole, statusRole
+
+
+## Actions
+
+@docs onDismiss
+
+-}
+
+import Accessibility.Styled as Html exposing (..)
+import Accessibility.Styled.Key exposing (tabbable)
+import Accessibility.Styled.Role as Role
+import Accessibility.Styled.Style exposing (invisibleStyle)
+import Content
+import Css exposing (..)
+import Css.Global
+import Css.Media exposing (MediaQuery)
+import Html.Styled.Attributes as Attributes
+import Http
+import MarkdownStyles
+import Nri.Ui
+import Nri.Ui.ClickableSvg.V2 as ClickableSvg
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
+import Nri.Ui.MediaQuery.V1 as MediaQuery
+import Nri.Ui.Shadows.V1 as Shadows
+import Nri.Ui.Svg.V1 as NriSvg exposing (Svg)
+import Nri.Ui.UiIcon.V1 as UiIcon
+
+
+{-|
+
+    view =
+        Message.view
+            [ Message.tip
+            , Message.markdown "Don't tip too much, or your waitress will **fall over**!"
+            ]
+
+-}
+view : List (Attribute msg) -> Html msg
+view attributes_ =
+    let
+        attributes =
+            configFromAttributes attributes_
+
+        role =
+            getRoleAttribute attributes.role
+
+        backgroundColor_ =
+            getBackgroundColor attributes.size attributes.theme
+
+        color_ =
+            getColor attributes.size attributes.theme
+
+        icon_ =
+            getIcon attributes.icon attributes.size attributes.theme
+
+        baseStyles =
+            [ Fonts.baseFont
+            , color color_
+            , boxSizing borderBox
+            , Css.batch attributes.customStyles
+            ]
+    in
+    case attributes.size of
+        Tiny ->
+            let
+                tinyMessage =
+                    div
+                        [ ExtraAttributes.nriDescription "Nri-Ui-Message--tiny"
+                        , Attributes.css
+                            (baseStyles
+                                ++ [ displayFlex
+                                   , justifyContent start
+                                   , alignItems center
+                                   , fontSize (px 13)
+                                   , Css.Global.children
+                                        [ Css.Global.div
+                                            [ nthChild "2"
+                                                [ marginTop (px -3)
+                                                , Css.Global.children
+                                                    [ Css.Global.p [ margin zero ] ]
+                                                ]
+                                            ]
+                                        ]
+                                   ]
+                            )
+                        ]
+                        [ div
+                            ([ Attributes.css
+                                [ displayFlex
+                                , alignItems center
+                                , paddingTop (px 6)
+                                , paddingBottom (px 8)
+                                ]
+                             , tabbable False
+                             ]
+                                ++ role
+                                ++ attributes.customAttributes
+                            )
+                            [ Nri.Ui.styled div
+                                "Nri-Ui-Message--icon"
+                                [ alignSelf flexStart ]
+                                []
+                                [ icon_
+                                ]
+                            , div [] attributes.content
+                            ]
+                        , case attributes.onDismiss of
+                            Nothing ->
+                                text ""
+
+                            Just msg ->
+                                tinyDismissButton msg
+                        ]
+            in
+            case attributes.codeDetails of
+                Just details ->
+                    div []
+                        [ tinyMessage
+                        , viewCodeDetails details
+                        ]
+
+                Nothing ->
+                    tinyMessage
+
+        Large ->
+            div
+                [ ExtraAttributes.nriDescription "Nri-Ui-Message-large"
+                , Attributes.css
+                    (baseStyles
+                        ++ [ -- Box
+                             borderRadius (px 8)
+                           , backgroundColor_
+                           , Shadows.low
+                           ]
+                    )
+                ]
+                [ div
+                    ([ Attributes.css
+                        [ displayFlex
+                        , property "width" "fit-content"
+                        , alignItems center
+                        , fontSize (px 15)
+                        , fontWeight (int 600)
+                        , lineHeight (px 21)
+                        , padding (px 20)
+                        , Css.Media.withMedia
+                            [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
+                            [ padding (px 15)
+                            ]
+                        ]
+                     , tabbable False
+                     ]
+                        ++ role
+                        ++ attributes.customAttributes
+                    )
+                    [ icon_
+                    , div
+                        [ Attributes.css
+                            [ minWidth (px 100)
+                            , flexBasis (px 100)
+                            , flexGrow (int 1)
+                            ]
+                        ]
+                        attributes.content
+                    , case attributes.onDismiss of
+                        Nothing ->
+                            text ""
+
+                        Just msg ->
+                            largeDismissButton msg
+                    ]
+                , case attributes.codeDetails of
+                    Just details ->
+                        viewCodeDetails details
+
+                    Nothing ->
+                        text ""
+                ]
+
+        Banner ->
+            div
+                [ ExtraAttributes.nriDescription "Nri-Ui-Message-banner"
+                , Attributes.css
+                    (baseStyles
+                        ++ [ backgroundColor_
+                           ]
+                    )
+                ]
+                [ div
+                    [ Attributes.css
+                        [ alignItems center
+                        , displayFlex
+                        , justifyContent center
+                        ]
+                    ]
+                    [ div
+                        ([ Attributes.css
+                            [ alignItems center
+                            , displayFlex
+                            , justifyContent center
+                            , property "width" "fit-content"
+                            , fontSize (px 20)
+                            , fontWeight (int 700)
+                            , lineHeight (num 1.4)
+                            , padding (px 20)
+                            , Css.Media.withMedia
+                                [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
+                                [ fontSize (px 15)
+                                , fontWeight (int 600)
+                                , padding (px 15)
+                                ]
+                            ]
+                         , tabbable False
+                         ]
+                            ++ role
+                            ++ attributes.customAttributes
+                        )
+                        [ icon_
+                        , Nri.Ui.styled div
+                            "banner-alert-notification"
+                            [ fontSize (px 20)
+                            , fontWeight (int 700)
+                            , lineHeight (num 1.4)
+                            , maxWidth (px 600)
+                            , minWidth (px 100)
+                            , flexShrink (int 1)
+                            , Fonts.baseFont
+                            , Css.Media.withMedia
+                                [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
+                                [ fontSize (px 15)
+                                , fontWeight (int 600)
+                                ]
+                            ]
+                            []
+                            attributes.content
+                        ]
+                    , case attributes.onDismiss of
+                        Nothing ->
+                            text ""
+
+                        Just msg ->
+                            bannerDismissButton msg
+                    ]
+                , case attributes.codeDetails of
+                    Just details ->
+                        viewCodeDetails details
+
+                    Nothing ->
+                        text ""
+                ]
+
+
+{-| Shows an appropriate error message for when something unhandled happened.
+
+    view maybeDetailedErrorMessage =
+        viewMaybe Message.somethingWentWrong maybeDetailedErrorMessage
+
+-}
+somethingWentWrong : String -> Html msg
+somethingWentWrong errorMessageForEngineers =
+    view
+        [ tiny
+        , error
+        , alertRole
+        , plaintext somethingWentWrongMessage
+        , codeDetails errorMessageForEngineers
+        ]
+
+
+somethingWentWrongMessage : String
+somethingWentWrongMessage =
+    "Sorry, something went wrong.  Please try again later."
+
+
+viewCodeDetails : String -> Html msg
+viewCodeDetails errorMessageForEngineers =
+    details []
+        [ summary
+            [ Attributes.css
+                [ Fonts.baseFont
+                , fontSize (px 14)
+                , color Colors.gray45
+                ]
+            ]
+            [ text "Details for NoRedInk engineers" ]
+        , code
+            [ Attributes.css
+                [ display block
+                , whiteSpace preWrap
+                , overflowWrap breakWord
+                , color Colors.gray45
+                , backgroundColor Colors.gray96
+                , border3 (px 1) solid Colors.gray92
+                , borderRadius (px 3)
+                , padding2 (px 2) (px 4)
+                , fontSize (px 12)
+                , fontFamily monospace
+                ]
+            ]
+            [ text errorMessageForEngineers ]
+        ]
+
+
+{-| Shows a tiny alert message. We commonly use these for validation errors and small hints to users.
+
+    Message.view [ Message.tiny ]
+
+This is the default size for a Message.
+
+-}
+tiny : Attribute msg
+tiny =
+    Attribute <| \config -> { config | size = Tiny }
+
+
+{-| Shows a large alert or callout message. We commonly use these for highlighted tips, instructions, or asides in page copy.
+
+    Message.view [ Message.large ]
+
+-}
+large : Attribute msg
+large =
+    Attribute <| \config -> { config | size = Large }
+
+
+{-| Shows a banner alert message. This is even more prominent than `Message.large`.
+We commonly use these for flash messages at the top of pages.
+
+    Message.view [ Message.banner ]
+
+-}
+banner : Attribute msg
+banner =
+    Attribute <| \config -> { config | size = Banner }
+
+
+{-| Provide a plain-text string.
+-}
+plaintext : String -> Attribute msg
+plaintext =
+    Attribute << Content.plaintext
+
+
+{-| Provide a plain-text string that will be put into a paragraph tag, with the default margin removed.
+-}
+paragraph : String -> Attribute msg
+paragraph =
+    Attribute << Content.paragraph
+
+
+{-| Provide a string that will be rendered as markdown.
+-}
+markdown : String -> Attribute msg
+markdown content =
+    Attribute <|
+        \config ->
+            { config
+                | content = Content.markdownContent content
+                , customStyles = MarkdownStyles.anchorAndButton ++ config.customStyles
+            }
+
+
+{-| Provide a list of custom HTML.
+-}
+html : List (Html msg) -> Attribute msg
+html =
+    Attribute << Content.html
+
+
+{-| Provide an HTTP error, which will be translated to user-friendly text.
+-}
+httpError : Http.Error -> Attribute msg
+httpError error_ =
+    let
+        ( codeDetails_, content ) =
+            case error_ of
+                Http.BadUrl url ->
+                    ( Just ("Bad url: " ++ url)
+                    , [ text somethingWentWrongMessage ]
+                    )
+
+                Http.Timeout ->
+                    ( Nothing
+                    , [ text "This request took too long to complete." ]
+                    )
+
+                Http.NetworkError ->
+                    ( Nothing
+                    , [ text "Something went wrong, and we think the problem is probably with your internet connection." ]
+                    )
+
+                Http.BadStatus 401 ->
+                    ( Nothing
+                    , [ text "You were logged out. Please log in again to continue working." ]
+                    )
+
+                Http.BadStatus 404 ->
+                    ( Nothing
+                    , [ text "We couldn’t find that!" ]
+                    )
+
+                Http.BadStatus status ->
+                    ( Just ("Bad status: " ++ String.fromInt status)
+                    , [ text somethingWentWrongMessage ]
+                    )
+
+                Http.BadBody body ->
+                    ( Just body
+                    , [ text somethingWentWrongMessage ]
+                    )
+    in
+    Attribute <| \config -> { config | content = content, codeDetails = codeDetails_ }
+
+
+{-| Details for Engineers
+
+Will be rendered in a closed details box
+
+-}
+codeDetails : String -> Attribute msg
+codeDetails code =
+    Attribute <| \config -> { config | codeDetails = Just code }
+
+
+{-| This is the default theme for a Message.
+-}
+tip : Attribute msg
+tip =
+    Attribute <| \config -> { config | theme = Tip }
+
+
+{-| -}
+error : Attribute msg
+error =
+    Attribute <| \config -> { config | theme = Error }
+
+
+{-| -}
+alert : Attribute msg
+alert =
+    Attribute <| \config -> { config | theme = Alert }
+
+
+{-| -}
+success : Attribute msg
+success =
+    Attribute <| \config -> { config | theme = Success }
+
+
+{-| -}
+customTheme : { color : Color, backgroundColor : Color } -> Attribute msg
+customTheme custom_ =
+    Attribute <| \config -> { config | theme = Custom custom_ }
+
+
+{-| -}
+icon : Svg -> Attribute msg
+icon icon_ =
+    Attribute <| \config -> { config | icon = Just icon_ }
+
+
+{-| Use this helper to add custom attributes.
+
+Do NOT use this helper to add css styles, as they may not be applied the way
+you want/expect if underlying styles change.
+Instead, please use the `css` helper.
+
+-}
+custom : List (Html.Attribute Never) -> Attribute msg
+custom attributes =
+    Attribute <|
+        \config ->
+            { config
+                | customAttributes = List.append config.customAttributes attributes
+            }
+
+
+{-| -}
+testId : String -> Attribute msg
+testId id_ =
+    custom [ ExtraAttributes.testId id_ ]
+
+
+{-| -}
+id : String -> Attribute msg
+id id_ =
+    custom [ Attributes.id id_ ]
+
+
+{-| -}
+hideIconForMobile : Attribute msg
+hideIconForMobile =
+    hideIconFor MediaQuery.mobile
+
+
+{-| -}
+hideIconFor : MediaQuery -> Attribute msg
+hideIconFor mediaQuery =
+    css
+        [ Css.Media.withMedia [ mediaQuery ]
+            [ Css.Global.descendants
+                [ ExtraAttributes.nriDescriptionSelector messageIconDescription
+                    [ invisibleStyle
+                    ]
+                ]
+            ]
+        ]
+
+
+{-| -}
+css : List Style -> Attribute msg
+css styles =
+    Attribute <|
+        \config ->
+            { config
+                | customStyles = List.append config.customStyles styles
+            }
+
+
+{-| Equivalent to:
+
+    Message.css
+        [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.notMobile ] styles ]
+
+-}
+notMobileCss : List Style -> Attribute msg
+notMobileCss styles =
+    css [ Css.Media.withMedia [ MediaQuery.notMobile ] styles ]
+
+
+{-| Equivalent to:
+
+    Message.css
+        [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.mobile ] styles ]
+
+-}
+mobileCss : List Style -> Attribute msg
+mobileCss styles =
+    css [ Css.Media.withMedia [ MediaQuery.mobile ] styles ]
+
+
+{-| Equivalent to:
+
+    Message.css
+        [ Css.Media.withMedia [ Nri.Ui.MediaQuery.V1.quizEngineMobile ] styles ]
+
+-}
+quizEngineMobileCss : List Style -> Attribute msg
+quizEngineMobileCss styles =
+    css [ Css.Media.withMedia [ MediaQuery.quizEngineMobile ] styles ]
+
+
+{-| Adds a dismiss ("X" icon) to a message which will produce the given `msg` when clicked.
+-}
+onDismiss : msg -> Attribute msg
+onDismiss msg =
+    Attribute <| \config -> { config | onDismiss = Just msg }
+
+
+{-| Use this attribute when a user's immediate attention on the Message is required.
+
+For example, use this attribute when:
+
+>   - An invalid value was entered into a form field
+>   - The user's login session is about to expire
+>   - The connection to the server was lost, local changes will not be saved
+
+-- Excerpted from [Using the alert role MDN docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role)
+
+-}
+alertRole : Attribute msg
+alertRole =
+    Attribute <| \config -> { config | role = Just AlertRole }
+
+
+{-| Use this attribute when a user's immediate attention on the Message is NOT required.
+
+This means that a `status` Message has a lower priority than an `alert` Message.
+
+-}
+statusRole : Attribute msg
+statusRole =
+    Attribute <| \config -> { config | role = Just StatusRole }
+
+
+
+--
+-- PRIVATE
+--
+
+
+{-| Construct an `Attribute` using a helper like `onDismiss` or `alert`.
+-}
+type Attribute msg
+    = Attribute (BannerConfig msg -> BannerConfig msg)
+
+
+{-| PRIVATE
+-}
+type alias BannerConfig msg =
+    { onDismiss : Maybe msg
+    , role : Maybe Role
+    , content : List (Html msg)
+    , codeDetails : Maybe String
+    , theme : Theme
+    , size : Size
+    , icon : Maybe Svg
+    , customAttributes : List (Html.Attribute Never)
+    , customStyles : List Style
+    }
+
+
+{-| PRIVATE
+-}
+configFromAttributes : List (Attribute msg) -> BannerConfig msg
+configFromAttributes attr =
+    List.foldl (\(Attribute set) -> set)
+        { onDismiss = Nothing
+        , role = Nothing
+        , content = []
+        , codeDetails = Nothing
+        , theme = Tip
+        , size = Tiny
+        , icon = Nothing
+        , customAttributes = []
+        , customStyles = []
+        }
+        attr
+
+
+
+-- Size
+
+
+type Size
+    = Tiny
+    | Large
+    | Banner
+
+
+
+-- Themes
+
+
+{-| `Error` / `Alert` / `Tip` / `Success`
+-}
+type Theme
+    = Error
+    | Alert
+    | Tip
+    | Success
+    | Custom { color : Color, backgroundColor : Color }
+
+
+getColor : Size -> Theme -> Color
+getColor size theme =
+    case theme of
+        Custom { color } ->
+            color
+
+        Error ->
+            case size of
+                Tiny ->
+                    Colors.purple
+
+                _ ->
+                    Colors.purpleDark
+
+        Alert ->
+            case size of
+                Tiny ->
+                    Colors.redDark
+
+                _ ->
+                    Colors.redDark
+
+        Tip ->
+            Colors.navy
+
+        Success ->
+            Colors.greenDarkest
+
+
+getBackgroundColor : Size -> Theme -> Style
+getBackgroundColor size theme =
+    case ( size, theme ) of
+        ( Tiny, _ ) ->
+            Css.batch []
+
+        ( Large, Tip ) ->
+            Css.backgroundColor Colors.sunshine
+
+        ( Banner, Tip ) ->
+            Css.backgroundColor Colors.sunshine
+
+        ( _, Error ) ->
+            Css.backgroundColor Colors.purpleLight
+
+        ( _, Alert ) ->
+            Css.backgroundColor Colors.sunshine
+
+        ( _, Success ) ->
+            Css.backgroundColor Colors.greenLightest
+
+        ( _, Custom { backgroundColor } ) ->
+            Css.backgroundColor backgroundColor
+
+
+getIcon : Maybe Svg -> Size -> Theme -> Html msg
+getIcon customIcon size theme =
+    let
+        ( iconSize, marginRight ) =
+            case size of
+                Tiny ->
+                    ( px 18, Css.marginRight (Css.px 5) )
+
+                Large ->
+                    ( px 35, Css.marginRight (Css.px 10) )
+
+                Banner ->
+                    ( px 35, Css.marginRight (Css.px 10) )
+    in
+    case ( customIcon, theme ) of
+        ( Nothing, Error ) ->
+            UiIcon.exclamation
+                |> NriSvg.withColor Colors.purple
+                |> NriSvg.withWidth iconSize
+                |> NriSvg.withHeight iconSize
+                |> NriSvg.withCss [ marginRight, Css.flexShrink Css.zero ]
+                |> NriSvg.withLabel "Error"
+                |> NriSvg.toHtml
+
+        ( Nothing, Alert ) ->
+            let
+                color =
+                    case size of
+                        Tiny ->
+                            Colors.red
+
+                        _ ->
+                            Colors.red
+            in
+            UiIcon.exclamation
+                |> NriSvg.withColor color
+                |> NriSvg.withWidth iconSize
+                |> NriSvg.withHeight iconSize
+                |> NriSvg.withCss [ marginRight, Css.flexShrink Css.zero ]
+                |> NriSvg.withLabel "Alert"
+                |> NriSvg.toHtml
+
+        ( Nothing, Tip ) ->
+            case size of
+                Tiny ->
+                    div
+                        [ Attributes.css
+                            [ borderRadius (pct 50)
+                            , height (px 20)
+                            , width (px 20)
+                            , Css.marginRight (Css.px 5)
+                            , backgroundColor Colors.navy
+                            , displayFlex
+                            , Css.flexShrink Css.zero
+                            , alignItems center
+                            , justifyContent center
+                            ]
+                        , ExtraAttributes.nriDescription messageIconDescription
+                        ]
+                        [ UiIcon.baldBulb
+                            |> NriSvg.withColor Colors.mustard
+                            |> NriSvg.withWidth (Css.px 13)
+                            |> NriSvg.withHeight (Css.px 13)
+                            |> NriSvg.toHtml
+                        ]
+
+                Large ->
+                    div
+                        [ Attributes.css
+                            [ borderRadius (pct 50)
+                            , height (px 35)
+                            , width (px 35)
+                            , Css.marginRight (Css.px 10)
+                            , backgroundColor Colors.navy
+                            , displayFlex
+                            , Css.flexShrink Css.zero
+                            , alignItems center
+                            , justifyContent center
+                            ]
+                        , ExtraAttributes.nriDescription messageIconDescription
+                        ]
+                        [ UiIcon.sparkleBulb
+                            |> NriSvg.withColor Colors.mustard
+                            |> NriSvg.withWidth (Css.px 22)
+                            |> NriSvg.withHeight (Css.px 22)
+                            |> NriSvg.toHtml
+                        ]
+
+                Banner ->
+                    div
+                        [ Attributes.css
+                            [ borderRadius (pct 50)
+                            , height (px 35)
+                            , width (px 35)
+                            , Css.marginRight (Css.px 10)
+                            , backgroundColor Colors.navy
+                            , displayFlex
+                            , Css.flexShrink Css.zero
+                            , alignItems center
+                            , justifyContent center
+                            , Css.Media.withMedia
+                                [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
+                                [ height (px 35)
+                                , width (px 35)
+                                ]
+                            ]
+                        , ExtraAttributes.nriDescription messageIconDescription
+                        ]
+                        [ UiIcon.sparkleBulb
+                            |> NriSvg.withColor Colors.mustard
+                            |> NriSvg.withWidth (Css.px 22)
+                            |> NriSvg.withHeight (Css.px 22)
+                            |> NriSvg.toHtml
+                        ]
+
+        ( Nothing, Success ) ->
+            UiIcon.checkmarkInCircle
+                |> NriSvg.withColor Colors.greenDark
+                |> NriSvg.withWidth iconSize
+                |> NriSvg.withHeight iconSize
+                |> NriSvg.withCss [ marginRight, Css.flexShrink Css.zero ]
+                |> NriSvg.withLabel "Success"
+                |> NriSvg.toHtml
+
+        ( Just icon_, _ ) ->
+            icon_
+                |> NriSvg.withWidth iconSize
+                |> NriSvg.withHeight iconSize
+                |> NriSvg.withCss [ marginRight, Css.flexShrink Css.zero ]
+                |> NriSvg.toHtml
+
+        ( Nothing, Custom _ ) ->
+            Html.text ""
+
+
+messageIconDescription : String
+messageIconDescription =
+    "Nri-Ui-Message-icon"
+
+
+
+-- Role
+
+
+type Role
+    = AlertRole
+    | StatusRole
+
+
+getRoleAttribute : Maybe Role -> List (Html.Attribute Never)
+getRoleAttribute role =
+    case role of
+        Just AlertRole ->
+            [ Role.alert ]
+
+        Just StatusRole ->
+            [ Role.status ]
+
+        Nothing ->
+            []
+
+
+
+-- Dismiss buttons
+
+
+tinyDismissButton : msg -> Html msg
+tinyDismissButton msg =
+    Nri.Ui.styled div
+        "dismiss-button-container"
+        []
+        []
+        [ ClickableSvg.button "Dismiss message"
+            UiIcon.x
+            [ ClickableSvg.onClick msg
+            , ClickableSvg.exactWidth 16
+            , ClickableSvg.exactHeight 16
+            , ClickableSvg.css
+                [ Css.verticalAlign Css.middle
+                , Css.marginLeft (Css.px 5)
+                ]
+            ]
+        ]
+
+
+largeDismissButton : msg -> Html msg
+largeDismissButton msg =
+    Nri.Ui.styled div
+        "dismiss-button-container"
+        [ padding2 zero (px 20)
+        , displayFlex
+        , Css.Media.withMedia
+            [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
+            [ padding4 (px 10) zero (px 10) (px 15)
+            ]
+        ]
+        []
+        [ ClickableSvg.button "Dismiss message"
+            UiIcon.x
+            [ ClickableSvg.onClick msg
+            , ClickableSvg.exactWidth 16
+            , ClickableSvg.exactHeight 16
+            ]
+        ]
+
+
+bannerDismissButton : msg -> Html msg
+bannerDismissButton msg =
+    Nri.Ui.styled div
+        "dismiss-button-container"
+        [ padding2 zero (px 20)
+        , displayFlex
+        , Css.Media.withMedia
+            [ Css.Media.all [ Css.Media.maxWidth (px 1000) ] ]
+            [ padding4 (px 10) zero (px 10) (px 15)
+            ]
+        ]
+        []
+        [ ClickableSvg.button "Dismiss banner"
+            UiIcon.x
+            [ ClickableSvg.onClick msg
+            , ClickableSvg.exactWidth 16
+            , ClickableSvg.exactHeight 16
+            ]
+        ]

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -51,6 +51,7 @@
         "Nri.Ui.MediaQuery.V1",
         "Nri.Ui.Menu.V4",
         "Nri.Ui.Message.V3",
+        "Nri.Ui.Message.V4",
         "Nri.Ui.Modal.V11",
         "Nri.Ui.Page.V3",
         "Nri.Ui.Pagination.V1",


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

- adds `status` role
- removes `alertdialog` role
- moves custom attributes and role to a div containing the icon and text
- makes this div programmatically focusable

[A11-3081 : Update Nri.Ui.Message to work nicely for AT notifications](https://linear.app/noredink/issue/A11-3081/update-nriuimessage-to-work-nicely-for-at-notifications)

## :framed_picture: What does this change look like?

<img width="468" alt="Screenshot 2023-07-25 at 18 39 13" src="https://github.com/NoRedInk/noredink-ui/assets/5647344/269bb200-79df-4c30-bb82-74bac6fc1996">
<img width="1340" alt="Screenshot 2023-07-25 at 18 39 34" src="https://github.com/NoRedInk/noredink-ui/assets/5647344/e2d86ccc-2c6e-44ed-944c-63ce4e0a05e9">
<img width="1361" alt="Screenshot 2023-07-25 at 18 39 47" src="https://github.com/NoRedInk/noredink-ui/assets/5647344/598076a2-8429-49fa-9f0b-412bde0da119">


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
