### PR TITLE
:wrench: Fix checkbox guidance alignment

### DIFF
--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -113,7 +113,7 @@ example =
                 [ Table.custom
                     { header = text "Attribute"
                     , view = .name >> text
-                    , width = Css.px 150
+                    , width = Css.pct 10
                     , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
                     , sort = Nothing
                     }
@@ -128,7 +128,7 @@ example =
                                 [ Checkbox.id (safeIdWithPrefix "guidance-and-error-example" name)
                                 , attribute
                                 ]
-                    , width = Css.px 150
+                    , width = Css.pct 50
                     , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
                     , sort = Nothing
                     }

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -19,6 +19,7 @@ import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Checkbox.V7 as Checkbox
+import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
@@ -65,9 +66,15 @@ example =
                 , renderExample = Code.unstyledView
                 , toExampleCode = \_ -> [ { sectionName = "Example", code = exampleCode } ]
                 }
-            , Heading.h2 [ Heading.plaintext "Customizable example" ]
+            , Heading.h2
+                [ Heading.plaintext "Customizable example"
+                , Heading.css [ Css.marginTop (Css.px 30) ]
+                ]
             , exampleView
-            , Heading.h2 [ Heading.plaintext "Examples" ]
+            , Heading.h2
+                [ Heading.plaintext "State Examples"
+                , Heading.css [ Css.marginTop (Css.px 30) ]
+                ]
             , Table.view []
                 [ Table.string
                     { header = "State"
@@ -97,6 +104,49 @@ example =
                     , ( "Selected", Checkbox.Selected )
                     ]
                 )
+            , Heading.h2
+                [ Heading.plaintext "Error and Guidance Examples"
+                , Heading.css [ Css.marginTop (Css.px 30) ]
+                ]
+            , Table.view []
+                [ Table.custom
+                    { header = text "Attribute"
+                    , view = .name >> text
+                    , width = Css.px 150
+                    , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+                    , sort = Nothing
+                    }
+                , Table.custom
+                    { header = text "Example"
+                    , view =
+                        \{ attribute } ->
+                            Checkbox.view
+                                { label = "I agree to the terms and conditions"
+                                , selected = Checkbox.NotSelected
+                                }
+                                [ attribute
+                                ]
+                    , width = Css.px 150
+                    , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+                    , sort = Nothing
+                    }
+                ]
+                [ { name = "guidance"
+                  , attribute = Checkbox.guidance "Be sure to read the terms and conditions before agreeing to follow them."
+                  }
+                , { name = "guidanceHtml"
+                  , attribute =
+                        Checkbox.guidanceHtml
+                            [ text "Be sure to read "
+                            , ClickableText.link "the terms and conditions"
+                                [ ClickableText.linkExternal "https://en.wikipedia.org/wiki/Terms_of_service"
+                                , ClickableText.caption
+                                , ClickableText.appearsInline
+                                ]
+                            , text " before agreeing to follow them."
+                            ]
+                  }
+                ]
             ]
     , categories = [ Inputs ]
     , keyboardSupport =

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -101,7 +101,7 @@ example =
     , categories = [ Inputs ]
     , keyboardSupport =
         [ { keys = [ Space ]
-          , result = "Select or deselect the checkbox (may cause page scroll)"
+          , result = "Select or deselect the checkbox"
           }
         ]
     }

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -106,7 +106,7 @@ example =
                     ]
                 )
             , Heading.h2
