### PR TITLE
:wrench: Modal.titleId

### DIFF
--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -160,6 +160,7 @@ view model =
 
 import Accessibility.Styled as Html exposing (..)
 import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Key as Key
 import Accessibility.Styled.Role as Role
 import Browser.Dom as Dom
 import Browser.Events.Extra
@@ -556,7 +557,11 @@ viewBackdrop wrapMsg color =
         []
 
 
-{-| -}
+{-| Id used for the `h1` that labels the modal.
+
+Useful if you're changing the modal contents and want to move the user's focus to the new modal's updated title to re-orient them.
+
+-}
 titleId : String
 titleId =
     "modal__title"
@@ -584,6 +589,7 @@ viewModal config =
             [ id titleId
             , Attrs.css (titleStyles config)
             , ExtraAttributes.nriDescription "modal-title"
+            , Key.tabbable False
             ]
             [ text config.title ]
         , div

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -17,6 +17,8 @@ module Nri.Ui.Modal.V11 exposing
   - adds `testId` helper
   - adds data-nri-descriptions to the header, content, and footer
   - use `Shadows`
+  - exposes `titleId`
+  - makes the title programmatically focusable
 
 
 # Changes from V10:

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -6,7 +6,7 @@ module Nri.Ui.Modal.V11 exposing
     , info, warning
     , showTitle, hideTitle
     , testId, css, custom
-    , isOpen
+    , isOpen, titleId
     )
 
 {-|
@@ -152,9 +152,9 @@ view model =
 @docs testId, css, custom
 
 
-### State checks
+### State checks and accessors
 
-@docs isOpen
+@docs isOpen, titleId
 
 -}
 
@@ -556,8 +556,9 @@ viewBackdrop wrapMsg color =
         []
 
 
-modalTitleId : String
-modalTitleId =
+{-| -}
+titleId : String
+titleId =
     "modal__title"
 
 
