### PR TITLE
Prevent default/stop propagation on Tooltip.disclosure click

### DIFF
--- a/component-catalog/src/Examples/Tooltip.elm
+++ b/component-catalog/src/Examples/Tooltip.elm
@@ -18,6 +18,7 @@ import Debug.Control.View as ControlView
 import EllieLink
 import Example exposing (Example)
 import Html.Styled.Attributes exposing (css, href, id)
+import Html.Styled.Events as Events
 import KeyboardSupport exposing (Key(..))
 import Markdown
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
@@ -93,6 +94,7 @@ example =
 type alias State =
     { openTooltip : Maybe TooltipId
     , staticExampleSettings : Control (List ( String, Tooltip.Attribute Never ))
+    , disclosureModel : { parentClicks : Int }
     , pageSettings : Control PageSettings
     }
 
@@ -101,6 +103,7 @@ init : State
 init =
     { openTooltip = Nothing
     , staticExampleSettings = initStaticExampleSettings
+    , disclosureModel = { parentClicks = 0 }
     , pageSettings =
         Control.record PageSettings
             |> Control.field "backgroundColor"
@@ -129,6 +132,11 @@ type Msg
     | SetControl (Control (List ( String, Tooltip.Attribute Never )))
     | UpdatePageSettings (Control PageSettings)
     | Log String
+    | DisclosureMsg DisclosureMsg
+
+
+type DisclosureMsg
+    = ParentClick
 
 
 update : Msg -> State -> ( State, Cmd Msg )
@@ -149,6 +157,9 @@ update msg model =
 
         Log message ->
             ( Debug.log "Tooltip Log:" |> always model, Cmd.none )
+
+        DisclosureMsg ParentClick ->
+            ( { model | disclosureModel = { parentClicks = model.disclosureModel.parentClicks + 1 } }, Cmd.none )
 
 
 view : EllieLink.Config -> State -> List (Html Msg)
@@ -238,7 +249,7 @@ Sometimes a tooltip trigger doesn't have any functionality itself outside of rev
 
 This behavior is analogous to disclosure behavior, except that it's presented different visually. (For more information, please read [Sarah Higley's "Tooltips in the time of WCAG 2.1" post](https://sarahmhigley.com/writing/tooltips-in-wcag-21).)
 """
-          , example = viewDisclosureToolip model.openTooltip
+          , example = viewDisclosureToolip model.openTooltip model.disclosureModel
           , tooltipId = Disclosure
           }
         , { name = "Tooltip.viewToggleTip"
@@ -304,8 +315,8 @@ viewAuxillaryDescriptionToolip openTooltip =
         ]
 
 
-viewDisclosureToolip : Maybe TooltipId -> Html Msg
-viewDisclosureToolip openTooltip =
+viewDisclosureToolip : Maybe TooltipId -> { parentClicks : Int } -> Html Msg
+viewDisclosureToolip openTooltip { parentClicks } =
     let
         triggerId =
             "tooltip__disclosure-trigger"
@@ -313,29 +324,36 @@ viewDisclosureToolip openTooltip =
         lastId =
             "tooltip__disclosure-what-is-mastery"
     in
-    Tooltip.view
-        { id = "tooltip__disclosure"
-        , trigger =
-            \eventHandlers ->
-                ClickableSvg.button "Previously mastered"
-                    (Svg.withColor Colors.green UiIcon.starFilled)
-                    [ ClickableSvg.custom eventHandlers
-                    , ClickableSvg.id triggerId
+    Html.button
+        [ css [ Css.padding (Css.px 40) ]
+        , Events.onClick (DisclosureMsg ParentClick)
+        , id "parent-button"
+        ]
+        [ Tooltip.view
+            { id = "tooltip__disclosure"
+            , trigger =
+                \eventHandlers ->
+                    ClickableSvg.button "Previously mastered"
+                        (Svg.withColor Colors.green UiIcon.starFilled)
+                        [ ClickableSvg.custom eventHandlers
+                        , ClickableSvg.id triggerId
+                        ]
+            }
+            [ Tooltip.html
+                [ Html.text "You mastered this skill in a previous year! Way to go! "
+                , Html.a
+                    [ id lastId
+                    , href "https://noredink.zendesk.com/hc/en-us/articles/203022319-What-is-mastery-"
                     ]
-        }
-        [ Tooltip.html
-            [ Html.text "You mastered this skill in a previous year! Way to go! "
-            , Html.a
-                [ id lastId
-                , href "https://noredink.zendesk.com/hc/en-us/articles/203022319-What-is-mastery-"
+                    [ Html.text "Learn more about NoRedInk Mastery" ]
                 ]
-                [ Html.text "Learn more about NoRedInk Mastery" ]
+            , Tooltip.disclosure { triggerId = triggerId, lastId = Just lastId }
+            , Tooltip.onToggle (ToggleTooltip Disclosure)
+            , Tooltip.open (openTooltip == Just Disclosure)
+            , Tooltip.smallPadding
+            , Tooltip.alignEndForMobile (Css.px 148)
             ]
-        , Tooltip.disclosure { triggerId = triggerId, lastId = Just lastId }
-        , Tooltip.onToggle (ToggleTooltip Disclosure)
-        , Tooltip.open (openTooltip == Just Disclosure)
-        , Tooltip.smallPadding
-        , Tooltip.alignEndForMobile (Css.px 148)
+        , Html.div [ id "parent-button-clicks" ] [ Html.text ("Parent Clicks: " ++ String.fromInt parentClicks) ]
         ]
 
 

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -175,30 +175,34 @@ describe("UI tests", function () {
     await page.waitForSelector("#parent-button-clicks");
 
     const buttonClick = async () => {
-      const button = await page.$('#parent-button');
-      await page.evaluate(el => el.click(), button);
+      const button = await page.$("#parent-button");
+      await page.evaluate((el) => el.click(), button);
       await page.waitForTimeout(100);
     };
 
     const getCounterText = async () => {
-      const counter = await page.$('#parent-button-clicks');
-      const text = await page.evaluate(el => el.innerText, counter);
+      const counter = await page.$("#parent-button-clicks");
+      const text = await page.evaluate((el) => el.innerText, counter);
       return text;
     };
 
     const tooltipTriggerClick = async () => {
-      const button = await page.$('#tooltip__disclosure-trigger');
-      await page.evaluate(el => el.click(), button);
+      const button = await page.$("#tooltip__disclosure-trigger");
+      await page.evaluate((el) => el.click(), button);
       await page.waitForTimeout(100);
     };
 
     const isTooltipVisible = async () => {
       let res = await page.evaluate(() => {
-        return getComputedStyle(document.getElementById('tooltip__disclosure').parentElement).getPropertyValue('display') != 'none';
+        return (
+          getComputedStyle(
+            document.getElementById("tooltip__disclosure").parentElement
+          ).getPropertyValue("display") != "none"
+        );
       });
 
       return res;
-    }
+    };
 
     assert.equal(await getCounterText(), "Parent Clicks: 0");
     assert.equal(await isTooltipVisible(), false);
@@ -211,7 +215,7 @@ describe("UI tests", function () {
     assert.equal(await getCounterText(), "Parent Clicks: 1");
     await buttonClick();
     assert.equal(await getCounterText(), "Parent Clicks: 2");
-  }
+  };
 
   const skippedRules = {
     // Loading's color contrast check seems to change behavior depending on whether Percy snapshots are taken or not

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -170,10 +170,55 @@ describe("UI tests", function () {
     handleAxeResults(name, results);
   };
 
+  const tooltipProcessing = async (name, location) => {
+    await defaultProcessing(name, location);
+    await page.waitForSelector("#parent-button-clicks");
+
+    const buttonClick = async () => {
+      const button = await page.$('#parent-button');
+      await page.evaluate(el => el.click(), button);
+      await page.waitForTimeout(100);
+    };
+
+    const getCounterText = async () => {
+      const counter = await page.$('#parent-button-clicks');
+      const text = await page.evaluate(el => el.innerText, counter);
+      return text;
+    };
+
+    const tooltipTriggerClick = async () => {
+      const button = await page.$('#tooltip__disclosure-trigger');
+      await page.evaluate(el => el.click(), button);
+      await page.waitForTimeout(100);
+    };
+
+    const isTooltipVisible = async () => {
+      let res = await page.evaluate(() => {
+        return getComputedStyle(document.getElementById('tooltip__disclosure').parentElement).getPropertyValue('display') != 'none';
+      });
+
+      return res;
+    }
+
+    assert.equal(await getCounterText(), "Parent Clicks: 0");
+    assert.equal(await isTooltipVisible(), false);
+    await tooltipTriggerClick();
+    assert.equal(await isTooltipVisible(), true);
+    await tooltipTriggerClick();
+    assert.equal(await isTooltipVisible(), false);
+    assert.equal(await getCounterText(), "Parent Clicks: 0");
+    await buttonClick();
+    assert.equal(await getCounterText(), "Parent Clicks: 1");
+    await buttonClick();
+    assert.equal(await getCounterText(), "Parent Clicks: 2");
+  }
+
   const skippedRules = {
     // Loading's color contrast check seems to change behavior depending on whether Percy snapshots are taken or not
     Loading: ["color-contrast"],
     RadioButton: ["duplicate-id"],
+    // We need nested-interactive to test the tooltip behavior
+    Tooltip: ["nested-interactive"],
   };
 
   const specialProcessing = {
@@ -184,6 +229,7 @@ describe("UI tests", function () {
     UiIcon: iconProcessing,
     Logo: iconProcessing,
     Pennant: iconProcessing,
+    Tooltip: tooltipProcessing,
   };
 
   it("All", async function () {

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -87,7 +87,7 @@ import Content
 import Css exposing (Color, Px, Style)
 import Css.Global as Global
 import Css.Media
-import EventExtras as Event
+import EventExtras as Events
 import Html.Styled as Root
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
@@ -941,7 +941,7 @@ viewTooltip_ { trigger, id } tooltip =
                                     , tabForwardAction = msg False
                                     }
                               ]
-                            , [ Event.onClickPreventDefaultAndStopPropagation (msg (not tooltip.isOpen))
+                            , [ Events.onClickPreventDefaultAndStopPropagation (msg (not tooltip.isOpen))
                               , Key.onKeyDown [ Key.escape (msg False) ]
                               ]
                             )

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -87,6 +87,7 @@ import Content
 import Css exposing (Color, Px, Style)
 import Css.Global as Global
 import Css.Media
+import EventExtras as Event
 import Html.Styled as Root
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
@@ -940,7 +941,7 @@ viewTooltip_ { trigger, id } tooltip =
                                     , tabForwardAction = msg False
                                     }
                               ]
-                            , [ Events.onClick (msg (not tooltip.isOpen))
+                            , [ Event.onClickPreventDefaultAndStopPropagation (msg (not tooltip.isOpen))
                               , Key.onKeyDown [ Key.escape (msg False) ]
                               ]
                             )

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -33,6 +33,7 @@ module Nri.Ui.Tooltip.V3 exposing
   - adds `paragraph` and `markdown` support
   - add partially-transparent white border around tooltips
   - Use Nri.Ui.WhenFocusLeaves.V2
+  - prevent default and stop propagation on click for disclosure tooltips
 
 Changes from V2:
 

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -941,8 +941,7 @@ viewTooltip_ { trigger, id } tooltip =
                                     , tabForwardAction = msg False
                                     }
                               ]
-                            , [ -- Event.onClickPreventDefaultAndStopPropagation (msg (not tooltip.isOpen))
-                                Events.onClick (msg (not tooltip.isOpen))
+                            , [ Event.onClickPreventDefaultAndStopPropagation (msg (not tooltip.isOpen))
                               , Key.onKeyDown [ Key.escape (msg False) ]
                               ]
                             )

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -941,7 +941,8 @@ viewTooltip_ { trigger, id } tooltip =
                                     , tabForwardAction = msg False
                                     }
                               ]
-                            , [ Event.onClickPreventDefaultAndStopPropagation (msg (not tooltip.isOpen))
+                            , [ -- Event.onClickPreventDefaultAndStopPropagation (msg (not tooltip.isOpen))
+                                Events.onClick (msg (not tooltip.isOpen))
                               , Key.onKeyDown [ Key.escape (msg False) ]
                               ]
                             )

--- a/tests/Spec/Nri/Ui/Tooltip.elm
+++ b/tests/Spec/Nri/Ui/Tooltip.elm
@@ -15,11 +15,6 @@ import Test.Html.Query as Query
 import Test.Html.Selector as Selector exposing (id, text)
 
 
-type Msg
-    = ParentClicked
-    | ToggleTooltip Bool
-
-
 spec : Test
 spec =
     describe "Nri.Ui.Tooltip.V3"
@@ -106,27 +101,23 @@ spec =
                         "trigger"
 
                     view model =
-                        HtmlStyled.div
-                            [ Events.onClick ParentClicked
-                            ]
-                            [ Tooltip.view
-                                { trigger =
-                                    \attributes ->
-                                        ClickableText.button triggerContent
-                                            [ ClickableText.custom attributes
-                                            , ClickableText.id triggerId
-                                            ]
-                                , id = tooltipId
+                        Tooltip.view
+                            { trigger =
+                                \attributes ->
+                                    ClickableText.button triggerContent
+                                        [ ClickableText.custom attributes
+                                        , ClickableText.id triggerId
+                                        ]
+                            , id = tooltipId
+                            }
+                            [ Tooltip.open model.isOpen
+                            , Tooltip.plaintext tooltipContent
+                            , Tooltip.primaryLabel
+                            , Tooltip.onToggle (\_ -> ())
+                            , Tooltip.disclosure
+                                { triggerId = triggerId
+                                , lastId = Nothing
                                 }
-                                [ Tooltip.open model.isOpen
-                                , Tooltip.plaintext tooltipContent
-                                , Tooltip.primaryLabel
-                                , Tooltip.onToggle ToggleTooltip
-                                , Tooltip.disclosure
-                                    { triggerId = triggerId
-                                    , lastId = Nothing
-                                    }
-                                ]
                             ]
                             |> HtmlStyled.toUnstyled
                 in

--- a/tests/Spec/Nri/Ui/Tooltip.elm
+++ b/tests/Spec/Nri/Ui/Tooltip.elm
@@ -4,7 +4,6 @@ import Accessibility.Aria as Aria
 import Expect
 import Html.Attributes
 import Html.Styled as HtmlStyled
-import Html.Styled.Events as Events
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Tooltip.V3 as Tooltip
 import ProgramTest exposing (ProgramTest, ensureViewHas, ensureViewHasNot)


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

This PR changes the default click behavior for disclosure tooltips to preventDefault and stopPropagation on click. This allows nesting Tooltips within clickable regions such.

https://noredink.slack.com/archives/C02NVG4M45U/p1692639132232799

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - not a major version
