### PR TITLE
A11-3441 Prevent applying hover styles after toggling highlight

### DIFF
--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -38,7 +38,7 @@ moduleName =
 
 version : Int
 version =
-    3
+    4
 
 
 {-| -}
@@ -78,7 +78,7 @@ example =
                 , settings = state.settings
                 , mainType = Nothing
                 , extraCode =
-                    [ "import Nri.Ui.Highlightable.V2 as Highlightable"
+                    [ "import Nri.Ui.Highlightable.V3 as Highlightable"
                     , "import Nri.Ui.HighlighterTool.V1 as Tool"
                     ]
                 , renderExample = Code.unstyledView

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -24,7 +24,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Highlightable.V3 as Highlightable exposing (Highlightable)
-import Nri.Ui.Highlighter.V4 as Highlighter
+import Nri.Ui.Highlighter.V5 as Highlighter
 import Nri.Ui.HighlighterTool.V1 as Tool
 import Nri.Ui.Table.V7 as Table
 import Nri.Ui.Text.V6 as Text
@@ -38,7 +38,7 @@ moduleName =
 
 version : Int
 version =
-    4
+    5
 
 
 {-| -}

--- a/elm.json
+++ b/elm.json
@@ -39,6 +39,7 @@
         "Nri.Ui.Heading.V3",
         "Nri.Ui.Highlightable.V3",
         "Nri.Ui.Highlighter.V4",
+        "Nri.Ui.Highlighter.V5",
         "Nri.Ui.HighlighterTool.V1",
         "Nri.Ui.HighlighterToolbar.V3",
         "Nri.Ui.Html.Attributes.V2",

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -109,6 +109,9 @@ hint = 'upgrade to V4'
 [forbidden."Nri.Ui.Highlighter.V3"]
 hint = 'upgrade to V4'
 
+[forbidden."Nri.Ui.Highlighter.V4"]
+hint = 'upgrade to V5'
+
 [forbidden."Nri.Ui.HighlighterToolbar.V1"]
 hint = 'upgrade to V3'
 

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -7,7 +7,7 @@ import Html.Styled exposing (Html, toUnstyled)
 import List.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Highlightable.V3 as Highlightable exposing (Highlightable)
-import Nri.Ui.Highlighter.V4 as Highlighter
+import Nri.Ui.Highlighter.V5 as Highlighter
 import Nri.Ui.HighlighterTool.V1 as Tool exposing (Tool)
 import ProgramTest exposing (..)
 import Sort

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -35,6 +35,7 @@
         "Nri.Ui.Heading.V3",
         "Nri.Ui.Highlightable.V3",
         "Nri.Ui.Highlighter.V4",
+        "Nri.Ui.Highlighter.V5",
         "Nri.Ui.HighlighterTool.V1",
         "Nri.Ui.HighlighterToolbar.V3",
         "Nri.Ui.Html.Attributes.V2",


### PR DESCRIPTION
# :wrench: Modifying a component

This change prevents hover styles from being applied immediately after toggling the highlight. This addresses an issue where users mistakenly believed that the highlight was still active after they had removed it.

## Context

- [A11-3441 : Hinting/hover style remains on highlight for too long, especially on touch](https://linear.app/noredink/issue/A11-3441/hintinghover-style-remains-on-highlight-for-too-long-especially-on)

## :framed_picture: What does this change look like?

### Before

https://github.com/NoRedInk/noredink-ui/assets/5647344/e44409c6-5fcc-4e89-92ba-011b68d5e955

### After

https://github.com/NoRedInk/noredink-ui/assets/5647344/f866ecf8-7083-4a23-8bcb-da4eb08905be

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
