### PR TITLE
:wrench: Add Tooltip border

### DIFF
--- a/component-catalog/src/Examples/Tooltip.elm
+++ b/component-catalog/src/Examples/Tooltip.elm
@@ -104,8 +104,8 @@ init =
         Control.record PageSettings
             |> Control.field "backgroundColor"
                 (Control.choice
-                    [ ( "azure", Control.value Colors.azure )
-                    , ( "white", Control.value Colors.white )
+                    [ ( "white", Control.value Colors.white )
+                    , ( "azure", Control.value Colors.azure )
                     ]
                 )
     }

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -1067,7 +1067,7 @@ viewTooltip tooltipId config =
                  , Css.position Css.absolute
                  , Css.zIndex (Css.int 100)
                  , Css.backgroundColor Colors.navy
-                 , Css.border3 (Css.px 1) Css.solid Colors.navy
+                 , Css.border3 (Css.px 1) Css.solid outlineColor
                  , MediaQuery.withViewport (Just mobileBreakpoint) Nothing <|
                     [ positioning config.direction config.alignment
                     , applyTail config.direction
@@ -1143,6 +1143,11 @@ tailSize =
 tooltipColor : Color
 tooltipColor =
     Colors.navy
+
+
+outlineColor : Color
+outlineColor =
+    Colors.white
 
 
 offCenterOffset : Float
@@ -1338,7 +1343,7 @@ bottomTail : Style
 bottomTail =
     Css.batch
         [ Css.before
-            [ Css.borderTopColor tooltipColor
+            [ Css.borderTopColor outlineColor
             , Css.property "border-width" (String.fromFloat (tailSize + 1) ++ "px")
             , Css.marginLeft (Css.px (-tailSize - 1))
             ]
@@ -1354,7 +1359,7 @@ topTail : Style
 topTail =
     Css.batch
         [ Css.before
-            [ Css.borderBottomColor tooltipColor
+            [ Css.borderBottomColor outlineColor
             , Css.property "border-width" (String.fromFloat (tailSize + 1) ++ "px")
             , Css.marginLeft (Css.px (-tailSize - 1))
             ]
@@ -1370,7 +1375,7 @@ rightTail : Style
 rightTail =
     Css.batch
         [ Css.before
-            [ Css.borderLeftColor tooltipColor
+            [ Css.borderLeftColor outlineColor
             , Css.property "border-width" (String.fromFloat (tailSize + 1) ++ "px")
             ]
         , Css.after
@@ -1386,7 +1391,7 @@ leftTail : Style
 leftTail =
     Css.batch
         [ Css.before
-            [ Css.borderRightColor tooltipColor
+            [ Css.borderRightColor outlineColor
             , Css.property "border-width" (String.fromFloat (tailSize + 1) ++ "px")
             ]
         , Css.after

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -1147,7 +1147,7 @@ tooltipColor =
 
 outlineColor : Color
 outlineColor =
-    Colors.white
+    Css.rgba 255 255 255 0.5
 
 
 offCenterOffset : Float

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -31,6 +31,7 @@ module Nri.Ui.Tooltip.V3 exposing
   - adds narrowMobileCss
   - use internal `Content` module
   - adds `paragraph` and `markdown` support
+  - add partially-transparent white border around tooltips
 
 Changes from V2:
 


### PR DESCRIPTION
When tooltips appear on top of dark backgrounds, the tooltip boundaries can become difficult to distinguish:

![image](https://github.com/NoRedInk/noredink-ui/assets/8811312/c9d6f71f-a974-4dd9-8a0c-56ef267633ea)

This PR adds a white border around the tooltip in order to ensure that it looks nice no matter what background it appears against.

## :framed_picture: What does this change look like?


| | Before | After |
| --- | --- | --- |
| White background | <img width="353" alt="Screen Shot 2023-08-04 at 4 25 05 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/db42f23f-a193-436f-ac81-ff48073fa9af"> | <img width="363" alt="Screen Shot 2023-08-04 at 4 42 59 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/688e2df5-137f-4a48-9a9b-397c9dd83afa"> |
| Azure background | <img width="362" alt="Screen Shot 2023-08-04 at 4 24 58 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/4caee05c-1ded-449d-a332-fdae533fed77"> | <img width="345" alt="Screen Shot 2023-08-04 at 4 42 48 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/62cbf061-4e7d-4335-a600-f35fff459c37"> |

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
