### PR TITLE
Add guidanceHtml to all input examples

### DIFF
--- a/component-catalog/src/CommonControls.elm
+++ b/component-catalog/src/CommonControls.elm
@@ -450,21 +450,31 @@ css_ helperName ( styles, default ) { moduleName, use } =
 guidanceAndErrorMessage :
     { moduleName : String
     , guidance : String -> b
+    , guidanceHtml : List (Html msg) -> b
     , message : String
     , errorMessage : Maybe (Maybe String -> b)
     }
     -> Control (List ( String, b ))
     -> Control (List ( String, b ))
 guidanceAndErrorMessage ({ moduleName } as config) controls =
-    [ ControlExtra.optionalListItem "guidance"
-        (Control.string config.message
-            |> Control.map
-                (\str ->
-                    ( Code.fromModule moduleName "guidance " ++ Code.string str
-                    , config.guidance str
+    [ Control.choice
+        [ ( "string"
+          , Control.string config.message
+                |> Control.map
+                    (\str ->
+                        ( Code.fromModule moduleName "guidance " ++ Code.string str
+                        , config.guidance str
+                        )
                     )
+          )
+        , ( "html"
+          , Control.value
+                ( Code.fromModule moduleName "guidanceHtml [ text \"There is \", b [] [ text \"something\" ], text \" you need to be aware of.\" ]"
+                , config.guidanceHtml [ Html.text "There is ", Html.b [] [ Html.text "something" ], Html.text " you need to be aware of." ]
                 )
-        )
+          )
+        ]
+        |> ControlExtra.optionalListItem "guidance"
         |> Just
     , Maybe.map
         (\errorMessage ->

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -179,7 +179,6 @@ init =
 
 type alias Settings =
     { label : String
-    , guidanceHtml : Maybe (List (Html Msg))
     , attributes : List ( String, Checkbox.Attribute Msg )
     }
 
@@ -188,8 +187,6 @@ controlSettings : Control Settings
 controlSettings =
     Control.record Settings
         |> Control.field "label" (Control.string "Enable Text-to-Speech")
-        |> Control.field "guidanceHtml"
-            (Control.maybe False (Control.value [ text "There is ", b [] [ text "something" ], text " you need to be aware of." ]))
         |> Control.field "attributes" initAttributes
 
 
@@ -199,6 +196,7 @@ initAttributes =
         |> CommonControls.guidanceAndErrorMessage
             { moduleName = moduleName
             , guidance = Checkbox.guidance
+            , guidanceHtml = Checkbox.guidanceHtml
             , errorMessage = Nothing
             , message = "There is something you need to be aware of."
             }
@@ -242,7 +240,6 @@ viewExampleWithCode state settings =
             (List.filterMap identity
                 [ Just <| Code.fromModule moduleName "id " ++ Code.string id
                 , Just <| Code.fromModule moduleName "onCheck " ++ "identity"
-                , settings.guidanceHtml |> Maybe.map (\_ -> "Checkbox.guidanceHtml [ text \"There is \", b [] [ text \"something\" ], text \" you need to be aware of.\" ]")
                 ]
                 ++ List.map Tuple.first settings.attributes
             )
@@ -256,7 +253,6 @@ viewExampleWithCode state settings =
         (List.filterMap identity
             [ Just <| Checkbox.id id
             , Just <| Checkbox.onCheck (ToggleCheck id)
-            , settings.guidanceHtml |> Maybe.map Checkbox.guidanceHtml
             ]
             ++ List.map Tuple.second settings.attributes
         )

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -11,6 +11,7 @@ import CheckboxIcons
 import Code
 import Css exposing (Style)
 import Debug.Control as Control exposing (Control)
+import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled exposing (..)
@@ -177,12 +178,12 @@ init =
 
 type alias Settings =
     { label : String
-    , disabled : Bool
     , hiddenLabel : Bool
     , containerCss : ( String, List Style )
     , labelCss : ( String, List Style )
     , guidance : Maybe String
     , guidanceHtml : Maybe (List (Html Msg))
+    , attributes : List ( String, Checkbox.Attribute Msg )
     }
 
 
@@ -190,7 +191,6 @@ controlSettings : Control Settings
 controlSettings =
     Control.record Settings
         |> Control.field "label" (Control.string "Enable Text-to-Speech")
-        |> Control.field "disabled" (Control.bool False)
         |> Control.field "hiddenLabel" (Control.bool False)
         |> Control.field "containerCss"
             (Control.choice
@@ -218,6 +218,13 @@ controlSettings =
             (Control.maybe False (Control.string "There is something you need to be aware of."))
         |> Control.field "guidanceHtml"
             (Control.maybe False (Control.value [ text "There is ", b [] [ text "something" ], text " you need to be aware of." ]))
+        |> Control.field "attributes" initAttributes
+
+
+initAttributes : Control (List ( String, Checkbox.Attribute Msg ))
+initAttributes =
+    ControlExtra.list
+        |> ControlExtra.optionalBoolListItem "disabled" ( "disabled", Checkbox.disabled )
 
 
 viewExampleWithCode : State -> Settings -> ( String, Html Msg )
@@ -235,11 +242,6 @@ viewExampleWithCode state settings =
       , Code.list
             (List.filterMap identity
                 [ Just <| "Checkbox.onCheck identity"
-                , if settings.disabled then
-                    Just <| "Checkbox.disabled"
-
-                  else
-                    Just <| "Checkbox.enabled"
                 , if settings.hiddenLabel then
                     Just <| "Checkbox.hiddenLabel"
 
@@ -250,6 +252,7 @@ viewExampleWithCode state settings =
                 , settings.guidance |> Maybe.map (\v -> "Checkbox.guidance " ++ Code.string v)
                 , settings.guidanceHtml |> Maybe.map (\_ -> "Checkbox.guidanceHtml [ text \"There is \", b [] [ text \"something\" ], text \" you need to be aware of.\" ]")
                 ]
+                ++ List.map Tuple.first settings.attributes
             )
       ]
         |> String.join ""
@@ -265,16 +268,12 @@ viewExampleWithCode state settings =
 
               else
                 Just <| Checkbox.visibleLabel
-            , if settings.disabled then
-                Just <| Checkbox.disabled
-
-              else
-                Just <| Checkbox.enabled
             , Just <| Checkbox.containerCss (Tuple.second settings.containerCss)
             , Just <| Checkbox.labelCss (Tuple.second settings.labelCss)
             , settings.guidance |> Maybe.map Checkbox.guidance
             , settings.guidanceHtml |> Maybe.map Checkbox.guidanceHtml
             ]
+            ++ List.map Tuple.second settings.attributes
         )
     )
 

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -237,10 +237,9 @@ viewExampleWithCode state settings =
             ]
             1
       , Code.listMultiline
-            (List.filterMap identity
-                [ Just <| Code.fromModule moduleName "id " ++ Code.string id
-                , Just <| Code.fromModule moduleName "onCheck " ++ "identity"
-                ]
+            ([ Code.fromModule moduleName "id " ++ Code.string id
+             , Code.fromModule moduleName "onCheck " ++ "identity"
+             ]
                 ++ List.map Tuple.first settings.attributes
             )
             1
@@ -250,10 +249,9 @@ viewExampleWithCode state settings =
         { label = settings.label
         , selected = state.isChecked
         }
-        (List.filterMap identity
-            [ Just <| Checkbox.id id
-            , Just <| Checkbox.onCheck (ToggleCheck id)
-            ]
+        ([ Checkbox.id id
+         , Checkbox.onCheck (ToggleCheck id)
+         ]
             ++ List.map Tuple.second settings.attributes
         )
     )

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -234,14 +234,16 @@ viewExampleWithCode state settings =
             , ( "selected", "Checkbox." ++ Debug.toString state.isChecked )
             ]
             1
-      , Code.list
+      , Code.listMultiline
             (List.filterMap identity
-                [ Just <| "Checkbox.onCheck identity"
+                [ Just <| Code.fromModule moduleName "id " ++ Code.string id
+                , Just <| "Checkbox.onCheck identity"
                 , settings.guidance |> Maybe.map (\v -> "Checkbox.guidance " ++ Code.string v)
                 , settings.guidanceHtml |> Maybe.map (\_ -> "Checkbox.guidanceHtml [ text \"There is \", b [] [ text \"something\" ], text \" you need to be aware of.\" ]")
                 ]
                 ++ List.map Tuple.first settings.attributes
             )
+            1
       ]
         |> String.join ""
     , Checkbox.view

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -9,6 +9,7 @@ module Examples.Checkbox exposing (Msg, State, example)
 import Category exposing (Category(..))
 import CheckboxIcons
 import Code
+import CommonControls
 import Css exposing (Style)
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
@@ -178,7 +179,6 @@ init =
 
 type alias Settings =
     { label : String
-    , guidance : Maybe String
     , guidanceHtml : Maybe (List (Html Msg))
     , attributes : List ( String, Checkbox.Attribute Msg )
     }
@@ -188,8 +188,6 @@ controlSettings : Control Settings
 controlSettings =
     Control.record Settings
         |> Control.field "label" (Control.string "Enable Text-to-Speech")
-        |> Control.field "guidance"
-            (Control.maybe False (Control.string "There is something you need to be aware of."))
         |> Control.field "guidanceHtml"
             (Control.maybe False (Control.value [ text "There is ", b [] [ text "something" ], text " you need to be aware of." ]))
         |> Control.field "attributes" initAttributes
@@ -198,6 +196,12 @@ controlSettings =
 initAttributes : Control (List ( String, Checkbox.Attribute Msg ))
 initAttributes =
     ControlExtra.list
+        |> CommonControls.guidanceAndErrorMessage
+            { moduleName = moduleName
+            , guidance = Checkbox.guidance
+            , errorMessage = Nothing
+            , message = "There is something you need to be aware of."
+            }
         |> ControlExtra.optionalBoolListItem "disabled" ( "disabled", Checkbox.disabled )
         |> ControlExtra.optionalBoolListItem "hiddenLabel" ( "hiddenLabel", Checkbox.hiddenLabel )
         |> ControlExtra.optionalListItem "containerCss"
@@ -238,7 +242,6 @@ viewExampleWithCode state settings =
             (List.filterMap identity
                 [ Just <| Code.fromModule moduleName "id " ++ Code.string id
                 , Just <| Code.fromModule moduleName "onCheck " ++ "identity"
-                , settings.guidance |> Maybe.map (\v -> "Checkbox.guidance " ++ Code.string v)
                 , settings.guidanceHtml |> Maybe.map (\_ -> "Checkbox.guidanceHtml [ text \"There is \", b [] [ text \"something\" ], text \" you need to be aware of.\" ]")
                 ]
                 ++ List.map Tuple.first settings.attributes
@@ -253,7 +256,6 @@ viewExampleWithCode state settings =
         (List.filterMap identity
             [ Just <| Checkbox.id id
             , Just <| Checkbox.onCheck (ToggleCheck id)
-            , settings.guidance |> Maybe.map Checkbox.guidance
             , settings.guidanceHtml |> Maybe.map Checkbox.guidanceHtml
             ]
             ++ List.map Tuple.second settings.attributes

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -228,16 +228,16 @@ viewExampleWithCode state settings =
         id =
             "unique-example-id"
     in
-    ( [ "Checkbox.view"
+    ( [ Code.fromModule moduleName "view"
       , Code.recordMultiline
             [ ( "label", Code.string settings.label )
-            , ( "selected", "Checkbox." ++ Debug.toString state.isChecked )
+            , ( "selected", Code.fromModule "Checkbox" (Debug.toString state.isChecked) )
             ]
             1
       , Code.listMultiline
             (List.filterMap identity
                 [ Just <| Code.fromModule moduleName "id " ++ Code.string id
-                , Just <| "Checkbox.onCheck identity"
+                , Just <| Code.fromModule moduleName "onCheck " ++ "identity"
                 , settings.guidance |> Maybe.map (\v -> "Checkbox.guidance " ++ Code.string v)
                 , settings.guidanceHtml |> Maybe.map (\_ -> "Checkbox.guidanceHtml [ text \"There is \", b [] [ text \"something\" ], text \" you need to be aware of.\" ]")
                 ]

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -178,9 +178,6 @@ init =
 
 type alias Settings =
     { label : String
-    , hiddenLabel : Bool
-    , containerCss : ( String, List Style )
-    , labelCss : ( String, List Style )
     , guidance : Maybe String
     , guidanceHtml : Maybe (List (Html Msg))
     , attributes : List ( String, Checkbox.Attribute Msg )
@@ -191,29 +188,6 @@ controlSettings : Control Settings
 controlSettings =
     Control.record Settings
         |> Control.field "label" (Control.string "Enable Text-to-Speech")
-        |> Control.field "hiddenLabel" (Control.bool False)
-        |> Control.field "containerCss"
-            (Control.choice
-                [ ( "[]", Control.value ( "[]", [] ) )
-                , ( "Red dashed border"
-                  , Control.value
-                        ( "[ Css.border3 (Css.px 4) Css.dashed Colors.red ]"
-                        , [ Css.border3 (Css.px 4) Css.dashed Colors.red ]
-                        )
-                  )
-                ]
-            )
-        |> Control.field "labelCss"
-            (Control.choice
-                [ ( "[]", Control.value ( "[]", [] ) )
-                , ( "Orange dotted border"
-                  , Control.value
-                        ( "[ Css.border3 (Css.px 4) Css.dotted Colors.orange ]"
-                        , [ Css.border3 (Css.px 4) Css.dotted Colors.orange ]
-                        )
-                  )
-                ]
-            )
         |> Control.field "guidance"
             (Control.maybe False (Control.string "There is something you need to be aware of."))
         |> Control.field "guidanceHtml"
@@ -225,6 +199,27 @@ initAttributes : Control (List ( String, Checkbox.Attribute Msg ))
 initAttributes =
     ControlExtra.list
         |> ControlExtra.optionalBoolListItem "disabled" ( "disabled", Checkbox.disabled )
+        |> ControlExtra.optionalBoolListItem "hiddenLabel" ( "hiddenLabel", Checkbox.hiddenLabel )
+        |> ControlExtra.optionalListItem "containerCss"
+            (Control.choice
+                [ ( "Red dashed border"
+                  , Control.value
+                        ( "Checkbox.containerCss [ Css.border3 (Css.px 4) Css.dashed Colors.red ]"
+                        , Checkbox.containerCss [ Css.border3 (Css.px 4) Css.dashed Colors.red ]
+                        )
+                  )
+                ]
+            )
+        |> ControlExtra.optionalListItem "labelCss"
+            (Control.choice
+                [ ( "Orange dotted border"
+                  , Control.value
+                        ( "Checkbox.labelCss [ Css.border3 (Css.px 4) Css.dotted Colors.orange ]"
+                        , Checkbox.labelCss [ Css.border3 (Css.px 4) Css.dotted Colors.orange ]
+                        )
+                  )
+                ]
+            )
 
 
 viewExampleWithCode : State -> Settings -> ( String, Html Msg )
@@ -242,13 +237,6 @@ viewExampleWithCode state settings =
       , Code.list
             (List.filterMap identity
                 [ Just <| "Checkbox.onCheck identity"
-                , if settings.hiddenLabel then
-                    Just <| "Checkbox.hiddenLabel"
-
-                  else
-                    Just <| "Checkbox.visibleLabel"
-                , Just <| "Checkbox.containerCss " ++ Tuple.first settings.containerCss
-                , Just <| "Checkbox.labelCss " ++ Tuple.first settings.labelCss
                 , settings.guidance |> Maybe.map (\v -> "Checkbox.guidance " ++ Code.string v)
                 , settings.guidanceHtml |> Maybe.map (\_ -> "Checkbox.guidanceHtml [ text \"There is \", b [] [ text \"something\" ], text \" you need to be aware of.\" ]")
                 ]
@@ -263,13 +251,6 @@ viewExampleWithCode state settings =
         (List.filterMap identity
             [ Just <| Checkbox.id id
             , Just <| Checkbox.onCheck (ToggleCheck id)
-            , if settings.hiddenLabel then
-                Just <| Checkbox.hiddenLabel
-
-              else
-                Just <| Checkbox.visibleLabel
-            , Just <| Checkbox.containerCss (Tuple.second settings.containerCss)
-            , Just <| Checkbox.labelCss (Tuple.second settings.labelCss)
             , settings.guidance |> Maybe.map Checkbox.guidance
             , settings.guidanceHtml |> Maybe.map Checkbox.guidanceHtml
             ]

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -10,7 +10,7 @@ import Category exposing (Category(..))
 import CheckboxIcons
 import Code
 import CommonControls
-import Css exposing (Style)
+import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -311,6 +311,7 @@ controlAttributes =
         |> CommonControls.guidanceAndErrorMessage
             { moduleName = moduleName
             , guidance = RadioButton.guidance
+            , guidanceHtml = RadioButton.guidanceHtml
             , errorMessage = Just RadioButton.errorMessage
             , message = "The statement must be true."
             }

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -311,7 +311,7 @@ controlAttributes =
         |> CommonControls.guidanceAndErrorMessage
             { moduleName = moduleName
             , guidance = RadioButton.guidance
-            , errorMessage = RadioButton.errorMessage
+            , errorMessage = Just RadioButton.errorMessage
             , message = "The statement must be true."
             }
 

--- a/component-catalog/src/Examples/Select.elm
+++ b/component-catalog/src/Examples/Select.elm
@@ -182,6 +182,7 @@ initControls =
         |> CommonControls.guidanceAndErrorMessage
             { moduleName = moduleName
             , guidance = Select.guidance
+            , guidanceHtml = Select.guidanceHtml
             , errorMessage = Just Select.errorMessage
             , message = "The right item must be selected."
             }

--- a/component-catalog/src/Examples/Select.elm
+++ b/component-catalog/src/Examples/Select.elm
@@ -89,7 +89,7 @@ example =
                     Note that if the value is bound (and why would you ever make a `Select` where it isn't?)
                     then changing the list of options will not change its value.
                     Furthermore, `Select` will only fire an event when a new value is selected.
-                    This means that if the starting value is `Nothing` and there is no `defaultDisplayText` 
+                    This means that if the starting value is `Nothing` and there is no `defaultDisplayText`
                     then you cannot select the first item in the list without first selecting another one.
                     Use the "choices" selector above to get a feel for what that means.
                 """
@@ -182,7 +182,7 @@ initControls =
         |> CommonControls.guidanceAndErrorMessage
             { moduleName = moduleName
             , guidance = Select.guidance
-            , errorMessage = Select.errorMessage
+            , errorMessage = Just Select.errorMessage
             , message = "The right item must be selected."
             }
         |> ControlExtra.optionalListItem "disabled"

--- a/component-catalog/src/Examples/TextArea.elm
+++ b/component-catalog/src/Examples/TextArea.elm
@@ -159,7 +159,7 @@ controlAttributes =
         |> CommonControls.guidanceAndErrorMessage
             { moduleName = moduleName
             , guidance = TextArea.guidance
-            , errorMessage = TextArea.errorMessage
+            , errorMessage = Just TextArea.errorMessage
             , message = "The statement must be true."
             }
         |> ControlExtra.optionalBoolListItem "disabled"

--- a/component-catalog/src/Examples/TextArea.elm
+++ b/component-catalog/src/Examples/TextArea.elm
@@ -159,6 +159,7 @@ controlAttributes =
         |> CommonControls.guidanceAndErrorMessage
             { moduleName = moduleName
             , guidance = TextArea.guidance
+            , guidanceHtml = TextArea.guidanceHtml
             , errorMessage = Just TextArea.errorMessage
             , message = "The statement must be true."
             }

--- a/component-catalog/src/Examples/TextInput.elm
+++ b/component-catalog/src/Examples/TextInput.elm
@@ -424,6 +424,7 @@ controlAttributes =
         |> CommonControls.guidanceAndErrorMessage
             { moduleName = moduleName
             , guidance = TextInput.guidance
+            , guidanceHtml = TextInput.guidanceHtml
             , errorMessage = Just TextInput.errorMessage
             , message = "The statement must be true."
             }

--- a/component-catalog/src/Examples/TextInput.elm
+++ b/component-catalog/src/Examples/TextInput.elm
@@ -424,7 +424,7 @@ controlAttributes =
         |> CommonControls.guidanceAndErrorMessage
             { moduleName = moduleName
             , guidance = TextInput.guidance
-            , errorMessage = TextInput.errorMessage
+            , errorMessage = Just TextInput.errorMessage
             , message = "The statement must be true."
             }
         |> ControlExtra.optionalBoolListItem "disabled"


### PR DESCRIPTION
https://github.com/NoRedInk/noredink-ui/pull/1441 added `guidanceHtml` to Checkbox.V7, RadioButton.V4, Select.V9, TextArea.V5, and TextInput.V7, but only extended the Component Catalog example of Checkbox to include a `guidanceHtml` option.

This PR:
- changes Checkbox's example to use the standard debug-controls attribute pattern
- adjusts `CommonControls.guidanceAndErrorMessage` to be usable by Checkbox (since Checkbox doesn't support error messages)
- extends `CommonControls.guidanceAndErrorMessage` to include `guidanceHtml`

This way, all the inputs that support guidanceHtml will have it available from their example pages.

### Checkbox:

<img width="754" alt="Screen Shot 2023-08-03 at 10 59 16 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/f0605292-4663-42e8-840f-66ca5efa6fcf">

### RadioButton:

<img width="789" alt="Screen Shot 2023-08-03 at 10 59 38 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/51c14447-9ebd-437b-b2d4-2ab63f487af1">

### Select:

<img width="836" alt="Screen Shot 2023-08-03 at 10 59 55 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/1ceef189-f814-46c2-8ab6-b026dae0901d">


### TextArea:

<img width="838" alt="Screen Shot 2023-08-03 at 11 00 11 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/2df95e09-0dfd-4dce-9f31-5b659cec1efa">


### TextInput:

<img width="838" alt="Screen Shot 2023-08-03 at 11 00 34 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/2d688abe-f3e0-4df3-aa17-b1826b4e948b">
