### PR TITLE
🔧 highlighter toolbar improvements

### DIFF
--- a/src/Nri/Ui/FocusRing/V1.elm
+++ b/src/Nri/Ui/FocusRing/V1.elm
@@ -56,6 +56,9 @@ forMouseUsers =
     , Css.Global.selector ":focus-within .Nri-RadioButton-RadioButtonIcon"
         [ Css.important (Css.boxShadow Css.none)
         ]
+    , Css.Global.selector ".highlighter-toolbar-label:focus-within"
+        [ Css.important (Css.boxShadow Css.none)
+        ]
     , Css.Global.selector ".segmented-control-radio-element:focus-within"
         [ Css.important (Css.boxShadow Css.none)
         ]

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -33,7 +33,7 @@ import Html.Styled.Events exposing (onClick)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Fonts.V1 as Fonts
-import Nri.Ui.Html.Attributes.V2 exposing (nriDescription)
+import Nri.Ui.Html.Attributes.V2 exposing (nriDescription, safeIdWithPrefix)
 import Nri.Ui.Html.V3 exposing (viewIf)
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -105,7 +105,7 @@ viewTool onSelect ({ name } as theme) tag model =
             model.currentTool == tag
     in
     label
-        [ id ("tag-" ++ name)
+        [ id (safeIdWithPrefix "tag" name)
         , css
             [ Css.cursor Css.pointer
             , Css.position Css.relative

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -28,7 +28,7 @@ import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Role as Role
 import Css exposing (Color)
 import Html.Styled exposing (..)
-import Html.Styled.Attributes as Attributes exposing (css, id)
+import Html.Styled.Attributes as Attributes exposing (class, css, id)
 import Html.Styled.Events exposing (onClick)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.FocusRing.V1 as FocusRing
@@ -113,6 +113,9 @@ viewTool onSelect ({ name } as theme) tag model =
             , Css.paddingBottom (Css.px 2)
             , Css.marginRight (Css.px 15)
             ]
+        , -- this class is used to remove focus styles for mouse users.
+          -- any changes should be applied to FocusRing as well.
+          class "highlighter-toolbar-label"
         ]
         [ input
             [ Attributes.value name

--- a/src/Nri/Ui/HighlighterToolbar/V3.elm
+++ b/src/Nri/Ui/HighlighterToolbar/V3.elm
@@ -14,6 +14,8 @@ module Nri.Ui.HighlighterToolbar.V3 exposing (view)
 ### Patch changes:
 
   - Ensure selected tool is clear in high contrast mode
+  - Remove focus rings from the tools on click
+  - Use safeId to generate valid HTML ids
 
 
 ### Changes from V1:


### PR DESCRIPTION
Fixes A11-3295

- removes focus rings from toolbar items on click
- uses `safeId` to ensure that the tool ids are valid

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - this is not a new major version
