### PR TITLE
Tessa/blank block suggestions

### DIFF
--- a/component-catalog/src/Debug/Control/Extra.elm
+++ b/component-catalog/src/Debug/Control/Extra.elm
@@ -1,7 +1,7 @@
 module Debug.Control.Extra exposing
     ( float, int
     , values, list, listItem, optionalListItem, optionalListItemDefaultChecked
-    , optionalBoolListItem
+    , optionalBoolListItem, optionalBoolListItemDefaultChecked
     , bool
     , rotatedChoice, specificChoice
     )
@@ -10,7 +10,7 @@ module Debug.Control.Extra exposing
 
 @docs float, int
 @docs values, list, listItem, optionalListItem, optionalListItemDefaultChecked
-@docs optionalBoolListItem
+@docs optionalBoolListItem, optionalBoolListItemDefaultChecked
 @docs bool
 @docs rotatedChoice, specificChoice
 
@@ -90,6 +90,18 @@ optionalListItem_ default name accessor accumulator =
 {-| -}
 optionalBoolListItem : String -> a -> Control (List a) -> Control (List a)
 optionalBoolListItem name f accumulator =
+    optionalBoolListItem_ False name f accumulator
+
+
+{-| -}
+optionalBoolListItemDefaultChecked : String -> a -> Control (List a) -> Control (List a)
+optionalBoolListItemDefaultChecked name f accumulator =
+    optionalBoolListItem_ True name f accumulator
+
+
+{-| -}
+optionalBoolListItem_ : Bool -> String -> a -> Control (List a) -> Control (List a)
+optionalBoolListItem_ startingValue name f accumulator =
     Control.field name
         (Control.map
             (\value ->
@@ -99,7 +111,7 @@ optionalBoolListItem name f accumulator =
                 else
                     []
             )
-            (Control.bool False)
+            (Control.bool startingValue)
         )
         (Control.map (++) accumulator)
 

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -391,7 +391,11 @@ example =
                             ]
                   }
                 , { pattern = Code.fromModule moduleName "view []"
-                  , description = "**Blank block**\n\nRepresents a blank in the sentence."
+                  , description =
+                        """**Blank block**
+
+Represents a blank in the sentence.
+"""
                   , example =
                         inParagraph
                             [ Block.view [ Block.plaintext "I am a seed with " ]
@@ -414,7 +418,16 @@ example =
                                         2
                                 ]
                                 1
-                  , description = "**Blank block with id and SingleCharacter length**\n\n"
+                  , description =
+                        """**Blank block and SingleCharacter width**
+
+Represents a blank in the sentence.
+
+Often, this width will be used to represent punctuation, but note that the accessible name is "blank."
+We must convey that we're looking for a single character in place of the blank elsewhere on the page to provide an equitable experience.
+
+??? When would this height be chosen???
+"""
                   , example =
                         inParagraph
                             [ Block.view [ Block.plaintext "I am a seed with " ]
@@ -441,7 +454,16 @@ example =
                                         2
                                 ]
                                 1
-                  , description = "**Blank block with id and ShortWordPhrase length**\n\n"
+                  , description =
+                        """**Blank block with id and ShortWordPhrase length**
+
+Represents a blank in the sentence.
+
+Often, this width will be used to represent  a short word or phrase, but note that the accessible name is "blank."
+We must convey that we're looking for a short word or phrase in place of the blank elsewhere on the page to provide an equitable experience.
+
+??? When would this height be chosen???
+"""
                   , example =
                         inParagraph
                             [ Block.view [ Block.plaintext "I am a seed with " ]
@@ -468,7 +490,16 @@ example =
                                         2
                                 ]
                                 1
-                  , description = "**Blank block with id and LongWordPhrase length**\n\n"
+                  , description =
+                        """**Blank block with id and LongWordPhrase length**
+
+Represents a blank in the sentence.
+
+Often, this width will be used to represent  a long word or phrase, but note that the accessible name is "blank."
+We must convey that we're looking for a long word or phrase in place of the blank elsewhere on the page to provide an equitable experience.
+
+??? When would this height be chosen???
+"""
                   , example =
                         inParagraph
                             [ Block.view [ Block.plaintext "I am a seed with " ]
@@ -495,7 +526,15 @@ example =
                                         2
                                 ]
                                 1
-                  , description = "**Blank block with id and CharacterCount 8 length**\n\n"
+                  , description =
+                        """**Blank block with id and specific CharacterCount-based length**
+
+Represents a blank in the sentence.
+
+The accessible name is "blank." If we're looking for a specific length of content to put in the blank, that _must_ be communicated elsewhere on the page to provide an equitable experience.
+
+??? When would this height be chosen???
+"""
                   , example =
                         inParagraph
                             [ Block.view [ Block.plaintext "I am a seed with " ]
@@ -520,7 +559,16 @@ example =
                                         2
                                 ]
                                 1
-                  , description = "**Full height blank block and SingleCharacter length**\n\n"
+                  , description =
+                        """**Full height blank block and SingleCharacter length**
+
+Represents a blank in the sentence.
+
+Often, this width will be used to represent  a short word or phrase, but note that the accessible name is "blank."
+We must convey that we're looking for a short word or phrase in place of the blank elsewhere on the page to provide an equitable experience.
+
+??? When would this height be chosen???
+"""
                   , example =
                         inParagraph
                             [ Block.view [ Block.plaintext "I am a seed with " ]
@@ -545,7 +593,16 @@ example =
                                         2
                                 ]
                                 1
-                  , description = "**Full height blank block and ShortWordPhrase length**\n\n"
+                  , description =
+                        """**Full height blank block and ShortWordPhrase length**
+
+Represents a blank in the sentence.
+
+Often, this width will be used to represent  a short word or phrase, but note that the accessible name is "blank."
+We must convey that we're looking for a short word or phrase in place of the blank elsewhere on the page to provide an equitable experience.
+
+??? When would this height be chosen???
+"""
                   , example =
                         inParagraph
                             [ Block.view [ Block.plaintext "I am a seed with " ]
@@ -570,7 +627,16 @@ example =
                                         2
                                 ]
                                 1
-                  , description = "**Full height blank block and LongWordPhrase length**\n\n"
+                  , description =
+                        """**Full height blank block and LongWordPhrase length**
+
+Represents a blank in the sentence.
+
+Often, this width will be used to represent  a long word or phrase, but note that the accessible name is "blank."
+We must convey that we're looking for a long word or phrase in place of the blank elsewhere on the page to provide an equitable experience.
+
+??? When would this height be chosen???
+    """
                   , example =
                         inParagraph
                             [ Block.view [ Block.plaintext "I am a seed with " ]
@@ -582,7 +648,16 @@ example =
                             , Block.view [ Block.plaintext " being used." ]
                             ]
                   }
