### PR TITLE
Adjust input method implementation to account for SRs being annoying

### DIFF
--- a/component-catalog/src/InputMethod.elm
+++ b/component-catalog/src/InputMethod.elm
@@ -73,7 +73,21 @@ subscriptions =
                                 Decode.fail "Not a navigation key. Discarding event."
                     )
             )
-        , Browser.Events.onMouseDown (Decode.succeed Mouse)
+        , Browser.Events.onMouseDown
+            -- Some screenreaders (NVDA, JAWS) transform keyboard events into mouse events.
+            -- annoying as this is, apparently we have to deal with it anyway.
+            -- here, we use the [detail](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail) property
+            -- to determine whether a _real_ mouse event has fired or not.
+            (Decode.map
+                (\clickCount ->
+                    if clickCount == 0 then
+                        Keyboard
+
+                    else
+                        Mouse
+                )
+                (Decode.field "detail" Decode.int)
+            )
         ]
 
 

--- a/component-catalog/src/InputMethod.elm
+++ b/component-catalog/src/InputMethod.elm
@@ -47,7 +47,7 @@ subscriptions =
                 (Decode.at [ "target", "tagName" ] Decode.string)
                 |> Decode.andThen
                     (\( key, tagName ) ->
-                        case key of
+                        case Debug.log "keyboard event" key of
                             "ArrowUp" ->
                                 unlessInInput tagName
 
@@ -80,11 +80,11 @@ subscriptions =
             -- to determine whether a _real_ mouse event has fired or not.
             (Decode.map
                 (\clickCount ->
-                    if clickCount == 0 then
-                        Keyboard
+                    if Debug.log "clickCount" clickCount == 0 then
+                        Debug.log "Interpreting mousedown as keyboard event" Keyboard
 
                     else
-                        Mouse
+                        Debug.log "Interpreting mousedown as mouse event" Mouse
                 )
                 (Decode.field "detail" Decode.int)
             )


### PR DESCRIPTION
Component catalog example change only.

Use the `detail` property of the UIEvent to determine whether SRs are lying about mouse events or not to fix the focus ring for programmatically-moved focus.