### PR TITLE
Message styles

### DIFF
--- a/component-catalog/src/CommonControls.elm
+++ b/component-catalog/src/CommonControls.elm
@@ -231,7 +231,11 @@ romeoAndJulietQuotation =
 
 markdown : String
 markdown =
-    "_Katie's dad suggests:_ Don't tip too much, or your waitress will **fall over**!"
+    """
+_Katie's dad suggests:_ Don't tip too much, or your waitress will **fall over**!
+
+A new paragraph and [last but not link](#)
+"""
 
 
 exampleHtml : List (Html msg)

--- a/src/MarkdownStyles.elm
+++ b/src/MarkdownStyles.elm
@@ -10,7 +10,13 @@ anchorAndButton =
     [ Css.Global.descendants
         [ Css.Global.a
             [ borderBottom3 (px 1) solid Colors.azure
+            , textDecoration none
+            , visited [ color Colors.azure ]
             , Css.Global.withAttribute "aria-disabled=true" [ borderBottom3 (px 1) solid Colors.gray45 ]
+            ]
+        , Css.Global.p
+            [ margin4 zero zero (px 5) zero
+            , lastChild [ margin zero ]
             ]
         ]
     ]


### PR DESCRIPTION
Sets the paragraph spacing for Message.markdown, improves the link styles, and updates the sample Markdown content.

Fixes https://linear.app/noredink/issue/A11-3393/messagev4-with-markdown-has-too-big-margins

<img width="1142" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/13528834/15c06d00-08b1-4f3f-a9fb-aa364c0ce883">