@@ -575,12 +576,12 @@ viewModal config =
     section
         ([ Role.dialog
          , Aria.modal True
-         , Aria.labeledBy modalTitleId
+         , Aria.labeledBy titleId
          ]
             ++ config.customAttributes
         )
         [ h1
-            [ id modalTitleId
+            [ id titleId
             , Attrs.css (titleStyles config)
             , ExtraAttributes.nriDescription "modal-title"
             ]

--- a/tests/Spec/Nri/Ui/Modal.elm
+++ b/tests/Spec/Nri/Ui/Modal.elm
@@ -58,7 +58,6 @@ init =
 type Msg
     = OpenModal String
     | ModalMsg Modal.Msg
-    | CloseModal
     | Focus String
     | Focused (Result Dom.Error ())
 
@@ -83,13 +82,6 @@ update msg model =
                         { dismissOnEscAndOverlayClick = True }
                         modalMsg
                         model
-            in
-            ( newModel, Cmd.map ModalMsg cmd )
-
-        CloseModal ->
-            let
-                ( newModel, cmd ) =
-                    Modal.close model
             in
             ( newModel, Cmd.map ModalMsg cmd )
 

--- a/tests/Spec/Nri/Ui/Modal.elm
+++ b/tests/Spec/Nri/Ui/Modal.elm
@@ -1,0 +1,128 @@
+module Spec.Nri.Ui.Modal exposing (spec)
+
+import Browser.Dom as Dom
+import Html.Styled as Html exposing (Html, toUnstyled)
+import Html.Styled.Attributes as Attributes
+import Html.Styled.Events as Events
+import Nri.Ui.Modal.V11 as Modal
+import ProgramTest exposing (..)
+import Task
+import Test exposing (..)
+import Test.Html.Selector exposing (..)
+
+
+spec : Test
+spec =
+    describe "Nri.Ui.Modal"
+        [ test "titleId is attached to the modal title" <|
+            \() ->
+                start
+                    |> clickButton "Open Modal"
+                    |> ensureViewHas
+                        [ id Modal.titleId
+                        , tag "h1"
+                        , containing [ text modalTitle ]
+                        ]
+                    |> done
+        ]
+
+
+start : ProgramTest Modal.Model Msg (Cmd Msg)
+start =
+    ProgramTest.createElement
+        { init = \_ -> init
+        , view = toUnstyled << view
+        , update = update
+        }
+        |> ProgramTest.start ()
+
+
+init : ( Modal.Model, Cmd Msg )
+init =
+    let
+        ( model, cmd ) =
+            -- When we load the page with a modal already open, we should return
+            -- the focus someplace sensible when the modal closes.
+            -- [This article](https://developer.paciellogroup.com/blog/2018/06/the-current-state-of-modal-dialog-accessibility/) recommends
+            -- focusing the main or body.
+            Modal.open
+                { startFocusOn = Modal.closeButtonId
+                , returnFocusTo = "maincontent"
+                }
+    in
+    ( model, Cmd.map ModalMsg cmd )
+
+
+type Msg
+    = OpenModal String
+    | ModalMsg Modal.Msg
+    | CloseModal
+    | Focus String
+    | Focused (Result Dom.Error ())
+
+
+update : Msg -> Modal.Model -> ( Modal.Model, Cmd Msg )
+update msg model =
+    case msg of
+        OpenModal returnFocusTo ->
+            let
+                ( newModel, cmd ) =
+                    Modal.open
+                        { startFocusOn = Modal.closeButtonId
+                        , returnFocusTo = returnFocusTo
+                        }
+            in
+            ( newModel, Cmd.map ModalMsg cmd )
+
+        ModalMsg modalMsg ->
+            let
+                ( newModel, cmd ) =
+                    Modal.update
+                        { dismissOnEscAndOverlayClick = True }
+                        modalMsg
+                        model
+            in
+            ( newModel, Cmd.map ModalMsg cmd )
+
+        CloseModal ->
+            let
+                ( newModel, cmd ) =
+                    Modal.close model
+            in
+            ( newModel, Cmd.map ModalMsg cmd )
+
+        Focus id ->
+            ( model, Task.attempt Focused (Dom.focus id) )
+
+        Focused _ ->
+            ( model, Cmd.none )
+
+
+view : Modal.Model -> Html Msg
+view model =
+    Html.main_ [ Attributes.id "maincontent" ]
+        [ Html.button
+            [ Attributes.id "open-modal"
+            , Events.onClick (OpenModal "open-modal")
+            ]
+            [ Html.text "Open Modal" ]
+        , Modal.view
+            { title = modalTitle
+            , wrapMsg = ModalMsg
+            , content = [ Html.text "Modal Content" ]
+            , footer = []
+            , focusTrap =
+                { focus = Focus
+                , firstId = Modal.closeButtonId
+                , lastId = Modal.closeButtonId
+                }
+            }
+            [ Modal.closeButton
+            ]
+            model
+        ]
+
+
+modalTitle : String
+modalTitle =
+    "Modal Title"

--- a/tests/Spec/Nri/Ui/Modal.elm
+++ b/tests/Spec/Nri/Ui/Modal.elm
@@ -1,5 +1,6 @@
 module Spec.Nri.Ui.Modal exposing (spec)
 
+import Accessibility.Key as Key
 import Browser.Dom as Dom
 import Html.Styled as Html exposing (Html, toUnstyled)
 import Html.Styled.Attributes as Attributes
@@ -22,6 +23,7 @@ spec =
                         [ id Modal.titleId
                         , tag "h1"
                         , containing [ text modalTitle ]
+                        , attribute (Key.tabbable False)
                         ]
                     |> done
         ]


### PR DESCRIPTION
## Context

Fixes A11-3185

Exposes `titleId` from `Modal`.
Makes the `title` (the `h1` labelling the Modal) programmatically focusable.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