-                [ Heading.plaintext "Error and Guidance Examples"
+                [ Heading.plaintext "Guidance Examples"
                 , Heading.css [ Css.marginTop (Css.px 30) ]
                 ]
             , Table.view []

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -23,6 +23,7 @@ import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Html.Attributes.V2 exposing (safeIdWithPrefix)
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Table.V7 as Table
 
@@ -119,12 +120,13 @@ example =
                 , Table.custom
                     { header = text "Example"
                     , view =
-                        \{ attribute } ->
+                        \{ name, attribute } ->
                             Checkbox.view
                                 { label = "I agree to the terms and conditions"
                                 , selected = Checkbox.NotSelected
                                 }
-                                [ attribute
+                                [ Checkbox.id (safeIdWithPrefix "guidance-and-error-example" name)
+                                , attribute
                                 ]
                     , width = Css.px 150
                     , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -215,7 +215,7 @@ inlineExample textSizeName size =
             [ ClickableText.appearsInline
             , size
             , ClickableText.onClick (ShowItWorked moduleName "in-line button")
-            , ClickableText.icon UiIcon.star
+            , ClickableText.icon UiIcon.starFilled
             ]
         , text (" to show up in-line with " ++ textSizeName ++ " content.")
         ]

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -37,7 +37,12 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , preview =
-        [ ClickableText.link "Small"
+        [ ClickableText.link "Caption"
+            [ ClickableText.icon UiIcon.link
+            , ClickableText.caption
+            , ClickableText.custom [ Key.tabbable False ]
+            ]
+        , ClickableText.link "Small"
             [ ClickableText.icon UiIcon.link
             , ClickableText.small
             , ClickableText.custom [ Key.tabbable False ]
@@ -179,7 +184,10 @@ viewExamples ellieLinkConfig (State control) =
         [ Text.html
             [ text "Sometimes, we'll want our clickable links: "
             , ClickableText.link settings.label
-                (ClickableText.appearsInline :: ClickableText.small :: clickableAttributes)
+                (ClickableText.appearsInline
+                    :: ClickableText.small
+                    :: clickableAttributes
+                )
             , text " and clickable buttons: "
             , ClickableText.button settings.label
                 (ClickableText.appearsInline
@@ -196,7 +204,8 @@ viewExamples ellieLinkConfig (State control) =
 
 sizes : List ( ClickableText.Attribute msg, String )
 sizes =
-    [ ( ClickableText.small, "small" )
+    [ ( ClickableText.caption, "caption" )
+    , ( ClickableText.small, "small" )
     , ( ClickableText.medium, "medium" )
     , ( ClickableText.large, "large" )
     ]

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -19,6 +19,7 @@ import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 
@@ -180,26 +181,48 @@ viewExamples ellieLinkConfig (State control) =
                 ]
         }
     , buttons settings
-    , Text.smallBody
-        [ Text.html
-            [ text "Sometimes, we'll want our clickable links: "
-            , ClickableText.link settings.label
-                (ClickableText.appearsInline
-                    :: ClickableText.small
-                    :: clickableAttributes
-                )
-            , text " and clickable buttons: "
-            , ClickableText.button settings.label
-                (ClickableText.appearsInline
-                    :: ClickableText.small
-                    :: ClickableText.onClick (ShowItWorked moduleName "in-line button")
-                    :: clickableAttributes
-                )
-            , text " to show up in-line."
-            ]
+    , Heading.h2
+        [ Heading.plaintext "Inline ClickableTexts"
+        , Heading.css [ Css.marginTop (Css.px 30) ]
         ]
+    , Text.caption (inlineExample "Text.caption" ClickableText.caption)
+    , Text.smallBody (inlineExample "Text.smallBody" ClickableText.small)
+    , Text.mediumBody (inlineExample "Text.mediumBody" ClickableText.medium)
     ]
         |> div []
+
+
+inlineExample : String -> ClickableText.Attribute Msg -> List (Text.Attribute Msg)
+inlineExample textSizeName size =
+    [ Text.html
+        [ text "Sometimes, we'll want our "
+        , ClickableText.link "internal links"
+            [ ClickableText.appearsInline
+            , size
+            , ClickableText.href "/"
+            ]
+        , text ", "
+        , ClickableText.link "external links"
+            [ ClickableText.appearsInline
+            , size
+            , ClickableText.linkExternal "https://www.google.com/search?q=puppies"
+            ]
+        , text ", "
+        , ClickableText.button "buttons"
+            [ ClickableText.appearsInline
+            , size
+            , ClickableText.onClick (ShowItWorked moduleName "in-line button")
+            ]
+        , text " and "
+        , ClickableText.button "ClickableTexts with icons"
+            [ ClickableText.appearsInline
+            , size
+            , ClickableText.onClick (ShowItWorked moduleName "in-line button")
+            , ClickableText.icon UiIcon.star
+            ]
+        , text (" to show up in-line with " ++ textSizeName ++ " content.")
+        ]
+    ]
 
 
 sizes : List ( ClickableText.Attribute msg, String )

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -148,9 +148,6 @@ viewExamples ellieLinkConfig (State control) =
     let
         settings =
             Control.currentValue control
-
-        clickableAttributes =
-            List.map Tuple.second settings.attributes
     in
     [ ControlView.view
         { ellieLinkConfig = ellieLinkConfig

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -272,16 +272,14 @@ view { label, selected } attributes =
                     )
     in
     checkboxContainer config_
-        ([ viewCheckbox config_
+        [ viewCheckbox config_
             (if config.isDisabled then
                 ( disabledLabelCss, disabledIcon )
 
              else
                 ( enabledLabelCss, icon )
             )
-         ]
-            ++ [ div [ css [ paddingLeft (px 40) ] ] (InputErrorAndGuidanceInternal.view config_.identifier (Css.marginTop Css.zero) config_) ]
-        )
+        ]
 
 
 {-| If your selectedness is always selected or not selected,
@@ -368,6 +366,8 @@ viewCheckbox :
         , label : String
         , hideLabel : Bool
         , labelCss : List Style
+        , error : InputErrorAndGuidanceInternal.ErrorState
+        , guidance : Guidance msg
     }
     ->
         ( List Style
@@ -399,10 +399,23 @@ viewCheckbox config ( styles, icon ) =
                             )
                         |> Maybe.withDefault []
                 ]
+
+        viewLabel =
+            if config.hideLabel then
+                Html.span Accessibility.Styled.Style.invisible
+                    [ Html.text config.label ]
+
+            else
+                Html.text config.label
     in
     Html.div attributes
         [ viewIcon [] icon
-        , labelView config
+        , Html.span []
+            (viewLabel
+                :: InputErrorAndGuidanceInternal.view config.identifier
+                    (Css.marginTop Css.zero)
+                    config
+            )
         ]
 
 
@@ -441,13 +454,3 @@ viewIcon styles icon =
             [ Nri.Ui.Svg.V1.toHtml (Nri.Ui.Svg.V1.withCss styles icon)
             ]
         ]
-
-
-labelView : { a | hideLabel : Bool, label : String } -> Html msg
-labelView config =
-    if config.hideLabel then
-        Html.span Accessibility.Styled.Style.invisible
-            [ Html.text config.label ]
-
-    else
-        Html.span [] [ Html.text config.label ]

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -349,18 +349,14 @@ onCheckMsg selected msg =
 
 enabledLabelCss : List Style
 enabledLabelCss =
-    [ displayFlex
-    , Css.alignItems Css.center
-    , textStyle
+    [ textStyle
     , cursor pointer
     ]
 
 
 disabledLabelCss : List Style
 disabledLabelCss =
-    [ displayFlex
-    , Css.alignItems Css.center
-    , textStyle
+    [ textStyle
     , Css.outline3 (Css.px 2) Css.solid Css.transparent
     , cursor auto
     , color Colors.gray45

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -12,6 +12,11 @@ module Nri.Ui.Checkbox.V7 exposing
 {-|
 
 
+## Patch changes:
+
+  - reposition the guidance to be right below the label text
+
+
 ## Changes from V6:
 
   - Reworked api similar to other components based on Attributes

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -383,6 +383,7 @@ viewCheckbox config ( styles, icon ) =
                   , Role.checkBox
                   , Key.tabbable True
                   , Attributes.id config.identifier
+                  , InputErrorAndGuidanceInternal.describedBy config.identifier config
                   , Aria.checked (selectedToMaybe config.selected)
                   ]
                 , if config.disabled then

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -383,7 +383,12 @@ viewCheckbox config ( styles, icon ) =
     let
         attributes =
             List.concat
-                [ [ css (styles ++ config.labelCss)
+                [ [ css
+                        (paddingLeft (Css.px checkboxIconWidth)
+                            :: marginLeft (Css.px -checkboxIconWidth)
+                            :: styles
+                            ++ config.labelCss
+                        )
                   , Attributes.class FocusRing.customClass
                   , Role.checkBox
                   , Key.tabbable True
@@ -417,6 +422,11 @@ viewCheckbox config ( styles, icon ) =
     Html.div attributes
         [ viewLabel
         ]
+
+
+checkboxIconWidth : Float
+checkboxIconWidth =
+    40
 
 
 inputGuidance :

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -272,15 +272,18 @@ view { label, selected } attributes =
                     )
     in
     checkboxContainer config_
-        (viewCheckbox config_
-            (if config.isDisabled then
-                ( disabledLabelCss, disabledIcon )
+        [ viewIcon [] icon
+        , span []
+            (viewCheckbox config_
+                (if config.isDisabled then
+                    ( disabledLabelCss, disabledIcon )
 
-             else
-                ( enabledLabelCss, icon )
+                 else
+                    ( enabledLabelCss, icon )
+                )
+                :: inputGuidance config_
             )
-            :: inputGuidance config_
-        )
+        ]
 
 
 {-| If your selectedness is always selected or not selected,
@@ -314,7 +317,8 @@ checkboxContainer : { a | identifier : String, containerCss : List Style } -> Li
 checkboxContainer model =
     Html.span
         [ css
-            [ display block
+            [ displayFlex
+            , alignItems center
             , marginLeft (px -4)
             , paddingTop (px 5)
             , paddingBottom (px 5)
@@ -411,8 +415,7 @@ viewCheckbox config ( styles, icon ) =
                 Html.text config.label
     in
     Html.div attributes
-        [ viewIcon [] icon
-        , viewLabel
+        [ viewLabel
         ]
 
 

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -386,6 +386,7 @@ viewCheckbox config ( styles, icon ) =
             List.concat
                 [ [ css
                         (paddingLeft (Css.px checkboxIconWidth)
+                            :: marginTop (Css.px -highContrastBorderWidth)
                             :: marginLeft (Css.px -checkboxIconWidth)
                             :: styles
                             ++ config.labelCss
@@ -458,7 +459,7 @@ viewIcon : List Style -> Svg -> Html msg
 viewIcon styles icon =
     Html.div
         [ css
-            [ border3 (px 2) solid transparent
+            [ border3 (px highContrastBorderWidth) solid transparent
             , borderRadius (px 3)
             , height (Css.px 27)
             , boxSizing contentBox
@@ -478,3 +479,8 @@ viewIcon styles icon =
             [ Nri.Ui.Svg.V1.toHtml (Nri.Ui.Svg.V1.withCss styles icon)
             ]
         ]
+
+
+highContrastBorderWidth : Float
+highContrastBorderWidth =
+    2

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -382,11 +382,19 @@ viewCheckbox :
     -> Html.Html msg
 viewCheckbox config ( styles, icon ) =
     let
+        marginTopAdjustment =
+            case config.guidance of
+                Just _ ->
+                    marginTop (Css.px -highContrastBorderWidth)
+
+                Nothing ->
+                    Css.batch []
+
         attributes =
             List.concat
                 [ [ css
                         (paddingLeft (Css.px checkboxIconWidth)
-                            :: marginTop (Css.px -highContrastBorderWidth)
+                            :: marginTopAdjustment
                             :: marginLeft (Css.px -checkboxIconWidth)
                             :: styles
                             ++ config.labelCss

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -272,14 +272,15 @@ view { label, selected } attributes =
                     )
     in
     checkboxContainer config_
-        [ viewCheckbox config_
+        (viewCheckbox config_
             (if config.isDisabled then
                 ( disabledLabelCss, disabledIcon )
 
              else
                 ( enabledLabelCss, icon )
             )
-        ]
+            :: inputGuidance config_
+        )
 
 
 {-| If your selectedness is always selected or not selected,
@@ -411,13 +412,21 @@ viewCheckbox config ( styles, icon ) =
     in
     Html.div attributes
         [ viewIcon [] icon
-        , Html.span []
-            (viewLabel
-                :: InputErrorAndGuidanceInternal.view config.identifier
-                    (Css.marginTop Css.zero)
-                    config
-            )
+        , viewLabel
         ]
+
+
+inputGuidance :
+    { a
+        | identifier : String
+        , error : InputErrorAndGuidanceInternal.ErrorState
+        , guidance : Guidance msg
+    }
+    -> List (Html msg)
+inputGuidance config =
+    InputErrorAndGuidanceInternal.view config.identifier
+        (Css.marginTop Css.zero)
+        config
 
 
 textStyle : Style

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -2,7 +2,7 @@ module Nri.Ui.ClickableText.V3 exposing
     ( button
     , link
     , Attribute
-    , small, medium, large, modal
+    , caption, small, medium, large, modal
     , appearsInline
     , onClick, submit, opensModal
     , href, linkSpa, linkExternal, linkWithMethod, linkWithTracking, linkExternalWithTracking
@@ -33,6 +33,7 @@ module Nri.Ui.ClickableText.V3 exposing
   - adds `hideTextForMobile` and `hideTextAt`
   - adds `submit` and `opensModal`
   - adds `disabled`
+  - adds `caption` size that matches up with Text.caption's font size
 
 
 # Changes from V2
@@ -68,7 +69,7 @@ HTML `<a>` elements and are created here with `*Link` functions.
 
 ## Sizing
 
-@docs small, medium, large, modal
+@docs caption, small, medium, large, modal
 
 
 ## Appearance
@@ -122,6 +123,13 @@ label label_ =
     set (\attributes -> { attributes | label = label_ })
 
 
+{-| This size setting corresponds to Text.caption's font size.
+-}
+caption : Attribute msg
+caption =
+    set (\attributes -> { attributes | size = Caption })
+
+
 {-| -}
 small : Attribute msg
 small =
@@ -154,7 +162,8 @@ modal =
 
 
 type Size
-    = Small
+    = Caption
+    | Small
     | Medium
     | Large
 
@@ -479,6 +488,9 @@ viewContent config =
 
         iconSize =
             case config.size of
+                Caption ->
+                    Css.px 3
+
                 Small ->
                     Css.px 3
 
@@ -565,6 +577,9 @@ clickableTextButtonStyles =
 sizeToPx : Size -> Css.Px
 sizeToPx size =
     case size of
+        Caption ->
+            Css.px 13
+
         Small ->
             Css.px 15
 

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -505,7 +505,6 @@ viewContent config =
                 [ Attributes.css
                     [ Css.display Css.inlineFlex
                     , Css.alignItems Css.center
-                    , Css.property "line-height" "normal"
                     , Css.fontSize fontSize
                     ]
                 ]

--- a/src/Nri/Ui/Text/V6.elm
+++ b/src/Nri/Ui/Text/V6.elm
@@ -176,6 +176,9 @@ mediumBody attributes =
     view
         (css
             (paragraphStyles
+                -- Caution: avoid changing font styles
+                -- unless you are also changing the font styles in
+                -- ClickableText
                 { font = Fonts.baseFont
                 , color = gray20
                 , size = 18
@@ -202,6 +205,9 @@ smallBody attributes =
     view
         (css
             (paragraphStyles
+                -- Caution: avoid changing font styles
+                -- unless you are also changing the font styles in
+                -- ClickableText
                 { font = Fonts.baseFont
                 , color = gray20
                 , size = 15
@@ -221,6 +227,9 @@ smallBodyGray attributes =
     view
         (css
             (paragraphStyles
+                -- Caution: avoid changing font styles
+                -- unless you are also changing the font styles in
+                -- ClickableText
                 { font = Fonts.baseFont
                 , color = gray45
                 , size = 15
@@ -264,6 +273,9 @@ caption attributes =
     view
         (css
             (paragraphStyles
+                -- Caution: avoid changing font styles
+                -- unless you are also changing the font styles in
+                -- ClickableText
                 { font = Fonts.baseFont
                 , color = gray45
                 , size = 13


### PR DESCRIPTION
Fixes https://github.com/NoRedInk/noredink-ui/issues/1454

- adds new ClickableText.caption size for use with Text.caption-size text
- adjusts the Checkbox implementation to reposition the guidance appropriately

## :framed_picture: What does this change look like?

<img width="757" alt="Screen Shot 2023-08-10 at 4 04 50 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/35171a5f-a245-40c1-b676-3e94b8ae437a">

I added a new section to the Checkbox example that always shows the guidance, because I feel like we've had trouble with alignment 🐛 s on the guidance that Percy could have caught.

Does this alignment look okay to you?

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - this is not a new major version