-                , { pattern =
+                , { description =
+                        """**Full height blank block and specific CharacterCount-based length**
+
+Represents a blank in the sentence.
+
+The accessible name is "blank." If we're looking for a specific length of content to put in the blank, that _must_ be communicated elsewhere on the page to provide an equitable experience.
+
+??? When would this height be chosen???
+"""
+                  , pattern =
                         Code.fromModule moduleName "view"
                             ++ Code.listMultiline
                                 [ Code.fromModule moduleName "content"
@@ -595,7 +670,6 @@ example =
                                         2
                                 ]
                                 1
-                  , description = "**Full height blank block and CharacterCount 8 length**\n\n"
                   , example =
                         inParagraph
                             [ Block.view [ Block.plaintext "I am a seed with " ]

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -25,6 +25,7 @@ import Nri.Ui.Button.V10 as Button
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V7 as Table
 import Nri.Ui.Text.V6 as Text
@@ -365,289 +366,13 @@ example =
                         """**Blank block**
 
 Represents a blank in the sentence.
+
+Please see the "Blank views and width guidance" table to learn more about using Blanks.
 """
                   , example =
                         inParagraph
                             [ Block.view [ Block.plaintext "I am a seed with " ]
                             , Block.view []
-                            , Block.view [ Block.plaintext " being used." ]
-                            ]
-                  }
-                , { pattern =
-                        Code.fromModule moduleName "view"
-                            ++ Code.listMultiline
-                                [ Code.fromModule moduleName "content"
-                                    ++ Code.listMultiline
-                                        [ "…"
-                                        , Code.fromModule moduleName "blankWithId "
-                                            ++ Code.string "[id]"
-                                            ++ " "
-                                            ++ Code.fromModule moduleName "SingleCharacter"
-                                        , "…"
-                                        ]
-                                        2
-                                ]
-                                1
-                  , description =
-                        """**Blank block and SingleCharacter width**
-
-Represents a blank in the sentence.
-
-Often, this width will be used to represent punctuation, but note that the accessible name is "blank."
-We must convey that we're looking for a single character in place of the blank elsewhere on the page to provide an equitable experience.
-
-??? When would this height be chosen???
-"""
-                  , example =
-                        inParagraph
-                            [ Block.view [ Block.plaintext "I am a seed with " ]
-                            , Block.view
-                                [ Block.content
-                                    [ Block.blankWithId "blank-with-id-single-character-example" Block.SingleCharacter
-                                    ]
-                                ]
-                            , Block.view [ Block.plaintext " being used." ]
-                            ]
-                  }
-                , { pattern =
-                        Code.fromModule moduleName "view"
-                            ++ Code.listMultiline
-                                [ Code.fromModule moduleName "content"
-                                    ++ Code.listMultiline
-                                        [ "…"
-                                        , Code.fromModule moduleName "blankWithId "
-                                            ++ Code.string "[id]"
-                                            ++ " "
-                                            ++ Code.fromModule moduleName "ShortWordPhrase"
-                                        , "…"
-                                        ]
-                                        2
-                                ]
-                                1
-                  , description =
-                        """**Blank block with id and ShortWordPhrase length**
-
-Represents a blank in the sentence.
-
-Often, this width will be used to represent  a short word or phrase, but note that the accessible name is "blank."
-We must convey that we're looking for a short word or phrase in place of the blank elsewhere on the page to provide an equitable experience.
-
-??? When would this height be chosen???
-"""
-                  , example =
-                        inParagraph
-                            [ Block.view [ Block.plaintext "I am a seed with " ]
-                            , Block.view
-                                [ Block.content
-                                    [ Block.blankWithId "blank-with-id-short-word-example" Block.ShortWordPhrase
-                                    ]
-                                ]
-                            , Block.view [ Block.plaintext " being used." ]
-                            ]
-                  }
-                , { pattern =
-                        Code.fromModule moduleName "view"
-                            ++ Code.listMultiline
-                                [ Code.fromModule moduleName "content"
-                                    ++ Code.listMultiline
-                                        [ "…"
-                                        , Code.fromModule moduleName "blankWithId "
-                                            ++ Code.string "[id]"
-                                            ++ " "
-                                            ++ Code.fromModule moduleName "LongWordPhrase"
-                                        , "…"
-                                        ]
-                                        2
-                                ]
-                                1
-                  , description =
-                        """**Blank block with id and LongWordPhrase length**
-
-Represents a blank in the sentence.
-
-Often, this width will be used to represent  a long word or phrase, but note that the accessible name is "blank."
-We must convey that we're looking for a long word or phrase in place of the blank elsewhere on the page to provide an equitable experience.
-
-??? When would this height be chosen???
-"""
-                  , example =
-                        inParagraph
-                            [ Block.view [ Block.plaintext "I am a seed with " ]
-                            , Block.view
-                                [ Block.content
-                                    [ Block.blankWithId "blank-with-id-long-word-example" Block.LongWordPhrase
-                                    ]
-                                ]
-                            , Block.view [ Block.plaintext " being used." ]
-                            ]
-                  }
-                , { pattern =
-                        Code.fromModule moduleName "view"
-                            ++ Code.listMultiline
-                                [ Code.fromModule moduleName "content"
-                                    ++ Code.listMultiline
-                                        [ "…"
-                                        , Code.fromModule moduleName "blankWithId "
-                                            ++ Code.string "[id]"
-                                            ++ " "
-                                            ++ Code.withParens (Code.fromModule moduleName "CharacterCount 8")
-                                        , "…"
-                                        ]
-                                        2
-                                ]
-                                1
-                  , description =
-                        """**Blank block with id and specific CharacterCount-based length**
-
-Represents a blank in the sentence.
-
-The accessible name is "blank." If we're looking for a specific length of content to put in the blank, that _must_ be communicated elsewhere on the page to provide an equitable experience.
-
-??? When would this height be chosen???
-"""
-                  , example =
-                        inParagraph
-                            [ Block.view [ Block.plaintext "I am a seed with " ]
-                            , Block.view
-                                [ Block.content
-                                    [ Block.blankWithId "blank-with-id-character-count-example" (Block.CharacterCount 8)
-                                    ]
-                                ]
-                            , Block.view [ Block.plaintext " being used." ]
-                            ]
-                  }
-                , { pattern =
-                        Code.fromModule moduleName "view"
-                            ++ Code.listMultiline
-                                [ Code.fromModule moduleName "content"
-                                    ++ Code.listMultiline
-                                        [ "…"
-                                        , Code.fromModule moduleName "fullHeightBlank "
-                                            ++ Code.fromModule moduleName "SingleCharacter"
-                                        , "…"
-                                        ]
-                                        2
-                                ]
-                                1
-                  , description =
-                        """**Full height blank block and SingleCharacter length**
-
-Represents a blank in the sentence.
-
-Often, this width will be used to represent  a short word or phrase, but note that the accessible name is "blank."
-We must convey that we're looking for a short word or phrase in place of the blank elsewhere on the page to provide an equitable experience.
-
-??? When would this height be chosen???
-"""
-                  , example =
-                        inParagraph
-                            [ Block.view [ Block.plaintext "I am a seed with " ]
-                            , Block.view
-                                [ Block.content
-                                    [ Block.fullHeightBlank Block.SingleCharacter
-                                    ]
-                                ]
-                            , Block.view [ Block.plaintext " being used." ]
-                            ]
-                  }
-                , { pattern =
-                        Code.fromModule moduleName "view"
-                            ++ Code.listMultiline
-                                [ Code.fromModule moduleName "content"
-                                    ++ Code.listMultiline
-                                        [ "…"
-                                        , Code.fromModule moduleName "fullHeightBlank "
-                                            ++ Code.fromModule moduleName "ShortWordPhrase"
-                                        , "…"
-                                        ]
-                                        2
-                                ]
-                                1
-                  , description =
-                        """**Full height blank block and ShortWordPhrase length**
-
-Represents a blank in the sentence.
-
-Often, this width will be used to represent  a short word or phrase, but note that the accessible name is "blank."
-We must convey that we're looking for a short word or phrase in place of the blank elsewhere on the page to provide an equitable experience.
-
-??? When would this height be chosen???
-"""
-                  , example =
-                        inParagraph
-                            [ Block.view [ Block.plaintext "I am a seed with " ]
-                            , Block.view
-                                [ Block.content
-                                    [ Block.fullHeightBlank Block.ShortWordPhrase
-                                    ]
-                                ]
-                            , Block.view [ Block.plaintext " being used." ]
-                            ]
-                  }
-                , { pattern =
-                        Code.fromModule moduleName "view"
-                            ++ Code.listMultiline
-                                [ Code.fromModule moduleName "content"
-                                    ++ Code.listMultiline
-                                        [ "…"
-                                        , Code.fromModule moduleName "fullHeightBlank "
-                                            ++ Code.fromModule moduleName "LongWordPhrase"
-                                        , "…"
-                                        ]
-                                        2
-                                ]
-                                1
-                  , description =
-                        """**Full height blank block and LongWordPhrase length**
-
-Represents a blank in the sentence.
-
-Often, this width will be used to represent  a long word or phrase, but note that the accessible name is "blank."
-We must convey that we're looking for a long word or phrase in place of the blank elsewhere on the page to provide an equitable experience.
-
-??? When would this height be chosen???
-    """
-                  , example =
-                        inParagraph
-                            [ Block.view [ Block.plaintext "I am a seed with " ]
-                            , Block.view
-                                [ Block.content
-                                    [ Block.fullHeightBlank Block.LongWordPhrase
-                                    ]
-                                ]
-                            , Block.view [ Block.plaintext " being used." ]
-                            ]
-                  }
-                , { description =
-                        """**Full height blank block and specific CharacterCount-based length**
-
-Represents a blank in the sentence.
-
-The accessible name is "blank." If we're looking for a specific length of content to put in the blank, that _must_ be communicated elsewhere on the page to provide an equitable experience.
-
-??? When would this height be chosen???
-"""
-                  , pattern =
-                        Code.fromModule moduleName "view"
-                            ++ Code.listMultiline
-                                [ Code.fromModule moduleName "content"
-                                    ++ Code.listMultiline
-                                        [ "…"
-                                        , Code.fromModule moduleName "fullHeightBlank "
-                                            ++ Code.withParens (Code.fromModule moduleName "CharacterCount 8")
-                                        , "…"
-                                        ]
-                                        2
-                                ]
-                                1
-                  , example =
-                        inParagraph
-                            [ Block.view [ Block.plaintext "I am a seed with " ]
-                            , Block.view
-                                [ Block.content
-                                    [ Block.fullHeightBlank (Block.CharacterCount 8)
-                                    ]
-                                ]
                             , Block.view [ Block.plaintext " being used." ]
                             ]
                   }
@@ -701,6 +426,129 @@ The accessible name is "blank." If we're looking for a specific length of conten
                                 [ Block.plaintext " in a seed."
                                 ]
                             ]
+                  }
+                ]
+            , Heading.h2
+                [ Heading.plaintext "Blank views and width guidance"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
+            , Table.view
+                []
+                [ Table.string
+                    { header = "Name"
+                    , value = .name
+                    , width = Css.pct 10
+                    , cellStyles = always []
+                    , sort = Nothing
+                    }
+                , Table.custom
+                    { header = text "Code"
+                    , view = \{ code } -> Html.Styled.code [] [ text code ]
+                    , width = Css.px 300
+                    , cellStyles =
+                        always
+                            [ Css.padding2 (Css.px 14) (Css.px 7)
+                            , Css.verticalAlign Css.top
+                            , Css.fontSize (Css.px 12)
+                            , Css.whiteSpace Css.preWrap
+                            ]
+                    , sort = Nothing
+                    }
+                , Table.custom
+                    { header = text "Description"
+                    , view =
+                        \{ description, guidance } ->
+                            Markdown.toHtml Nothing (description ++ "\n\n" ++ guidance)
+                                |> List.map fromUnstyled
+                                |> div []
+                    , width = Css.px 300
+                    , cellStyles = always [ Css.padding2 Css.zero (Css.px 7), Css.verticalAlign Css.top ]
+                    , sort = Nothing
+                    }
+                , Table.custom
+                    { header = text "SingleCharacter"
+                    , view = .singleCharacter
+                    , width = Css.px 300
+                    , cellStyles = always [ Css.padding2 Css.zero (Css.px 7), Css.verticalAlign Css.top ]
+                    , sort = Nothing
+                    }
+                , Table.custom
+                    { header = text "ShortWordPhrase"
+                    , view = .shortWordPhrase
+                    , width = Css.px 300
+                    , cellStyles = always [ Css.padding2 Css.zero (Css.px 7), Css.verticalAlign Css.top ]
+                    , sort = Nothing
+                    }
+                , Table.custom
+                    { header = text "LongWordPhrase"
+                    , view = .longWordPhrase
+                    , width = Css.px 300
+                    , cellStyles = always [ Css.padding2 Css.zero (Css.px 7), Css.verticalAlign Css.top ]
+                    , sort = Nothing
+                    }
+                , Table.custom
+                    { header = text "CharacterCount 20"
+                    , view = .characterCount
+                    , width = Css.px 300
+                    , cellStyles = always [ Css.padding2 Css.zero (Css.px 7), Css.verticalAlign Css.top ]
+                    , sort = Nothing
+                    }
+                ]
+                [ { name = ""
+                  , code = ""
+                  , singleCharacter = text "Often, this width will be used to represent punctuation, but note that the accessible name is \"blank.\"\nWe must convey that we're looking for a single character in place of the blank elsewhere on the page to provide an equitable experience."
+                  , shortWordPhrase = text "Often, this width will be used to represent a short word or phrase, but note that the accessible name is \"blank.\" We must convey that we're looking for a short word or phrase in place of the blank elsewhere on the page to provide an equitable experience."
+                  , longWordPhrase = text "Often, this width will be used to represent  a long word or phrase, but note that the accessible name is \"blank.\" We must convey that we're looking for a long word or phrase in place of the blank elsewhere on the page to provide an equitable experience."
+                  , characterCount = text "The accessible name is \"blank.\" If we're looking for a specific length of content to put in the blank, that _must_ be communicated elsewhere on the page to provide an equitable experience."
+                  , description = ""
+                  , guidance = ""
+                  }
+                , { name = "(none)"
+                  , code = Code.fromModule moduleName "view []"
+                  , singleCharacter = text "N/A"
+                  , shortWordPhrase = text "N/A"
+                  , longWordPhrase = text "N/A"
+                  , characterCount = text "N/A"
+                  , description = "When no other attributes are passed to `Block.view`, Block will render a blank."
+                  , guidance = "This behavior is primarily provided as a convenience to devs."
+                  }
+                , { name = "blankWithId"
+                  , code =
+                        Code.fromModule moduleName "view"
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "content"
+                                    ++ Code.listMultiline
+                                        [ Code.fromModule moduleName "blankWithId "
+                                            ++ Code.string "[id]"
+                                            ++ " [block length]"
+                                        ]
+                                        2
+                                ]
+                                1
+                  , singleCharacter = Block.view [ Block.content [ Block.blankWithId "blankWithId-single-char" Block.SingleCharacter ] ]
+                  , shortWordPhrase = Block.view [ Block.content [ Block.blankWithId "blankWithId-short-word-phrase" Block.ShortWordPhrase ] ]
+                  , longWordPhrase = Block.view [ Block.content [ Block.blankWithId "blankWithId-long-word-phrase" Block.LongWordPhrase ] ]
+                  , characterCount = Block.view [ Block.content [ Block.blankWithId "blankWithId-char-count" (Block.CharacterCount 20) ] ]
+                  , description = "`blankWithId` will render a blank with the specified id. The blank's height will not expand past the content."
+                  , guidance = "??? When should this helper be used ???"
+                  }
+                , { name = "fullHeightBlank"
+                  , code =
+                        Code.fromModule moduleName "view"
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "content"
+                                    ++ Code.listMultiline
+                                        [ Code.fromModule moduleName "fullHeightBlank [block length]"
+                                        ]
+                                        2
+                                ]
+                                1
+                  , singleCharacter = Block.view [ Block.content [ Block.fullHeightBlank Block.SingleCharacter ] ]
+                  , shortWordPhrase = Block.view [ Block.content [ Block.fullHeightBlank Block.ShortWordPhrase ] ]
+                  , longWordPhrase = Block.view [ Block.content [ Block.fullHeightBlank Block.LongWordPhrase ] ]
+                  , characterCount = Block.view [ Block.content [ Block.fullHeightBlank (Block.CharacterCount 20) ] ]
+                  , description = "`fullHeightBlank` will render a blank whose height will be taller than the surrounding text"
+                  , guidance = "??? When should this helper be used ???"
                   }
                 ]
             ]

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -279,36 +279,6 @@ example =
                 ]
             , Table.view []
                 [ Table.custom
-                    { header = text "Blank Width"
-                    , view = String.fromInt >> text
-                    , width = Css.px 125
-                    , cellStyles = always []
-                    , sort = Nothing
-                    }
-                , Table.custom
-                    { header = text "Example"
-                    , view = \characters -> Block.view [ Block.content [ Block.fullHeightBlank (Block.CharacterCount characters) ] ]
-                    , width = Css.auto
-                    , cellStyles = always [ Css.fontSize (Css.px 30) ]
-                    , sort = Nothing
-                    }
-                , Table.custom
-                    { header = text "Code"
-                    , view = \characters -> code [] [ text <| "Block.view \n  [ Block.content \n    [ Block.fullHeightBlank (Block.CharacterCount " ++ String.fromInt characters ++ ") \n    ] \n  ]" ]
-                    , width = Css.px 500
-                    , cellStyles =
-                        always
-                            [ Css.padding2 (Css.px 14) (Css.px 7)
-                            , Css.verticalAlign Css.top
-                            , Css.fontSize (Css.px 12)
-                            , Css.whiteSpace Css.preWrap
-                            ]
-                    , sort = Nothing
-                    }
-                ]
-                [ 1, 2, 3, 4, 5, 6, 7, 8 ]
-            , Table.view []
-                [ Table.custom
                     { header = text "Pattern name & description"
                     , view = .description >> Markdown.toHtml Nothing >> List.map fromUnstyled >> div []
                     , width = Css.px 125
@@ -849,65 +819,60 @@ controlContent =
                     )
                 )
           )
