### PR TITLE
[PHX-1071] :wrench: Add `enabled`/`disabled` attributes to `RadioButtonDotless`

### DIFF
--- a/component-catalog/src/Examples/RadioButtonDotless.elm
+++ b/component-catalog/src/Examples/RadioButtonDotless.elm
@@ -132,12 +132,14 @@ sizeControl =
         , ( "large", Control.value ( "RadioButtonDotless.large", RadioButtonDotless.large ) )
         ]
 
-enablementControl : Control ( String, RadioButtonDotless.Attribute ControlSelection Msg)
+
+enablementControl : Control ( String, RadioButtonDotless.Attribute ControlSelection Msg )
 enablementControl =
-    Control.choice 
-        [ ("enabled", Control.value ( "RadioButtonDotless.enabled", RadioButtonDotless.enabled ))
-        , ("disabled", Control.value ("RadioButtonDotless.disabled", RadioButtonDotless.disabled))
+    Control.choice
+        [ ( "enabled", Control.value ( "RadioButtonDotless.enabled", RadioButtonDotless.enabled ) )
+        , ( "disabled", Control.value ( "RadioButtonDotless.disabled", RadioButtonDotless.disabled ) )
         ]
+
 
 moduleName : String
 moduleName =

--- a/component-catalog/src/Examples/RadioButtonDotless.elm
+++ b/component-catalog/src/Examples/RadioButtonDotless.elm
@@ -70,6 +70,7 @@ controlAttributes =
         |> ControlExtra.optionalListItem "textAlign" textAlignControl
         |> ControlExtra.optionalListItem "width" widthControl
         |> ControlExtra.optionalListItem "size" sizeControl
+        |> ControlExtra.optionalListItem "enablement" enablementControl
         |> ControlExtra.optionalListItem "containerCss"
             (Control.choice
                 [ ( "max-width with border"
@@ -131,6 +132,12 @@ sizeControl =
         , ( "large", Control.value ( "RadioButtonDotless.large", RadioButtonDotless.large ) )
         ]
 
+enablementControl : Control ( String, RadioButtonDotless.Attribute ControlSelection Msg)
+enablementControl =
+    Control.choice 
+        [ ("enabled", Control.value ( "RadioButtonDotless.enabled", RadioButtonDotless.enabled ))
+        , ("disabled", Control.value ("RadioButtonDotless.disabled", RadioButtonDotless.disabled))
+        ]
 
 moduleName : String
 moduleName =

--- a/component-catalog/src/Examples/RadioButtonDotless.elm
+++ b/component-catalog/src/Examples/RadioButtonDotless.elm
@@ -214,7 +214,7 @@ update msg state =
         Select selection ->
             ( { state | selectedValue = Just selection }, Cmd.none )
 
-        NoOp -> 
+        NoOp ->
             ( state, Cmd.none )
 
 

--- a/component-catalog/src/Examples/RadioButtonDotless.elm
+++ b/component-catalog/src/Examples/RadioButtonDotless.elm
@@ -62,6 +62,7 @@ type Msg
     | LongRadioSelect String
     | SetSelectionSettings (Control SelectionSettings)
     | Select ControlSelection
+    | NoOp
 
 
 controlAttributes : Control (List ( String, RadioButtonDotless.Attribute ControlSelection Msg ))
@@ -137,7 +138,7 @@ enablementControl : Control ( String, RadioButtonDotless.Attribute ControlSelect
 enablementControl =
     Control.choice
         [ ( "enabled", Control.value ( "RadioButtonDotless.enabled", RadioButtonDotless.enabled ) )
-        , ( "disabled", Control.value ( "RadioButtonDotless.disabled", RadioButtonDotless.disabled ) )
+        , ( "disabled", Control.value ( "RadioButtonDotless.disabled NoOp", RadioButtonDotless.disabled NoOp ) )
         ]
 
 
@@ -212,6 +213,9 @@ update msg state =
 
         Select selection ->
             ( { state | selectedValue = Just selection }, Cmd.none )
+
+        NoOp -> 
+            ( state, Cmd.none )
 
 
 preview : List (Html Never)

--- a/src/Nri/Ui/RadioButtonDotless/V1.elm
+++ b/src/Nri/Ui/RadioButtonDotless/V1.elm
@@ -13,6 +13,11 @@ module Nri.Ui.RadioButtonDotless.V1 exposing
 {-| Looks like a standard button, behaves like a radio button
 
 
+### Patch changes:
+
+    - Introduce `enabled`/`disabled` attributes and styles
+
+
 # Create a radio button
 
 @docs view

--- a/src/Nri/Ui/RadioButtonDotless/V1.elm
+++ b/src/Nri/Ui/RadioButtonDotless/V1.elm
@@ -5,6 +5,7 @@ module Nri.Ui.RadioButtonDotless.V1 exposing
     , unboundedWidth, fillContainerWidth
     , textAlignCenter, textAlignLeft
     , small, medium, large
+    , enabled, disabled
     , containerCss, labelCss
     , id, custom, nriDescription, testId
     )
@@ -28,6 +29,7 @@ module Nri.Ui.RadioButtonDotless.V1 exposing
 @docs unboundedWidth, fillContainerWidth
 @docs textAlignCenter, textAlignLeft
 @docs small, medium, large
+@docs enabled, disabled
 @docs containerCss, labelCss
 
 
@@ -78,6 +80,7 @@ type alias Config value msg =
     , width : ButtonWidth
     , textAlign : TextAlign
     , size : ButtonSize
+    , isDisabled : Bool
     , containerCss : List Style
     , labelCss : List Style
     , customAttributes : List (Html.Attribute Never)
@@ -138,6 +141,20 @@ medium =
 large : Attribute value msg
 large =
     Attribute <| \config -> { config | size = Large }
+
+
+{-| Enable the input (this is the default)
+-}
+enabled : Attribute value msg
+enabled =
+    Attribute <| \config -> { config | isDisabled = False }
+
+
+{-| Disable the input
+-}
+disabled : Attribute value msg
+disabled =
+    Attribute <| \config -> { config | isDisabled = True }
 
 
 {-| Adds CSS to the element containing the input.
@@ -204,6 +221,7 @@ emptyConfig =
     , width = UnboundedWidth
     , textAlign = TextAlignCenter
     , size = Medium
+    , isDisabled = False
     , containerCss = []
     , labelCss = []
     , customAttributes = []

--- a/src/Nri/Ui/RadioButtonDotless/V1.elm
+++ b/src/Nri/Ui/RadioButtonDotless/V1.elm
@@ -45,6 +45,7 @@ module Nri.Ui.RadioButtonDotless.V1 exposing
 -}
 
 import Accessibility.Styled exposing (..)
+import Accessibility.Styled.Aria as Aria
 import Css exposing (..)
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes exposing (css)
@@ -282,12 +283,15 @@ view { label, name, value, valueToString, selectedValue } attributes =
             isChecked
             ([ Attributes.id idValue
              , Attributes.class "Nri-RadioButton-HiddenRadioInput"
-             , Attributes.disabled config.isDisabled
-             , case config.onSelect of
-                Just onSelect_ ->
+             , Aria.disabled config.isDisabled
+             , case ( config.isDisabled, config.onSelect ) of
+                ( True, _ ) ->
+                    AttributeExtra.none
+
+                ( False, Just onSelect_ ) ->
                     Events.onClick (onSelect_ value)
 
-                Nothing ->
+                ( False, Nothing ) ->
                     AttributeExtra.none
              , css
                 [ position absolute

--- a/src/Nri/Ui/RadioButtonDotless/V1.elm
+++ b/src/Nri/Ui/RadioButtonDotless/V1.elm
@@ -277,6 +277,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
             isChecked
             ([ Attributes.id idValue
              , Attributes.class "Nri-RadioButton-HiddenRadioInput"
+             , Attributes.disabled config.isDisabled
              , case config.onSelect of
                 Just onSelect_ ->
                     Events.onClick (onSelect_ value)
@@ -304,7 +305,11 @@ view { label, name, value, valueToString, selectedValue } attributes =
                 , borderStyle solid
                 , Fonts.baseFont
                 , fontWeight (int 600)
-                , cursor pointer
+                , if config.isDisabled then
+                    cursor notAllowed
+
+                  else
+                    cursor pointer
                 , case config.textAlign of
                     TextAlignLeft ->
                         Css.batch
@@ -339,24 +344,39 @@ view { label, name, value, valueToString, selectedValue } attributes =
                             , lineHeight (px 22)
                             ]
                 , width (pct 100)
-                , if isChecked then
-                    Css.batch
-                        [ color Colors.navy
-                        , backgroundColor Colors.glacier
-                        , borderColor Colors.azure
-                        ]
-
-                  else
-                    Css.batch
-                        [ color Colors.azure
-                        , backgroundColor Colors.white
-                        , borderColor Colors.glacier
-                        , hover
+                , case ( isChecked, config.isDisabled ) of
+                    ( True, False ) ->
+                        Css.batch
                             [ color Colors.navy
                             , backgroundColor Colors.glacier
-                            , borderColor Colors.glacier
+                            , borderColor Colors.azure
                             ]
-                        ]
+
+                    ( False, False ) ->
+                        Css.batch
+                            [ color Colors.azure
+                            , backgroundColor Colors.white
+                            , borderColor Colors.glacier
+                            , hover
+                                [ color Colors.navy
+                                , backgroundColor Colors.glacier
+                                , borderColor Colors.glacier
+                                ]
+                            ]
+
+                    ( True, True ) ->
+                        Css.batch
+                            [ color Colors.gray45
+                            , backgroundColor Colors.gray92
+                            , borderColor Colors.gray45
+                            ]
+
+                    ( False, True ) ->
+                        Css.batch
+                            [ color Colors.gray45
+                            , backgroundColor Colors.gray92
+                            , borderWidth zero
+                            ]
                 ]
             ]
             [ span


### PR DESCRIPTION
I'm rather frustrated in the corner that I was backed in to by Elm in this PR.  

The only way to do disablement in a a11y friendly manner is to use `aria-disabled` in combination with `preventDefault`.  However, we simply **cannot** use `preventDefault` in Elm without producing a `msg`.  Which is exactly the opposite behavior that we want in this case because we are *preventing* the user from taking an action.   This leads us to require a `NoOp` message for **every** consumer of `RadioButtonDotless` if they want to take advantage of the disabled state.  

- https://github.com/elm/html/issues/96
- https://github.com/elm/html/issues/137

Judging by Evan's comment in the thread above, this won't be fixed on the Elm side anytime soon.

> That said, I'd like to keep it closed. I think it is fine to have a NoOp for now, and if you think of the scenarios you were running into, please open a new issue that describes why it would be helpful.

This doesn't bode well for our existing `RadioButton` and `Button` components - which similarly have broken disabled behavior. 

# :wrench: Modifying a component

## Context

[PHX-1071 Add disabled style to RadioButtonDotless](https://linear.app/noredink/issue/PHX-1071/add-disabled-style-to-radiobuttondotless)

## :framed_picture: What does this change look like?

<img width="1402" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/12899207/dc8c8f26-c388-4de8-b5bb-65598a832aca">

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
