### PR TITLE
Tooltip text styles

### DIFF
--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -1086,14 +1086,14 @@ viewTooltip tooltipId config =
                     , applyTail narrowMobileDirection
                     ]
                  , Fonts.baseFont
-                 , Css.fontSize (Css.px 16)
+                 , Css.fontSize (Css.px 15)
                  , Css.fontWeight (Css.int 600)
                  , Css.color Colors.white
                  , Shadows.high
                  , Global.descendants
                     [ Global.a
-                        [ Css.textDecoration Css.underline
-                        , Css.color Colors.white
+                        [ Css.color Colors.white
+                        , Css.borderColor Colors.white
                         , Css.visited [ Css.color Colors.white ]
                         , Css.hover [ Css.color Colors.white ]
                         , Css.pseudoClass "focus-visible"


### PR DESCRIPTION
- Remove text decoration declaration so that it can be set as needed (otherwise the default always wins the specificity war)
- Set border color to white so clickable texts don't show with a blue underline
- Reduce body copy to 15px

<img width="397" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/13528834/f4f7a484-35d9-43a8-acc8-7a2e2b1bb1f1">