-        , ( "single character blank"
+        , blankType ( "blank", Block.blank )
+        , blankType ( "blankWithId \"example-id\"", Block.blankWithId "example-id" )
+        , blankType ( "fullHeightBlank", Block.fullHeightBlank )
+        ]
+
+
+blankType : ( String, Block.BlankLength -> Block.Content msg ) -> ( String, Control ( String, Block.Attribute msg ) )
+blankType ( typeStr, blank ) =
+    ( typeStr
+    , Control.map
+        (\( widthStr, width ) ->
+            ( Code.fromModule moduleName "content "
+                ++ Code.withParens
+                    (Code.fromModule moduleName typeStr
+                        ++ " "
+                        ++ widthStr
+                    )
+            , Block.content [ blank width ]
+            )
+        )
+        controlBlankWidth
+    )
+
+
+controlBlankWidth : Control ( String, Block.BlankLength )
+controlBlankWidth =
+    Control.choice
+        [ ( "SingleCharacter"
           , Control.value
-                ( Code.fromModule moduleName "content "
-                    ++ Code.withParens
-                        (Code.fromModule moduleName "blank "
-                            ++ Code.fromModule moduleName "SingleCharacter"
-                        )
-                , Block.content [ Block.blank Block.SingleCharacter ]
+                ( Code.fromModule moduleName "SingleCharacter"
+                , Block.SingleCharacter
                 )
           )
-        , ( "short word phrase blank"
+        , ( "ShortWordPhrase"
           , Control.value
-                ( Code.fromModule moduleName "content "
-                    ++ Code.withParens
-                        (Code.fromModule moduleName "blank "
-                            ++ Code.fromModule moduleName "ShortWordPhrase"
-                        )
-                , Block.content [ Block.blank Block.ShortWordPhrase ]
+                ( Code.fromModule moduleName "ShortWordPhrase"
+                , Block.ShortWordPhrase
                 )
           )
-        , ( "long word phrase blank"
+        , ( "LongWordPhrase"
           , Control.value
-                ( Code.fromModule moduleName "content "
-                    ++ Code.withParens
-                        (Code.fromModule moduleName "blank "
-                            ++ Code.fromModule moduleName "LongWordPhrase"
-                        )
-                , Block.content [ Block.blank Block.LongWordPhrase ]
+                ( Code.fromModule moduleName "LongWordPhrase"
+                , Block.LongWordPhrase
                 )
           )
-        , ( "full height single character blank"
-          , Control.value
-                ( Code.fromModule moduleName "content "
-                    ++ Code.withParens
-                        (Code.fromModule moduleName "fullHeightBlank "
-                            ++ Code.fromModule moduleName "SingleCharacter"
-                        )
-                , Block.content [ Block.fullHeightBlank Block.SingleCharacter ]
+        , ( "CharacterCount"
+          , Control.map
+                (\int ->
+                    ( Code.withParens
+                        (Code.fromModule moduleName "CharacterCount " ++ Code.int int)
+                    , Block.CharacterCount int
+                    )
                 )
-          )
-        , ( "full height short word phrase blank"
-          , Control.value
-                ( Code.fromModule moduleName "content "
-                    ++ Code.withParens
-                        (Code.fromModule moduleName "fullHeightBlank "
-                            ++ Code.fromModule moduleName "ShortWordPhrase"
-                        )
-                , Block.content [ Block.fullHeightBlank Block.ShortWordPhrase ]
-                )
-          )
-        , ( "full height long word phrase blank"
-          , Control.value
-                ( Code.fromModule moduleName "content "
-                    ++ Code.withParens
-                        (Code.fromModule moduleName "fullHeightBlank "
-                            ++ Code.fromModule moduleName "LongWordPhrase"
-                        )
-                , Block.content [ Block.fullHeightBlank Block.LongWordPhrase ]
-                )
+                (ControlExtra.int 0)
           )
         ]
 

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -485,7 +485,7 @@ Please see the "Blank views and width guidance" table to learn more about using 
                     , sort = Nothing
                     }
                 , Table.custom
-                    { header = text "CharacterCount 20"
+                    { header = text "CharacterCount [int]"
                     , view = .characterCount
                     , width = Css.px 300
                     , cellStyles = always [ Css.padding2 Css.zero (Css.px 7), Css.verticalAlign Css.top ]
@@ -494,10 +494,29 @@ Please see the "Blank views and width guidance" table to learn more about using 
                 ]
                 [ { name = "Width"
                   , code = ""
-                  , singleCharacter = text "Often, this width will be used to represent punctuation."
-                  , shortWordPhrase = text "Often, this width will be used to represent a short word or phrase."
-                  , longWordPhrase = text "Often, this width will be used to represent  a long word or phrase."
-                  , characterCount = text ""
+                  , singleCharacter =
+                        "Typically used to represent punctuation.\n\nThe width is 0.83em."
+                            |> Markdown.toHtml Nothing
+                            |> List.map fromUnstyled
+                            |> div []
+                  , shortWordPhrase =
+                        "Typically used to represent a short word or phrase.\n\nThe width is 4em."
+                            |> Markdown.toHtml Nothing
+                            |> List.map fromUnstyled
+                            |> div []
+                  , longWordPhrase =
+                        "Typically used to represent  a long word or phrase.\n\nThe width is 6.66em."
+                            |> Markdown.toHtml Nothing
+                            |> List.map fromUnstyled
+                            |> div []
+                  , characterCount =
+                        [ "Uses the number of characters expected in the blank to calculate a rough monospace-based width that visually looks like it _could_ match."
+                        , "Multiplies the number of characters by 0.5 to get the width in em. The width must be at least 0.83."
+                        ]
+                            |> String.join "\n\n"
+                            |> Markdown.toHtml Nothing
+                            |> List.map fromUnstyled
+                            |> div []
                   , description = "The accessible name of all blanks, regardless of width and view used, is \"blank.\""
                   , guidance = "If we're looking for a specific length of content to put in the blank, that _must_ be communicated elsewhere on the page to provide an equitable experience."
                   }

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -25,7 +25,6 @@ import Nri.Ui.Button.V10 as Button
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
-import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V7 as Table
 import Nri.Ui.Text.V6 as Text

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -591,8 +591,8 @@ type alias Settings =
 initControl : Control Settings
 initControl =
     ControlExtra.list
-        |> ControlExtra.optionalListItem "content" controlContent
-        |> ControlExtra.optionalBoolListItem "emphasize" ( Code.fromModule moduleName "emphasize", Block.emphasize )
+        |> ControlExtra.optionalListItemDefaultChecked "content" controlContent
+        |> ControlExtra.optionalBoolListItemDefaultChecked "emphasize" ( Code.fromModule moduleName "emphasize", Block.emphasize )
         |> ControlExtra.optionalListItem "label"
             (CommonControls.string ( Code.fromModule moduleName "label", Block.label ) "Fruit")
         |> ControlExtra.optionalListItem "labelPosition"

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -361,21 +361,6 @@ example =
                                 ]
                             ]
                   }
-                , { pattern = Code.fromModule moduleName "view []"
-                  , description =
-                        """**Blank block**
-
-Represents a blank in the sentence.
-
-Please see the "Blank views and width guidance" table to learn more about using Blanks.
-"""
-                  , example =
-                        inParagraph
-                            [ Block.view [ Block.plaintext "I am a seed with " ]
-                            , Block.view []
-                            , Block.view [ Block.plaintext " being used." ]
-                            ]
-                  }
                 , { pattern =
                         Code.fromModule moduleName "view "
                             ++ Code.listMultiline
@@ -383,7 +368,14 @@ Please see the "Blank views and width guidance" table to learn more about using 
                                 , Code.fromModule moduleName "purple"
                                 ]
                                 1
-                  , description = "**Labeled blank block**\n\nA labelled blank in the sentence"
+                  , description =
+                        """**Labeled blank block**
+
+A labelled blank in the sentence.
+
+Please see the "Blank views and width guidance" table to learn more about using Blanks.
+
+"""
                   , example =
                         inParagraph
                             [ Block.view [ Block.plaintext "If a volcano is extinct, " ]

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -434,16 +434,14 @@ Please see the "Blank views and width guidance" table to learn more about using 
                 ]
             , Table.view
                 []
-                [ Table.string
-                    { header = "Name"
-                    , value = .name
-                    , width = Css.pct 10
-                    , cellStyles = always []
-                    , sort = Nothing
-                    }
-                , Table.custom
-                    { header = text "Code"
-                    , view = \{ code } -> Html.Styled.code [] [ text code ]
+                [ Table.custom
+                    { header = text "Pattern"
+                    , view =
+                        \{ name, code } ->
+                            div []
+                                [ Text.smallBody [ Text.plaintext name ]
+                                , Html.Styled.code [] [ text code ]
+                                ]
                     , width = Css.px 300
                     , cellStyles =
                         always
@@ -494,16 +492,16 @@ Please see the "Blank views and width guidance" table to learn more about using 
                     , sort = Nothing
                     }
                 ]
-                [ { name = ""
+                [ { name = "Width"
                   , code = ""
-                  , singleCharacter = text "Often, this width will be used to represent punctuation, but note that the accessible name is \"blank.\"\nWe must convey that we're looking for a single character in place of the blank elsewhere on the page to provide an equitable experience."
-                  , shortWordPhrase = text "Often, this width will be used to represent a short word or phrase, but note that the accessible name is \"blank.\" We must convey that we're looking for a short word or phrase in place of the blank elsewhere on the page to provide an equitable experience."
-                  , longWordPhrase = text "Often, this width will be used to represent  a long word or phrase, but note that the accessible name is \"blank.\" We must convey that we're looking for a long word or phrase in place of the blank elsewhere on the page to provide an equitable experience."
-                  , characterCount = text "The accessible name is \"blank.\" If we're looking for a specific length of content to put in the blank, that _must_ be communicated elsewhere on the page to provide an equitable experience."
-                  , description = ""
-                  , guidance = ""
+                  , singleCharacter = text "Often, this width will be used to represent punctuation."
+                  , shortWordPhrase = text "Often, this width will be used to represent a short word or phrase."
+                  , longWordPhrase = text "Often, this width will be used to represent  a long word or phrase."
+                  , characterCount = text ""
+                  , description = "The accessible name of all blanks, regardless of width and view used, is \"blank.\""
+                  , guidance = "If we're looking for a specific length of content to put in the blank, that _must_ be communicated elsewhere on the page to provide an equitable experience."
                   }
-                , { name = "(none)"
+                , { name = ""
                   , code = Code.fromModule moduleName "view []"
                   , singleCharacter = text "N/A"
                   , shortWordPhrase = text "N/A"

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -702,36 +702,37 @@ blankType ( typeStr, blank ) =
 
 controlBlankWidth : Control ( String, Block.BlankLength )
 controlBlankWidth =
-    Control.choice
-        [ ( "SingleCharacter"
-          , Control.value
-                ( Code.fromModule moduleName "SingleCharacter"
-                , Block.SingleCharacter
+    [ ( "SingleCharacter"
+      , Control.value
+            ( Code.fromModule moduleName "SingleCharacter"
+            , Block.SingleCharacter
+            )
+      )
+    , ( "ShortWordPhrase"
+      , Control.value
+            ( Code.fromModule moduleName "ShortWordPhrase"
+            , Block.ShortWordPhrase
+            )
+      )
+    , ( "LongWordPhrase"
+      , Control.value
+            ( Code.fromModule moduleName "LongWordPhrase"
+            , Block.LongWordPhrase
+            )
+      )
+    , ( "CharacterCount"
+      , Control.map
+            (\int ->
+                ( Code.withParens
+                    (Code.fromModule moduleName "CharacterCount " ++ Code.int int)
+                , Block.CharacterCount int
                 )
-          )
-        , ( "ShortWordPhrase"
-          , Control.value
-                ( Code.fromModule moduleName "ShortWordPhrase"
-                , Block.ShortWordPhrase
-                )
-          )
-        , ( "LongWordPhrase"
-          , Control.value
-                ( Code.fromModule moduleName "LongWordPhrase"
-                , Block.LongWordPhrase
-                )
-          )
-        , ( "CharacterCount"
-          , Control.map
-                (\int ->
-                    ( Code.withParens
-                        (Code.fromModule moduleName "CharacterCount " ++ Code.int int)
-                    , Block.CharacterCount int
-                    )
-                )
-                (ControlExtra.int 0)
-          )
-        ]
+            )
+            (ControlExtra.int 0)
+      )
+    ]
+        |> List.reverse
+        |> Control.choice
 
 
 ageId : String

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -390,12 +390,220 @@ example =
                                 ]
                             ]
                   }
-                , { pattern = Code.fromModule moduleName "view"
-                  , description = "**Blank block**\n\nRepresents a blank in the sentence. Used in Cycling interface scaffolding."
+                , { pattern = Code.fromModule moduleName "view []"
+                  , description = "**Blank block**\n\nRepresents a blank in the sentence."
                   , example =
                         inParagraph
                             [ Block.view [ Block.plaintext "I am a seed with " ]
                             , Block.view []
+                            , Block.view [ Block.plaintext " being used." ]
+                            ]
+                  }
+                , { pattern =
+                        Code.fromModule moduleName "view"
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "content"
+                                    ++ Code.listMultiline
+                                        [ "…"
+                                        , Code.fromModule moduleName "blankWithId "
+                                            ++ Code.string "[id]"
+                                            ++ " "
+                                            ++ Code.fromModule moduleName "SingleCharacter"
+                                        , "…"
+                                        ]
+                                        2
+                                ]
+                                1
+                  , description = "**Blank block with id and SingleCharacter length**\n\n"
+                  , example =
+                        inParagraph
+                            [ Block.view [ Block.plaintext "I am a seed with " ]
+                            , Block.view
+                                [ Block.content
+                                    [ Block.blankWithId "blank-with-id-single-character-example" Block.SingleCharacter
+                                    ]
+                                ]
+                            , Block.view [ Block.plaintext " being used." ]
+                            ]
+                  }
+                , { pattern =
+                        Code.fromModule moduleName "view"
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "content"
+                                    ++ Code.listMultiline
+                                        [ "…"
+                                        , Code.fromModule moduleName "blankWithId "
+                                            ++ Code.string "[id]"
+                                            ++ " "
+                                            ++ Code.fromModule moduleName "ShortWordPhrase"
+                                        , "…"
+                                        ]
+                                        2
+                                ]
+                                1
+                  , description = "**Blank block with id and ShortWordPhrase length**\n\n"
+                  , example =
+                        inParagraph
+                            [ Block.view [ Block.plaintext "I am a seed with " ]
+                            , Block.view
+                                [ Block.content
+                                    [ Block.blankWithId "blank-with-id-short-word-example" Block.ShortWordPhrase
+                                    ]
+                                ]
+                            , Block.view [ Block.plaintext " being used." ]
+                            ]
+                  }
+                , { pattern =
+                        Code.fromModule moduleName "view"
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "content"
+                                    ++ Code.listMultiline
+                                        [ "…"
+                                        , Code.fromModule moduleName "blankWithId "
+                                            ++ Code.string "[id]"
+                                            ++ " "
+                                            ++ Code.fromModule moduleName "LongWordPhrase"
+                                        , "…"
+                                        ]
+                                        2
+                                ]
+                                1
+                  , description = "**Blank block with id and LongWordPhrase length**\n\n"
+                  , example =
+                        inParagraph
+                            [ Block.view [ Block.plaintext "I am a seed with " ]
+                            , Block.view
+                                [ Block.content
+                                    [ Block.blankWithId "blank-with-id-long-word-example" Block.LongWordPhrase
+                                    ]
+                                ]
+                            , Block.view [ Block.plaintext " being used." ]
+                            ]
+                  }
+                , { pattern =
+                        Code.fromModule moduleName "view"
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "content"
+                                    ++ Code.listMultiline
+                                        [ "…"
+                                        , Code.fromModule moduleName "blankWithId "
+                                            ++ Code.string "[id]"
+                                            ++ " "
+                                            ++ Code.withParens (Code.fromModule moduleName "CharacterCount 8")
+                                        , "…"
+                                        ]
+                                        2
+                                ]
+                                1
+                  , description = "**Blank block with id and CharacterCount 8 length**\n\n"
+                  , example =
+                        inParagraph
+                            [ Block.view [ Block.plaintext "I am a seed with " ]
+                            , Block.view
+                                [ Block.content
+                                    [ Block.blankWithId "blank-with-id-character-count-example" (Block.CharacterCount 8)
+                                    ]
+                                ]
+                            , Block.view [ Block.plaintext " being used." ]
+                            ]
+                  }
+                , { pattern =
+                        Code.fromModule moduleName "view"
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "content"
+                                    ++ Code.listMultiline
+                                        [ "…"
+                                        , Code.fromModule moduleName "fullHeightBlank "
+                                            ++ Code.fromModule moduleName "SingleCharacter"
+                                        , "…"
+                                        ]
+                                        2
+                                ]
+                                1
+                  , description = "**Full height blank block and SingleCharacter length**\n\n"
+                  , example =
+                        inParagraph
+                            [ Block.view [ Block.plaintext "I am a seed with " ]
+                            , Block.view
+                                [ Block.content
+                                    [ Block.fullHeightBlank Block.SingleCharacter
+                                    ]
+                                ]
+                            , Block.view [ Block.plaintext " being used." ]
+                            ]
+                  }
+                , { pattern =
+                        Code.fromModule moduleName "view"
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "content"
+                                    ++ Code.listMultiline
+                                        [ "…"
+                                        , Code.fromModule moduleName "fullHeightBlank "
+                                            ++ Code.fromModule moduleName "ShortWordPhrase"
+                                        , "…"
+                                        ]
+                                        2
+                                ]
+                                1
+                  , description = "**Full height blank block and ShortWordPhrase length**\n\n"
+                  , example =
+                        inParagraph
+                            [ Block.view [ Block.plaintext "I am a seed with " ]
+                            , Block.view
+                                [ Block.content
+                                    [ Block.fullHeightBlank Block.ShortWordPhrase
+                                    ]
+                                ]
+                            , Block.view [ Block.plaintext " being used." ]
+                            ]
+                  }
+                , { pattern =
+                        Code.fromModule moduleName "view"
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "content"
+                                    ++ Code.listMultiline
+                                        [ "…"
+                                        , Code.fromModule moduleName "fullHeightBlank "
+                                            ++ Code.fromModule moduleName "LongWordPhrase"
+                                        , "…"
+                                        ]
+                                        2
+                                ]
+                                1
+                  , description = "**Full height blank block and LongWordPhrase length**\n\n"
+                  , example =
+                        inParagraph
+                            [ Block.view [ Block.plaintext "I am a seed with " ]
+                            , Block.view
+                                [ Block.content
+                                    [ Block.fullHeightBlank Block.LongWordPhrase
+                                    ]
+                                ]
+                            , Block.view [ Block.plaintext " being used." ]
+                            ]
+                  }
+                , { pattern =
+                        Code.fromModule moduleName "view"
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "content"
+                                    ++ Code.listMultiline
+                                        [ "…"
+                                        , Code.fromModule moduleName "fullHeightBlank "
+                                            ++ Code.withParens (Code.fromModule moduleName "CharacterCount 8")
+                                        , "…"
+                                        ]
+                                        2
+                                ]
+                                1
+                  , description = "**Full height blank block and CharacterCount 8 length**\n\n"
+                  , example =
+                        inParagraph
+                            [ Block.view [ Block.plaintext "I am a seed with " ]
+                            , Block.view
+                                [ Block.content
+                                    [ Block.fullHeightBlank (Block.CharacterCount 8)
+                                    ]
+                                ]
                             , Block.view [ Block.plaintext " being used." ]
                             ]
                   }
@@ -424,7 +632,13 @@ example =
                             ++ Code.listMultiline
                                 [ Code.fromModule moduleName "emphasize"
                                 , Code.fromModule moduleName "content "
-                                    ++ Code.list [ "…" ]
+                                    ++ Code.listMultiline
+                                        [ "…"
+                                        , Code.fromModule moduleName "blank "
+                                            ++ Code.fromModule moduleName "ShortWordPhrase"
+                                        , "…"
+                                        ]
+                                        2
                                 ]
                                 1
                   , description = "**Blanks with emphasis block**\n\nHelp students focus in on a phrase that includes a blank"


### PR DESCRIPTION
Branched off of https://github.com/NoRedInk/noredink-ui/pull/1458

Okay so I think part of my concern on extending the API for blank widths to include character-count-based widths (in addition to the a11y stuff we're continuing to discuss in slack) is that I was starting to feel like I didn't understand the API anymore.

So what I've done in this suggestion PR is:
- ensure that CharacterCount is an option from the `content` dropdown in the Settings

<img width="334" alt="Screen Shot 2023-08-14 at 5 32 05 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/deaef1d6-ba76-40e2-bada-66c2d5519dfc">

- add a new table, "Blank views and width guidance," that describes every width pattern available and every blank view pattern available. 

<img width="1385" alt="Screen Shot 2023-08-14 at 5 32 14 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/ce1972ec-57e5-4315-ba77-176bd00b1959">

Some of the guidance in the table is still "???" because, like I said, I don't have the context to know when these helpers should actually be used.

Note that the documentation in Block.V5 is also out of date/non-specific, and should be updated to explain when each of these helpers should be used.