### PR TITLE
🔧 Fix disabled Checkbox style

### DIFF
--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -16,6 +16,7 @@ module Nri.Ui.Checkbox.V7 exposing
 
   - reposition the guidance to be right below the label text
   - fix the hiddenLabel checkbox behavior
+  - fix the disabled styles
 
 
 ## Changes from V6:
@@ -278,14 +279,20 @@ view { label, selected } attributes =
                     )
     in
     checkboxContainer config_
-        [ viewIcon [] icon
+        [ viewIcon []
+            (if config.isDisabled then
+                disabledIcon
+
+             else
+                icon
+            )
         , span []
             (viewCheckbox config_
                 (if config.isDisabled then
-                    ( disabledLabelCss, disabledIcon )
+                    disabledLabelCss
 
                  else
-                    ( enabledLabelCss, icon )
+                    enabledLabelCss
                 )
                 :: inputGuidance config_
             )
@@ -376,12 +383,9 @@ viewCheckbox :
         , error : InputErrorAndGuidanceInternal.ErrorState
         , guidance : Guidance msg
     }
-    ->
-        ( List Style
-        , Svg
-        )
+    -> List Style
     -> Html.Html msg
-viewCheckbox config ( styles, icon ) =
+viewCheckbox config styles =
     let
         marginTopAdjustment =
             case config.guidance of


### PR DESCRIPTION
Fixes the disabled checkbox style

See https://noredink.slack.com/archives/C02NMHB1K55/p1692732761105889

## :framed_picture: What does this change look like?

<img width="1003" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/b69c37ab-617f-4066-b055-0218713009bb">


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - this is not a new major version
