### PR TITLE
🔧 Fix hidden label checkbox

### DIFF
--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -396,6 +396,12 @@ viewCheckbox config ( styles, icon ) =
                         (paddingLeft (Css.px checkboxIconWidth)
                             :: marginTopAdjustment
                             :: marginLeft (Css.px -checkboxIconWidth)
+                            :: (if config.hideLabel then
+                                    minHeight (Css.px checkboxIconHeight)
+
+                                else
+                                    Css.batch []
+                               )
                             :: styles
                             ++ config.labelCss
                         )
@@ -439,6 +445,11 @@ checkboxIconWidth =
     40
 
 
+checkboxIconHeight : Float
+checkboxIconHeight =
+    27
+
+
 inputGuidance :
     { a
         | identifier : String
@@ -469,7 +480,7 @@ viewIcon styles icon =
         [ css
             [ border3 (px highContrastBorderWidth) solid transparent
             , borderRadius (px 3)
-            , height (Css.px 27)
+            , height (Css.px checkboxIconHeight)
             , boxSizing contentBox
             , margin (px 2)
             , marginRight (px 7)
@@ -480,7 +491,7 @@ viewIcon styles icon =
             [ css
                 [ display inlineBlock
                 , backgroundColor Colors.white
-                , height (Css.px 27)
+                , height (Css.px checkboxIconHeight)
                 , borderRadius (px 4)
                 ]
             ]

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -15,6 +15,7 @@ module Nri.Ui.Checkbox.V7 exposing
 ## Patch changes:
 
   - reposition the guidance to be right below the label text
+  - fix the hiddenLabel checkbox behavior
 
 
 ## Changes from V6:


### PR DESCRIPTION
## Context

https://github.com/NoRedInk/noredink-ui/pull/1460 broke checkboxes with hiddenLabels. See [slack](https://noredink.slack.com/archives/C0398SY837X/p1692716316063759) for report.

This fixes!

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - this is not a new major version
