### PR TITLE
Canonize sideNav width

### DIFF
--- a/component-catalog/src/Examples/SideNav.elm
+++ b/component-catalog/src/Examples/SideNav.elm
@@ -133,7 +133,6 @@ view ellieLinkConfig state =
         }
         [ SideNav.navLabel "Complex example"
         , SideNav.navId "complex-example-sidenav"
-        , SideNav.navNotMobileCss [ Css.maxWidth (Css.px 300) ]
         ]
         [ SideNav.html
             [ Text.smallBody
@@ -172,7 +171,6 @@ view ellieLinkConfig state =
         }
         [ SideNav.navLabel "Compact groups example"
         , SideNav.navId "compact-groups-example-sidenav"
-        , SideNav.navNotMobileCss [ Css.maxWidth (Css.px 300) ]
         ]
         [ SideNav.compactGroup "Support"
             []

--- a/src/Nri/Ui/SideNav/V5.elm
+++ b/src/Nri/Ui/SideNav/V5.elm
@@ -254,6 +254,7 @@ view config navAttributes entries =
             , borderRadius (px 8)
             , backgroundColor Colors.gray96
             , alignSelf flexStart
+            , width (px 300)
             , Css.Media.withMedia [ MediaQuery.mobile ]
                 [ Css.property "flex-basis" "unset"
                 , marginRight Css.zero


### PR DESCRIPTION
Rather than rely on setting it per instance, add it to the component.

<img width="1552" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/13528834/55f699c4-2ce0-468b-a014-f1ce99ce64fc">