### PR TITLE
Only subscribe to the current example's subscriptions

### DIFF
--- a/component-catalog/src/App.elm
+++ b/component-catalog/src/App.elm
@@ -230,9 +230,15 @@ perform navigationKey effect =
 subscriptions : Model key -> Sub Msg
 subscriptions model =
     Sub.batch
-        [ Dict.values model.moduleStates
-            |> List.map (\example -> Sub.map (UpdateModuleStates example.name) (example.subscriptions example.state))
-            |> Sub.batch
+        [ case model.route of
+            Routes.Doodad example ->
+                Sub.map (UpdateModuleStates example.name) (example.subscriptions example.state)
+
+            Routes.CategoryDoodad _ example ->
+                Sub.map (UpdateModuleStates example.name) (example.subscriptions example.state)
+
+            _ ->
+                Sub.none
         , Sub.map NewInputMethod InputMethod.subscriptions
         ]
 


### PR DESCRIPTION
Component Catalog 🐛 -- no change to underlying components.

Fixes A11-3323

Nothing should happen after navigating to the Highlighter example, navigating to a different component example, and then clicking the whitespace.