### PR TITLE
Fix custom accordion icon example

### DIFF
--- a/component-catalog/src/Examples/Accordion.elm
+++ b/component-catalog/src/Examples/Accordion.elm
@@ -27,6 +27,8 @@ import Nri.Ui.Accordion.V3 as Accordion exposing (AccordionEntry(..))
 import Nri.Ui.Colors.Extra as ColorsExtra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.FocusRing.V1 as FocusRing
+import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -140,6 +142,13 @@ view ellieLinkConfig model =
                   }
                 ]
         }
+    , Heading.h2
+        [ Heading.plaintext "Examples"
+        , Heading.css
+            [ Css.marginTop Spacing.verticalSpacerPx
+            , Css.marginBottom (Css.px 20)
+            ]
+        ]
     , Accordion.view
         { entries =
             [ AccordionEntry

--- a/component-catalog/src/Examples/Accordion.elm
+++ b/component-catalog/src/Examples/Accordion.elm
@@ -361,6 +361,7 @@ controlIcon =
                                     [ code
                                     , "Svg.withWidth (Css.px 20)"
                                     , "Svg.withHeight (Css.px 20)"
+                                    , "Svg.withCss [ Css.marginRight (Css.px 8) ]"
                                     , "Svg.toHtml"
                                     ]
                                     6
@@ -369,6 +370,7 @@ controlIcon =
                         icon
                             |> Svg.withWidth (Css.px 20)
                             |> Svg.withHeight (Css.px 20)
+                            |> Svg.withCss [ Css.marginRight (Css.px 8) ]
                             |> Svg.toHtml
                     )
                 )

--- a/component-catalog/src/Examples/Accordion.elm
+++ b/component-catalog/src/Examples/Accordion.elm
@@ -119,7 +119,7 @@ view ellieLinkConfig model =
                             , "              , entryClass = \"customizable-example\""
                             , "              , headerContent = " ++ Tuple.first settings.headerContent
                             , "              , headerId = \"customizable-example-header\""
-                            , "              , headerLevel = Accordion.H4"
+                            , "              , headerLevel = Accordion.H3"
                             , "              , isExpanded = True"
                             , "              , toggle = Nothing"
                             , "              }"
@@ -157,7 +157,7 @@ view ellieLinkConfig model =
                 , entryClass = "customizable-example"
                 , headerContent = Tuple.second settings_.headerContent
                 , headerId = "customizable-example-header"
-                , headerLevel = Accordion.H4
+                , headerLevel = Accordion.H3
                 , isExpanded = Set.member 4 model.expanded
                 , toggle = Just (Toggle 4)
                 }
@@ -168,7 +168,7 @@ view ellieLinkConfig model =
                 , entryClass = "accordion-example"
                 , headerContent = Html.text "Apples (has children)"
                 , headerId = "accordion-entry__1"
-                , headerLevel = Accordion.H4
+                , headerLevel = Accordion.H3
                 , isExpanded = Set.member 1 model.expanded
                 , toggle = Just (Toggle 1)
                 }
@@ -187,7 +187,7 @@ view ellieLinkConfig model =
                     , entryClass = "accordion-example-child"
                     , headerContent = Html.text "Gala"
                     , headerId = "accordion-entry__11"
-                    , headerLevel = Accordion.H5
+                    , headerLevel = Accordion.H4
                     , isExpanded = Set.member 11 model.expanded
                     , toggle = Just (Toggle 11)
                     }
@@ -207,7 +207,7 @@ view ellieLinkConfig model =
                     , entryClass = "accordion-example-child"
                     , headerContent = Html.text "Granny Smith"
                     , headerId = "accordion-entry__12"
-                    , headerLevel = Accordion.H5
+                    , headerLevel = Accordion.H4
                     , isExpanded = Set.member 12 model.expanded
                     , toggle = Just (Toggle 12)
                     }
@@ -227,7 +227,7 @@ view ellieLinkConfig model =
                     , entryClass = "accordion-example-child"
                     , headerContent = Html.text "Fuji"
                     , headerId = "accordion-entry__13"
-                    , headerLevel = Accordion.H5
+                    , headerLevel = Accordion.H4
                     , isExpanded = Set.member 13 model.expanded
                     , toggle = Just (Toggle 13)
                     }
@@ -239,7 +239,7 @@ view ellieLinkConfig model =
                 , entryClass = "accordion-example"
                 , headerContent = Html.text "Oranges"
                 , headerId = "accordion-entry__2"
-                , headerLevel = Accordion.H4
+                , headerLevel = Accordion.H3
                 , isExpanded = Set.member 2 model.expanded
                 , toggle = Just (Toggle 2)
                 }
@@ -271,7 +271,7 @@ view ellieLinkConfig model =
                 , entryClass = "fixed-positioning-accordion-example"
                 , headerContent = Html.text "Advanced Example: Expand & Scroll!"
                 , headerId = "accordion-entry__6"
-                , headerLevel = Accordion.H4
+                , headerLevel = Accordion.H3
                 , isExpanded = Set.member 6 model.expanded
                 , toggle = Just (Toggle 6)
                 }

--- a/component-catalog/src/Examples/Accordion.elm
+++ b/component-catalog/src/Examples/Accordion.elm
@@ -372,7 +372,7 @@ controlIcon =
                             |> Svg.toHtml
                     )
                 )
-                CommonControls.uiIcon
+                (CommonControls.rotatedUiIcon 1)
           )
         ]
 

--- a/component-catalog/src/Examples/Accordion.elm
+++ b/component-catalog/src/Examples/Accordion.elm
@@ -354,8 +354,22 @@ controlIcon =
         , ( "UiIcon"
           , Control.map
                 (\( code, icon ) ->
-                    ( "\\_ -> Svg.toHtml " ++ code
-                    , \_ -> Svg.toHtml icon
+                    ( Code.newlineWithIndent 5
+                        ++ Code.anonymousFunction "_"
+                            (Code.newlineWithIndent 6
+                                ++ Code.pipelineMultiline
+                                    [ code
+                                    , "Svg.withWidth (Css.px 20)"
+                                    , "Svg.withHeight (Css.px 20)"
+                                    , "Svg.toHtml"
+                                    ]
+                                    6
+                            )
+                    , \_ ->
+                        icon
+                            |> Svg.withWidth (Css.px 20)
+                            |> Svg.withHeight (Css.px 20)
+                            |> Svg.toHtml
                     )
                 )
                 CommonControls.uiIcon

--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -1,6 +1,7 @@
 Nri.Ui.Block.V4,upgrade to V6
 Nri.Ui.Block.V5,upgrade to V6
 Nri.Ui.WhenFocusLeaves.V1,upgrade to V2
+Nri.Ui.Highlighter.V4,upgrade to V5
 Nri.Ui.Mark.V2,upgrade to V5
 Nri.Ui.Mark.V3,upgrade to V5
 Nri.Ui.Mark.V4,upgrade to V5


### PR DESCRIPTION
Fixes https://github.com/NoRedInk/noredink-ui/issues/1473

<img width="417" alt="Screen Shot 2023-08-23 at 10 09 42 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/9c7fd480-d266-4934-b358-09ffd914374c">

(Only touches the component catalog example.)