### PR TITLE
:wrench: Remove checkbox input from Switch implementation

### DIFF
--- a/component-catalog/src/Examples/Switch.elm
+++ b/component-catalog/src/Examples/Switch.elm
@@ -10,11 +10,14 @@ import Accessibility.Styled.Key as Key
 import Category
 import Code
 import CommonControls
+import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import KeyboardSupport exposing (Key(..))
+import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Switch.V2 as Switch
 
 
@@ -80,6 +83,10 @@ example =
                           }
                         ]
                 }
+            , Heading.h2
+                [ Heading.plaintext "Interactive example"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , Switch.view { label = currentValue.label, id = "view-switch-example" }
                 (Switch.selected state.selected
                     :: Switch.onSwitch Switch

--- a/component-catalog/src/Examples/Switch.elm
+++ b/component-catalog/src/Examples/Switch.elm
@@ -19,7 +19,7 @@ import Html.Styled exposing (..)
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
-import Nri.Ui.Switch.V2 as Switch
+import Nri.Ui.Switch.V3 as Switch
 import Nri.Ui.Table.V7 as Table
 
 
@@ -30,7 +30,7 @@ moduleName =
 
 version : Int
 version =
-    2
+    3
 
 
 example : Example State Msg

--- a/component-catalog/src/Examples/Switch.elm
+++ b/component-catalog/src/Examples/Switch.elm
@@ -15,10 +15,12 @@ import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
+import Html.Styled exposing (..)
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Switch.V2 as Switch
+import Nri.Ui.Table.V7 as Table
 
 
 moduleName : String
@@ -84,7 +86,7 @@ example =
                         ]
                 }
             , Heading.h2
-                [ Heading.plaintext "Interactive example"
+                [ Heading.plaintext "Customizable example"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
             , Switch.view { label = currentValue.label, id = "view-switch-example" }
@@ -92,6 +94,70 @@ example =
                     :: Switch.onSwitch Switch
                     :: List.map Tuple.second currentValue.attributes
                 )
+            , Heading.h2
+                [ Heading.plaintext "Examples"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
+            , Table.view []
+                [ Table.string
+                    { header = "State"
+                    , value = .state
+                    , width = Css.pct 30
+                    , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle, Css.fontWeight Css.bold ]
+                    , sort = Nothing
+                    }
+                , Table.custom
+                    { header = text "Enabled"
+                    , view = .enabled
+                    , width = Css.px 150
+                    , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+                    , sort = Nothing
+                    }
+                , Table.custom
+                    { header = text "Disabled"
+                    , view = .disabled
+                    , width = Css.px 150
+                    , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+                    , sort = Nothing
+                    }
+                ]
+                [ { state = "Off"
+                  , enabled =
+                        Switch.view
+                            { label = "Show dropped students"
+                            , id = "show-dropped-students-off-enabled"
+                            }
+                            [ Switch.selected False
+                            , Switch.onSwitch (\_ -> Swallow)
+                            ]
+                  , disabled =
+                        Switch.view
+                            { label = "Show dropped students"
+                            , id = "show-dropped-students-off-disabled"
+                            }
+                            [ Switch.selected False
+                            , Switch.disabled True
+                            ]
+                  }
+                , { state = "On"
+                  , enabled =
+                        Switch.view
+                            { label = "Show dropped students"
+                            , id = "show-dropped-students-on-enabled"
+                            }
+                            [ Switch.selected True
+                            , Switch.onSwitch (\_ -> Swallow)
+                            ]
+                  , disabled =
+                        Switch.view
+                            { label = "Show dropped students"
+                            , id = "show-dropped-students-on-disabled"
+                            }
+                            [ Switch.selected True
+                            , Switch.disabled True
+                            ]
+                  }
+                ]
             ]
     , categories = [ Category.Inputs ]
     , keyboardSupport =
@@ -139,6 +205,7 @@ initAttributes =
 type Msg
     = Switch Bool
     | UpdateSettings (Control Settings)
+    | Swallow
 
 
 update : Msg -> State -> ( State, Cmd Msg )
@@ -151,5 +218,10 @@ update msg state =
 
         UpdateSettings settings ->
             ( { state | settings = settings }
+            , Cmd.none
+            )
+
+        Swallow ->
+            ( state
             , Cmd.none
             )

