### PR TITLE
Add FocusRing example

### DIFF
--- a/component-catalog/src/Examples.elm
+++ b/component-catalog/src/Examples.elm
@@ -17,6 +17,7 @@ import Examples.Colors as Colors
 import Examples.Confetti as Confetti
 import Examples.Container as Container
 import Examples.Divider as Divider
+import Examples.FocusRing as FocusRing
 import Examples.Fonts as Fonts
 import Examples.Header as Header
 import Examples.Heading as Heading
@@ -374,6 +375,25 @@ all =
             (\msg ->
                 case msg of
                     FontsState childState ->
+                        Just childState
+
+                    _ ->
+                        Nothing
+            )
+    , FocusRing.example
+        |> Example.wrapMsg FocusRingMsg
+            (\msg ->
+                case msg of
+                    FocusRingMsg childMsg ->
+                        Just childMsg
+
+                    _ ->
+                        Nothing
+            )
+        |> Example.wrapState FocusRingState
+            (\msg ->
+                case msg of
+                    FocusRingState childState ->
                         Just childState
 
                     _ ->
@@ -1046,6 +1066,7 @@ type State
     | ContainerState Container.State
     | DividerState Divider.State
     | FontsState Fonts.State
+    | FocusRingState FocusRing.State
     | HeaderState Header.State
     | HeadingState Heading.State
     | HighlighterState Highlighter.State
@@ -1100,6 +1121,7 @@ type Msg
     | ContainerMsg Container.Msg
     | DividerMsg Divider.Msg
     | FontsMsg Fonts.Msg
+    | FocusRingMsg FocusRing.Msg
     | HeaderMsg Header.Msg
     | HeadingMsg Heading.Msg
     | HighlighterMsg Highlighter.Msg

--- a/component-catalog/src/Examples/FocusRing.elm
+++ b/component-catalog/src/Examples/FocusRing.elm
@@ -1,0 +1,64 @@
+module Examples.FocusRing exposing (example, State, Msg)
+
+{-|
+
+@docs example, State, Msg
+
+-}
+
+import Category exposing (Category(..))
+import Css exposing (Style)
+import Example exposing (Example)
+import Html.Styled as Html exposing (..)
+import Html.Styled.Attributes exposing (css)
+import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.FocusRing.V1 as FocusRing
+import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Table.V7 as Table
+
+
+{-| -}
+type alias State =
+    ()
+
+
+{-| -}
+type alias Msg =
+    ()
+
+
+{-| -}
+example : Example State Msg
+example =
+    { name = "FocusRing"
+    , version = 1
+    , categories = [ Text, Atoms ]
+    , keyboardSupport = []
+    , state = ()
+    , update = \_ state -> ( state, Cmd.none )
+    , subscriptions = \_ -> Sub.none
+    , preview =
+        [ div
+            [ css
+                [ Css.width (Css.pct 100)
+                , Css.height (Css.px 20)
+                , Css.batch FocusRing.styles
+                , Css.marginBottom (Css.px 30)
+                ]
+            ]
+            []
+        , div
+            [ css
+                [ Css.width (Css.pct 100)
+                , Css.height (Css.px 20)
+                , Css.batch FocusRing.tightStyles
+                ]
+            ]
+            []
+        ]
+    , about = []
+    , view =
+        \_ _ ->
+            [ Heading.h2 [ Heading.plaintext "Examples" ]
+            ]
+    }

--- a/component-catalog/src/Examples/FocusRing.elm
+++ b/component-catalog/src/Examples/FocusRing.elm
@@ -20,7 +20,6 @@ import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.FocusRing.V1 as FocusRing
-import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.RadioButton.V4 as RadioButton
 import Nri.Ui.SegmentedControl.V14 as SegmentedControl

--- a/component-catalog/src/Examples/FocusRing.elm
+++ b/component-catalog/src/Examples/FocusRing.elm
@@ -11,6 +11,7 @@ import Css exposing (Style)
 import Example exposing (Example)
 import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes exposing (css)
+import Markdown
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.FocusRing.V1 as FocusRing
@@ -90,7 +91,11 @@ viewTable =
             { header = Html.text "Name"
             , view = \{ name } -> code [] [ text name ]
             , width = Css.pct 10
-            , cellStyles = always [ Css.textAlign Css.left ]
+            , cellStyles =
+                always
+                    [ Css.textAlign Css.left
+                    , Css.padding2 (Css.px 8) (Css.px 16)
+                    ]
             , sort = Nothing
             }
         , Table.custom
@@ -100,11 +105,19 @@ viewTable =
             , cellStyles = always []
             , sort = Nothing
             }
