### PR TITLE
Make tiny success smaller

### DIFF
--- a/src/Nri/Ui/Message/V3.elm
+++ b/src/Nri/Ui/Message/V3.elm
@@ -808,8 +808,8 @@ getIcon customIcon size theme =
                     div
                         [ Attributes.css
                             [ borderRadius (pct 50)
-                            , height (px 20)
-                            , width (px 20)
+                            , height (px 18)
+                            , width (px 18)
                             , Css.marginRight (Css.px 5)
                             , backgroundColor Colors.navy
                             , displayFlex


### PR DESCRIPTION
So it's in line with the other tinies.

<img width="630" alt="Napkin 16 07-28-23, 11 46 21 AM" src="https://github.com/NoRedInk/noredink-ui/assets/13528834/3909d0d7-0e3d-4302-8695-6abbdc07c09b">