--- a/component-catalog/src/Examples/Switch.elm
+++ b/component-catalog/src/Examples/Switch.elm
@@ -70,18 +70,20 @@ example =
                     \{ label, attributes } ->
                         [ { sectionName = "Example"
                           , code =
-                                moduleName
-                                    ++ ".view"
-                                    ++ " \""
-                                    ++ label
-                                    ++ "\"\t"
-                                    ++ Code.list
+                                Code.fromModule moduleName "view"
+                                    ++ Code.recordMultiline
+                                        [ ( "label", Code.string label )
+                                        , ( "id", Code.string "view-switch-example" )
+                                        ]
+                                        1
+                                    ++ Code.listMultiline
                                         (("Switch.selected "
                                             ++ Debug.toString state.selected
-                                            ++ Code.commentInline "\n,  Switch.onSwitch Switch -- <- you'll need to wire in a Msg for the Switch to work"
                                          )
+                                            :: "Switch.onSwitch Switch -- <- you'll need to wire in a Msg for the Switch to work"
                                             :: List.map Tuple.first attributes
                                         )
+                                        1
                           }
                         ]
                 }

--- a/component-catalog/tests/SwitchExampleSpec.elm
+++ b/component-catalog/tests/SwitchExampleSpec.elm
@@ -1,9 +1,13 @@
 module SwitchExampleSpec exposing (suite)
 
+import Accessibility.Aria as Aria
+import Accessibility.Role as Role
 import Examples.Switch exposing (Msg, State, example)
 import ProgramTest exposing (..)
 import Routes exposing (Route)
 import Test exposing (..)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
 import Test.Html.Selector exposing (..)
 import TestApp exposing (app)
 
@@ -20,11 +24,22 @@ suite =
             \() ->
                 app route
                     |> ensureViewHas [ text "Nri.Ui.Switch" ]
-                    -- switch starts with checked=true
-                    |> ensureViewHas [ checked True ]
+                    -- switch starts with aria-checked=true
+                    |> ensureViewHas [ attribute (Aria.checked (Just True)) ]
                     -- user can click the first switch
-                    |> check "view-switch-example" "Show pandas in results" False
-                    -- the switch now has checked=false
-                    |> ensureViewHas [ checked False ]
+                    |> switchIt "Show pandas in results"
+                    -- the switch now has aria-checked=false
+                    |> ensureViewHas [ attribute (Aria.checked (Just False)) ]
                     |> done
         ]
+
+
+switchIt : String -> ProgramTest a b c -> ProgramTest a b c
+switchIt name =
+    simulateDomEvent
+        (Query.find
+            [ attribute Role.switch
+            , containing [ text name ]
+            ]
+        )
+        Event.click

--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -4,5 +4,6 @@ Nri.Ui.Mark.V2,upgrade to V4
 Nri.Ui.Mark.V3,upgrade to V4
 Nri.Ui.Message.V3,upgrade to V4
 Nri.Ui.SideNav.V4,upgrade to V5
+Nri.Ui.Switch.V2,upgrade to V3
 Nri.Ui.Table.V6,upgrade to V7
 Nri.Ui.Tabs.V6,upgrade to V8

--- a/elm.json
+++ b/elm.json
@@ -73,6 +73,7 @@
         "Nri.Ui.Sprite.V1",
         "Nri.Ui.Svg.V1",
         "Nri.Ui.Switch.V2",
+        "Nri.Ui.Switch.V3",
         "Nri.Ui.Table.V6",
         "Nri.Ui.Table.V7",
         "Nri.Ui.Tabs.V6",

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -229,6 +229,9 @@ hint = 'upgrade to V4'
 [forbidden."Nri.Ui.Switch.V1"]
 hint = 'upgrade to V2'
 
+[forbidden."Nri.Ui.Switch.V2"]
+hint = 'upgrade to V3'
+
 [forbidden."Nri.Ui.Table.V4"]
 hint = 'upgrade to V5'
 

--- a/src/Nri/Ui/Switch/V2.elm
+++ b/src/Nri/Ui/Switch/V2.elm
@@ -154,6 +154,9 @@ view { label, id } attrs =
     let
         config =
             List.foldl (\(Attribute update) -> update) defaultConfig attrs
