### PR TITLE
[PHX-1008] Set minheight on the proper element

### DIFF
--- a/src/Nri/Ui/QuestionBox/V6.elm
+++ b/src/Nri/Ui/QuestionBox/V6.elm
@@ -256,7 +256,6 @@ viewContainer config =
                     , Css.borderBottom3 (Css.px 8) Css.solid shadowColor
                     ]
         , Css.width (Css.pct 100)
-        , Css.minHeight (Css.px 80)
         , Css.batch config.containerCss
         ]
         [ AttributesExtra.nriDescription "question-box-container"
@@ -277,6 +276,9 @@ viewContainer config =
             , Css.displayFlex
             , Css.property "gap" "30px"
             , Css.flexDirection Css.column
+
+            -- Approximately one line of text
+            , Css.minHeight (Css.px 53)
             , case config.theme of
                 Tip ->
                     Css.batch


### PR DESCRIPTION
## Context

- https://linear.app/noredink/issue/PHX-1008/questionboxv6-side-borders-dont-necessarily-extend-down-to-the-bottom

`min-height` was set on the container instead of the content, resulting in a "gap" in the border in some cases.

## :framed_picture: What does this change look like?

| | Chrome | FF | Safari |
|---|---|---|---|
| Before | <img width="213" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/12899207/a6dab2e4-ff97-465f-a8e5-667c83dc8719"> | <img width="215" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/12899207/9e7bb237-84df-4a77-af3c-d4efa6f0b0db"> | <img width="212" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/12899207/f04b4ced-d993-45b5-b963-f812122723aa">|
| After | <img width="229" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/12899207/1a6cdb52-592a-4d8a-a6a4-5c9a62d6fb12"> | <img width="217" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/12899207/7ab78c18-4b93-43a9-bf93-9891d98a0a7e"> | <img width="216" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/12899207/a2a77398-096b-4ac0-a635-ccf9d709fb0d">|

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