-        , Table.string
-            { header = "About"
-            , value = .about
-            , width = Css.pct 10
-            , cellStyles = \_ -> [ Fonts.baseFont, Css.padding (Css.px 8) ]
+        , Table.custom
+            { header = text "About"
+            , view =
+                .about
+                    >> Markdown.toHtml Nothing
+                    >> List.map fromUnstyled
+                    >> div []
+            , width = Css.px 300
+            , cellStyles =
+                always
+                    [ Css.padding2 (Css.px 8) (Css.px 16)
+                    , Css.verticalAlign Css.top
+                    ]
             , sort = Nothing
             }
         ]

--- a/component-catalog/src/Examples/FocusRing.elm
+++ b/component-catalog/src/Examples/FocusRing.elm
@@ -135,19 +135,24 @@ viewTable model =
             { header = text "Two-toned"
             , view =
                 \{ twoToned } ->
-                    if twoToned then
-                        UiIcon.checkmark
-                            |> Svg.withLabel "Yes"
-                            |> Svg.withWidth (Css.px 20)
-                            |> Svg.withColor Colors.greenDark
-                            |> Svg.toHtml
+                    twoToned
+                        |> Maybe.map
+                            (\twoToned_ ->
+                                if twoToned_ then
+                                    UiIcon.checkmark
+                                        |> Svg.withLabel "Yes"
+                                        |> Svg.withWidth (Css.px 20)
+                                        |> Svg.withColor Colors.greenDark
+                                        |> Svg.toHtml
 
-                    else
-                        UiIcon.x
-                            |> Svg.withLabel "No"
-                            |> Svg.withWidth (Css.px 20)
-                            |> Svg.withColor Colors.red
-                            |> Svg.toHtml
+                                else
+                                    UiIcon.x
+                                        |> Svg.withLabel "No"
+                                        |> Svg.withWidth (Css.px 20)
+                                        |> Svg.withColor Colors.red
+                                        |> Svg.toHtml
+                            )
+                        |> Maybe.withDefault (text "N/A")
             , width = Css.pct 1
             , cellStyles = always [ Css.padding2 (Css.px 8) (Css.px 16) ]
             , sort = Nothing
@@ -170,7 +175,7 @@ viewTable model =
         ]
         [ { name = "styles"
           , view = exampleWithBorderAndBG FocusRing.styles
-          , twoToned = True
+          , twoToned = Just True
           , examples =
                 [ button [] [ text "Button" ]
                 , label [] [ input [] [], text "Input" ]
@@ -188,7 +193,7 @@ NOTE: use `boxShadows` instead if your focusable element:
           }
         , { name = "tightStyles"
           , view = exampleWithBorderAndBG FocusRing.tightStyles
-          , twoToned = True
+          , twoToned = Just True
           , examples =
                 [ ClickableText.button "ClickableText button" [ ClickableText.small ]
                 , ClickableText.link "ClickableText link" [ ClickableText.small ]
@@ -211,7 +216,7 @@ NOTE: use `boxShadows` instead if your focusable element:
           }
         , { name = "boxShadows"
           , view = exampleWithBorderAndBG [ FocusRing.boxShadows [] ]
-          , twoToned = True
+          , twoToned = Just True
           , examples =
                 [ Switch.view { label = "Switch", id = "switch" } []
                 , ClickableSvg.button "ClickableSvg button" UiIcon.playInCircle []
@@ -236,7 +241,7 @@ NOTE: use `boxShadows` instead if your focusable element:
           }
         , { name = "insetBoxShadows"
           , view = exampleWithBorderAndBG [ FocusRing.insetBoxShadows [] ]
-          , twoToned = True
+          , twoToned = Just True
           , examples =
                 [ Accordion.view
                     { entries =
@@ -259,13 +264,13 @@ NOTE: use `boxShadows` instead if your focusable element:
           }
         , { name = "outerBoxShadow"
           , view = exampleWithBorderAndBG [ FocusRing.outerBoxShadow ]
-          , twoToned = False
+          , twoToned = Just False
           , examples = [ text "(See Tabs and TabsMinimal)" ]
           , about = "In special cases, we don't use a two-tone focus ring. Be very sure this is what you need before using this!"
           }
         , { name = "insetBoxShadow"
           , view = exampleWithBorderAndBG [ FocusRing.insetBoxShadow ]
-          , twoToned = False
+          , twoToned = Just False
           , examples = [ text "(See SideNav)" ]
           , about = "In special cases, we don't use a two-tone focus ring, and an outset focus ring would be obscured. Be very sure this is what you need before using this!"
           }
@@ -275,7 +280,7 @@ NOTE: use `boxShadows` instead if your focusable element:
                     [ Css.border3 (Css.px 2) Css.solid Colors.gray20
                     , Css.backgroundColor FocusRing.outerColor
                     ]
-          , twoToned = False
+          , twoToned = Nothing
           , examples = []
           , about = "Colors.red"
           }
@@ -285,7 +290,7 @@ NOTE: use `boxShadows` instead if your focusable element:
                     [ Css.border3 (Css.px 2) Css.solid Colors.gray20
                     , Css.backgroundColor FocusRing.innerColor
                     ]
-          , twoToned = False
+          , twoToned = Nothing
           , examples = []
           , about = "Colors.white"
           }

--- a/component-catalog/src/Examples/FocusRing.elm
+++ b/component-catalog/src/Examples/FocusRing.elm
@@ -14,6 +14,7 @@ import Html.Styled.Attributes exposing (css)
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.FocusRing.V1 as FocusRing
+import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V7 as Table
@@ -89,47 +90,62 @@ viewTable =
             { header = Html.text "Name"
             , view = \{ name } -> code [] [ text name ]
             , width = Css.pct 10
-            , cellStyles = always []
+            , cellStyles = always [ Css.textAlign Css.left ]
             , sort = Nothing
             }
         , Table.custom
-            { header = text "view"
+            { header = text "View"
             , view = .view
             , width = Css.pct 10
             , cellStyles = always []
             , sort = Nothing
             }
-
-        --, Table.string
-        --    { header = "about"
-        --    , value = \_ -> text ""
-        --    , width = Css.pct 10
-        --    , cellStyles = always []
-        --    , sort = Nothing
-        --    }
+        , Table.string
+            { header = "About"
+            , value = .about
+            , width = Css.pct 10
+            , cellStyles = \_ -> [ Fonts.baseFont, Css.padding (Css.px 8) ]
+            , sort = Nothing
+            }
         ]
         [ { name = "styles"
           , view = exampleWithBorder FocusRing.styles
+          , about =
+                """
+A two-tone focus ring that will be visually apparent for any background/element combination.
+
+NOTE: use `boxShadows` instead if your focusable element:
+
+  - already has a box shadow
+  - has an explicit border radius set
+"""
           }
         , { name = "tightStyles"
           , view = exampleWithBorder FocusRing.tightStyles
+          , about = "Prefer `styles` over tightStyles, except in cases where line spacing/font size will otherwise cause obscured content."
           }
         , { name = "boxShadows"
           , view = exampleWithBorder [ FocusRing.boxShadows [] ]
+          , about = ""
           }
         , { name = "insetBoxShadows"
           , view = exampleWithBorder [ FocusRing.insetBoxShadows [] ]
+          , about = "Please be sure that the padding on the element you add this style too is sufficient (at least 6px on all sides) that the inset box shadow won't cover any content."
           }
         , { name = "outerBoxShadow"
           , view = exampleWithBorder [ FocusRing.outerBoxShadow ]
+          , about = "In special cases, we don't use a two-tone focus ring. Be very sure this is what you need before using this!"
           }
         , { name = "insetBoxShadow"
           , view = exampleWithBorder [ FocusRing.insetBoxShadow ]
+          , about = "In special cases, we don't use a two-tone focus ring, and an outset focus ring would be obscured. Be very sure this is what you need before using this!"
           }
         , { name = "outerColor"
           , view = exampleWithBorder [ Css.backgroundColor FocusRing.outerColor ]
+          , about = "Colors.red"
           }
         , { name = "innerColor"
           , view = exampleWithBorder [ Css.backgroundColor FocusRing.innerColor ]
+          , about = "Colors.white"
           }
         ]

--- a/component-catalog/src/Examples/FocusRing.elm
+++ b/component-catalog/src/Examples/FocusRing.elm
@@ -37,7 +37,7 @@ example : Example State Msg
 example =
     { name = "FocusRing"
     , version = 1
-    , categories = [ Text, Atoms ]
+    , categories = [ Atoms ]
     , keyboardSupport = []
     , state = { isAccordionOpen = False }
     , update = update

--- a/component-catalog/src/Examples/FocusRing.elm
+++ b/component-catalog/src/Examples/FocusRing.elm
@@ -23,6 +23,7 @@ import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.RadioButton.V4 as RadioButton
+import Nri.Ui.SegmentedControl.V14 as SegmentedControl
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Switch.V3 as Switch
 import Nri.Ui.Table.V7 as Table
@@ -188,6 +189,21 @@ NOTE: use `boxShadows` instead if your focusable element:
           , examples =
                 [ Switch.view { label = "Switch", id = "switch" } []
                 , ClickableSvg.button "ClickableSvg button" UiIcon.playInCircle []
+                , SegmentedControl.viewRadioGroup
+                    { legend = "SegmentedControls.viewRadioGroup"
+                    , onSelect = \_ -> NoOp
+                    , options =
+                        [ { icon = Nothing
+                          , label = text "SegmentedControls"
+                          , value = 1
+                          , idString = "radio-1"
+                          , tooltip = []
+                          , attributes = []
+                          }
+                        ]
+                    , selected = Nothing
+                    , positioning = SegmentedControl.Left SegmentedControl.FitContent
+                    }
                 , Button.button "Button button" [ Button.small, Button.secondary ]
                 ]
           , about = ""
@@ -246,7 +262,7 @@ type alias State =
 type Msg
     = ToggleAccordion Bool
     | Focus String
-    | Focused
+    | NoOp
 
 
 update : Msg -> State -> ( State, Cmd Msg )
@@ -259,8 +275,8 @@ update msg model =
 
         Focus id ->
             ( model
-            , Task.attempt (\_ -> Focused) (Browser.Dom.focus id)
+            , Task.attempt (\_ -> NoOp) (Browser.Dom.focus id)
             )
 
-        Focused ->
+        NoOp ->
             ( model, Cmd.none )

--- a/component-catalog/src/Examples/FocusRing.elm
+++ b/component-catalog/src/Examples/FocusRing.elm
@@ -25,6 +25,7 @@ import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.RadioButton.V4 as RadioButton
 import Nri.Ui.SegmentedControl.V14 as SegmentedControl
 import Nri.Ui.Spacing.V1 as Spacing
+import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Switch.V3 as Switch
 import Nri.Ui.Table.V7 as Table
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -85,10 +86,11 @@ example_ styles =
         []
 
 
-exampleWithBorder : List Style -> Html msg
-exampleWithBorder styles =
+exampleWithBorderAndBG : List Style -> Html msg
+exampleWithBorderAndBG styles =
     example_
         (Css.border3 (Css.px 2) Css.dashed Colors.gray20
+            :: Css.backgroundColor Colors.gray75
             :: styles
         )
 
@@ -130,6 +132,27 @@ viewTable model =
             , sort = Nothing
             }
         , Table.custom
+            { header = text "Two-toned"
+            , view =
+                \{ twoToned } ->
+                    if twoToned then
+                        UiIcon.checkmark
+                            |> Svg.withLabel "Yes"
+                            |> Svg.withWidth (Css.px 20)
+                            |> Svg.withColor Colors.greenDark
+                            |> Svg.toHtml
+
+                    else
+                        UiIcon.x
+                            |> Svg.withLabel "No"
+                            |> Svg.withWidth (Css.px 20)
+                            |> Svg.withColor Colors.red
+                            |> Svg.toHtml
+            , width = Css.pct 1
+            , cellStyles = always [ Css.padding2 (Css.px 8) (Css.px 16) ]
+            , sort = Nothing
+            }
+        , Table.custom
             { header = text "Examples"
             , view =
                 .examples
@@ -146,7 +169,8 @@ viewTable model =
             }
         ]
         [ { name = "styles"
-          , view = exampleWithBorder FocusRing.styles
+          , view = exampleWithBorderAndBG FocusRing.styles
+          , twoToned = True
           , examples =
                 [ button [] [ text "Button" ]
                 , label [] [ input [] [], text "Input" ]
@@ -163,7 +187,8 @@ NOTE: use `boxShadows` instead if your focusable element:
 """
           }
         , { name = "tightStyles"
-          , view = exampleWithBorder FocusRing.tightStyles
+          , view = exampleWithBorderAndBG FocusRing.tightStyles
+          , twoToned = True
           , examples =
                 [ ClickableText.button "ClickableText button" [ ClickableText.small ]
                 , ClickableText.link "ClickableText link" [ ClickableText.small ]
@@ -185,7 +210,8 @@ NOTE: use `boxShadows` instead if your focusable element:
           , about = "Prefer `styles` over tightStyles, except in cases where line spacing/font size will otherwise cause obscured content."
           }
         , { name = "boxShadows"
-          , view = exampleWithBorder [ FocusRing.boxShadows [] ]
+          , view = exampleWithBorderAndBG [ FocusRing.boxShadows [] ]
+          , twoToned = True
           , examples =
                 [ Switch.view { label = "Switch", id = "switch" } []
                 , ClickableSvg.button "ClickableSvg button" UiIcon.playInCircle []
@@ -209,7 +235,8 @@ NOTE: use `boxShadows` instead if your focusable element:
           , about = ""
           }
         , { name = "insetBoxShadows"
-          , view = exampleWithBorder [ FocusRing.insetBoxShadows [] ]
+          , view = exampleWithBorderAndBG [ FocusRing.insetBoxShadows [] ]
+          , twoToned = True
           , examples =
                 [ Accordion.view
                     { entries =
@@ -231,22 +258,34 @@ NOTE: use `boxShadows` instead if your focusable element:
           , about = "Please be sure that the padding on the element you add this style too is sufficient (at least 6px on all sides) that the inset box shadow won't cover any content."
           }
         , { name = "outerBoxShadow"
-          , view = exampleWithBorder [ FocusRing.outerBoxShadow ]
+          , view = exampleWithBorderAndBG [ FocusRing.outerBoxShadow ]
+          , twoToned = False
           , examples = [ text "(See Tabs and TabsMinimal)" ]
           , about = "In special cases, we don't use a two-tone focus ring. Be very sure this is what you need before using this!"
           }
         , { name = "insetBoxShadow"
-          , view = exampleWithBorder [ FocusRing.insetBoxShadow ]
+          , view = exampleWithBorderAndBG [ FocusRing.insetBoxShadow ]
+          , twoToned = False
           , examples = [ text "(See SideNav)" ]
           , about = "In special cases, we don't use a two-tone focus ring, and an outset focus ring would be obscured. Be very sure this is what you need before using this!"
           }
         , { name = "outerColor"
-          , view = exampleWithBorder [ Css.backgroundColor FocusRing.outerColor ]
+          , view =
+                example_
+                    [ Css.border3 (Css.px 2) Css.solid Colors.gray20
+                    , Css.backgroundColor FocusRing.outerColor
+                    ]
+          , twoToned = False
           , examples = []
           , about = "Colors.red"
           }
         , { name = "innerColor"
-          , view = exampleWithBorder [ Css.backgroundColor FocusRing.innerColor ]
+          , view =
+                example_
+                    [ Css.border3 (Css.px 2) Css.solid Colors.gray20
+                    , Css.backgroundColor FocusRing.innerColor
+                    ]
+          , twoToned = False
           , examples = []
           , about = "Colors.white"
           }

--- a/component-catalog/src/Examples/FocusRing.elm
+++ b/component-catalog/src/Examples/FocusRing.elm
@@ -12,8 +12,10 @@ import Example exposing (Example)
 import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V7 as Table
 
 
@@ -38,27 +40,96 @@ example =
     , update = \_ state -> ( state, Cmd.none )
     , subscriptions = \_ -> Sub.none
     , preview =
-        [ div
-            [ css
-                [ Css.width (Css.pct 100)
-                , Css.height (Css.px 20)
-                , Css.batch FocusRing.styles
-                , Css.marginBottom (Css.px 30)
-                ]
-            ]
-            []
-        , div
-            [ css
-                [ Css.width (Css.pct 100)
-                , Css.height (Css.px 20)
-                , Css.batch FocusRing.tightStyles
-                ]
-            ]
-            []
+        [ example_ (Css.marginBottom (Css.px 30) :: FocusRing.styles)
+        , example_ FocusRing.tightStyles
         ]
-    , about = []
+    , about =
+        [ text "Custom high-contrast focus ring styles. Learn more about this component in "
+        , ClickableText.link "Custom Focus Rings on the NoRedInk blog"
+            [ ClickableText.linkExternal "https://blog.noredink.com/post/703458632758689792/custom-focus-rings"
+            , ClickableText.appearsInline
+            ]
+        , text "."
+        ]
     , view =
         \_ _ ->
-            [ Heading.h2 [ Heading.plaintext "Examples" ]
+            [ Heading.h2
+                [ Heading.plaintext "Examples"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
+            , viewTable
             ]
     }
+
+
+example_ : List Style -> Html msg
+example_ styles =
+    div
+        [ css
+            [ Css.width (Css.pct 100)
+            , Css.height (Css.px 20)
+            , Css.batch styles
+            ]
+        ]
+        []
+
+
+exampleWithBorder : List Style -> Html msg
+exampleWithBorder styles =
+    example_
+        (Css.border3 (Css.px 2) Css.dashed Colors.gray20
+            :: styles
+        )
+
+
+viewTable : Html msg
+viewTable =
+    Table.view []
+        [ Table.rowHeader
+            { header = Html.text "Name"
+            , view = \{ name } -> code [] [ text name ]
+            , width = Css.pct 10
+            , cellStyles = always []
+            , sort = Nothing
+            }
+        , Table.custom
+            { header = text "view"
+            , view = .view
+            , width = Css.pct 10
+            , cellStyles = always []
+            , sort = Nothing
+            }
+
+        --, Table.string
+        --    { header = "about"
+        --    , value = \_ -> text ""
+        --    , width = Css.pct 10
+        --    , cellStyles = always []
+        --    , sort = Nothing
+        --    }
+        ]
+        [ { name = "styles"
+          , view = exampleWithBorder FocusRing.styles
+          }
+        , { name = "tightStyles"
+          , view = exampleWithBorder FocusRing.tightStyles
+          }
+        , { name = "boxShadows"
+          , view = exampleWithBorder [ FocusRing.boxShadows [] ]
+          }
+        , { name = "insetBoxShadows"
+          , view = exampleWithBorder [ FocusRing.insetBoxShadows [] ]
+          }
+        , { name = "outerBoxShadow"
+          , view = exampleWithBorder [ FocusRing.outerBoxShadow ]
+          }
+        , { name = "insetBoxShadow"
+          , view = exampleWithBorder [ FocusRing.insetBoxShadow ]
+          }
+        , { name = "outerColor"
+          , view = exampleWithBorder [ Css.backgroundColor FocusRing.outerColor ]
+          }
+        , { name = "innerColor"
+          , view = exampleWithBorder [ Css.backgroundColor FocusRing.innerColor ]
+          }
+        ]

--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -1,6 +1,7 @@
 Nri.Ui.Block.V4,upgrade to V6
 Nri.Ui.Block.V5,upgrade to V6
 Nri.Ui.WhenFocusLeaves.V1,upgrade to V2
+Nri.Ui.Highlighter.V4,upgrade to V5
 Nri.Ui.Mark.V2,upgrade to V5
 Nri.Ui.Mark.V3,upgrade to V5
 Nri.Ui.Mark.V4,upgrade to V5


### PR DESCRIPTION
Adds FocusRing helpers to Component Catalog as an atom, to hopefully make the FocusRing behavior more clear and discoverable.


![localhost_8000_ (8)](https://github.com/NoRedInk/noredink-ui/assets/8811312/a8ad96d3-6699-4310-bce5-4570f85d10d9)