+
+        isDisabled_ =
+            notOperable config
     in
     Html.label
         ([ Attributes.id (id ++ "-container")
@@ -182,18 +185,18 @@ view { label, id } attrs =
             (viewSwitch
                 { id = id
                 , isSelected = config.isSelected
-                , isDisabled = notOperable config
+                , isDisabled = isDisabled_
                 }
             )
         , Html.span
             [ Attributes.css
                 [ Css.fontWeight (Css.int 600)
                 , Css.color
-                    (if not config.isDisabled then
-                        Colors.navy
+                    (if isDisabled_ then
+                        Colors.gray45
 
                      else
-                        Colors.gray45
+                        Colors.navy
                     )
                 , Css.paddingLeft (Css.px 5)
                 , Fonts.baseFont

--- a/src/Nri/Ui/Switch/V3.elm
+++ b/src/Nri/Ui/Switch/V3.elm
@@ -25,11 +25,12 @@ module Nri.Ui.Switch.V3 exposing
 
 -}
 
-import Accessibility.Styled as Html exposing (Html)
 import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Key as Key
 import Accessibility.Styled.Role as Role
 import Css exposing (Color, Style)
 import Css.Global as Global
+import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Nri.Ui.Colors.Extra exposing (toCssString)
@@ -145,13 +146,13 @@ view { label, id } attrs =
         isDisabled_ =
             notOperable config
     in
-    Html.label
+    Html.div
         ([ Attributes.id (id ++ "-container")
          , Attributes.css
             [ Css.display Css.inlineFlex
             , Css.alignItems Css.center
-            , Css.position Css.relative
             , Css.fontSize (Css.px 15)
+            , Css.outline Css.none
             , Css.pseudoClass "focus-within"
                 [ Global.descendants
                     [ Global.class "switch-track"
@@ -160,15 +161,21 @@ view { label, id } attrs =
                         ]
                     ]
                 ]
-            , cursorStyle config
+            , Css.cursor
+                (if isDisabled_ then
+                    Css.notAllowed
+
+                 else
+                    Css.pointer
+                )
             , Css.batch config.containerCss
             ]
-         , Attributes.for id
+         , Attributes.class FocusRing.customClass
          ]
+            ++ switchAttributes id config
             ++ List.map (Attributes.map never) config.custom
         )
-        [ viewCheckbox id config
-        , Nri.Ui.Svg.V1.toHtml
+        [ Nri.Ui.Svg.V1.toHtml
             (viewSwitch
                 { id = id
                 , isSelected = config.isSelected
@@ -194,42 +201,32 @@ view { label, id } attrs =
         ]
 
 
-viewCheckbox : String -> Config msg -> Html msg
-viewCheckbox id config =
-    Html.checkbox id
-        (Just config.isSelected)
-        [ Attributes.id id
-        , Role.switch
-        , Attributes.css
-            [ Css.position Css.absolute
-            , Css.top (Css.px 10)
-            , Css.left (Css.px 10)
-            , Css.opacity (Css.num 0)
-            , cursorStyle config
-            ]
-        , case ( config.onSwitch, config.isDisabled ) of
-            ( Just onSwitch_, False ) ->
-                Events.onCheck onSwitch_
+switchAttributes : String -> Config msg -> List (Html.Attribute msg)
+switchAttributes id config =
+    let
+        eventsOrDisabled =
+            case ( config.onSwitch, config.isDisabled ) of
+                ( Just onSwitch_, False ) ->
+                    [ Events.onClick (onSwitch_ (not config.isSelected))
+                    , Key.onKeyDownPreventDefault
+                        [ Key.space (onSwitch_ (not config.isSelected))
+                        ]
+                    ]
 
-            _ ->
-                Aria.disabled True
-        ]
+                _ ->
+                    [ Aria.disabled True ]
+    in
+    [ Attributes.id id
+    , Role.switch
+    , Aria.checked (Just config.isSelected)
+    , Key.tabbable True
+    ]
+        ++ eventsOrDisabled
 
 
 notOperable : Config msg -> Bool
 notOperable config =
     config.onSwitch == Nothing || config.isDisabled
-
-
-cursorStyle : Config msg -> Style
-cursorStyle config =
-    Css.cursor
-        (if notOperable config then
-            Css.notAllowed
-
-         else
-            Css.pointer
-        )
 
 
 viewSwitch :

--- a/src/Nri/Ui/Switch/V3.elm
+++ b/src/Nri/Ui/Switch/V3.elm
@@ -148,8 +148,7 @@ view { label, id } attrs =
             notOperable config
     in
     Html.div
-        ([ Attributes.id (id ++ "-container")
-         , Attributes.css
+        ([ Attributes.css
             [ Css.display Css.inlineFlex
             , Css.alignItems Css.center
             , Css.fontSize (Css.px 15)

--- a/src/Nri/Ui/Switch/V3.elm
+++ b/src/Nri/Ui/Switch/V3.elm
@@ -12,6 +12,7 @@ module Nri.Ui.Switch.V3 exposing
 ### Changes from V2:
 
     - Replace underlying checkbox input with a custom implementation
+    - Allow attributes that produce msgs to be passed through
 
 @docs view
 
@@ -79,7 +80,7 @@ you want/expect if underlying styles change.
 Instead, please use `containerCss` or `labelCss`.
 
 -}
-custom : List (Html.Attribute Never) -> Attribute msg
+custom : List (Html.Attribute msg) -> Attribute msg
 custom custom_ =
     Attribute <| \config -> { config | custom = config.custom ++ custom_ }
 
@@ -119,7 +120,7 @@ type alias Config msg =
     , labelCss : List Style
     , isDisabled : Bool
     , isSelected : Bool
-    , custom : List (Html.Attribute Never)
+    , custom : List (Html.Attribute msg)
     }
 
 
@@ -173,7 +174,7 @@ view { label, id } attrs =
          , Attributes.class FocusRing.customClass
          ]
             ++ switchAttributes id config
-            ++ List.map (Attributes.map never) config.custom
+            ++ config.custom
         )
         [ Nri.Ui.Svg.V1.toHtml
             (viewSwitch

--- a/src/Nri/Ui/Switch/V3.elm
+++ b/src/Nri/Ui/Switch/V3.elm
@@ -1,4 +1,4 @@
-module Nri.Ui.Switch.V2 exposing
+module Nri.Ui.Switch.V3 exposing
     ( view
     , Attribute
     , selected
@@ -9,22 +9,9 @@ module Nri.Ui.Switch.V2 exposing
 {-|
 
 
-### Patch Changes:
+### Changes from V2:
 
-    - Fix cursor styles when hovering over the transparent checkbox
-
-
-### Changes from V1:
-
-    - Fixes invalid ARIA use, [conformance requirements](https://www.w3.org/TR/html-aria/#docconformance)
-    - labels should only support strings (this is the only way they're actually used in practice)
-    - extends API to be more consistent with other form/control components
-    - Use Colors values instead of hardcoded hex strings
-    - Move the status (selected or not selected) to the list api
-    - REQUIRE label and id always
-    - Move custom attributes to the container
-    - change disabled to take a bool (which I think is the slighty more common pattern)
-    - Adds `role="switch"`
+    - Replace underlying checkbox input with a custom implementation
 
 @docs view
 

--- a/src/Nri/Ui/Switch/V3.elm
+++ b/src/Nri/Ui/Switch/V3.elm
@@ -1,0 +1,414 @@
+module Nri.Ui.Switch.V2 exposing
+    ( view
+    , Attribute
+    , selected
+    , containerCss, labelCss, custom, nriDescription, testId
+    , onSwitch, disabled
+    )
+
+{-|
+
+
+### Patch Changes:
+
+    - Fix cursor styles when hovering over the transparent checkbox
+
+
+### Changes from V1:
+
+    - Fixes invalid ARIA use, [conformance requirements](https://www.w3.org/TR/html-aria/#docconformance)
+    - labels should only support strings (this is the only way they're actually used in practice)
+    - extends API to be more consistent with other form/control components
+    - Use Colors values instead of hardcoded hex strings
+    - Move the status (selected or not selected) to the list api
+    - REQUIRE label and id always
+    - Move custom attributes to the container
+    - change disabled to take a bool (which I think is the slighty more common pattern)
+    - Adds `role="switch"`
+
+@docs view
+
+
+### Attributes
+
+@docs Attribute
+@docs selected
+@docs containerCss, labelCss, custom, nriDescription, testId
+@docs onSwitch, disabled
+
+-}
+
+import Accessibility.Styled as Html exposing (Html)
+import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Role as Role
+import Css exposing (Color, Style)
+import Css.Global as Global
+import Html.Styled.Attributes as Attributes
+import Html.Styled.Events as Events
+import Nri.Ui.Colors.Extra exposing (toCssString)
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.FocusRing.V1 as FocusRing
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Html.Attributes.V2 as Extra
+import Nri.Ui.MediaQuery.V1 as MediaQuery
+import Nri.Ui.Svg.V1 exposing (Svg)
+import Svg.Styled as Svg
+import Svg.Styled.Attributes as SvgAttributes
+
+
+{-| -}
+type Attribute msg
+    = Attribute (Config msg -> Config msg)
+
+
+{-| What is the status of the Switch, selected or not?
+-}
+selected : Bool -> Attribute msg
+selected isSelected =
+    Attribute <| \config -> { config | isSelected = isSelected }
+
+
+{-| Specify what happens when the switch is toggled.
+-}
+onSwitch : (Bool -> msg) -> Attribute msg
+onSwitch onSwitch_ =
+    Attribute <| \config -> { config | onSwitch = Just onSwitch_ }
+
+
+{-| Explicitly specify that you want this switch to be disabled. If you don't
+specify `onSwitch`, this is the default, but it's provided so you don't have
+to resort to `filterMap` or similar to build a clean list of attributes.
+-}
+disabled : Bool -> Attribute msg
+disabled isDisabled =
+    Attribute <| \config -> { config | isDisabled = isDisabled }
+
+
+{-| Pass custom attributes through to be attached to the underlying input.
+
+Do NOT use this helper to add css styles, as they may not be applied the way
+you want/expect if underlying styles change.
+Instead, please use `containerCss` or `labelCss`.
+
+-}
+custom : List (Html.Attribute Never) -> Attribute msg
+custom custom_ =
+    Attribute <| \config -> { config | custom = config.custom ++ custom_ }
+
+
+{-| -}
+nriDescription : String -> Attribute msg
+nriDescription description =
+    custom [ Extra.nriDescription description ]
+
+
+{-| -}
+testId : String -> Attribute msg
+testId id_ =
+    custom [ Extra.testId id_ ]
+
+
+{-| Adds CSS to the Switch container.
+-}
+containerCss : List Css.Style -> Attribute msg
+containerCss styles =
+    Attribute <| \config -> { config | containerCss = config.containerCss ++ styles }
+
+
+{-| Adds CSS to the element containing the label text.
+
+Note that these styles don't apply to the literal HTML label element, since it contains the icon SVG as well.
+
+-}
+labelCss : List Css.Style -> Attribute msg
+labelCss styles =
+    Attribute <| \config -> { config | labelCss = config.labelCss ++ styles }
+
+
+type alias Config msg =
+    { onSwitch : Maybe (Bool -> msg)
+    , containerCss : List Style
+    , labelCss : List Style
+    , isDisabled : Bool
+    , isSelected : Bool
+    , custom : List (Html.Attribute Never)
+    }
+
+
+defaultConfig : Config msg
+defaultConfig =
+    { onSwitch = Nothing
+    , containerCss = []
+    , labelCss = []
+    , isDisabled = False
+    , isSelected = False
+    , custom = []
+    }
+
+
+{-| Render a switch. The boolean here indicates whether the switch is on
+or not.
+-}
+view : { label : String, id : String } -> List (Attribute msg) -> Html msg
+view { label, id } attrs =
+    let
+        config =
+            List.foldl (\(Attribute update) -> update) defaultConfig attrs
+
+        isDisabled_ =
+            notOperable config
+    in
+    Html.label
+        ([ Attributes.id (id ++ "-container")
+         , Attributes.css
+            [ Css.display Css.inlineFlex
+            , Css.alignItems Css.center
+            , Css.position Css.relative
+            , Css.fontSize (Css.px 15)
+            , Css.pseudoClass "focus-within"
+                [ Global.descendants
+                    [ Global.class "switch-track"
+                        [ FocusRing.boxShadows []
+                        , Css.borderRadius (Css.px 16)
+                        ]
+                    ]
+                ]
+            , cursorStyle config
+            , Css.batch config.containerCss
+            ]
+         , Attributes.for id
+         ]
+            ++ List.map (Attributes.map never) config.custom
+        )
+        [ viewCheckbox id config
+        , Nri.Ui.Svg.V1.toHtml
+            (viewSwitch
+                { id = id
+                , isSelected = config.isSelected
+                , isDisabled = isDisabled_
+                }
+            )
+        , Html.span
+            [ Attributes.css
+                [ Css.fontWeight (Css.int 600)
+                , Css.color
+                    (if isDisabled_ then
+                        Colors.gray45
+
+                     else
+                        Colors.navy
+                    )
+                , Css.paddingLeft (Css.px 5)
+                , Fonts.baseFont
+                , Css.batch config.labelCss
+                ]
+            ]
+            [ Html.text label ]
+        ]
+
+
+viewCheckbox : String -> Config msg -> Html msg
+viewCheckbox id config =
+    Html.checkbox id
+        (Just config.isSelected)
+        [ Attributes.id id
+        , Role.switch
+        , Attributes.css
+            [ Css.position Css.absolute
+            , Css.top (Css.px 10)
+            , Css.left (Css.px 10)
+            , Css.opacity (Css.num 0)
+            , cursorStyle config
+            ]
+        , case ( config.onSwitch, config.isDisabled ) of
+            ( Just onSwitch_, False ) ->
+                Events.onCheck onSwitch_
+
+            _ ->
+                Aria.disabled True
+        ]
+
+
+notOperable : Config msg -> Bool
+notOperable config =
+    config.onSwitch == Nothing || config.isDisabled
+
+
+cursorStyle : Config msg -> Style
+cursorStyle config =
+    Css.cursor
+        (if notOperable config then
+            Css.notAllowed
+
+         else
+            Css.pointer
+        )
+
+
+viewSwitch :
+    { id : String
+    , isSelected : Bool
+    , isDisabled : Bool
+    }
+    -> Svg
+viewSwitch config =
+    let
+        shadowFilterId =
+            config.id ++ "-shadow-filter"
+
+        shadowBoxId =
+            config.id ++ "-shadow-box"
+
+        disabledPrimaryCircleColor =
+            if config.isSelected then
+                Colors.gray45
+
+            else
+                Colors.gray75
+    in
+    Nri.Ui.Svg.V1.init "0 0 43 32"
+        [ Svg.defs []
+            [ Svg.filter
+                [ SvgAttributes.id shadowFilterId
+                , SvgAttributes.width "105%"
+                , SvgAttributes.height "106.7%"
+                , SvgAttributes.x "-2.5%"
+                , SvgAttributes.y "-3.3%"
+                , SvgAttributes.filterUnits "objectBoundingBox"
+                ]
+                [ Svg.feOffset
+                    [ SvgAttributes.dy "2"
+                    , SvgAttributes.in_ "SourceAlpha"
+                    , SvgAttributes.result "shadowOffsetInner1"
+                    ]
+                    []
+                , Svg.feComposite
+                    [ SvgAttributes.in_ "shadowOffsetInner1"
+                    , SvgAttributes.in2 "SourceAlpha"
+                    , SvgAttributes.k2 "-1"
+                    , SvgAttributes.k3 "1"
+                    , SvgAttributes.operator "arithmetic"
+                    , SvgAttributes.result "shadowInnerInner1"
+                    ]
+                    []
+                , Svg.feColorMatrix
+                    [ SvgAttributes.in_ "shadowInnerInner1"
+                    , SvgAttributes.values "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"
+                    ]
+                    []
+                ]
+            , Svg.rect
+                [ SvgAttributes.id shadowBoxId
+                , SvgAttributes.width "40"
+                , SvgAttributes.height "30"
+                , SvgAttributes.x "0"
+                , SvgAttributes.y "0"
+                , SvgAttributes.rx "15"
+                ]
+                []
+            ]
+        , Svg.g
+            [ SvgAttributes.fill "none"
+            , SvgAttributes.fillRule "even-odd"
+            , SvgAttributes.transform "translate(1, 1)"
+            ]
+            [ Svg.g []
+                [ Svg.use
+                    [ SvgAttributes.xlinkHref ("#" ++ shadowBoxId)
+                    , SvgAttributes.css
+                        [ if config.isDisabled then
+                            if config.isSelected then
+                                Css.fill Colors.gray75
+
+                            else
+                                Css.fill Colors.gray85
+
+                          else if config.isSelected then
+                            Css.fill Colors.glacier
+
+                          else
+                            Css.fill Colors.gray92
+                        , transition "fill 0.2s"
+                        ]
+                    ]
+                    []
+                , if not config.isDisabled then
+                    Svg.use
+                        [ SvgAttributes.xlinkHref ("#" ++ shadowBoxId)
+                        , SvgAttributes.fill "#000"
+                        , SvgAttributes.filter ("url(#" ++ shadowFilterId ++ ")")
+                        ]
+                        []
+
+                  else
+                    Svg.g [] []
+                ]
+            , Svg.g
+                [ SvgAttributes.css
+                    [ if config.isSelected then
+                        Css.transform (Css.translateX (Css.px 11))
+
+                      else
+                        Css.transform (Css.translateX (Css.px 0))
+                    , transition "transform 0.2s ease-in-out"
+                    ]
+                ]
+                [ Svg.circle
+                    [ SvgAttributes.cx "15"
+                    , SvgAttributes.cy "15"
+                    , SvgAttributes.r "14.5"
+                    , SvgAttributes.fill
+                        (if config.isDisabled then
+                            disabledPrimaryCircleColor
+
+                         else
+                            Colors.white
+                        ).value
+                    , SvgAttributes.css
+                        [ if config.isDisabled then
+                            stroke disabledPrimaryCircleColor
+
+                          else if config.isSelected then
+                            stroke Colors.azure
+
+                          else
+                            stroke Colors.gray75
+                        , transition "stroke 0.1s"
+                        ]
+                    , SvgAttributes.class "switch-slider"
+                    ]
+                    []
+                , Svg.path
+                    [ SvgAttributes.strokeLinecap "round"
+                    , SvgAttributes.strokeLinejoin "round"
+                    , SvgAttributes.strokeWidth "3"
+                    , SvgAttributes.d "M8 15.865L12.323 20 21.554 10"
+                    , SvgAttributes.css
+                        [ if config.isDisabled && config.isSelected then
+                            stroke Colors.white
+
+                          else if config.isSelected then
+                            stroke Colors.azure
+
+                          else
+                            Css.display Css.none
+                        , transition "stroke 0.2s"
+                        ]
+                    ]
+                    []
+                ]
+            ]
+        ]
+        |> Nri.Ui.Svg.V1.withWidth (Css.px 43)
+        |> Nri.Ui.Svg.V1.withHeight (Css.px 32)
+        |> Nri.Ui.Svg.V1.withCustom [ SvgAttributes.class "switch-track" ]
+
+
+stroke : Color -> Style
+stroke color =
+    Css.property "stroke" (toCssString color)
+
+
+transition : String -> Css.Style
+transition transitionRules =
+    MediaQuery.anyMotion [ Css.property "transition" transitionRules ]

--- a/tests/Spec/Nri/Ui/Switch.elm
+++ b/tests/Spec/Nri/Ui/Switch.elm
@@ -23,6 +23,8 @@ hasCorrectRole =
         \() ->
             Switch.view { id = "switch", label = "Switch" }
                 []
+                |> List.singleton
+                |> div []
                 |> toUnstyled
                 |> Query.fromHtml
                 |> Query.find [ Selector.id "switch" ]
@@ -36,6 +38,8 @@ hasCorrectAriaDisabled =
         \() ->
             Switch.view { id = "switch", label = "Switch" }
                 [ Switch.disabled True ]
+                |> List.singleton
+                |> div []
                 |> toUnstyled
                 |> Query.fromHtml
                 |> Query.find [ Selector.id "switch" ]

--- a/tests/Spec/Nri/Ui/Switch.elm
+++ b/tests/Spec/Nri/Ui/Switch.elm
@@ -3,7 +3,7 @@ module Spec.Nri.Ui.Switch exposing (..)
 import Accessibility.Aria as Aria
 import Accessibility.Role as Role
 import Html.Styled exposing (..)
-import Nri.Ui.Switch.V2 as Switch
+import Nri.Ui.Switch.V3 as Switch
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -69,6 +69,7 @@
         "Nri.Ui.Sprite.V1",
         "Nri.Ui.Svg.V1",
         "Nri.Ui.Switch.V2",
+        "Nri.Ui.Switch.V3",
         "Nri.Ui.Table.V6",
         "Nri.Ui.Table.V7",
         "Nri.Ui.Tabs.V6",


### PR DESCRIPTION
Fixes A11-3200

Changes the Switch component to not be backed by a checkbox input.

Also improves the Switch component catalog example:

<img width="1400" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/5ffd0dfc-9e28-4b08-a0c5-f9e95317b94e">

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - https://linear.app/noredink/issue/A11-3391/upgrade-to-switchv3
