### PR TITLE
:wrench: Fix accidental major version change in Mark, adds Mark.V4

### DIFF
--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -1,6 +1,7 @@
 Nri.Ui.Block.V4,upgrade to V5
 Nri.Ui.WhenFocusLeaves.V1,upgrade to V2
-Nri.Ui.Mark.V2,upgrade to V3
+Nri.Ui.Mark.V2,upgrade to V4
+Nri.Ui.Mark.V3,upgrade to V4
 Nri.Ui.Message.V3,upgrade to V4
 Nri.Ui.Table.V6,upgrade to V7
 Nri.Ui.Tabs.V6,upgrade to V8

--- a/elm.json
+++ b/elm.json
@@ -47,6 +47,7 @@
         "Nri.Ui.Logo.V1",
         "Nri.Ui.Mark.V2",
         "Nri.Ui.Mark.V3",
+        "Nri.Ui.Mark.V4",
         "Nri.Ui.MasteryIcon.V1",
         "Nri.Ui.MediaQuery.V1",
         "Nri.Ui.Menu.V4",

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -131,8 +131,11 @@ hint = 'upgrade to V2'
 usages = ['component-catalog/../src/Nri/Ui/Block/V1.elm']
 
 [forbidden."Nri.Ui.Mark.V2"]
-hint = 'upgrade to V3'
+hint = 'upgrade to V4'
 usages = ['component-catalog/../src/Nri/Ui/Block/V4.elm']
+
+[forbidden."Nri.Ui.Mark.V3"]
+hint = 'upgrade to V4'
 
 [forbidden."Nri.Ui.Menu.V1"]
 hint = 'upgrade to V3'

--- a/src/Nri/Ui/Block/V5.elm
+++ b/src/Nri/Ui/Block/V5.elm
@@ -67,7 +67,7 @@ import Html.Styled.Attributes as Attributes exposing (css)
 import List.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (nriDescription)
-import Nri.Ui.Mark.V3 as Mark exposing (Mark)
+import Nri.Ui.Mark.V4 as Mark exposing (Mark)
 import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Position exposing (xOffsetPx)
 

--- a/src/Nri/Ui/Highlighter/V4.elm
+++ b/src/Nri/Ui/Highlighter/V4.elm
@@ -63,7 +63,7 @@ import Markdown.Inline
 import Nri.Ui.Highlightable.V3 as Highlightable exposing (Highlightable)
 import Nri.Ui.HighlighterTool.V1 as Tool
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
-import Nri.Ui.Mark.V3 as Mark exposing (Mark)
+import Nri.Ui.Mark.V4 as Mark exposing (Mark)
 import Set exposing (Set)
 import Sort exposing (Sorter)
 import Sort.Dict as Dict

--- a/src/Nri/Ui/Mark/V4.elm
+++ b/src/Nri/Ui/Mark/V4.elm
@@ -1,4 +1,4 @@
-module Nri.Ui.Mark.V3 exposing
+module Nri.Ui.Mark.V4 exposing
     ( Mark
     , view, viewWithInlineTags, viewWithBalloonTags
     , viewWithOverlaps
@@ -6,6 +6,11 @@ module Nri.Ui.Mark.V3 exposing
     )
 
 {-|
+
+
+### Changes from V3
+
+  - adds `labelCss` to `viewWithBalloonTags`
 
 @docs Mark
 @docs view, viewWithInlineTags, viewWithBalloonTags
@@ -177,6 +182,7 @@ viewWithBalloonTags :
     , maybeMarker : Maybe Mark
     , labelPosition : Maybe LabelPosition
     , labelState : LabelState
+    , labelCss : List Css.Style
     , labelId : Maybe String
     , labelContentId : Maybe String
     }
@@ -275,6 +281,7 @@ viewMarkedByBalloon :
         | backgroundColor : Color
         , labelState : LabelState
         , labelPosition : Maybe LabelPosition
+        , labelCss : List Css.Style
         , labelId : Maybe String
         , labelContentId : Maybe String
     }
@@ -491,6 +498,7 @@ viewBalloon :
         | backgroundColor : Color
         , labelState : LabelState
         , labelPosition : Maybe LabelPosition
+        , labelCss : List Css.Style
         , labelId : Maybe String
         , labelContentId : Maybe String
     }
@@ -517,8 +525,7 @@ viewBalloon config label =
             , case config.labelState of
                 FadeOut ->
                     Css.batch
-                        [ Css.property "animation-delay" "0.4s"
-                        , Css.property "animation-duration" "0.3s"
+                        [ Css.property "animation-duration" "0.3s"
                         , Css.property "animation-fill-mode" "forwards"
                         , Css.animationName
                             (Css.Animations.keyframes
@@ -531,8 +538,7 @@ viewBalloon config label =
 
                 Visible ->
                     Css.batch
-                        [ Css.property "animation-delay" "0.4s"
-                        , Css.property "animation-duration" "0.3s"
+                        [ Css.property "animation-duration" "0.3s"
                         , Css.property "animation-fill-mode" "forwards"
                         , Css.animationName
                             (Css.Animations.keyframes
@@ -543,6 +549,7 @@ viewBalloon config label =
                         , Css.property "animation-timing-function" "linear"
                         , Css.opacity Css.zero
                         ]
+            , Css.batch config.labelCss
             ]
         , Balloon.css
             [ Css.padding3 Css.zero (Css.px 6) (Css.px 1)

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -43,6 +43,7 @@
         "Nri.Ui.Logo.V1",
         "Nri.Ui.Mark.V2",
         "Nri.Ui.Mark.V3",
+        "Nri.Ui.Mark.V4",
         "Nri.Ui.MasteryIcon.V1",
         "Nri.Ui.MediaQuery.V1",
         "Nri.Ui.Menu.V4",


### PR DESCRIPTION
https://github.com/NoRedInk/noredink-ui/pull/1452 changed the API for `Mark.V3.viewWithBalloonTags`, which causes a major version bump (and which I didn't notice in review -- sorry!).

Having a separate `Mark` version will make the upgrade process smoother, and something that Phoenix can handle totally independently of the noredink-ui release cycle.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [ ] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
   - @omnibs could you please create and link a story for upgrading to Mark.V4? thanks!
