### PR TITLE
gray20 for select selected option text

### DIFF
--- a/src/Nri/Ui/Select/V9.elm
+++ b/src/Nri/Ui/Select/V9.elm
@@ -324,7 +324,6 @@ view label attributes =
 
                else
                 Css.paddingTop (Css.px InputStyles.defaultMarginTop)
-             , Css.color Colors.gray20
              ]
                 ++ config.containerCss
             )
@@ -490,6 +489,7 @@ viewSelect config_ config =
             , Css.textOverflow Css.ellipsis
             , Css.overflow Css.hidden
             , Css.whiteSpace Css.noWrap
+            , Css.color Colors.gray20
 
             -- Interaction
             , Css.cursor


### PR DESCRIPTION
It was getting overridden because it was in the wrong place?

<img width="1552" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/13528834/e86de8a7-96d4-4381-a140-34ceec5b6642">