### PR TITLE
Implement new carousel types

### DIFF
--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -409,7 +409,7 @@ viewCustomizableWithCombinedControls model =
         allItems =
             settings.items
                 |> indicesForItemCount
-                |> List.map toTabbedCarouselItem
+                |> List.map toCombinedCarouselItem
 
         { tabControls, slides, viewPreviousButton, viewNextButton, containerAttributes } =
             Carousel.viewWithCombinedControls
@@ -560,13 +560,46 @@ toTabbedCarouselItem :
         ( String
         , { id : Int
           , idString : String
+          , slideHtml : Html msg
+          , tabControlHtml : Html Never
+          }
+        )
+toTabbedCarouselItem id =
+    let
+        idString =
+            Attributes.safeIdWithPrefix "slide" <| String.fromInt id
+
+        humanizedId =
+            String.fromInt (id + 1)
+    in
+    ( Code.recordMultiline
+        [ ( "id", Code.int id )
+        , ( "idString", Code.string (String.fromInt id) )
+        , ( "tabControlHtml", "Html.text " ++ Code.string ("Slide " ++ humanizedId) )
+        , ( "slideHtml", "Html.text " ++ Code.string ("Contents for slide " ++ humanizedId) )
+        ]
+        3
+    , { id = id
+      , idString = idString
+      , tabControlHtml = Html.text ("Slide " ++ humanizedId)
+      , slideHtml = Html.text ("Contents for slide " ++ humanizedId)
+      }
+    )
+
+
+toCombinedCarouselItem :
+    Int
+    ->
+        ( String
+        , { id : Int
+          , idString : String
           , name : String
           , visibleLabelId : Maybe String
           , slideHtml : Html msg
           , tabControlHtml : Html Never
           }
         )
-toTabbedCarouselItem id =
+toCombinedCarouselItem id =
     let
         idString =
             Attributes.safeIdWithPrefix "slide" <| String.fromInt id
@@ -677,22 +710,16 @@ viewTestimonials selected =
                 , slides =
                     [ { id = GreatService
                       , idString = "great-service"
-                      , name = "Great Service"
-                      , visibleLabelId = Nothing
                       , slideHtml = text "Great service!"
                       , tabControlHtml = span Style.invisible [ text "Testimonial 1" ]
                       }
                     , { id = GreatProduct
                       , idString = "great-product"
-                      , name = "Great Product"
-                      , visibleLabelId = Nothing
                       , slideHtml = text "Great product!"
                       , tabControlHtml = span Style.invisible [ text "Testimonial 2" ]
                       }
                     , { id = GreatMission
                       , idString = "great-mission"
-                      , name = "Great Mission"
-                      , visibleLabelId = Nothing
                       , slideHtml = text "Great mission!"
                       , tabControlHtml = span Style.invisible [ text "Testimonial 3" ]
                       }

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -421,8 +421,8 @@ viewCustomizableWithCombinedControls model =
             Carousel.viewWithCombinedControls
                 { selected = model.selected
                 , slides = List.map Tuple.second allItems
-                , tabControlStyles = \_ -> []
-                , tabControlListStyles = []
+                , tabStyles = \_ -> []
+                , tabListStyles = []
                 , previousButton =
                     { attributes = [], icon = UiIcon.arrowLeft, name = "Previous" }
                 , nextButton =
@@ -438,8 +438,8 @@ viewCustomizableWithCombinedControls model =
             ++ Code.record
                 [ ( "selected", Code.int model.selected )
                 , ( "slides", Code.listMultiline (List.map Tuple.first allItems) 2 )
-                , ( "tabControlStyles", "(\\_ -> [])" )
-                , ( "tabControlListStyles", Code.list [] )
+                , ( "tabStyles", "(\\_ -> [])" )
+                , ( "tabListStyles", Code.list [] )
                 , ( "previousButton"
                   , Code.recordMultiline
                         [ ( "name", Code.string "Previous" )
@@ -487,8 +487,8 @@ viewCustomizableWithTabControls model =
             Carousel.viewWithTabControls
                 { selected = model.selected
                 , slides = List.map Tuple.second allItems
-                , tabControlStyles = \_ -> []
-                , tabControlListStyles = []
+                , tabStyles = \_ -> []
+                , tabListStyles = []
                 , role = Carousel.Group
                 , name = "Items"
                 , visibleLabelId = Nothing
@@ -506,8 +506,8 @@ viewCustomizableWithTabControls model =
             ++ Code.record
                 [ ( "selected", Code.int model.selected )
                 , ( "slides", Code.listMultiline (List.map Tuple.first allItems) 2 )
-                , ( "tabControlStyles", "(\\_ -> [])" )
-                , ( "tabControlListStyles", Code.list [] )
+                , ( "tabStyles", "(\\_ -> [])" )
+                , ( "tabListStyles", Code.list [] )
                 , ( "role", Code.fromModule moduleName "Group" )
                 , ( "name", Code.string "Items" )
                 , ( "visibleLabelId", Code.maybe Nothing )
@@ -735,8 +735,8 @@ viewTestimonials selected =
                       , tabControlHtml = span Style.invisible [ text "Testimonial 3" ]
                       }
                     ]
-                , tabControlStyles = tabControlStyles
-                , tabControlListStyles = tabControlListStyles
+                , tabStyles = tabStyles
+                , tabListStyles = tabListStyles
                 , role = Carousel.Group
                 , name = "Testimonials"
                 , visibleLabelId = Nothing
@@ -788,8 +788,8 @@ viewPackages selected =
                       , tabControlHtml = span Style.invisible [ text "Enterprise tier" ]
                       }
                     ]
-                , tabControlStyles = tabControlStyles
-                , tabControlListStyles = tabControlListStyles
+                , tabStyles = tabStyles
+                , tabListStyles = tabListStyles
                 , previousButton =
                     { attributes =
                         [ ClickableSvg.withBorder
@@ -846,8 +846,8 @@ type Package
     | EnterpriseTier
 
 
-tabControlStyles : Bool -> List Style
-tabControlStyles isSelected =
+tabStyles : Bool -> List Style
+tabStyles isSelected =
     [ borderRadius (pct 100)
     , overflow hidden
     , padding zero
@@ -870,8 +870,8 @@ tabControlStyles isSelected =
     ]
 
 
-tabControlListStyles : List Style
-tabControlListStyles =
+tabListStyles : List Style
+tabListStyles =
     [ displayFlex
     , property "gap" "15px"
     , justifyContent center

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -272,8 +272,20 @@ viewWithPreviousAndNextControls model =
             ++ Code.recordMultiline
                 [ ( "selected", Code.string (String.fromInt model.selected) )
                 , ( "slides", Code.listMultiline (List.map Tuple.first allItems) 3 )
-                , ( "previousButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Previous\" }" )
-                , ( "nextButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Next\" }" )
+                , ( "previousButton"
+                  , Code.record
+                        [ ( "name", Code.string "Previous" )
+                        , ( "icon", "UiIcon.arrowLeft" )
+                        , ( "attributes", Code.list [] )
+                        ]
+                  )
+                , ( "nextButton"
+                  , Code.record
+                        [ ( "name", Code.string "Previous" )
+                        , ( "icon", "UiIcon.arrowRight" )
+                        , ( "attributes", Code.list [] )
+                        ]
+                  )
                 , ( "name", "Items" )
                 , ( "visibleLabelId", "Nothing" )
                 , ( "role", Code.fromModule moduleName "Group" )
@@ -327,8 +339,20 @@ viewWithCombinedControls model =
                 , ( "tabControlListStyles", Tuple.first settings.controlListStyles )
                 , ( "tabControlStyles", Tuple.first settings.controlStyles )
                 , ( "slides", Code.listMultiline (List.map Tuple.first allItems) 2 )
-                , ( "previousButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Previous\" }" )
-                , ( "nextButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Next\" }" )
+                , ( "previousButton"
+                  , Code.record
+                        [ ( "name", Code.string "Previous" )
+                        , ( "icon", "UiIcon.arrowLeft" )
+                        , ( "attributes", Code.list [] )
+                        ]
+                  )
+                , ( "nextButton"
+                  , Code.record
+                        [ ( "name", Code.string "Previous" )
+                        , ( "icon", "UiIcon.arrowRight" )
+                        , ( "attributes", Code.list [] )
+                        ]
+                  )
                 , ( "labelledBy", Code.fromModule moduleName "LabelledByIdOfVisibleLabel " ++ Code.string "Items" )
                 , ( "role", Code.fromModule moduleName "Group" )
                 ]
@@ -417,7 +441,7 @@ toNonTabbedCarouselItem id =
         , ( "visibleLabelId", Code.maybe Nothing )
         , ( "slideHtml", "Html.text " ++ Code.string ("Contents for slide " ++ humanizedId) )
         ]
-        2
+        4
     , { id = id
       , idString = idString
       , name = "Slide " ++ humanizedId
@@ -455,7 +479,7 @@ toTabbedCarouselItem id =
         , ( "tabControlHtml", "Html.text " ++ Code.string ("Slide " ++ humanizedId) )
         , ( "slideHtml", "Html.text " ++ Code.string ("Contents for slide " ++ humanizedId) )
         ]
-        2
+        3
     , { id = id
       , idString = idString
       , name = "Slide " ++ humanizedId

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -417,7 +417,7 @@ viewCustomizableWithCombinedControls model =
                 |> indicesForItemCount
                 |> List.map toCombinedCarouselItem
 
-        { tabControls, slides, viewPreviousButton, viewNextButton, containerAttributes } =
+        { tabs, slides, viewPreviousButton, viewNextButton, containerAttributes } =
             Carousel.viewWithCombinedControls
                 { selected = model.selected
                 , slides = List.map Tuple.second allItems
@@ -462,13 +462,13 @@ viewCustomizableWithCombinedControls model =
                 , ( "focusAndSelect", "FocusAndSelect" )
                 , ( "announceAndSelect", "AnnounceAndSelect" )
                 ]
-        , Code.anonymousFunction "{ tabControls, slides, viewPreviousButton, viewNextButton, containerAttributes }"
+        , Code.anonymousFunction "{ tabs, slides, viewPreviousButton, viewNextButton, containerAttributes }"
             (Code.newlineWithIndent 2
-                ++ "section containerAttributes [ slides, tabControls, viewPreviousButton, viewNextButton  ]"
+                ++ "section containerAttributes [ slides, tabs, viewPreviousButton, viewNextButton  ]"
             )
         ]
         0
-    , Html.div containerAttributes [ slides, tabControls, viewPreviousButton, viewNextButton ]
+    , Html.div containerAttributes [ slides, tabs, viewPreviousButton, viewNextButton ]
     )
 
 
@@ -483,7 +483,7 @@ viewCustomizableWithTabControls model =
                 |> indicesForItemCount
                 |> List.map toTabbedCarouselItem
 
-        { controls, slides, containerAttributes } =
+        { tabs, slides, containerAttributes } =
             Carousel.viewWithTabControls
                 { selected = model.selected
                 , slides = List.map Tuple.second allItems
@@ -514,13 +514,13 @@ viewCustomizableWithTabControls model =
                 , ( "focusAndSelect", "FocusAndSelect" )
                 , ( "announceAndSelect", "AnnounceAndSelect" )
                 ]
-        , Code.anonymousFunction "{ controls, slides, containerAttributes }"
+        , Code.anonymousFunction "{ tabs, slides, containerAttributes }"
             (Code.newlineWithIndent 2
-                ++ "section containerAttributes [ slides, controls ]"
+                ++ "section containerAttributes [ slides, tabs ]"
             )
         ]
         0
-    , Html.div containerAttributes [ slides, controls ]
+    , Html.div containerAttributes [ slides, tabs ]
     )
 
 
@@ -715,7 +715,7 @@ type Tip
 viewTestimonials : Testimonial -> Html Msg
 viewTestimonials selected =
     let
-        { controls, slides, containerAttributes } =
+        { tabs, slides, containerAttributes } =
             Carousel.viewWithTabControls
                 { selected = selected
                 , slides =
@@ -748,7 +748,7 @@ viewTestimonials selected =
         , Container.css [ maxWidth (px 210) ]
         , Container.html
             [ slides
-            , controls
+            , tabs
             ]
         ]
 
@@ -762,7 +762,7 @@ type Testimonial
 viewPackages : Package -> Html Msg
 viewPackages selected =
     let
-        { tabControls, slides, viewPreviousButton, viewNextButton, containerAttributes } =
+        { tabs, slides, viewPreviousButton, viewNextButton, containerAttributes } =
             Carousel.viewWithCombinedControls
                 { selected = selected
                 , slides =
@@ -835,7 +835,7 @@ viewPackages selected =
             ]
         , Container.html
             [ div [] [ viewPreviousButton, slides, viewNextButton ]
-            , tabControls
+            , tabs
             ]
         ]
 

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -21,7 +21,7 @@ import Debug.Control.Extra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled as Html exposing (..)
-import Html.Styled.Attributes as Attributes exposing (css)
+import Html.Styled.Attributes as Attributes exposing (class, css)
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Carousel.V2 as Carousel
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
@@ -729,19 +729,19 @@ viewTestimonials selected =
                       , idString = "great-service"
                       , slideView = text "Great service!"
                       , tabView = span Style.invisible [ text "Testimonial 1" ]
-                      , tabAttributes = []
+                      , tabAttributes = [ class FocusRing.customClass ]
                       }
                     , { id = GreatProduct
                       , idString = "great-product"
                       , slideView = text "Great product!"
                       , tabView = span Style.invisible [ text "Testimonial 2" ]
-                      , tabAttributes = []
+                      , tabAttributes = [ class FocusRing.customClass ]
                       }
                     , { id = GreatMission
                       , idString = "great-mission"
                       , slideView = text "Great mission!"
                       , tabView = span Style.invisible [ text "Testimonial 3" ]
-                      , tabAttributes = []
+                      , tabAttributes = [ class FocusRing.customClass ]
                       }
                     ]
                 , tabStyles = tabStyles
@@ -781,7 +781,7 @@ viewPackages selected =
                       , visibleLabelId = Nothing
                       , slideView = text "Free trial"
                       , tabView = span Style.invisible [ text "Free trial" ]
-                      , tabAttributes = []
+                      , tabAttributes = [ class FocusRing.customClass ]
                       }
                     , { id = DeveloperTier
                       , idString = "developer-tier"
@@ -789,7 +789,7 @@ viewPackages selected =
                       , visibleLabelId = Nothing
                       , slideView = text "Developer Tier"
                       , tabView = span Style.invisible [ text "Developer tier" ]
-                      , tabAttributes = []
+                      , tabAttributes = [ class FocusRing.customClass ]
                       }
                     , { id = EnterpriseTier
                       , idString = "enterprise-tier"
@@ -797,7 +797,7 @@ viewPackages selected =
                       , visibleLabelId = Nothing
                       , slideView = text "Enterprise Tier"
                       , tabView = span Style.invisible [ text "Enterprise tier" ]
-                      , tabAttributes = []
+                      , tabAttributes = [ class FocusRing.customClass ]
                       }
                     ]
                 , tabStyles = tabStyles

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -117,7 +117,7 @@ controlControlStyles =
 
 
 type Msg
-    = FocusAndSelectItem { select : Int, focus : Maybe String }
+    = FocusAndSelect { select : Int, focus : Maybe String }
     | AnnounceAndSelect { select : Int, announce : String }
     | Focused (Result Dom.Error ())
     | SetSettings (Control Settings)
@@ -126,7 +126,7 @@ type Msg
 update : Msg -> State -> ( State, Cmd Msg )
 update msg model =
     case msg of
-        FocusAndSelectItem { select, focus } ->
+        FocusAndSelect { select, focus } ->
             ( { model | selected = select }
             , focus
                 |> Maybe.map (Dom.focus >> Task.attempt Focused)
@@ -270,26 +270,28 @@ viewWithPreviousAndNextControls model =
     ( Code.pipelineMultiline
         [ Code.fromModule moduleName "viewWithPreviousAndNextControls"
             ++ Code.recordMultiline
-                [ ( "selected", Code.string (String.fromInt model.selected) )
+                [ ( "selected", Code.int model.selected )
                 , ( "slides", Code.listMultiline (List.map Tuple.first allItems) 3 )
                 , ( "previousButton"
-                  , Code.record
+                  , Code.recordMultiline
                         [ ( "name", Code.string "Previous" )
                         , ( "icon", "UiIcon.arrowLeft" )
                         , ( "attributes", Code.list [] )
                         ]
+                        2
                   )
                 , ( "nextButton"
-                  , Code.record
+                  , Code.recordMultiline
                         [ ( "name", Code.string "Previous" )
                         , ( "icon", "UiIcon.arrowRight" )
                         , ( "attributes", Code.list [] )
                         ]
+                        2
                   )
                 , ( "name", "Items" )
-                , ( "visibleLabelId", "Nothing" )
+                , ( "visibleLabelId", Code.maybe Nothing )
                 , ( "role", Code.fromModule moduleName "Group" )
-                , ( "focusAndSelect", "FocusAndSelectItem" )
+                , ( "announceAndSelect", "AnnounceAndSelect" )
                 ]
                 1
         , Code.anonymousFunction "{ viewPreviousButton, viewNextButton, slides, containerAttributes }"
@@ -326,35 +328,38 @@ viewWithCombinedControls model =
                 , role = Carousel.Group
                 , name = "Items"
                 , visibleLabelId = Nothing
-                , focusAndSelect = FocusAndSelectItem
+                , focusAndSelect = FocusAndSelect
                 , announceAndSelect = AnnounceAndSelect
                 }
     in
     ( Code.pipelineMultiline
         [ Code.fromModule moduleName "viewWithCombinedControls"
             ++ Code.record
-                [ ( "focusAndSelect", "identity" )
-                , ( "announceAndSelect", "identity" )
-                , ( "selected", Code.string (String.fromInt model.selected) )
+                [ ( "selected", Code.int model.selected )
+                , ( "slides", Code.listMultiline (List.map Tuple.first allItems) 2 )
                 , ( "tabControlListStyles", Tuple.first settings.controlListStyles )
                 , ( "tabControlStyles", Tuple.first settings.controlStyles )
-                , ( "slides", Code.listMultiline (List.map Tuple.first allItems) 2 )
                 , ( "previousButton"
-                  , Code.record
+                  , Code.recordMultiline
                         [ ( "name", Code.string "Previous" )
                         , ( "icon", "UiIcon.arrowLeft" )
                         , ( "attributes", Code.list [] )
                         ]
+                        2
                   )
                 , ( "nextButton"
-                  , Code.record
+                  , Code.recordMultiline
                         [ ( "name", Code.string "Previous" )
                         , ( "icon", "UiIcon.arrowRight" )
                         , ( "attributes", Code.list [] )
                         ]
+                        2
                   )
-                , ( "labelledBy", Code.fromModule moduleName "LabelledByIdOfVisibleLabel " ++ Code.string "Items" )
                 , ( "role", Code.fromModule moduleName "Group" )
+                , ( "name", Code.string "Items" )
+                , ( "visibleLabelId", Code.maybe Nothing )
+                , ( "focusAndSelect", "FocusAndSelect" )
+                , ( "announceAndSelect", "AnnounceAndSelect" )
                 ]
         , Code.anonymousFunction "{ tabControls, slides, viewPreviousButton, viewNextButton, containerAttributes }"
             (Code.newlineWithIndent 2
@@ -381,24 +386,26 @@ viewWithTabControls model =
             Carousel.viewWithTabControls
                 { selected = model.selected
                 , slides = List.map Tuple.second allItems
-                , focusAndSelect = FocusAndSelectItem
                 , tabControlListStyles = Tuple.second settings.controlListStyles
                 , tabControlStyles = Tuple.second settings.controlStyles
                 , role = Carousel.Group
                 , name = "Items"
                 , visibleLabelId = Nothing
+                , focusAndSelect = FocusAndSelect
                 }
     in
     ( Code.pipelineMultiline
         [ Code.fromModule moduleName "viewWithTabControls"
             ++ Code.record
-                [ ( "focusAndSelect", "identity" )
-                , ( "selected", Code.string (String.fromInt model.selected) )
+                [ ( "selected", Code.int model.selected )
+                , ( "slides", Code.listMultiline (List.map Tuple.first allItems) 2 )
                 , ( "tabControlListStyles", Tuple.first settings.controlListStyles )
                 , ( "tabControlStyles", Tuple.first settings.controlStyles )
-                , ( "slides", Code.listMultiline (List.map Tuple.first allItems) 2 )
-                , ( "labelledBy", Code.fromModule moduleName "LabelledByIdOfVisibleLabel " ++ Code.string "Items" )
                 , ( "role", Code.fromModule moduleName "Group" )
+                , ( "name", "Items" )
+                , ( "visibleLabelId", Code.maybe Nothing )
+                , ( "focusAndSelect", "FocusAndSelect" )
+                , ( "announceAndSelect", "AnnounceAndSelect" )
                 ]
         , Code.anonymousFunction "{ controls, slides, containerAttributes }"
             (Code.newlineWithIndent 2

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -263,7 +263,6 @@ viewWithPreviousAndNextControls model =
         [ Code.fromModule moduleName "viewWithPreviousAndNextControls"
             ++ Code.recordMultiline
                 [ ( "selected", Code.string (String.fromInt model.selected) )
-                , ( "controlListStyles", Tuple.first settings.controlListStyles )
                 , ( "panels", Code.listMultiline (List.map Tuple.first allItems) 3 )
                 , ( "viewPreviousButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Previous\" }" )
                 , ( "viewNextButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Next\" }" )

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -13,7 +13,7 @@ module Examples.Carousel exposing
 import Browser.Dom as Dom
 import Category exposing (Category(..))
 import Code
-import Css exposing (Style)
+import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra
 import Debug.Control.View as ControlView
@@ -25,7 +25,7 @@ import Nri.Ui.Carousel.V2 as Carousel
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as Attributes
-import Nri.Ui.UiIcon.V1 as UiIcon exposing (arrowLeft, arrowRight)
+import Nri.Ui.UiIcon.V1 as UiIcon
 import Task
 
 

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -304,6 +304,7 @@ viewWithCombinedControls model =
         [ Code.fromModule moduleName "viewWithCombinedControls"
             ++ Code.record
                 [ ( "focusAndSelect", "identity" )
+                , ( "announceAndSelect", "identity")
                 , ( "selected", Code.string (String.fromInt model.selected) )
                 , ( "tabControlListStyles", Tuple.first settings.controlListStyles )
                 , ( "tabControlStyles", Tuple.first settings.controlStyles )

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -117,6 +117,7 @@ controlControlStyles =
 
 type Msg
     = FocusAndSelectItem { select : Int, focus : Maybe String }
+    | SelectAndAnnounce { select : Int, announce : String }
     | Focused (Result Dom.Error ())
     | SetSettings (Control Settings)
 
@@ -136,6 +137,11 @@ update msg model =
 
         SetSettings settings ->
             ( { model | settings = settings }, Cmd.none )
+
+        SelectAndAnnounce { select, announce } ->
+            ( { model | selected = select }
+            , Cmd.none
+            )
 
 
 moduleName : String
@@ -232,15 +238,17 @@ viewWithPreviousAndNextControls model =
                             [ ( "id", String.fromInt id )
                             , ( "idString", "\"" ++ String.fromInt id ++ "\"" )
                             , ( "slideHtml", "Html.text " ++ Code.string (String.fromInt (id + 1) ++ " slide") )
-                            , ( "labelledBy"
+                            , ( "accessibleLabel"
                               , Code.fromModule moduleName "LabelledByIdOfVisibleLabel "
                                     ++ Code.string (String.fromInt (id + 1) ++ " of " ++ String.fromInt settings.items)
                               )
+                            , ( "visibleLabelId", "Nothing" )
                             ]
                             3
                         , { id = id
                           , slideHtml = Html.text (String.fromInt (id + 1))
-                          , labelledBy = Carousel.LabelledByIdOfVisibleLabel (String.fromInt (id + 1) ++ " of " ++ String.fromInt settings.items)
+                          , accessibleLabel = String.fromInt (id + 1) ++ " of " ++ String.fromInt settings.items
+                          , visibleLabelId = Nothing
                           , idString = String.fromInt id
                           }
                         )
@@ -250,13 +258,14 @@ viewWithPreviousAndNextControls model =
             Carousel.viewWithPreviousAndNextControls
                 { selected = model.selected
                 , panels = List.map Tuple.second allItems
-                , viewPreviousButton =
+                , previousButton =
                     { attributes = [], icon = UiIcon.arrowLeft, name = "Previous" }
-                , viewNextButton =
+                , nextButton =
                     { attributes = [], icon = UiIcon.arrowRight, name = "Next" }
-                , labelledBy = Carousel.LabelledByIdOfVisibleLabel "Items"
+                , accessibleLabel = "Items"
+                , visibleLabelId = Nothing
                 , role = Carousel.Group
-                , focusAndSelect = FocusAndSelectItem
+                , selectAndAnnounce = SelectAndAnnounce
                 }
     in
     ( Code.pipelineMultiline
@@ -264,9 +273,10 @@ viewWithPreviousAndNextControls model =
             ++ Code.recordMultiline
                 [ ( "selected", Code.string (String.fromInt model.selected) )
                 , ( "panels", Code.listMultiline (List.map Tuple.first allItems) 3 )
-                , ( "viewPreviousButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Previous\" }" )
-                , ( "viewNextButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Next\" }" )
-                , ( "labelledBy", Code.fromModule moduleName "LabelledByIdOfVisibleLabel" ++ Code.string "Items" )
+                , ( "previousButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Previous\" }" )
+                , ( "nextButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Next\" }" )
+                , ( "accessibleLabel", "Items" )
+                , ( "visibleLabelId", "Nothing" )
                 , ( "role", Code.fromModule moduleName "Group" )
                 , ( "focusAndSelect", "FocusAndSelectItem" )
                 ]
@@ -298,9 +308,9 @@ viewWithCombinedControls model =
                 , tabControlListStyles = Tuple.second settings.controlListStyles
                 , tabControlStyles = Tuple.second settings.controlStyles
                 , panels = List.map Tuple.second allItems
-                , viewPreviousButton =
+                , previousButton =
                     { attributes = [], icon = UiIcon.arrowLeft, name = "Previous" }
-                , viewNextButton =
+                , nextButton =
                     { attributes = [], icon = UiIcon.arrowRight, name = "Next" }
                 , labelledBy = Carousel.LabelledByIdOfVisibleLabel "Items"
                 , role = Carousel.Group
@@ -314,8 +324,8 @@ viewWithCombinedControls model =
                 , ( "tabControlListStyles", Tuple.first settings.controlListStyles )
                 , ( "tabControlStyles", Tuple.first settings.controlStyles )
                 , ( "panels", Code.listMultiline (List.map Tuple.first allItems) 2 )
-                , ( "viewPreviousButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Previous\" }" )
-                , ( "viewNextButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Next\" }" )
+                , ( "previousButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Previous\" }" )
+                , ( "nextButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Next\" }" )
                 , ( "labelledBy", Code.fromModule moduleName "LabelledByIdOfVisibleLabel " ++ Code.string "Items" )
                 , ( "role", Code.fromModule moduleName "Group" )
                 ]

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -117,7 +117,7 @@ controlControlStyles =
 
 type Msg
     = FocusAndSelectItem { select : Int, focus : Maybe String }
-    | SelectAndAnnounce { select : Int, announce : String }
+    | AnnounceAndSelect { select : Int, announce : String }
     | Focused (Result Dom.Error ())
     | SetSettings (Control Settings)
 
@@ -138,7 +138,7 @@ update msg model =
         SetSettings settings ->
             ( { model | settings = settings }, Cmd.none )
 
-        SelectAndAnnounce { select, announce } ->
+        AnnounceAndSelect { select, announce } ->
             ( { model | selected = select }
             , Cmd.none
             )
@@ -265,7 +265,7 @@ viewWithPreviousAndNextControls model =
                 , accessibleLabel = "Items"
                 , visibleLabelId = Nothing
                 , role = Carousel.Group
-                , selectAndAnnounce = SelectAndAnnounce
+                , announceAndSelect = AnnounceAndSelect
                 }
     in
     ( Code.pipelineMultiline

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -304,7 +304,7 @@ viewWithCombinedControls model =
         [ Code.fromModule moduleName "viewWithCombinedControls"
             ++ Code.record
                 [ ( "focusAndSelect", "identity" )
-                , ( "announceAndSelect", "identity")
+                , ( "announceAndSelect", "identity" )
                 , ( "selected", Code.string (String.fromInt model.selected) )
                 , ( "tabControlListStyles", Tuple.first settings.controlListStyles )
                 , ( "tabControlStyles", Tuple.first settings.controlStyles )

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -19,12 +19,13 @@ import Debug.Control.Extra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
-import Html.Styled.Attributes as Attributes
+import Html.Styled.Attributes as Attributes exposing (css)
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Carousel.V2 as Carousel
+import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as Attributes
-import Nri.Ui.UiIcon.V1 as UiIcon
+import Nri.Ui.UiIcon.V1 as UiIcon exposing (arrowLeft, arrowRight)
 import Task
 
 
@@ -176,12 +177,29 @@ example =
     , preview =
         [ -- faking a mini version of the Carousel component to give Component Catalog users a sense of what the
           -- component might look like
-          Html.div []
-            [ Html.text "1 slide"
-            , Html.div [ Attributes.css [ Css.displayFlex, Css.property "gap" "5px" ] ]
+          Html.div [ css [ Css.position Css.relative ] ]
+            [ Html.div
+                [ css
+                    [ Css.displayFlex
+                    , Css.alignItems Css.center
+                    , Css.justifyContent Css.spaceBetween
+                    , Css.marginBottom (Css.px 10)
+                    ]
+                ]
+                [ ClickableSvg.button "Previous" UiIcon.arrowLeft []
+                , Html.text "First Slide"
+                , ClickableSvg.button "Next" UiIcon.arrowRight []
+                ]
+            , Html.div
+                [ Attributes.css
+                    [ Css.displayFlex
+                    , Css.justifyContent Css.center
+                    , Css.property "gap" "5px"
+                    ]
+                ]
                 [ Html.div [ Attributes.css (controlStyles True) ] [ Html.text "1" ]
                 , Html.div [ Attributes.css (controlStyles False) ] [ Html.text "2" ]
-                , Html.div [ Attributes.css (controlStyles False) ] [ Html.text "2" ]
+                , Html.div [ Attributes.css (controlStyles False) ] [ Html.text "3" ]
                 ]
             ]
         ]

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -67,8 +67,8 @@ initSettings =
 controlCarouselType : Control CarouselType
 controlCarouselType =
     Control.choice
-        [ ( "viewWithTabControls", Control.value Tabs )
-        , ( "viewWithPreviousAndNextControls", Control.value PrevNext )
+        [ ( "viewWithPreviousAndNextControls", Control.value PrevNext )
+        , ( "viewWithTabControls", Control.value Tabs )
         , ( "viewWithCombinedControls", Control.value Combined )
         ]
 

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -10,6 +10,7 @@ module Examples.Carousel exposing
 
 -}
 
+import Accessibility.Styled.Live as Live
 import Accessibility.Styled.Style as Style
 import Browser.Dom as Dom
 import Category exposing (Category(..))
@@ -24,12 +25,15 @@ import Html.Styled.Attributes as Attributes exposing (css)
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Carousel.V2 as Carousel
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
+import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Html.Attributes.V2 as Attributes
+import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Task
 
@@ -40,6 +44,7 @@ type alias State =
     , tip : Tip
     , testimonial : Testimonial
     , package : Package
+    , announcement : Maybe String
     }
 
 
@@ -50,6 +55,7 @@ init =
     , tip = AvoidWhiteAfterLaborDay
     , testimonial = GreatService
     , package = FreeTrial
+    , announcement = Nothing
     }
 
 
@@ -128,15 +134,19 @@ update msg model =
             ( { model | settings = settings }, Cmd.none )
 
         AnnounceAndSelect { select, announce } ->
-            ( { model | selected = select }
-            , -- TODO: actually announce!
-              Cmd.none
+            ( { model
+                | selected = select
+                , announcement = Just announce
+              }
+            , Cmd.none
             )
 
         SelectTip { select, announce } ->
-            ( { model | tip = select }
-            , -- TODO: actually announce!
-              Cmd.none
+            ( { model
+                | tip = select
+                , announcement = Just announce
+              }
+            , Cmd.none
             )
 
         SelectTestimonial { select, focus } ->
@@ -154,9 +164,11 @@ update msg model =
             )
 
         SelectPackageAndAnnounce { select, announce } ->
-            ( { model | package = select }
-            , -- TODO: actually announce!
-              Cmd.none
+            ( { model
+                | package = select
+                , announcement = Just announce
+              }
+            , Cmd.none
             )
 
 
@@ -297,6 +309,30 @@ example =
                 , { viewName = "viewWithCombinedControls"
                   , example = viewPackages model.package
                   }
+                ]
+            , Heading.h2
+                [ Heading.plaintext "Assistive Technology Announcement Center"
+                , Heading.css [ Css.marginTop (Css.px 30) ]
+                ]
+            , Text.smallBody
+                [ Text.html
+                    [ text "NRI employees can learn more about the real ATAC in "
+                    , ClickableText.link "Assistive Technology Announcement Center (“ATAC”)"
+                        [ ClickableText.appearsInline
+                        , ClickableText.linkExternal "https://paper.dropbox.com/doc/Assistive-Technology-Announcement-Center-ATAC--B_GuqwWltzU432ueq7p6Z42mAg-bOnmcnzOj631NRls1IBe3"
+                        , ClickableText.small
+                        ]
+                    ]
+                ]
+            , div
+                [ Live.polite
+                , Live.atomic True
+                ]
+                [ viewJust
+                    (\announcement ->
+                        Text.mediumBody [ Text.plaintext announcement ]
+                    )
+                    model.announcement
                 ]
             ]
     }

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -20,10 +20,8 @@ import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
-import Html.Styled.Events as Events
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Carousel.V2 as Carousel
-import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as Attributes
 import Nri.Ui.UiIcon.V1 as UiIcon

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -573,6 +573,7 @@ toTabbedCarouselItem :
           , idString : String
           , slideView : Html msg
           , tabView : Html Never
+          , tabAttributes : List (Html.Attribute msg)
           }
         )
 toTabbedCarouselItem id =
@@ -586,14 +587,16 @@ toTabbedCarouselItem id =
     ( Code.recordMultiline
         [ ( "id", Code.int id )
         , ( "idString", Code.string (String.fromInt id) )
-        , ( "tabView", "Html.text " ++ Code.string ("Slide " ++ humanizedId) )
         , ( "slideView", "Html.text " ++ Code.string ("Contents for slide " ++ humanizedId) )
+        , ( "tabView", "Html.text " ++ Code.string ("Slide " ++ humanizedId) )
+        , ( "tabAttributes", Code.list [] )
         ]
         3
     , { id = id
       , idString = idString
-      , tabView = Html.text ("Slide " ++ humanizedId)
       , slideView = Html.text ("Contents for slide " ++ humanizedId)
+      , tabView = Html.text ("Slide " ++ humanizedId)
+      , tabAttributes = []
       }
     )
 
@@ -608,6 +611,7 @@ toCombinedCarouselItem :
           , visibleLabelId : Maybe String
           , slideView : Html msg
           , tabView : Html Never
+          , tabAttributes : List (Html.Attribute msg)
           }
         )
 toCombinedCarouselItem id =
@@ -623,16 +627,18 @@ toCombinedCarouselItem id =
         , ( "idString", Code.string (String.fromInt id) )
         , ( "name", Code.string ("Slide " ++ humanizedId) )
         , ( "visibleLabelId", Code.maybe Nothing )
-        , ( "tabView", "Html.text " ++ Code.string ("Slide " ++ humanizedId) )
         , ( "slideView", "Html.text " ++ Code.string ("Contents for slide " ++ humanizedId) )
+        , ( "tabView", "Html.text " ++ Code.string ("Slide " ++ humanizedId) )
+        , ( "tabAttributes", Code.list [] )
         ]
         3
     , { id = id
       , idString = idString
       , name = "Slide " ++ humanizedId
       , visibleLabelId = Nothing
-      , tabView = Html.text ("Slide " ++ humanizedId)
       , slideView = Html.text ("Contents for slide " ++ humanizedId)
+      , tabView = Html.text ("Slide " ++ humanizedId)
+      , tabAttributes = []
       }
     )
 
@@ -723,16 +729,19 @@ viewTestimonials selected =
                       , idString = "great-service"
                       , slideView = text "Great service!"
                       , tabView = span Style.invisible [ text "Testimonial 1" ]
+                      , tabAttributes = []
                       }
                     , { id = GreatProduct
                       , idString = "great-product"
                       , slideView = text "Great product!"
                       , tabView = span Style.invisible [ text "Testimonial 2" ]
+                      , tabAttributes = []
                       }
                     , { id = GreatMission
                       , idString = "great-mission"
                       , slideView = text "Great mission!"
                       , tabView = span Style.invisible [ text "Testimonial 3" ]
+                      , tabAttributes = []
                       }
                     ]
                 , tabStyles = tabStyles
@@ -772,6 +781,7 @@ viewPackages selected =
                       , visibleLabelId = Nothing
                       , slideView = text "Free trial"
                       , tabView = span Style.invisible [ text "Free trial" ]
+                      , tabAttributes = []
                       }
                     , { id = DeveloperTier
                       , idString = "developer-tier"
@@ -779,6 +789,7 @@ viewPackages selected =
                       , visibleLabelId = Nothing
                       , slideView = text "Developer Tier"
                       , tabView = span Style.invisible [ text "Developer tier" ]
+                      , tabAttributes = []
                       }
                     , { id = EnterpriseTier
                       , idString = "enterprise-tier"
@@ -786,6 +797,7 @@ viewPackages selected =
                       , visibleLabelId = Nothing
                       , slideView = text "Enterprise Tier"
                       , tabView = span Style.invisible [ text "Enterprise tier" ]
+                      , tabAttributes = []
                       }
                     ]
                 , tabStyles = tabStyles

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -261,7 +261,7 @@ viewWithPreviousAndNextControls model =
                         ]
                         2
                   )
-                , ( "name", "Items" )
+                , ( "name", Code.string "Items" )
                 , ( "visibleLabelId", Code.maybe Nothing )
                 , ( "role", Code.fromModule moduleName "Group" )
                 , ( "announceAndSelect", "AnnounceAndSelect" )
@@ -269,7 +269,7 @@ viewWithPreviousAndNextControls model =
                 1
         , Code.anonymousFunction "{ viewPreviousButton, viewNextButton, slides, containerAttributes }"
             (Code.newlineWithIndent 2
-                ++ "section containerAttributes [ slides, controls, viewPreviousButton, viewNextButton ]"
+                ++ "section containerAttributes [ slides, viewPreviousButton, viewNextButton ]"
             )
         ]
         0
@@ -375,7 +375,7 @@ viewWithTabControls model =
                 , ( "tabControlStyles", "(\\_ -> [])" )
                 , ( "tabControlListStyles", Code.list [] )
                 , ( "role", Code.fromModule moduleName "Group" )
-                , ( "name", "Items" )
+                , ( "name", Code.string "Items" )
                 , ( "visibleLabelId", Code.maybe Nothing )
                 , ( "focusAndSelect", "FocusAndSelect" )
                 , ( "announceAndSelect", "AnnounceAndSelect" )

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -44,8 +44,6 @@ init =
 
 type alias Settings =
     { items : Int
-    , controlListStyles : ( String, List Style )
-    , controlStyles : ( String, Bool -> List Style )
     , carouselType : CarouselType
     }
 
@@ -60,8 +58,6 @@ initSettings : Control Settings
 initSettings =
     Control.record Settings
         |> Control.field "items" (Debug.Control.Extra.int 4)
-        |> Control.field "controlListStyles" controlControlListStyles
-        |> Control.field "controlStyles" controlControlStyles
         |> Control.field "carouselType" controlCarouselType
 
 
@@ -72,16 +68,6 @@ controlCarouselType =
         , ( "viewWithTabControls", Control.value Tabs )
         , ( "viewWithCombinedControls", Control.value Combined )
         ]
-
-
-controlControlListStyles : Control ( String, List Style )
-controlControlListStyles =
-    ( "[ Css.displayFlex, Css.property \"gap\" \"20px\" ]"
-    , [ Css.displayFlex, Css.property "gap" "20px" ]
-    )
-        |> Control.value
-        |> Control.maybe False
-        |> Control.map (Maybe.withDefault ( "[]", [] ))
 
 
 controlStyles : Bool -> List Css.Style
@@ -101,19 +87,6 @@ controlStyles isSelected =
     , Css.color textColor
     , Css.cursor Css.pointer
     ]
-
-
-controlControlStyles : Control ( String, Bool -> List Css.Style )
-controlControlStyles =
-    let
-        simplifiedCodeVersion =
-            "\\isSelected -> [ -- styles that depend on selection status\n    ]"
-    in
-    controlStyles
-        |> Control.value
-        |> Control.maybe False
-        |> Control.map (Maybe.withDefault (\_ -> []))
-        |> Control.map (\v -> ( simplifiedCodeVersion, v ))
 
 
 type Msg
@@ -319,8 +292,8 @@ viewWithCombinedControls model =
             Carousel.viewWithCombinedControls
                 { selected = model.selected
                 , slides = List.map Tuple.second allItems
-                , tabControlListStyles = Tuple.second settings.controlListStyles
-                , tabControlStyles = Tuple.second settings.controlStyles
+                , tabControlStyles = \_ -> []
+                , tabControlListStyles = []
                 , previousButton =
                     { attributes = [], icon = UiIcon.arrowLeft, name = "Previous" }
                 , nextButton =
@@ -337,8 +310,8 @@ viewWithCombinedControls model =
             ++ Code.record
                 [ ( "selected", Code.int model.selected )
                 , ( "slides", Code.listMultiline (List.map Tuple.first allItems) 2 )
-                , ( "tabControlListStyles", Tuple.first settings.controlListStyles )
-                , ( "tabControlStyles", Tuple.first settings.controlStyles )
+                , ( "tabControlStyles", "(\\_ -> [])" )
+                , ( "tabControlListStyles", Code.list [] )
                 , ( "previousButton"
                   , Code.recordMultiline
                         [ ( "name", Code.string "Previous" )
@@ -386,8 +359,8 @@ viewWithTabControls model =
             Carousel.viewWithTabControls
                 { selected = model.selected
                 , slides = List.map Tuple.second allItems
-                , tabControlListStyles = Tuple.second settings.controlListStyles
-                , tabControlStyles = Tuple.second settings.controlStyles
+                , tabControlStyles = \_ -> []
+                , tabControlListStyles = []
                 , role = Carousel.Group
                 , name = "Items"
                 , visibleLabelId = Nothing
@@ -399,8 +372,8 @@ viewWithTabControls model =
             ++ Code.record
                 [ ( "selected", Code.int model.selected )
                 , ( "slides", Code.listMultiline (List.map Tuple.first allItems) 2 )
-                , ( "tabControlListStyles", Tuple.first settings.controlListStyles )
-                , ( "tabControlStyles", Tuple.first settings.controlStyles )
+                , ( "tabControlStyles", "(\\_ -> [])" )
+                , ( "tabControlListStyles", Code.list [] )
                 , ( "role", Code.fromModule moduleName "Group" )
                 , ( "name", "Items" )
                 , ( "visibleLabelId", Code.maybe Nothing )

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -257,7 +257,7 @@ viewWithPreviousAndNextControls model =
         { viewPreviousButton, viewNextButton, slides, containerAttributes } =
             Carousel.viewWithPreviousAndNextControls
                 { selected = model.selected
-                , panels = List.map Tuple.second allItems
+                , slides = List.map Tuple.second allItems
                 , previousButton =
                     { attributes = [], icon = UiIcon.arrowLeft, name = "Previous" }
                 , nextButton =
@@ -272,7 +272,7 @@ viewWithPreviousAndNextControls model =
         [ Code.fromModule moduleName "viewWithPreviousAndNextControls"
             ++ Code.recordMultiline
                 [ ( "selected", Code.string (String.fromInt model.selected) )
-                , ( "panels", Code.listMultiline (List.map Tuple.first allItems) 3 )
+                , ( "slides", Code.listMultiline (List.map Tuple.first allItems) 3 )
                 , ( "previousButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Previous\" }" )
                 , ( "nextButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Next\" }" )
                 , ( "accessibleLabel", "Items" )
@@ -307,7 +307,7 @@ viewWithCombinedControls model =
                 , selected = model.selected
                 , tabControlListStyles = Tuple.second settings.controlListStyles
                 , tabControlStyles = Tuple.second settings.controlStyles
-                , panels = List.map Tuple.second allItems
+                , slides = List.map Tuple.second allItems
                 , previousButton =
                     { attributes = [], icon = UiIcon.arrowLeft, name = "Previous" }
                 , nextButton =
@@ -323,7 +323,7 @@ viewWithCombinedControls model =
                 , ( "selected", Code.string (String.fromInt model.selected) )
                 , ( "tabControlListStyles", Tuple.first settings.controlListStyles )
                 , ( "tabControlStyles", Tuple.first settings.controlStyles )
-                , ( "panels", Code.listMultiline (List.map Tuple.first allItems) 2 )
+                , ( "slides", Code.listMultiline (List.map Tuple.first allItems) 2 )
                 , ( "previousButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Previous\" }" )
                 , ( "nextButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Next\" }" )
                 , ( "labelledBy", Code.fromModule moduleName "LabelledByIdOfVisibleLabel " ++ Code.string "Items" )
@@ -355,7 +355,7 @@ viewWithTabControls model =
                 , selected = model.selected
                 , tabControlListStyles = Tuple.second settings.controlListStyles
                 , tabControlStyles = Tuple.second settings.controlStyles
-                , panels = List.map Tuple.second allItems
+                , slides = List.map Tuple.second allItems
                 , labelledBy = Carousel.LabelledByIdOfVisibleLabel "Items"
                 , role = Carousel.Group
                 }
@@ -367,7 +367,7 @@ viewWithTabControls model =
                 , ( "selected", Code.string (String.fromInt model.selected) )
                 , ( "tabControlListStyles", Tuple.first settings.controlListStyles )
                 , ( "tabControlStyles", Tuple.first settings.controlStyles )
-                , ( "panels", Code.listMultiline (List.map Tuple.first allItems) 2 )
+                , ( "slides", Code.listMultiline (List.map Tuple.first allItems) 2 )
                 , ( "labelledBy", Code.fromModule moduleName "LabelledByIdOfVisibleLabel " ++ Code.string "Items" )
                 , ( "role", Code.fromModule moduleName "Group" )
                 ]

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -537,7 +537,7 @@ toNonTabbedCarouselItem :
           , idString : String
           , name : String
           , visibleLabelId : Maybe String
-          , slideHtml : Html msg
+          , slideView : Html msg
           }
         )
 toNonTabbedCarouselItem id =
@@ -553,14 +553,14 @@ toNonTabbedCarouselItem id =
         , ( "idString", Code.string (String.fromInt id) )
         , ( "name", Code.string ("Slide " ++ humanizedId) )
         , ( "visibleLabelId", Code.maybe Nothing )
-        , ( "slideHtml", "Html.text " ++ Code.string ("Contents for slide " ++ humanizedId) )
+        , ( "slideView", "Html.text " ++ Code.string ("Contents for slide " ++ humanizedId) )
         ]
         4
     , { id = id
       , idString = idString
       , name = "Slide " ++ humanizedId
       , visibleLabelId = Nothing
-      , slideHtml = Html.text ("Contents for slide " ++ humanizedId)
+      , slideView = Html.text ("Contents for slide " ++ humanizedId)
       }
     )
 
@@ -571,8 +571,8 @@ toTabbedCarouselItem :
         ( String
         , { id : Int
           , idString : String
-          , slideHtml : Html msg
-          , tabControlHtml : Html Never
+          , slideView : Html msg
+          , tabView : Html Never
           }
         )
 toTabbedCarouselItem id =
@@ -586,14 +586,14 @@ toTabbedCarouselItem id =
     ( Code.recordMultiline
         [ ( "id", Code.int id )
         , ( "idString", Code.string (String.fromInt id) )
-        , ( "tabControlHtml", "Html.text " ++ Code.string ("Slide " ++ humanizedId) )
-        , ( "slideHtml", "Html.text " ++ Code.string ("Contents for slide " ++ humanizedId) )
+        , ( "tabView", "Html.text " ++ Code.string ("Slide " ++ humanizedId) )
+        , ( "slideView", "Html.text " ++ Code.string ("Contents for slide " ++ humanizedId) )
         ]
         3
     , { id = id
       , idString = idString
-      , tabControlHtml = Html.text ("Slide " ++ humanizedId)
-      , slideHtml = Html.text ("Contents for slide " ++ humanizedId)
+      , tabView = Html.text ("Slide " ++ humanizedId)
+      , slideView = Html.text ("Contents for slide " ++ humanizedId)
       }
     )
 
@@ -606,8 +606,8 @@ toCombinedCarouselItem :
           , idString : String
           , name : String
           , visibleLabelId : Maybe String
-          , slideHtml : Html msg
-          , tabControlHtml : Html Never
+          , slideView : Html msg
+          , tabView : Html Never
           }
         )
 toCombinedCarouselItem id =
@@ -623,16 +623,16 @@ toCombinedCarouselItem id =
         , ( "idString", Code.string (String.fromInt id) )
         , ( "name", Code.string ("Slide " ++ humanizedId) )
         , ( "visibleLabelId", Code.maybe Nothing )
-        , ( "tabControlHtml", "Html.text " ++ Code.string ("Slide " ++ humanizedId) )
-        , ( "slideHtml", "Html.text " ++ Code.string ("Contents for slide " ++ humanizedId) )
+        , ( "tabView", "Html.text " ++ Code.string ("Slide " ++ humanizedId) )
+        , ( "slideView", "Html.text " ++ Code.string ("Contents for slide " ++ humanizedId) )
         ]
         3
     , { id = id
       , idString = idString
       , name = "Slide " ++ humanizedId
       , visibleLabelId = Nothing
-      , tabControlHtml = Html.text ("Slide " ++ humanizedId)
-      , slideHtml = Html.text ("Contents for slide " ++ humanizedId)
+      , tabView = Html.text ("Slide " ++ humanizedId)
+      , slideView = Html.text ("Contents for slide " ++ humanizedId)
       }
     )
 
@@ -648,19 +648,19 @@ viewTips selected =
                       , idString = "avoid-white-after-labor-day"
                       , name = "Avoid White After Labor Day"
                       , visibleLabelId = Nothing
-                      , slideHtml = text "Avoid wearing white after Labor Day"
+                      , slideView = text "Avoid wearing white after Labor Day"
                       }
                     , { id = AvoidNavyAndBlack
                       , idString = "avoid-navy-and-black"
                       , name = "Avoid pairing navy and black"
                       , visibleLabelId = Nothing
-                      , slideHtml = text "Avoid pairing navy and black"
+                      , slideView = text "Avoid pairing navy and black"
                       }
                     , { id = TailorOffTheShelfClothes
                       , idString = "tailor-off-the-shelf-clothes"
                       , name = "Tailor off the shelf clothes"
                       , visibleLabelId = Nothing
-                      , slideHtml = text "Tailor off the shelf clothes"
+                      , slideView = text "Tailor off the shelf clothes"
                       }
                     ]
                 , previousButton =
@@ -721,18 +721,18 @@ viewTestimonials selected =
                 , slides =
                     [ { id = GreatService
                       , idString = "great-service"
-                      , slideHtml = text "Great service!"
-                      , tabControlHtml = span Style.invisible [ text "Testimonial 1" ]
+                      , slideView = text "Great service!"
+                      , tabView = span Style.invisible [ text "Testimonial 1" ]
                       }
                     , { id = GreatProduct
                       , idString = "great-product"
-                      , slideHtml = text "Great product!"
-                      , tabControlHtml = span Style.invisible [ text "Testimonial 2" ]
+                      , slideView = text "Great product!"
+                      , tabView = span Style.invisible [ text "Testimonial 2" ]
                       }
                     , { id = GreatMission
                       , idString = "great-mission"
-                      , slideHtml = text "Great mission!"
-                      , tabControlHtml = span Style.invisible [ text "Testimonial 3" ]
+                      , slideView = text "Great mission!"
+                      , tabView = span Style.invisible [ text "Testimonial 3" ]
                       }
                     ]
                 , tabStyles = tabStyles
@@ -770,22 +770,22 @@ viewPackages selected =
                       , idString = "free-trial"
                       , name = "Free trial"
                       , visibleLabelId = Nothing
-                      , slideHtml = text "Free trial"
-                      , tabControlHtml = span Style.invisible [ text "Free trial" ]
+                      , slideView = text "Free trial"
+                      , tabView = span Style.invisible [ text "Free trial" ]
                       }
                     , { id = DeveloperTier
                       , idString = "developer-tier"
                       , name = "Developer Tier"
                       , visibleLabelId = Nothing
-                      , slideHtml = text "Developer Tier"
-                      , tabControlHtml = span Style.invisible [ text "Developer tier" ]
+                      , slideView = text "Developer Tier"
+                      , tabView = span Style.invisible [ text "Developer tier" ]
                       }
                     , { id = EnterpriseTier
                       , idString = "enterprise-tier"
                       , name = "Enterprise Tier"
                       , visibleLabelId = Nothing
-                      , slideHtml = text "Enterprise Tier"
-                      , tabControlHtml = span Style.invisible [ text "Enterprise tier" ]
+                      , slideView = text "Enterprise Tier"
+                      , tabView = span Style.invisible [ text "Enterprise tier" ]
                       }
                     ]
                 , tabStyles = tabStyles

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -243,7 +243,7 @@ viewWithPreviousAndNextControls model =
                     { attributes = [], icon = UiIcon.arrowLeft, name = "Previous" }
                 , nextButton =
                     { attributes = [], icon = UiIcon.arrowRight, name = "Next" }
-                , accessibleLabel = "Items"
+                , name = "Items"
                 , visibleLabelId = Nothing
                 , role = Carousel.Group
                 , announceAndSelect = AnnounceAndSelect
@@ -256,7 +256,7 @@ viewWithPreviousAndNextControls model =
                 , ( "slides", Code.listMultiline (List.map Tuple.first allItems) 3 )
                 , ( "previousButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Previous\" }" )
                 , ( "nextButton", "{ attributes = [], icon = UiIcon.arrowLeft , name = \"Next\" }" )
-                , ( "accessibleLabel", "Items" )
+                , ( "name", "Items" )
                 , ( "visibleLabelId", "Nothing" )
                 , ( "role", Code.fromModule moduleName "Group" )
                 , ( "focusAndSelect", "FocusAndSelectItem" )
@@ -294,7 +294,7 @@ viewWithCombinedControls model =
                 , nextButton =
                     { attributes = [], icon = UiIcon.arrowRight, name = "Next" }
                 , role = Carousel.Group
-                , accessibleLabel = "Items"
+                , name = "Items"
                 , visibleLabelId = Nothing
                 , focusAndSelect = FocusAndSelectItem
                 , announceAndSelect = AnnounceAndSelect
@@ -342,7 +342,7 @@ viewWithTabControls model =
                 , tabControlListStyles = Tuple.second settings.controlListStyles
                 , tabControlStyles = Tuple.second settings.controlStyles
                 , role = Carousel.Group
-                , accessibleLabel = "Items"
+                , name = "Items"
                 , visibleLabelId = Nothing
                 }
     in
@@ -378,7 +378,7 @@ toNonTabbedCarouselItem :
         ( String
         , { id : Int
           , idString : String
-          , accessibleLabel : String
+          , name : String
           , visibleLabelId : Maybe String
           , slideHtml : Html msg
           }
@@ -394,14 +394,14 @@ toNonTabbedCarouselItem id =
     ( Code.recordMultiline
         [ ( "id", Code.int id )
         , ( "idString", Code.string (String.fromInt id) )
-        , ( "accessibleLabel", Code.string ("Slide " ++ humanizedId) )
+        , ( "name", Code.string ("Slide " ++ humanizedId) )
         , ( "visibleLabelId", Code.maybe Nothing )
         , ( "slideHtml", "Html.text " ++ Code.string ("Contents for slide " ++ humanizedId) )
         ]
         2
     , { id = id
       , idString = idString
-      , accessibleLabel = "Slide " ++ humanizedId
+      , name = "Slide " ++ humanizedId
       , visibleLabelId = Nothing
       , slideHtml = Html.text ("Contents for slide " ++ humanizedId)
       }
@@ -414,7 +414,7 @@ toTabbedCarouselItem :
         ( String
         , { id : Int
           , idString : String
-          , accessibleLabel : String
+          , name : String
           , visibleLabelId : Maybe String
           , slideHtml : Html msg
           , tabControlHtml : Html Never
@@ -431,7 +431,7 @@ toTabbedCarouselItem id =
     ( Code.recordMultiline
         [ ( "id", Code.int id )
         , ( "idString", Code.string (String.fromInt id) )
-        , ( "accessibleLabel", Code.string ("Slide " ++ humanizedId) )
+        , ( "name", Code.string ("Slide " ++ humanizedId) )
         , ( "visibleLabelId", Code.maybe Nothing )
         , ( "tabControlHtml", "Html.text " ++ Code.string ("Slide " ++ humanizedId) )
         , ( "slideHtml", "Html.text " ++ Code.string ("Contents for slide " ++ humanizedId) )
@@ -439,7 +439,7 @@ toTabbedCarouselItem id =
         2
     , { id = id
       , idString = idString
-      , accessibleLabel = "Slide " ++ humanizedId
+      , name = "Slide " ++ humanizedId
       , visibleLabelId = Nothing
       , tabControlHtml = Html.text ("Slide " ++ humanizedId)
       , slideHtml = Html.text ("Contents for slide " ++ humanizedId)

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -285,57 +285,39 @@ viewWithCombinedControls config =
         { controls, slides, containerAttributes } =
             viewWithTabControls config
 
-        -- let's de duplicate this!
-        currentSlideIndex =
-            List.Extra.findIndex (\p -> p.id == config.selected) config.slides
+        { viewPreviousButton, viewNextButton } =
+            case findPreviousAndNextSlides .id config of
+                Nothing ->
+                    { viewPreviousButton = text "", viewNextButton = text "" }
 
-        previousSlide =
-            currentSlideIndex
-                |> Maybe.andThen
-                    (\index ->
-                        List.Extra.getAt
-                            (if index - 1 >= 0 then
-                                index - 1
-
-                             else
-                                List.length config.slides - 1
-                            )
-                            config.slides
-                    )
-
-        nextSlide =
-            currentSlideIndex
-                |> Maybe.andThen
-                    (\index ->
-                        List.Extra.getAt
-                            (if index + 1 < List.length config.slides then
-                                index + 1
-
-                             else
-                                0
-                            )
-                            config.slides
-                    )
+                Just { previousSlide, nextSlide } ->
+                    { viewPreviousButton =
+                        viewSlideChangeButton
+                            { name = config.previousButton.name
+                            , icon = config.previousButton.icon
+                            , attributes = config.previousButton.attributes
+                            , targetSlideId = previousSlide.id
+                            , targetSlideLabel = previousSlide.accessibleLabel
+                            , carouselLabel = config.accessibleLabel
+                            , announceAndSelect = config.announceAndSelect
+                            }
+                    , viewNextButton =
+                        viewSlideChangeButton
+                            { name = config.nextButton.name
+                            , icon = config.nextButton.icon
+                            , attributes = config.nextButton.attributes
+                            , targetSlideId = nextSlide.id
+                            , targetSlideLabel = nextSlide.accessibleLabel
+                            , carouselLabel = config.accessibleLabel
+                            , announceAndSelect = config.announceAndSelect
+                            }
+                    }
     in
     { tabControls = controls
     , slides = slides
     , containerAttributes = containerAttributes
-    , viewPreviousButton =
-        ClickableSvg.button config.previousButton.name
-            config.previousButton.icon
-            (config.previousButton.attributes
-                ++ (Maybe.map (\p -> ClickableSvg.onClick (config.focusAndSelect { select = p.id, focus = Just p.idString })) previousSlide
-                        |> Maybe.Extra.toList
-                   )
-            )
-    , viewNextButton =
-        ClickableSvg.button config.nextButton.name
-            config.nextButton.icon
-            (config.nextButton.attributes
-                ++ (Maybe.map (\p -> ClickableSvg.onClick (config.focusAndSelect { select = p.id, focus = Just p.idString })) nextSlide
-                        |> Maybe.Extra.toList
-                   )
-            )
+    , viewPreviousButton = viewPreviousButton
+    , viewNextButton = viewNextButton
     }
 
 

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -136,7 +136,7 @@ viewWithPreviousAndNextControls config =
 {-| Builds a carousel with tab buttons
 Returns:
 
-  - `controls`: tabs control buttons
+  - `tabs`: tabs control buttons
   - `slides` container with the carousel contents
   - `containerAttributes` attributes that should be used on the parent div of both the button and slides elements
 
@@ -158,7 +158,7 @@ viewWithTabControls :
     , focusAndSelect : { select : id, focus : Maybe String } -> msg
     }
     ->
-        { controls : Html msg
+        { tabs : Html msg
         , slides : Html msg
         , containerAttributes : List (Attribute msg)
         }
@@ -179,7 +179,7 @@ viewWithTabControls config =
                 , tabListStyles = config.tabControlListStyles
                 }
     in
-    { controls = tabList
+    { tabs = tabList
     , slides = tabPanels
     , containerAttributes =
         [ roleAttribute config.role
@@ -192,7 +192,7 @@ viewWithTabControls config =
 {-| Builds a carousel with tab buttons
 Returns:
 
-  - `tabControls`: tabs control buttons
+  - `tabs`: tabs control buttons
   - `slides` container with the carousel contents
   - `viewPreviousButton` previous button
   - `viewNextButton` next button
@@ -220,7 +220,7 @@ viewWithCombinedControls :
     , select : { select : id, announce : Maybe String, focus : Maybe String } -> msg
     }
     ->
-        { tabControls : Html msg
+        { tabs : Html msg
         , viewPreviousButton : Html msg
         , viewNextButton : Html msg
         , slides : Html msg
@@ -244,7 +244,7 @@ viewWithCombinedControls config =
                     , focus = Nothing
                     }
 
-        { controls, slides, containerAttributes } =
+        { tabs, slides, containerAttributes } =
             viewWithTabControls
                 { selected = config.selected
                 , slides =
@@ -293,7 +293,7 @@ viewWithCombinedControls config =
                             }
                     }
     in
-    { tabControls = controls
+    { tabs = tabs
     , slides = slides
     , containerAttributes = containerAttributes
     , viewPreviousButton = viewPreviousButton

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -18,6 +18,7 @@ module Nri.Ui.Carousel.V2 exposing
 
 import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Key
+import Accessibility.Styled.Landmark as Landmark
 import Accessibility.Styled.Role as Role
 import Css exposing (..)
 import Html.Styled as Html exposing (..)
@@ -322,7 +323,7 @@ roleAttribute role =
             Role.group
 
         Region ->
-            Attrs.attribute "role" "region"
+            Landmark.region
 
 
 findPreviousAndNextSlides :

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -2,7 +2,7 @@ module Nri.Ui.Carousel.V2 exposing
     ( viewWithPreviousAndNextControls
     , viewWithTabControls
     , viewWithCombinedControls
-    , LabelledBy(..), Role(..)
+    , Role(..)
     )
 
 {-| Patch changes:
@@ -12,7 +12,7 @@ module Nri.Ui.Carousel.V2 exposing
 @docs viewWithPreviousAndNextControls
 @docs viewWithTabControls
 @docs viewWithCombinedControls
-@docs LabelledBy, Role
+@docs Role
 
 -}
 
@@ -23,19 +23,9 @@ import Css exposing (..)
 import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes as Attrs exposing (id)
 import List.Extra
-import Maybe.Extra
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Svg.V1 exposing (Svg)
 import TabsInternal.V2 as TabsInternal
-
-
-{-| Type which represents the type of aria label which will be used
-`LabelledByIdOfVisibleLabel` will point to an existing element id on the DOM
-`LabelledByAccessibleLabelOnly` will be a label of the element
--}
-type LabelledBy
-    = LabelledByIdOfVisibleLabel String
-    | LabelledByAccessibleLabelOnly String
 
 
 {-| `Role`, which can be either [Group](https://w3c.github.io/aria/#group) or [Region](https://w3c.github.io/aria/#region)

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -129,57 +129,6 @@ viewWithPreviousAndNextControls config =
     }
 
 
-findPreviousAndNextSlides :
-    (slide -> id)
-    -> { config | selected : id, slides : List slide }
-    -> Maybe { previousSlide : slide, nextSlide : slide }
-findPreviousAndNextSlides getId { selected, slides } =
-    let
-        currentIndex =
-            slides
-                |> List.Extra.findIndex (\slide -> getId slide == selected)
-                |> -- assuming the provided id is valid. there's not much we can
-                   -- do otherwise, anyways!
-                   Maybe.withDefault 0
-
-        length =
-            List.length slides
-
-        getByIndexWrappingAround index =
-            List.Extra.getAt (modBy length index) slides
-    in
-    case ( getByIndexWrappingAround (currentIndex - 1), getByIndexWrappingAround (currentIndex + 1) ) of
-        ( Just a, Just b ) ->
-            Just { previousSlide = a, nextSlide = b }
-
-        _ ->
-            Nothing
-
-
-viewSlideChangeButton :
-    { name : String
-    , icon : Svg
-    , attributes : List (ClickableSvg.Attribute msg)
-    , targetSlideId : id
-    , targetSlideLabel : String
-    , carouselLabel : String
-    , announceAndSelect : { select : id, announce : String } -> msg
-    }
-    -> Html msg
-viewSlideChangeButton { name, icon, attributes, targetSlideId, targetSlideLabel, carouselLabel, announceAndSelect } =
-    ClickableSvg.button name
-        icon
-        (attributes
-            ++ [ ClickableSvg.onClick
-                    (announceAndSelect
-                        { select = targetSlideId
-                        , announce = "Active slide of " ++ carouselLabel ++ " changed to " ++ targetSlideLabel
-                        }
-                    )
-               ]
-        )
-
-
 {-| Builds a carousel with tab buttons
 Returns:
 
@@ -334,3 +283,54 @@ roleToString role =
 
         Region ->
             "region"
+
+
+findPreviousAndNextSlides :
+    (slide -> id)
+    -> { config | selected : id, slides : List slide }
+    -> Maybe { previousSlide : slide, nextSlide : slide }
+findPreviousAndNextSlides getId { selected, slides } =
+    let
+        currentIndex =
+            slides
+                |> List.Extra.findIndex (\slide -> getId slide == selected)
+                |> -- assuming the provided id is valid. there's not much we can
+                   -- do otherwise, anyways!
+                   Maybe.withDefault 0
+
+        length =
+            List.length slides
+
+        getByIndexWrappingAround index =
+            List.Extra.getAt (modBy length index) slides
+    in
+    case ( getByIndexWrappingAround (currentIndex - 1), getByIndexWrappingAround (currentIndex + 1) ) of
+        ( Just a, Just b ) ->
+            Just { previousSlide = a, nextSlide = b }
+
+        _ ->
+            Nothing
+
+
+viewSlideChangeButton :
+    { name : String
+    , icon : Svg
+    , attributes : List (ClickableSvg.Attribute msg)
+    , targetSlideId : id
+    , targetSlideLabel : String
+    , carouselLabel : String
+    , announceAndSelect : { select : id, announce : String } -> msg
+    }
+    -> Html msg
+viewSlideChangeButton { name, icon, attributes, targetSlideId, targetSlideLabel, carouselLabel, announceAndSelect } =
+    ClickableSvg.button name
+        icon
+        (attributes
+            ++ [ ClickableSvg.onClick
+                    (announceAndSelect
+                        { select = targetSlideId
+                        , announce = "Active slide of " ++ carouselLabel ++ " changed to " ++ targetSlideLabel
+                        }
+                    )
+               ]
+        )

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -126,7 +126,7 @@ viewWithPreviousAndNextControls config =
                 config.slides
             )
     , containerAttributes =
-        [ Attrs.attribute "role" (roleToString config.role)
+        [ roleToString config.role
         , Aria.roleDescription "carousel"
         , labelAttribute config
         ]
@@ -181,7 +181,7 @@ viewWithTabControls config =
     { controls = tabList
     , slides = tabPanels
     , containerAttributes =
-        [ Attrs.attribute "role" (roleToString config.role)
+        [ roleToString config.role
         , Aria.roleDescription "carousel"
         , labelAttribute config
         ]
@@ -294,14 +294,14 @@ labelAttribute { name, visibleLabelId } =
             Aria.label name
 
 
-roleToString : Role -> String
+roleToString : Role -> Html.Attribute msg
 roleToString role =
     case role of
         Group ->
-            "group"
+            Role.group
 
         Region ->
-            "region"
+            Attrs.attribute "role" "region"
 
 
 findPreviousAndNextSlides :

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -60,8 +60,8 @@ viewWithPreviousAndNextControls :
             , slideHtml : Html msg
             , labelledBy : LabelledBy
             }
-    , previousButton : { attributes : List (ClickableSvg.Attribute msg), icon : Svg, name : String }
-    , nextButton : { attributes : List (ClickableSvg.Attribute msg), icon : Svg, name : String }
+    , previousButton : { name : String, icon : Svg, attributes : List (ClickableSvg.Attribute msg) }
+    , nextButton : { name : String, icon : Svg, attributes : List (ClickableSvg.Attribute msg) }
     , labelledBy : LabelledBy
     , role : Role
     , focusAndSelect : { select : id, focus : Maybe String } -> msg
@@ -221,8 +221,8 @@ viewWithCombinedControls :
     , focusAndSelect : { select : id, focus : Maybe String } -> msg
     , tabControlStyles : Bool -> List Style
     , tabControlListStyles : List Style
-    , previousButton : { attributes : List (ClickableSvg.Attribute msg), icon : Svg, name : String }
-    , nextButton : { attributes : List (ClickableSvg.Attribute msg), icon : Svg, name : String }
+    , previousButton : { name : String, icon : Svg, attributes : List (ClickableSvg.Attribute msg) }
+    , nextButton : { name : String, icon : Svg, attributes : List (ClickableSvg.Attribute msg) }
     , role : Role
     , labelledBy : LabelledBy
     }

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -16,7 +16,7 @@ import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Role as Role
 import Css exposing (..)
 import Html.Styled as Html exposing (..)
-import Html.Styled.Attributes as Attrs exposing (css, id)
+import Html.Styled.Attributes as Attrs exposing (id)
 import List.Extra
 import Maybe.Extra
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -181,8 +181,10 @@ viewSlideChangeButton { name, icon, attributes, targetSlideId, targetSlideLabel,
 
 {-| Builds a carousel with tab buttons
 Returns:
-`controls`: tabs control buttons
-`slides` container with the carousel contents
+
+  - `controls`: tabs control buttons
+  - `slides` container with the carousel contents
+
 -}
 viewWithTabControls :
     { cfg
@@ -237,10 +239,12 @@ viewWithTabControls config =
 
 {-| Builds a carousel with tab buttons
 Returns:
-`tabControls`: tabs control buttons
-`slides` container with the carousel contents
-`viewPreviousButton` previous button
-`viewNextButton` next button
+
+  - `tabControls`: tabs control buttons
+  - `slides` container with the carousel contents
+  - `viewPreviousButton` previous button
+  - `viewNextButton` next button
+
 -}
 viewWithCombinedControls :
     { selected : id

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -1,14 +1,18 @@
 module Nri.Ui.Carousel.V2 exposing
-    ( viewWithCombinedControls, viewWithPreviousAndNextControls
-    , viewWithTabControls, LabelledBy(..), Role(..)
+    ( viewWithPreviousAndNextControls
+    , viewWithTabControls
+    , viewWithCombinedControls
+    , LabelledBy(..), Role(..)
     )
 
 {-| Patch changes:
 
   - added new carousel APIs (with tabbed controls/previous and next controls, and combined controls) using [W3C guidelines](https://www.w3.org/WAI/ARIA/apg/patterns/carousel/)
 
-@docs viewWithCombinedControls, viewWithPreviousAndNextControls
-@docs viewWithTabControls, LabelledBy, Role
+@docs viewWithPreviousAndNextControls
+@docs viewWithTabControls
+@docs viewWithCombinedControls
+@docs LabelledBy, Role
 
 -}
 

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -126,7 +126,7 @@ viewWithPreviousAndNextControls config =
                 config.slides
             )
     , containerAttributes =
-        [ roleToString config.role
+        [ roleAttribute config.role
         , Aria.roleDescription "carousel"
         , labelAttribute config
         ]
@@ -182,7 +182,7 @@ viewWithTabControls config =
     { controls = tabList
     , slides = tabPanels
     , containerAttributes =
-        [ roleToString config.role
+        [ roleAttribute config.role
         , Aria.roleDescription "carousel"
         , labelAttribute config
         ]
@@ -296,8 +296,8 @@ labelAttribute { name, visibleLabelId } =
             Aria.label name
 
 
-roleToString : Role -> Html.Attribute msg
-roleToString role =
+roleAttribute : Role -> Html.Attribute msg
+roleAttribute role =
     case role of
         Group ->
             Role.group

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -125,13 +125,13 @@ viewWithPreviousAndNextControls config =
                     , Aria.roleDescription "slide"
                     , id panel.idString
                     , labelledByToAttr panel.labelledBy
-                    , css
-                        [ if config.selected == panel.id then
-                            Css.display Css.block
 
-                          else
-                            Css.display Css.none
-                        ]
+                    -- use as attribute for testing
+                    , if config.selected == panel.id then
+                        Attrs.style "display" "block"
+
+                      else
+                        Attrs.style "display" "none"
                     ]
                     [ panel.slideHtml ]
             )

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -22,6 +22,7 @@ import Maybe.Extra
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Svg.V1 exposing (Svg)
 import TabsInternal.V2 as TabsInternal
+import Accessibility.Styled.Key
 
 
 {-| Type which represents the type of aria label which will be used
@@ -136,7 +137,7 @@ viewWithPreviousAndNextControls config =
                     [ panel.slideHtml ]
             )
             config.panels
-            |> Html.div [ Attrs.attribute "atomic" "false", Attrs.attribute "live" "polite" ]
+            |> Html.div [ Attrs.attribute "atomic" "false", Accessibility.Styled.Key.tabbable False ]
     , containerAttributes =
         [ Attrs.attribute "role" (roleToString config.role)
         , Aria.roleDescription "carousel"

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -206,12 +206,12 @@ viewWithTabControls :
                 , slideHtml : Html msg
                 , tabControlHtml : Html Never
                 }
-        , focusAndSelect : { select : id, focus : Maybe String } -> msg
         , tabControlStyles : Bool -> List Style
         , tabControlListStyles : List Style
         , role : Role
         , accessibleLabel : String
         , visibleLabelId : Maybe String
+        , focusAndSelect : { select : id, focus : Maybe String } -> msg
     }
     ->
         { controls : Html msg

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -70,7 +70,7 @@ viewWithPreviousAndNextControls :
     , accessibleLabel : String
     , visibleLabelId : Maybe String
     , role : Role
-    , selectAndAnnounce : { select : id, announce : String } -> msg
+    , announceAndSelect : { select : id, announce : String } -> msg
     }
     ->
         { viewPreviousButton : Html msg
@@ -94,7 +94,7 @@ viewWithPreviousAndNextControls config =
                             , targetSlideId = previousSlide.id
                             , targetSlideLabel = previousSlide.accessibleLabel
                             , carouselLabel = config.accessibleLabel
-                            , selectAndAnnounce = config.selectAndAnnounce
+                            , announceAndSelect = config.announceAndSelect
                             }
                     , viewNextButton =
                         viewSlideChangeButton
@@ -104,7 +104,7 @@ viewWithPreviousAndNextControls config =
                             , targetSlideId = nextSlide.id
                             , targetSlideLabel = nextSlide.accessibleLabel
                             , carouselLabel = config.accessibleLabel
-                            , selectAndAnnounce = config.selectAndAnnounce
+                            , announceAndSelect = config.announceAndSelect
                             }
                     }
     in
@@ -172,15 +172,15 @@ viewSlideChangeButton :
     , targetSlideId : id
     , targetSlideLabel : String
     , carouselLabel : String
-    , selectAndAnnounce : { select : id, announce : String } -> msg
+    , announceAndSelect : { select : id, announce : String } -> msg
     }
     -> Html msg
-viewSlideChangeButton { name, icon, attributes, targetSlideId, targetSlideLabel, carouselLabel, selectAndAnnounce } =
+viewSlideChangeButton { name, icon, attributes, targetSlideId, targetSlideLabel, carouselLabel, announceAndSelect } =
     ClickableSvg.button name
         icon
         (attributes
             ++ [ ClickableSvg.onClick
-                    (selectAndAnnounce
+                    (announceAndSelect
                         { select = targetSlideId
                         , announce = "Active slide of " ++ carouselLabel ++ " changed to " ++ targetSlideLabel
                         }

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -57,7 +57,7 @@ Returns:
 -}
 viewWithPreviousAndNextControls :
     { selected : id
-    , panels :
+    , slides :
         List
             { id : id
             , idString : String
@@ -80,16 +80,16 @@ viewWithPreviousAndNextControls :
         }
 viewWithPreviousAndNextControls config =
     let
-        currentPanelIndex =
-            config.panels
+        currentSlideIndex =
+            config.slides
                 |> List.Extra.findIndex (\p -> p.id == config.selected)
                 |> -- assuming the provided id is valid. there's not much we can
                    -- do otherwise, anyways!
                    Maybe.withDefault 0
 
         viewSlideChangeButtonWithDelta delta buttonConfig =
-            config.panels
-                |> List.Extra.getAt (modBy (List.length config.panels) (currentPanelIndex + delta))
+            config.slides
+                |> List.Extra.getAt (modBy (List.length config.slides) (currentSlideIndex + delta))
                 |> Maybe.map
                     (\slide ->
                         viewSlideChangeButton
@@ -106,23 +106,23 @@ viewWithPreviousAndNextControls config =
     , viewNextButton = viewSlideChangeButtonWithDelta 1 config.nextButton
     , slides =
         List.map
-            (\panel ->
+            (\slide ->
                 Html.div
                     [ Role.group
                     , Aria.roleDescription "slide"
-                    , id panel.idString
-                    , labelAttribute panel
+                    , id slide.idString
+                    , labelAttribute slide
 
                     -- use as attribute for testing
-                    , if config.selected == panel.id then
+                    , if config.selected == slide.id then
                         Attrs.style "display" "block"
 
                       else
                         Attrs.style "display" "none"
                     ]
-                    [ panel.slideHtml ]
+                    [ slide.slideHtml ]
             )
-            config.panels
+            config.slides
             |> Html.div [ Attrs.attribute "atomic" "false", Accessibility.Styled.Key.tabbable False ]
     , containerAttributes =
         [ Attrs.attribute "role" (roleToString config.role)
@@ -162,7 +162,7 @@ Returns:
 viewWithTabControls :
     { cfg
         | selected : id
-        , panels :
+        , slides :
             List
                 { id : id
                 , slideHtml : Html msg
@@ -192,7 +192,7 @@ viewWithTabControls config =
             TabsInternal.views
                 { focusAndSelect = config.focusAndSelect
                 , selected = config.selected
-                , tabs = List.map buildTab config.panels
+                , tabs = List.map buildTab config.slides
                 , tabStyles = always config.tabControlStyles
                 , tabListStyles = config.tabControlListStyles
                 }
@@ -216,7 +216,7 @@ Returns:
 -}
 viewWithCombinedControls :
     { selected : id
-    , panels :
+    , slides :
         List
             { id : id
             , slideHtml : Html msg
@@ -244,11 +244,11 @@ viewWithCombinedControls config =
             viewWithTabControls config
 
         -- let's de duplicate this!
-        currentPanelIndex =
-            List.Extra.findIndex (\p -> p.id == config.selected) config.panels
+        currentSlideIndex =
+            List.Extra.findIndex (\p -> p.id == config.selected) config.slides
 
-        previousPanel =
-            currentPanelIndex
+        previousSlide =
+            currentSlideIndex
                 |> Maybe.andThen
                     (\index ->
                         List.Extra.getAt
@@ -256,23 +256,23 @@ viewWithCombinedControls config =
                                 index - 1
 
                              else
-                                List.length config.panels - 1
+                                List.length config.slides - 1
                             )
-                            config.panels
+                            config.slides
                     )
 
-        nextPanel =
-            currentPanelIndex
+        nextSlide =
+            currentSlideIndex
                 |> Maybe.andThen
                     (\index ->
                         List.Extra.getAt
-                            (if index + 1 < List.length config.panels then
+                            (if index + 1 < List.length config.slides then
                                 index + 1
 
                              else
                                 0
                             )
-                            config.panels
+                            config.slides
                     )
     in
     { tabControls = controls
@@ -282,7 +282,7 @@ viewWithCombinedControls config =
         ClickableSvg.button config.previousButton.name
             config.previousButton.icon
             (config.previousButton.attributes
-                ++ (Maybe.map (\p -> ClickableSvg.onClick (config.focusAndSelect { select = p.id, focus = Just p.idString })) previousPanel
+                ++ (Maybe.map (\p -> ClickableSvg.onClick (config.focusAndSelect { select = p.id, focus = Just p.idString })) previousSlide
                         |> Maybe.Extra.toList
                    )
             )
@@ -290,7 +290,7 @@ viewWithCombinedControls config =
         ClickableSvg.button config.nextButton.name
             config.nextButton.icon
             (config.nextButton.attributes
-                ++ (Maybe.map (\p -> ClickableSvg.onClick (config.focusAndSelect { select = p.id, focus = Just p.idString })) nextPanel
+                ++ (Maybe.map (\p -> ClickableSvg.onClick (config.focusAndSelect { select = p.id, focus = Just p.idString })) nextSlide
                         |> Maybe.Extra.toList
                    )
             )

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -137,23 +137,22 @@ Returns:
 
 -}
 viewWithTabControls :
-    { cfg
-        | selected : id
-        , slides :
-            List
-                { id : id
-                , idString : String
-                , name : String
-                , visibleLabelId : Maybe String
-                , slideHtml : Html msg
-                , tabControlHtml : Html Never
-                }
-        , tabControlStyles : Bool -> List Style
-        , tabControlListStyles : List Style
-        , role : Role
-        , name : String
-        , visibleLabelId : Maybe String
-        , focusAndSelect : { select : id, focus : Maybe String } -> msg
+    { selected : id
+    , slides :
+        List
+            { id : id
+            , idString : String
+            , name : String
+            , visibleLabelId : Maybe String
+            , slideHtml : Html msg
+            , tabControlHtml : Html Never
+            }
+    , tabControlStyles : Bool -> List Style
+    , tabControlListStyles : List Style
+    , role : Role
+    , name : String
+    , visibleLabelId : Maybe String
+    , focusAndSelect : { select : id, focus : Maybe String } -> msg
     }
     ->
         { controls : Html msg
@@ -227,7 +226,16 @@ viewWithCombinedControls :
 viewWithCombinedControls config =
     let
         { controls, slides, containerAttributes } =
-            viewWithTabControls config
+            viewWithTabControls
+                { selected = config.selected
+                , slides = config.slides
+                , tabControlStyles = config.tabControlStyles
+                , tabControlListStyles = config.tabControlListStyles
+                , role = config.role
+                , name = config.name
+                , visibleLabelId = config.visibleLabelId
+                , focusAndSelect = config.focusAndSelect
+                }
 
         { viewPreviousButton, viewNextButton } =
             case findPreviousAndNextSlides .id config of

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -310,7 +310,11 @@ findPreviousAndNextSlides getId { selected, slides } =
             List.length slides
 
         getByIndexWrappingAround index =
-            List.Extra.getAt (modBy length index) slides
+            if length > 0 then
+                List.Extra.getAt (modBy length index) slides
+
+            else
+                Nothing
     in
     case ( getByIndexWrappingAround (currentIndex - 1), getByIndexWrappingAround (currentIndex + 1) ) of
         ( Just a, Just b ) ->

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -149,6 +149,7 @@ viewWithTabControls :
             , idString : String
             , slideView : Html msg
             , tabView : Html Never
+            , tabAttributes : List (Html.Attribute msg)
             }
     , tabStyles : Bool -> List Style
     , tabListStyles : List Style
@@ -168,6 +169,7 @@ viewWithTabControls config =
             TabsInternal.fromList { id = tabConfig.id, idString = tabConfig.idString }
                 [ \tab -> { tab | panelView = tabConfig.slideView }
                 , \tab -> { tab | tabView = [ Html.map never tabConfig.tabView ] }
+                , \tab -> { tab | tabAttributes = tabConfig.tabAttributes }
                 ]
 
         { tabList, tabPanels } =
@@ -209,6 +211,7 @@ viewWithCombinedControls :
             , visibleLabelId : Maybe String
             , slideView : Html msg
             , tabView : Html Never
+            , tabAttributes : List (Html.Attribute msg)
             }
     , tabStyles : Bool -> List Style
     , tabListStyles : List Style
@@ -254,6 +257,7 @@ viewWithCombinedControls config =
                             , idString = slide.idString
                             , slideView = slide.slideView
                             , tabView = slide.tabView
+                            , tabAttributes = slide.tabAttributes
                             }
                         )
                         config.slides

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -101,25 +101,26 @@ viewWithPreviousAndNextControls config =
     { viewPreviousButton = viewPreviousButton
     , viewNextButton = viewNextButton
     , slides =
-        List.map
-            (\slide ->
-                Html.div
-                    [ Role.group
-                    , Aria.roleDescription "slide"
-                    , id slide.idString
-                    , labelAttribute slide
+        Html.div [ Accessibility.Styled.Key.tabbable False ]
+            (List.map
+                (\slide ->
+                    Html.div
+                        [ Role.group
+                        , Aria.roleDescription "slide"
+                        , id slide.idString
+                        , labelAttribute slide
 
-                    -- use as attribute for testing
-                    , if config.selected == slide.id then
-                        Attrs.style "display" "block"
+                        -- use as attribute for testing
+                        , if config.selected == slide.id then
+                            Attrs.style "display" "block"
 
-                      else
-                        Attrs.style "display" "none"
-                    ]
-                    [ slide.slideHtml ]
+                          else
+                            Attrs.style "display" "none"
+                        ]
+                        [ slide.slideHtml ]
+                )
+                config.slides
             )
-            config.slides
-            |> Html.div [ Attrs.attribute "atomic" "false", Accessibility.Styled.Key.tabbable False ]
     , containerAttributes =
         [ Attrs.attribute "role" (roleToString config.role)
         , Aria.roleDescription "carousel"

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -138,6 +138,7 @@ Returns:
 
   - `controls`: tabs control buttons
   - `slides` container with the carousel contents
+  - `containerAttributes` attributes that should be used on the parent div of both the button and slides elements
 
 -}
 viewWithTabControls :
@@ -195,6 +196,7 @@ Returns:
   - `slides` container with the carousel contents
   - `viewPreviousButton` previous button
   - `viewNextButton` next button
+  - `containerAttributes` attributes that should be used on the parent div of both the button and slides elements
 
 -}
 viewWithCombinedControls :

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -150,8 +150,8 @@ viewWithTabControls :
             , slideHtml : Html msg
             , tabControlHtml : Html Never
             }
-    , tabControlStyles : Bool -> List Style
-    , tabControlListStyles : List Style
+    , tabStyles : Bool -> List Style
+    , tabListStyles : List Style
     , role : Role
     , name : String
     , visibleLabelId : Maybe String
@@ -175,8 +175,8 @@ viewWithTabControls config =
                 { focusAndSelect = config.focusAndSelect
                 , selected = config.selected
                 , tabs = List.map buildTab config.slides
-                , tabStyles = always config.tabControlStyles
-                , tabListStyles = config.tabControlListStyles
+                , tabStyles = always config.tabStyles
+                , tabListStyles = config.tabListStyles
                 }
     in
     { tabs = tabList
@@ -210,8 +210,8 @@ viewWithCombinedControls :
             , slideHtml : Html msg
             , tabControlHtml : Html Never
             }
-    , tabControlStyles : Bool -> List Style
-    , tabControlListStyles : List Style
+    , tabStyles : Bool -> List Style
+    , tabListStyles : List Style
     , previousButton : { name : String, icon : Svg, attributes : List (ClickableSvg.Attribute msg) }
     , nextButton : { name : String, icon : Svg, attributes : List (ClickableSvg.Attribute msg) }
     , role : Role
@@ -257,8 +257,8 @@ viewWithCombinedControls config =
                             }
                         )
                         config.slides
-                , tabControlStyles = config.tabControlStyles
-                , tabControlListStyles = config.tabControlListStyles
+                , tabStyles = config.tabStyles
+                , tabListStyles = config.tabListStyles
                 , role = config.role
                 , name = config.name
                 , visibleLabelId = config.visibleLabelId

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -233,15 +233,15 @@ viewWithCombinedControls config =
             viewWithTabControls
                 { selected = config.selected
                 , slides =
-                    config.slides
-                        |> List.map
-                            (\slide ->
-                                { id = slide.id
-                                , idString = slide.idString
-                                , slideHtml = slide.slideHtml
-                                , tabControlHtml = slide.tabControlHtml
-                                }
-                            )
+                    List.map
+                        (\slide ->
+                            { id = slide.id
+                            , idString = slide.idString
+                            , slideHtml = slide.slideHtml
+                            , tabControlHtml = slide.tabControlHtml
+                            }
+                        )
+                        config.slides
                 , tabControlStyles = config.tabControlStyles
                 , tabControlListStyles = config.tabControlListStyles
                 , role = config.role

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -51,13 +51,13 @@ viewWithPreviousAndNextControls :
         List
             { id : id
             , idString : String
-            , accessibleLabel : String
+            , name : String
             , visibleLabelId : Maybe String
             , slideHtml : Html msg
             }
     , previousButton : { name : String, icon : Svg, attributes : List (ClickableSvg.Attribute msg) }
     , nextButton : { name : String, icon : Svg, attributes : List (ClickableSvg.Attribute msg) }
-    , accessibleLabel : String
+    , name : String
     , visibleLabelId : Maybe String
     , role : Role
     , announceAndSelect : { select : id, announce : String } -> msg
@@ -82,8 +82,8 @@ viewWithPreviousAndNextControls config =
                             , icon = config.previousButton.icon
                             , attributes = config.previousButton.attributes
                             , targetSlideId = previousSlide.id
-                            , targetSlideLabel = previousSlide.accessibleLabel
-                            , carouselLabel = config.accessibleLabel
+                            , targetSlideLabel = previousSlide.name
+                            , carouselLabel = config.name
                             , announceAndSelect = config.announceAndSelect
                             }
                     , viewNextButton =
@@ -92,8 +92,8 @@ viewWithPreviousAndNextControls config =
                             , icon = config.nextButton.icon
                             , attributes = config.nextButton.attributes
                             , targetSlideId = nextSlide.id
-                            , targetSlideLabel = nextSlide.accessibleLabel
-                            , carouselLabel = config.accessibleLabel
+                            , targetSlideLabel = nextSlide.name
+                            , carouselLabel = config.name
                             , announceAndSelect = config.announceAndSelect
                             }
                     }
@@ -191,7 +191,7 @@ viewWithTabControls :
             List
                 { id : id
                 , idString : String
-                , accessibleLabel : String
+                , name : String
                 , visibleLabelId : Maybe String
                 , slideHtml : Html msg
                 , tabControlHtml : Html Never
@@ -199,7 +199,7 @@ viewWithTabControls :
         , tabControlStyles : Bool -> List Style
         , tabControlListStyles : List Style
         , role : Role
-        , accessibleLabel : String
+        , name : String
         , visibleLabelId : Maybe String
         , focusAndSelect : { select : id, focus : Maybe String } -> msg
     }
@@ -248,7 +248,7 @@ viewWithCombinedControls :
         List
             { id : id
             , idString : String
-            , accessibleLabel : String
+            , name : String
             , visibleLabelId : Maybe String
             , slideHtml : Html msg
             , tabControlHtml : Html Never
@@ -258,7 +258,7 @@ viewWithCombinedControls :
     , previousButton : { name : String, icon : Svg, attributes : List (ClickableSvg.Attribute msg) }
     , nextButton : { name : String, icon : Svg, attributes : List (ClickableSvg.Attribute msg) }
     , role : Role
-    , accessibleLabel : String
+    , name : String
     , visibleLabelId : Maybe String
     , focusAndSelect : { select : id, focus : Maybe String } -> msg
     , announceAndSelect : { select : id, announce : String } -> msg
@@ -287,8 +287,8 @@ viewWithCombinedControls config =
                             , icon = config.previousButton.icon
                             , attributes = config.previousButton.attributes
                             , targetSlideId = previousSlide.id
-                            , targetSlideLabel = previousSlide.accessibleLabel
-                            , carouselLabel = config.accessibleLabel
+                            , targetSlideLabel = previousSlide.name
+                            , carouselLabel = config.name
                             , announceAndSelect = config.announceAndSelect
                             }
                     , viewNextButton =
@@ -297,8 +297,8 @@ viewWithCombinedControls config =
                             , icon = config.nextButton.icon
                             , attributes = config.nextButton.attributes
                             , targetSlideId = nextSlide.id
-                            , targetSlideLabel = nextSlide.accessibleLabel
-                            , carouselLabel = config.accessibleLabel
+                            , targetSlideLabel = nextSlide.name
+                            , carouselLabel = config.name
                             , announceAndSelect = config.announceAndSelect
                             }
                     }
@@ -311,14 +311,14 @@ viewWithCombinedControls config =
     }
 
 
-labelAttribute : { c | accessibleLabel : String, visibleLabelId : Maybe String } -> Attribute msg
-labelAttribute { accessibleLabel, visibleLabelId } =
+labelAttribute : { c | name : String, visibleLabelId : Maybe String } -> Attribute msg
+labelAttribute { name, visibleLabelId } =
     case visibleLabelId of
         Just visibleLabelId_ ->
             Aria.labeledBy visibleLabelId_
 
         Nothing ->
-            Aria.label accessibleLabel
+            Aria.label name
 
 
 roleToString : Role -> String

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -5,7 +5,7 @@ module Nri.Ui.Carousel.V2 exposing
     , Role(..)
     )
 
-{-| Patch changes:
+{-| Changes from V1:
 
   - added new carousel APIs (with tabbed controls/previous and next controls, and combined controls) using [W3C guidelines](https://www.w3.org/WAI/ARIA/apg/patterns/carousel/)
 

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -29,6 +29,8 @@ import TabsInternal.V2 as TabsInternal
 
 
 {-| `Role`, which can be either [Group](https://w3c.github.io/aria/#group) or [Region](https://w3c.github.io/aria/#region)
+  - Use `Group` when the contents of the slides are not intended to be included in a page summary or table of contents by assistive technologies.
+  - Use `Region` when the contents the slides should be included in a page summary or table of contents.
 -}
 type Role
     = Group

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -13,6 +13,7 @@ module Nri.Ui.Carousel.V2 exposing
 -}
 
 import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Key
 import Accessibility.Styled.Role as Role
 import Css exposing (..)
 import Html.Styled as Html exposing (..)
@@ -22,7 +23,6 @@ import Maybe.Extra
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Svg.V1 exposing (Svg)
 import TabsInternal.V2 as TabsInternal
-import Accessibility.Styled.Key
 
 
 {-| Type which represents the type of aria label which will be used
@@ -42,23 +42,26 @@ type Role
 
 
 {-| Builds a carousel with previous and next controls
+
 Returns:
-`slides` the container with the carousel contents
-`viewPreviousButton` previous button
-`viewNextButton` next button
-`containerAttributes` attributes that should be used on the parent div of both the button and slides elements
+
+  - `slides` the container with the carousel contents
+  - `viewPreviousButton` previous button
+  - `viewNextButton` next button
+  - `containerAttributes` attributes that should be used on the parent div of both the button and slides elements
+
 -}
 viewWithPreviousAndNextControls :
     { selected : id
     , panels :
         List
             { id : id
+            , idString : String
             , slideHtml : Html msg
             , labelledBy : LabelledBy
-            , idString : String
             }
-    , viewPreviousButton : { attributes : List (ClickableSvg.Attribute msg), icon : Svg, name : String }
-    , viewNextButton : { attributes : List (ClickableSvg.Attribute msg), icon : Svg, name : String }
+    , previousButton : { attributes : List (ClickableSvg.Attribute msg), icon : Svg, name : String }
+    , nextButton : { attributes : List (ClickableSvg.Attribute msg), icon : Svg, name : String }
     , labelledBy : LabelledBy
     , role : Role
     , focusAndSelect : { select : id, focus : Maybe String } -> msg
@@ -103,17 +106,17 @@ viewWithPreviousAndNextControls config =
                     )
     in
     { viewPreviousButton =
-        ClickableSvg.button config.viewPreviousButton.name
-            config.viewPreviousButton.icon
-            (config.viewPreviousButton.attributes
+        ClickableSvg.button config.previousButton.name
+            config.previousButton.icon
+            (config.previousButton.attributes
                 ++ (Maybe.map (\p -> ClickableSvg.onClick (config.focusAndSelect { select = p.id, focus = Just p.idString })) previousPanel
                         |> Maybe.Extra.toList
                    )
             )
     , viewNextButton =
-        ClickableSvg.button config.viewNextButton.name
-            config.viewNextButton.icon
-            (config.viewNextButton.attributes
+        ClickableSvg.button config.nextButton.name
+            config.nextButton.icon
+            (config.nextButton.attributes
                 ++ (Maybe.map (\p -> ClickableSvg.onClick (config.focusAndSelect { select = p.id, focus = Just p.idString })) nextPanel
                         |> Maybe.Extra.toList
                    )
@@ -218,8 +221,8 @@ viewWithCombinedControls :
     , focusAndSelect : { select : id, focus : Maybe String } -> msg
     , tabControlStyles : Bool -> List Style
     , tabControlListStyles : List Style
-    , viewPreviousButton : { attributes : List (ClickableSvg.Attribute msg), icon : Svg, name : String }
-    , viewNextButton : { attributes : List (ClickableSvg.Attribute msg), icon : Svg, name : String }
+    , previousButton : { attributes : List (ClickableSvg.Attribute msg), icon : Svg, name : String }
+    , nextButton : { attributes : List (ClickableSvg.Attribute msg), icon : Svg, name : String }
     , role : Role
     , labelledBy : LabelledBy
     }
@@ -270,17 +273,17 @@ viewWithCombinedControls config =
     , slides = slides
     , containerAttributes = containerAttributes
     , viewPreviousButton =
-        ClickableSvg.button config.viewPreviousButton.name
-            config.viewPreviousButton.icon
-            (config.viewPreviousButton.attributes
+        ClickableSvg.button config.previousButton.name
+            config.previousButton.icon
+            (config.previousButton.attributes
                 ++ (Maybe.map (\p -> ClickableSvg.onClick (config.focusAndSelect { select = p.id, focus = Just p.idString })) previousPanel
                         |> Maybe.Extra.toList
                    )
             )
     , viewNextButton =
-        ClickableSvg.button config.viewNextButton.name
-            config.viewNextButton.icon
-            (config.viewNextButton.attributes
+        ClickableSvg.button config.nextButton.name
+            config.nextButton.icon
+            (config.nextButton.attributes
                 ++ (Maybe.map (\p -> ClickableSvg.onClick (config.focusAndSelect { select = p.id, focus = Just p.idString })) nextPanel
                         |> Maybe.Extra.toList
                    )

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -200,15 +200,18 @@ viewWithTabControls :
         , slides :
             List
                 { id : id
+                , idString : String
+                , accessibleLabel : String
+                , visibleLabelId : Maybe String
                 , slideHtml : Html msg
                 , tabControlHtml : Html Never
-                , idString : String
                 }
         , focusAndSelect : { select : id, focus : Maybe String } -> msg
         , tabControlStyles : Bool -> List Style
         , tabControlListStyles : List Style
         , role : Role
-        , labelledBy : LabelledBy
+        , accessibleLabel : String
+        , visibleLabelId : Maybe String
     }
     ->
         { controls : Html msg
@@ -237,7 +240,7 @@ viewWithTabControls config =
     , containerAttributes =
         [ Attrs.attribute "role" (roleToString config.role)
         , Aria.roleDescription "carousel"
-        , labelledByToAttr config.labelledBy
+        , labelAttribute config
         ]
     }
 
@@ -254,17 +257,21 @@ viewWithCombinedControls :
     , slides :
         List
             { id : id
+            , idString : String
+            , accessibleLabel : String
+            , visibleLabelId : Maybe String
             , slideHtml : Html msg
             , tabControlHtml : Html Never
-            , idString : String
             }
-    , focusAndSelect : { select : id, focus : Maybe String } -> msg
     , tabControlStyles : Bool -> List Style
     , tabControlListStyles : List Style
     , previousButton : { name : String, icon : Svg, attributes : List (ClickableSvg.Attribute msg) }
     , nextButton : { name : String, icon : Svg, attributes : List (ClickableSvg.Attribute msg) }
     , role : Role
-    , labelledBy : LabelledBy
+    , accessibleLabel : String
+    , visibleLabelId : Maybe String
+    , focusAndSelect : { select : id, focus : Maybe String } -> msg
+    , announceAndSelect : { select : id, announce : String } -> msg
     }
     ->
         { tabControls : Html msg
@@ -340,16 +347,6 @@ labelAttribute { accessibleLabel, visibleLabelId } =
 
         Nothing ->
             Aria.label accessibleLabel
-
-
-labelledByToAttr : LabelledBy -> Attribute msg
-labelledByToAttr label =
-    case label of
-        LabelledByIdOfVisibleLabel l ->
-            Aria.labeledBy l
-
-        LabelledByAccessibleLabelOnly l ->
-            Aria.label l
 
 
 roleToString : Role -> String

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -217,8 +217,7 @@ viewWithCombinedControls :
     , role : Role
     , name : String
     , visibleLabelId : Maybe String
-    , focusAndSelect : { select : id, focus : Maybe String } -> msg
-    , announceAndSelect : { select : id, announce : String } -> msg
+    , select : { select : id, announce : Maybe String, focus : Maybe String } -> msg
     }
     ->
         { tabControls : Html msg
@@ -229,6 +228,22 @@ viewWithCombinedControls :
         }
 viewWithCombinedControls config =
     let
+        onTabSelection =
+            \{ select, focus } ->
+                config.select
+                    { select = select
+                    , announce = Nothing
+                    , focus = focus
+                    }
+
+        onButtonSelection =
+            \{ select, announce } ->
+                config.select
+                    { select = select
+                    , announce = Just announce
+                    , focus = Nothing
+                    }
+
         { controls, slides, containerAttributes } =
             viewWithTabControls
                 { selected = config.selected
@@ -247,7 +262,7 @@ viewWithCombinedControls config =
                 , role = config.role
                 , name = config.name
                 , visibleLabelId = config.visibleLabelId
-                , focusAndSelect = config.focusAndSelect
+                , focusAndSelect = onTabSelection
                 }
 
         { viewPreviousButton, viewNextButton } =
@@ -264,7 +279,7 @@ viewWithCombinedControls config =
                             , targetSlideId = previousSlide.id
                             , targetSlideLabel = previousSlide.name
                             , carouselLabel = config.name
-                            , announceAndSelect = config.announceAndSelect
+                            , announceAndSelect = onButtonSelection
                             }
                     , viewNextButton =
                         viewSlideChangeButton
@@ -274,7 +289,7 @@ viewWithCombinedControls config =
                             , targetSlideId = nextSlide.id
                             , targetSlideLabel = nextSlide.name
                             , carouselLabel = config.name
-                            , announceAndSelect = config.announceAndSelect
+                            , announceAndSelect = onButtonSelection
                             }
                     }
     in

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -29,8 +29,10 @@ import TabsInternal.V2 as TabsInternal
 
 
 {-| `Role`, which can be either [Group](https://w3c.github.io/aria/#group) or [Region](https://w3c.github.io/aria/#region)
+
   - Use `Group` when the contents of the slides are not intended to be included in a page summary or table of contents by assistive technologies.
   - Use `Region` when the contents the slides should be included in a page summary or table of contents.
+
 -}
 type Role
     = Group
@@ -144,8 +146,6 @@ viewWithTabControls :
         List
             { id : id
             , idString : String
-            , name : String
-            , visibleLabelId : Maybe String
             , slideHtml : Html msg
             , tabControlHtml : Html Never
             }
@@ -230,7 +230,16 @@ viewWithCombinedControls config =
         { controls, slides, containerAttributes } =
             viewWithTabControls
                 { selected = config.selected
-                , slides = config.slides
+                , slides =
+                    config.slides
+                        |> List.map
+                            (\slide ->
+                                { id = slide.id
+                                , idString = slide.idString
+                                , slideHtml = slide.slideHtml
+                                , tabControlHtml = slide.tabControlHtml
+                                }
+                            )
                 , tabControlStyles = config.tabControlStyles
                 , tabControlListStyles = config.tabControlListStyles
                 , role = config.role

--- a/src/Nri/Ui/Carousel/V2.elm
+++ b/src/Nri/Ui/Carousel/V2.elm
@@ -57,7 +57,7 @@ viewWithPreviousAndNextControls :
             , idString : String
             , name : String
             , visibleLabelId : Maybe String
-            , slideHtml : Html msg
+            , slideView : Html msg
             }
     , previousButton : { name : String, icon : Svg, attributes : List (ClickableSvg.Attribute msg) }
     , nextButton : { name : String, icon : Svg, attributes : List (ClickableSvg.Attribute msg) }
@@ -121,7 +121,7 @@ viewWithPreviousAndNextControls config =
                           else
                             Attrs.style "display" "none"
                         ]
-                        [ slide.slideHtml ]
+                        [ slide.slideView ]
                 )
                 config.slides
             )
@@ -147,8 +147,8 @@ viewWithTabControls :
         List
             { id : id
             , idString : String
-            , slideHtml : Html msg
-            , tabControlHtml : Html Never
+            , slideView : Html msg
+            , tabView : Html Never
             }
     , tabStyles : Bool -> List Style
     , tabListStyles : List Style
@@ -166,8 +166,8 @@ viewWithTabControls config =
     let
         buildTab tabConfig =
             TabsInternal.fromList { id = tabConfig.id, idString = tabConfig.idString }
-                [ \tab -> { tab | panelView = tabConfig.slideHtml }
-                , \tab -> { tab | tabView = [ Html.map never tabConfig.tabControlHtml ] }
+                [ \tab -> { tab | panelView = tabConfig.slideView }
+                , \tab -> { tab | tabView = [ Html.map never tabConfig.tabView ] }
                 ]
 
         { tabList, tabPanels } =
@@ -207,8 +207,8 @@ viewWithCombinedControls :
             , idString : String
             , name : String
             , visibleLabelId : Maybe String
-            , slideHtml : Html msg
-            , tabControlHtml : Html Never
+            , slideView : Html msg
+            , tabView : Html Never
             }
     , tabStyles : Bool -> List Style
     , tabListStyles : List Style
@@ -252,8 +252,8 @@ viewWithCombinedControls config =
                         (\slide ->
                             { id = slide.id
                             , idString = slide.idString
-                            , slideHtml = slide.slideHtml
-                            , tabControlHtml = slide.tabControlHtml
+                            , slideView = slide.slideView
+                            , tabView = slide.tabView
                             }
                         )
                         config.slides

--- a/tests/Spec/Nri/Ui/Carousel.elm
+++ b/tests/Spec/Nri/Ui/Carousel.elm
@@ -224,8 +224,8 @@ viewWithCombinedControls model =
               , slideHtml = text "Slide 2"
               }
             ]
-        , viewNextButton = { attributes = [], icon = UiIcon.arrowRight, name = "Next" }
-        , viewPreviousButton = { attributes = [], icon = UiIcon.arrowLeft, name = "Previous" }
+        , previousButton = { attributes = [], icon = UiIcon.arrowLeft, name = "Previous" }
+        , nextButton = { attributes = [], icon = UiIcon.arrowRight, name = "Next" }
         }
         |> (\{ tabControls, slides, containerAttributes, viewNextButton, viewPreviousButton } ->
                 section containerAttributes [ slides, tabControls, viewNextButton, viewPreviousButton ]
@@ -249,8 +249,8 @@ viewWithPreviousAndNextControls slidesCount model =
                     }
                 )
                 (List.range 0 (slidesCount - 1))
-        , viewNextButton = { attributes = [], icon = UiIcon.arrowRight, name = "Next" }
-        , viewPreviousButton = { attributes = [], icon = UiIcon.arrowLeft, name = "Previous" }
+        , previousButton = { attributes = [], icon = UiIcon.arrowLeft, name = "Previous" }
+        , nextButton = { attributes = [], icon = UiIcon.arrowRight, name = "Next" }
         }
         |> (\{ viewPreviousButton, viewNextButton, slides, containerAttributes } ->
                 section containerAttributes [ slides, viewPreviousButton, viewNextButton ]

--- a/tests/Spec/Nri/Ui/Carousel.elm
+++ b/tests/Spec/Nri/Ui/Carousel.elm
@@ -25,32 +25,35 @@ import Test.Html.Selector as Selector
 
 
 type PreviousAndNextProgramMsg
-    = FocusAndSelect { select : Int, focus : Maybe String }
+    = SelectAndAnnounce { select : Int, announce : String }
 
 
 previousAndNextCarouselProgram : Int -> ProgramTest { selected : Int } PreviousAndNextProgramMsg ()
 previousAndNextCarouselProgram slidesCount =
     -- TODO: use program rather than sandbox so we can test effects
+    -- TODO: test label behavior
     ProgramTest.createSandbox
         { init = { selected = 0 }
         , update =
             \msg _ ->
                 case msg of
-                    FocusAndSelect { select } ->
+                    SelectAndAnnounce { select } ->
                         { selected = select }
         , view =
             \model ->
                 Carousel.viewWithPreviousAndNextControls
-                    { focusAndSelect = FocusAndSelect
+                    { selectAndAnnounce = SelectAndAnnounce
                     , selected = model.selected
                     , role = Carousel.Group
-                    , labelledBy = Carousel.LabelledByAccessibleLabelOnly "Label"
+                    , accessibleLabel = "Label"
+                    , visibleLabelId = Nothing
                     , panels =
                         List.map
                             (\i ->
                                 { id = i
                                 , idString = "slide-" ++ String.fromInt i
-                                , labelledBy = Carousel.LabelledByAccessibleLabelOnly ("Control " ++ String.fromInt i)
+                                , accessibleLabel = "Control " ++ String.fromInt i
+                                , visibleLabelId = Nothing
                                 , slideHtml = text ("Slide " ++ String.fromInt i)
                                 }
                             )

--- a/tests/Spec/Nri/Ui/Carousel.elm
+++ b/tests/Spec/Nri/Ui/Carousel.elm
@@ -80,7 +80,7 @@ viewWithPreviousAndNextControlsSpec =
 
                     VisibleLabel ->
                         Just ("slide-" ++ String.fromInt index ++ "-label")
-            , slideHtml =
+            , slideView =
                 div [ StyledAttrs.id ("slide-" ++ String.fromInt index ++ "-label") ]
                     [ text ("Slide " ++ String.fromInt index) ]
             }
@@ -249,18 +249,18 @@ viewWithTabControlsSpec =
         allSlides =
             [ { id = 0
               , idString = "slide-0"
-              , tabControlHtml = text "Control 0"
-              , slideHtml = text "Slide 0"
+              , tabView = text "Control 0"
+              , slideView = text "Slide 0"
               }
             , { id = 1
               , idString = "slide-1"
-              , tabControlHtml = text "Control 1"
-              , slideHtml = text "Slide 1"
+              , tabView = text "Control 1"
+              , slideView = text "Slide 1"
               }
             , { id = 2
               , idString = "slide-2"
-              , tabControlHtml = text "Control 2"
-              , slideHtml = text "Slide 2"
+              , tabView = text "Control 2"
+              , slideView = text "Slide 2"
               }
             ]
 
@@ -404,22 +404,22 @@ viewWithCombinedControlsSpec =
               , idString = "slide-0"
               , name = "Slide 0"
               , visibleLabelId = Nothing
-              , tabControlHtml = text "Control 0"
-              , slideHtml = text "Slide 0"
+              , tabView = text "Control 0"
+              , slideView = text "Slide 0"
               }
             , { id = 1
               , idString = "slide-1"
               , name = "Slide 1"
               , visibleLabelId = Nothing
-              , tabControlHtml = text "Control 1"
-              , slideHtml = text "Slide 1"
+              , tabView = text "Control 1"
+              , slideView = text "Slide 1"
               }
             , { id = 2
               , idString = "slide-2"
               , name = "Slide 2"
               , visibleLabelId = Nothing
-              , tabControlHtml = text "Control 2"
-              , slideHtml = text "Slide 2"
+              , tabView = text "Control 2"
+              , slideView = text "Slide 2"
               }
             ]
 

--- a/tests/Spec/Nri/Ui/Carousel.elm
+++ b/tests/Spec/Nri/Ui/Carousel.elm
@@ -16,7 +16,8 @@ spec =
     describe "Nri.Ui.Carousel.V2"
         [ describe "viewWithTabControls rendering" panelRenderingTests
         , describe "keyboard behavior on viewWithTabControls" keyboardTests
-        , describe "viewWithPreviousAndNextControlsTests rendering" viewWithPreviousAndNextControlsTests
+        , describe "viewWithPreviousAndNextControls rendering" viewWithPreviousAndNextControlsTests
+        , describe "viewWithCombinedControls rendering" viewWithCombinedControlsTests
         ]
 
 
@@ -125,6 +126,28 @@ viewWithPreviousAndNextControlsTests =
     ]
 
 
+viewWithCombinedControlsTests : List Test
+viewWithCombinedControlsTests =
+    [ test "rotate back and forward with 3 slides" <|
+        \() ->
+            program viewWithCombinedControls
+                |> ensurePanelDisplayed "Slide 0"
+                |> clickButton "Next"
+                |> ensurePanelDisplayed "Slide 1"
+                |> clickButton "Next"
+                |> ensurePanelDisplayed "Slide 2"
+                |> clickButton "Next"
+                |> ensurePanelDisplayed "Slide 0"
+                |> clickButton "Previous"
+                |> ensurePanelDisplayed "Slide 2"
+                |> clickButton "Previous"
+                |> ensurePanelDisplayed "Slide 1"
+                |> clickButton "Previous"
+                |> ensurePanelDisplayed "Slide 0"
+                |> done
+    ]
+
+
 ensureSlideIsVisible : String -> ProgramTest.ProgramTest model msg effect -> ProgramTest.ProgramTest model msg effect
 ensureSlideIsVisible id =
     ensureViewHas [ Selector.id id, Selector.style "display" "block" ]
@@ -173,6 +196,40 @@ viewWithTabControls model =
             ]
         }
         |> (\{ controls, slides, containerAttributes } -> section containerAttributes [ slides, controls ])
+
+
+viewWithCombinedControls : State -> Html Msg
+viewWithCombinedControls model =
+    Carousel.viewWithCombinedControls
+        { focusAndSelect = FocusAndSelectTab
+        , selected = model.selected
+        , tabControlListStyles = []
+        , role = Carousel.Group
+        , tabControlStyles = \_ -> []
+        , labelledBy = Carousel.LabelledByAccessibleLabelOnly "Label"
+        , panels =
+            [ { id = 0
+              , idString = "slide-0"
+              , tabControlHtml = text "Control 0"
+              , slideHtml = text "Slide 0"
+              }
+            , { id = 1
+              , idString = "slide-1"
+              , tabControlHtml = text "Control 1"
+              , slideHtml = text "Slide 1"
+              }
+            , { id = 2
+              , idString = "slide-2"
+              , tabControlHtml = text "Control 2"
+              , slideHtml = text "Slide 2"
+              }
+            ]
+        , viewNextButton = { attributes = [], icon = UiIcon.arrowRight, name = "Next" }
+        , viewPreviousButton = { attributes = [], icon = UiIcon.arrowLeft, name = "Previous" }
+        }
+        |> (\{ tabControls, slides, containerAttributes, viewNextButton, viewPreviousButton } ->
+                section containerAttributes [ slides, tabControls, viewNextButton, viewPreviousButton ]
+           )
 
 
 viewWithPreviousAndNextControls : Int -> State -> Html Msg

--- a/tests/Spec/Nri/Ui/Carousel.elm
+++ b/tests/Spec/Nri/Ui/Carousel.elm
@@ -292,8 +292,8 @@ viewWithTabControlsSpec =
                                         , focus = focus
                                         }
                             }
-                            |> (\{ controls, slides, containerAttributes } ->
-                                    section containerAttributes [ slides, controls ]
+                            |> (\{ tabs, slides, containerAttributes } ->
+                                    section containerAttributes [ slides, tabs ]
                                )
                             |> toUnstyled
                 }
@@ -441,8 +441,8 @@ viewWithCombinedControlsSpec =
                             , nextButton = { attributes = [], icon = UiIcon.arrowRight, name = "Next" }
                             , select = Select
                             }
-                            |> (\{ tabControls, slides, containerAttributes, viewNextButton, viewPreviousButton } ->
-                                    section containerAttributes [ slides, tabControls, viewNextButton, viewPreviousButton ]
+                            |> (\{ tabs, slides, containerAttributes, viewNextButton, viewPreviousButton } ->
+                                    section containerAttributes [ slides, tabs, viewNextButton, viewPreviousButton ]
                                )
                             |> toUnstyled
                 }

--- a/tests/Spec/Nri/Ui/Carousel.elm
+++ b/tests/Spec/Nri/Ui/Carousel.elm
@@ -249,18 +249,21 @@ viewWithTabControlsSpec =
         allSlides =
             [ { id = 0
               , idString = "slide-0"
-              , tabView = text "Control 0"
               , slideView = text "Slide 0"
+              , tabView = text "Control 0"
+              , tabAttributes = []
               }
             , { id = 1
               , idString = "slide-1"
-              , tabView = text "Control 1"
               , slideView = text "Slide 1"
+              , tabView = text "Control 1"
+              , tabAttributes = []
               }
             , { id = 2
               , idString = "slide-2"
-              , tabView = text "Control 2"
               , slideView = text "Slide 2"
+              , tabView = text "Control 2"
+              , tabAttributes = []
               }
             ]
 
@@ -404,22 +407,25 @@ viewWithCombinedControlsSpec =
               , idString = "slide-0"
               , name = "Slide 0"
               , visibleLabelId = Nothing
-              , tabView = text "Control 0"
               , slideView = text "Slide 0"
+              , tabView = text "Control 0"
+              , tabAttributes = []
               }
             , { id = 1
               , idString = "slide-1"
               , name = "Slide 1"
               , visibleLabelId = Nothing
-              , tabView = text "Control 1"
               , slideView = text "Slide 1"
+              , tabView = text "Control 1"
+              , tabAttributes = []
               }
             , { id = 2
               , idString = "slide-2"
               , name = "Slide 2"
               , visibleLabelId = Nothing
-              , tabView = text "Control 2"
               , slideView = text "Slide 2"
+              , tabView = text "Control 2"
+              , tabAttributes = []
               }
             ]
 

--- a/tests/Spec/Nri/Ui/Carousel.elm
+++ b/tests/Spec/Nri/Ui/Carousel.elm
@@ -278,7 +278,6 @@ viewWithTabControlsSpec =
                                     VisibleLabel ->
                                         Just "carousel-label"
                             , focusAndSelect = FocusAndSelect
-                            , announceAndSelect = AnnounceAndSelect
                             }
                             |> (\{ controls, slides, containerAttributes } ->
                                     section containerAttributes [ slides, controls ]

--- a/tests/Spec/Nri/Ui/Carousel.elm
+++ b/tests/Spec/Nri/Ui/Carousel.elm
@@ -26,7 +26,7 @@ import Test.Html.Selector as Selector
 
 
 type PreviousAndNextProgramMsg
-    = SelectAndAnnounce { select : Int, announce : String }
+    = AnnounceAndSelect { select : Int, announce : String }
 
 
 type PreviousAndNextProgramEffect
@@ -42,14 +42,14 @@ previousAndNextCarouselProgram slidesCount =
         , update =
             \msg _ ->
                 case msg of
-                    SelectAndAnnounce { select, announce } ->
+                    AnnounceAndSelect { select, announce } ->
                         ( { selected = select }
                         , Announce announce
                         )
         , view =
             \model ->
                 Carousel.viewWithPreviousAndNextControls
-                    { selectAndAnnounce = SelectAndAnnounce
+                    { announceAndSelect = AnnounceAndSelect
                     , selected = model.selected
                     , role = Carousel.Group
                     , accessibleLabel = "Previous/Next Carousel"

--- a/tests/Spec/Nri/Ui/Carousel.elm
+++ b/tests/Spec/Nri/Ui/Carousel.elm
@@ -78,7 +78,7 @@ viewWithPreviousAndNextControlsSpec =
                             { announceAndSelect = AnnounceAndSelect
                             , selected = model.selected
                             , role = Carousel.Group
-                            , name = "Previous/Next Carousel"
+                            , name = "Slides"
                             , visibleLabelId =
                                 if relyOnVisibileLabelForContainer then
                                     Just "carousel-label"
@@ -108,7 +108,7 @@ viewWithPreviousAndNextControlsSpec =
                             }
                             |> (\{ viewPreviousButton, viewNextButton, slides, containerAttributes } ->
                                     section (StyledAttrs.id "carousel-root" :: containerAttributes)
-                                        [ span [ StyledAttrs.id "carousel-label" ] [ text "Previous/Next Carousel" ]
+                                        [ span [ StyledAttrs.id "carousel-label" ] [ text "Slides" ]
                                         , slides
                                         , viewPreviousButton
                                         , viewNextButton
@@ -150,11 +150,11 @@ viewWithPreviousAndNextControlsSpec =
                 start { relyOnVisibleLabelForSlides = False, relyOnVisibileLabelForContainer = False, slideCount = 3 }
                     |> ensureSlideIsVisible "slide-0"
                     |> clickButton "Next"
-                    |> ensureLastEffect (Expect.equal (Announce "Active slide of Previous/Next Carousel changed to Slide 1"))
+                    |> ensureLastEffect (Expect.equal (Announce "Active slide of Slides changed to Slide 1"))
                     |> clickButton "Next"
-                    |> ensureLastEffect (Expect.equal (Announce "Active slide of Previous/Next Carousel changed to Slide 2"))
+                    |> ensureLastEffect (Expect.equal (Announce "Active slide of Slides changed to Slide 2"))
                     |> clickButton "Previous"
-                    |> ensureLastEffect (Expect.equal (Announce "Active slide of Previous/Next Carousel changed to Slide 1"))
+                    |> ensureLastEffect (Expect.equal (Announce "Active slide of Slides changed to Slide 1"))
                     |> done
         , test "If the visibleLabelId is Nothing the container aria label is set to the name" <|
             \_ ->
@@ -162,7 +162,7 @@ viewWithPreviousAndNextControlsSpec =
                     |> ensureViewHas
                         [ Selector.all
                             [ Selector.id "carousel-root"
-                            , Selector.attribute (Attrs.attribute "aria-label" "Previous/Next Carousel")
+                            , Selector.attribute (Attrs.attribute "aria-label" "Slides")
                             ]
                         ]
                     |> done

--- a/tests/Spec/Nri/Ui/Carousel.elm
+++ b/tests/Spec/Nri/Ui/Carousel.elm
@@ -7,7 +7,6 @@ module Spec.Nri.Ui.Carousel exposing
 import Accessibility.Aria as Aria
 import Accessibility.Role as Role
 import Expect
-import Html.Attributes as Attrs
 import Html.Styled exposing (..)
 import Html.Styled.Attributes as StyledAttrs
 import Nri.Ui.Carousel.V2 as Carousel
@@ -249,22 +248,16 @@ viewWithTabControlsSpec =
         allSlides =
             [ { id = 0
               , idString = "slide-0"
-              , name = "Slide 0"
-              , visibleLabelId = Nothing
               , tabControlHtml = text "Control 0"
               , slideHtml = text "Slide 0"
               }
             , { id = 1
               , idString = "slide-1"
-              , name = "Slide 1"
-              , visibleLabelId = Nothing
               , tabControlHtml = text "Control 1"
               , slideHtml = text "Slide 1"
               }
             , { id = 2
               , idString = "slide-2"
-              , name = "Slide 2"
-              , visibleLabelId = Nothing
               , tabControlHtml = text "Control 2"
               , slideHtml = text "Slide 2"
               }

--- a/tests/Spec/Nri/Ui/Carousel.elm
+++ b/tests/Spec/Nri/Ui/Carousel.elm
@@ -332,7 +332,6 @@ viewWithTabControlsSpec =
                                 ]
                             ]
                         |> done
-
             , test "If the visibleLabelId is set the container aria labelledby is set to the visibleLabelId" <|
                 \_ ->
                     start True
@@ -421,4 +420,4 @@ viewWithCombinedControlsSpec =
 
 ensureSlideIsVisible : String -> ProgramTest.ProgramTest model msg effect -> ProgramTest.ProgramTest model msg effect
 ensureSlideIsVisible id =
-    ensureViewHas [ Selector.id id, Selector.style "display" "block" ]
+    ensureViewHas [ Selector.all [ Selector.id id, Selector.style "display" "block" ] ]

--- a/tests/Spec/Nri/Ui/Carousel.elm
+++ b/tests/Spec/Nri/Ui/Carousel.elm
@@ -4,6 +4,7 @@ module Spec.Nri.Ui.Carousel exposing
     , viewWithTabControlsSpec
     )
 
+import Accessibility.Aria as Aria
 import Expect
 import Html.Attributes as Attrs
 import Html.Styled exposing (..)
@@ -182,8 +183,8 @@ viewWithPreviousAndNextControlsSpec =
                     }
                     |> ensureViewHas
                         [ Selector.all
-                            [ Selector.attribute (Attrs.attribute "aria-roledescription" "carousel")
-                            , Selector.attribute (Attrs.attribute "aria-label" "Slides")
+                            [ Selector.attribute (Aria.roleDescription "carousel")
+                            , Selector.attribute (Aria.label "Slides")
                             ]
                         ]
                     |> done
@@ -196,8 +197,8 @@ viewWithPreviousAndNextControlsSpec =
                     }
                     |> ensureViewHas
                         [ Selector.all
-                            [ Selector.attribute (Attrs.attribute "aria-roledescription" "carousel")
-                            , Selector.attribute (Attrs.attribute "aria-labelledby" "carousel-label")
+                            [ Selector.attribute (Aria.roleDescription "carousel")
+                            , Selector.attribute (Aria.labelledBy "carousel-label")
                             ]
                         ]
                     |> done
@@ -211,7 +212,7 @@ viewWithPreviousAndNextControlsSpec =
                     |> ensureViewHas
                         [ Selector.all
                             [ Selector.id "slide-0"
-                            , Selector.attribute (Attrs.attribute "aria-label" "Slide 0")
+                            , Selector.attribute (Aria.label "Slide 0")
                             ]
                         ]
                     |> done
@@ -225,7 +226,7 @@ viewWithPreviousAndNextControlsSpec =
                     |> ensureViewHas
                         [ Selector.all
                             [ Selector.id "slide-0"
-                            , Selector.attribute (Attrs.attribute "aria-labelledby" "slide-0-label")
+                            , Selector.attribute (Aria.labelledBy "slide-0-label")
                             ]
                         ]
                     |> done
@@ -359,8 +360,8 @@ viewWithTabControlsSpec =
                     start AccessibleLabel
                         |> ensureViewHas
                             [ Selector.all
-                                [ Selector.attribute (Attrs.attribute "aria-roledescription" "carousel")
-                                , Selector.attribute (Attrs.attribute "aria-label" "Slides")
+                                [ Selector.attribute (Aria.roleDescription "carousel")
+                                , Selector.attribute (Aria.label "Slides")
                                 ]
                             ]
                         |> done
@@ -369,8 +370,8 @@ viewWithTabControlsSpec =
                     start VisibleLabel
                         |> ensureViewHas
                             [ Selector.all
-                                [ Selector.attribute (Attrs.attribute "aria-roledescription" "carousel")
-                                , Selector.attribute (Attrs.attribute "aria-labelledby" "carousel-label")
+                                [ Selector.attribute (Aria.roleDescription "carousel")
+                                , Selector.attribute (Aria.labelledBy "carousel-label")
                                 ]
                             ]
                         |> done

--- a/tests/Spec/Nri/Ui/Carousel.elm
+++ b/tests/Spec/Nri/Ui/Carousel.elm
@@ -5,7 +5,16 @@ import Html.Styled exposing (..)
 import Nri.Ui.Carousel.V2 as Carousel
 import Nri.Ui.UiIcon.V1 as UiIcon
 import ProgramTest exposing (..)
-import Spec.TabsInternalHelpers exposing (..)
+import Spec.TabsInternalHelpers as TabsHelpers
+    exposing
+        ( ensureOnlyOnePanelDisplayed
+        , ensureOnlyOneTabInSequence
+        , ensurePanelDisplayed
+        , ensurePanelsFocusable
+        , ensureTabbable
+        , releaseLeftArrow
+        , releaseRightArrow
+        )
 import Task
 import Test exposing (..)
 import Test.Html.Selector as Selector
@@ -153,25 +162,25 @@ ensureSlideIsVisible id =
     ensureViewHas [ Selector.id id, Selector.style "display" "block" ]
 
 
-update : Msg -> State -> State
+update : TabsHelpers.Msg -> TabsHelpers.State -> TabsHelpers.State
 update msg model =
     case msg of
-        FocusAndSelectTab { select, focus } ->
+        TabsHelpers.FocusAndSelectTab { select, focus } ->
             Tuple.first
                 ( { model | selected = select }
                 , focus
-                    |> Maybe.map (Dom.focus >> Task.attempt Focused)
+                    |> Maybe.map (Dom.focus >> Task.attempt TabsHelpers.Focused)
                     |> Maybe.withDefault Cmd.none
                 )
 
-        Focused _ ->
+        TabsHelpers.Focused _ ->
             Tuple.first ( model, Cmd.none )
 
 
-viewWithTabControls : State -> Html Msg
+viewWithTabControls : TabsHelpers.State -> Html TabsHelpers.Msg
 viewWithTabControls model =
     Carousel.viewWithTabControls
-        { focusAndSelect = FocusAndSelectTab
+        { focusAndSelect = TabsHelpers.FocusAndSelectTab
         , selected = model.selected
         , tabControlListStyles = []
         , role = Carousel.Group
@@ -198,10 +207,10 @@ viewWithTabControls model =
         |> (\{ controls, slides, containerAttributes } -> section containerAttributes [ slides, controls ])
 
 
-viewWithCombinedControls : State -> Html Msg
+viewWithCombinedControls : TabsHelpers.State -> Html TabsHelpers.Msg
 viewWithCombinedControls model =
     Carousel.viewWithCombinedControls
-        { focusAndSelect = FocusAndSelectTab
+        { focusAndSelect = TabsHelpers.FocusAndSelectTab
         , selected = model.selected
         , tabControlListStyles = []
         , role = Carousel.Group
@@ -232,10 +241,10 @@ viewWithCombinedControls model =
            )
 
 
-viewWithPreviousAndNextControls : Int -> State -> Html Msg
+viewWithPreviousAndNextControls : Int -> TabsHelpers.State -> Html TabsHelpers.Msg
 viewWithPreviousAndNextControls slidesCount model =
     Carousel.viewWithPreviousAndNextControls
-        { focusAndSelect = FocusAndSelectTab
+        { focusAndSelect = TabsHelpers.FocusAndSelectTab
         , selected = model.selected
         , role = Carousel.Group
         , labelledBy = Carousel.LabelledByAccessibleLabelOnly "Label"
@@ -257,10 +266,10 @@ viewWithPreviousAndNextControls slidesCount model =
            )
 
 
-program : (State -> Html Msg) -> TestContext
+program : (TabsHelpers.State -> Html TabsHelpers.Msg) -> TabsHelpers.TestContext
 program view =
     ProgramTest.createSandbox
-        { init = init
+        { init = TabsHelpers.init
         , update = update
         , view = view >> toUnstyled
         }

--- a/tests/Spec/Nri/Ui/Carousel.elm
+++ b/tests/Spec/Nri/Ui/Carousel.elm
@@ -54,7 +54,7 @@ previousAndNextCarouselProgram slidesCount =
                     , role = Carousel.Group
                     , accessibleLabel = "Previous/Next Carousel"
                     , visibleLabelId = Nothing
-                    , panels =
+                    , slides =
                         List.map
                             (\i ->
                                 { id = i
@@ -245,7 +245,7 @@ viewWithTabControls model =
         , role = Carousel.Group
         , tabControlStyles = \_ -> []
         , labelledBy = Carousel.LabelledByAccessibleLabelOnly "Label"
-        , panels =
+        , slides =
             [ { id = 0
               , idString = "slide-0"
               , tabControlHtml = text "Control 0"
@@ -275,7 +275,7 @@ viewWithCombinedControls model =
         , role = Carousel.Group
         , tabControlStyles = \_ -> []
         , labelledBy = Carousel.LabelledByAccessibleLabelOnly "Label"
-        , panels =
+        , slides =
             [ { id = 0
               , idString = "slide-0"
               , tabControlHtml = text "Control 0"

--- a/tests/Spec/Nri/Ui/Carousel.elm
+++ b/tests/Spec/Nri/Ui/Carousel.elm
@@ -273,8 +273,8 @@ viewWithTabControlsSpec =
                         Carousel.viewWithTabControls
                             { selected = model.selected
                             , slides = List.take slideCount allSlides
-                            , tabControlStyles = \_ -> []
-                            , tabControlListStyles = []
+                            , tabStyles = \_ -> []
+                            , tabListStyles = []
                             , role = Carousel.Group
                             , name = "Slides"
                             , visibleLabelId =
@@ -433,8 +433,8 @@ viewWithCombinedControlsSpec =
                             { selected = model.selected
                             , slides = List.take slideCount allSlides
                             , role = Carousel.Group
-                            , tabControlStyles = \_ -> []
-                            , tabControlListStyles = []
+                            , tabStyles = \_ -> []
+                            , tabListStyles = []
                             , name = "Slides"
                             , visibleLabelId = Nothing
                             , previousButton = { attributes = [], icon = UiIcon.arrowLeft, name = "Previous" }

--- a/tests/Spec/Nri/Ui/Carousel.elm
+++ b/tests/Spec/Nri/Ui/Carousel.elm
@@ -78,7 +78,7 @@ viewWithPreviousAndNextControlsSpec =
                             { announceAndSelect = AnnounceAndSelect
                             , selected = model.selected
                             , role = Carousel.Group
-                            , accessibleLabel = "Previous/Next Carousel"
+                            , name = "Previous/Next Carousel"
                             , visibleLabelId =
                                 if relyOnVisibileLabelForContainer then
                                     Just "carousel-label"
@@ -90,7 +90,7 @@ viewWithPreviousAndNextControlsSpec =
                                     (\i ->
                                         { id = i
                                         , idString = "slide-" ++ String.fromInt i
-                                        , accessibleLabel = "Slide " ++ String.fromInt i
+                                        , name = "Slide " ++ String.fromInt i
                                         , visibleLabelId =
                                             if relyOnVisibleLabelForSlides then
                                                 Just ("slide-" ++ String.fromInt i ++ "-label")
@@ -156,7 +156,7 @@ viewWithPreviousAndNextControlsSpec =
                     |> clickButton "Previous"
                     |> ensureLastEffect (Expect.equal (Announce "Active slide of Previous/Next Carousel changed to Slide 1"))
                     |> done
-        , test "If the visibleLabelId is Nothing the container aria label is set to the accessibleLabel" <|
+        , test "If the visibleLabelId is Nothing the container aria label is set to the name" <|
             \_ ->
                 start { relyOnVisibleLabelForSlides = False, relyOnVisibileLabelForContainer = False, slideCount = 3 }
                     |> ensureViewHas
@@ -176,7 +176,7 @@ viewWithPreviousAndNextControlsSpec =
                             ]
                         ]
                     |> done
-        , test "If the visibleLabelId is Nothing the slides container aria label is set to the accessibleLabel" <|
+        , test "If the visibleLabelId is Nothing the slides container aria label is set to the name" <|
             \_ ->
                 start { relyOnVisibleLabelForSlides = False, relyOnVisibileLabelForContainer = False, slideCount = 1 }
                     |> ensureViewHas
@@ -213,21 +213,21 @@ viewWithTabControlsSpec =
                             , slides =
                                 [ { id = 0
                                   , idString = "slide-0"
-                                  , accessibleLabel = "Slide 0"
+                                  , name = "Slide 0"
                                   , visibleLabelId = Nothing
                                   , tabControlHtml = text "Control 0"
                                   , slideHtml = text "Slide 0"
                                   }
                                 , { id = 1
                                   , idString = "slide-1"
-                                  , accessibleLabel = "Slide 1"
+                                  , name = "Slide 1"
                                   , visibleLabelId = Nothing
                                   , tabControlHtml = text "Control 1"
                                   , slideHtml = text "Slide 1"
                                   }
                                 , { id = 2
                                   , idString = "slide-2"
-                                  , accessibleLabel = "Slide 2"
+                                  , name = "Slide 2"
                                   , visibleLabelId = Nothing
                                   , tabControlHtml = text "Control 2"
                                   , slideHtml = text "Slide 2"
@@ -236,7 +236,7 @@ viewWithTabControlsSpec =
                             , tabControlStyles = \_ -> []
                             , tabControlListStyles = []
                             , role = Carousel.Group
-                            , accessibleLabel = "Slides"
+                            , name = "Slides"
                             , visibleLabelId =
                                 if relyOnVisibileLabelForContainer then
                                     Just "container-label"
@@ -322,7 +322,7 @@ viewWithTabControlsSpec =
                         |> ensureTabbable "Control 0"
                         |> ensureOnlyOneTabInSequence [ "Control 0", "Control 1", "Control 2" ]
                         |> done
-            , test "If the visibleLabelId is Nothing the container aria label is set to the accessibleLabel" <|
+            , test "If the visibleLabelId is Nothing the container aria label is set to the name" <|
                 \_ ->
                     start False
                         |> ensureViewHas
@@ -361,21 +361,21 @@ viewWithCombinedControlsSpec =
                             , slides =
                                 [ { id = 0
                                   , idString = "slide-0"
-                                  , accessibleLabel = "Slide 0"
+                                  , name = "Slide 0"
                                   , visibleLabelId = Nothing
                                   , tabControlHtml = text "Control 0"
                                   , slideHtml = text "Slide 0"
                                   }
                                 , { id = 1
                                   , idString = "slide-1"
-                                  , accessibleLabel = "Slide 1"
+                                  , name = "Slide 1"
                                   , visibleLabelId = Nothing
                                   , tabControlHtml = text "Control 1"
                                   , slideHtml = text "Slide 1"
                                   }
                                 , { id = 2
                                   , idString = "slide-2"
-                                  , accessibleLabel = "Slide 2"
+                                  , name = "Slide 2"
                                   , visibleLabelId = Nothing
                                   , tabControlHtml = text "Control 2"
                                   , slideHtml = text "Slide 2"
@@ -384,7 +384,7 @@ viewWithCombinedControlsSpec =
                             , role = Carousel.Group
                             , tabControlStyles = \_ -> []
                             , tabControlListStyles = []
-                            , accessibleLabel = "Slides"
+                            , name = "Slides"
                             , visibleLabelId = Nothing
                             , previousButton = { attributes = [], icon = UiIcon.arrowLeft, name = "Previous" }
                             , nextButton = { attributes = [], icon = UiIcon.arrowRight, name = "Next" }

--- a/tests/Spec/TabsInternalHelpers.elm
+++ b/tests/Spec/TabsInternalHelpers.elm
@@ -31,7 +31,7 @@ type alias TestContext =
     ProgramTest State Msg ()
 
 
-ensureTabbable : String -> TestContext -> TestContext
+ensureTabbable : String -> ProgramTest model msg effect -> ProgramTest model msg effect
 ensureTabbable word testContext =
     testContext
         |> ensureView
@@ -40,7 +40,7 @@ ensureTabbable word testContext =
             )
 
 
-ensurePanelsFocusable : List String -> TestContext -> TestContext
+ensurePanelsFocusable : List String -> ProgramTest model msg effect -> ProgramTest model msg effect
 ensurePanelsFocusable words testContext =
     testContext
         |> ensureView
@@ -49,7 +49,7 @@ ensurePanelsFocusable words testContext =
             )
 
 
-ensurePanelDisplayed : String -> TestContext -> TestContext
+ensurePanelDisplayed : String -> ProgramTest model msg effect -> ProgramTest model msg effect
 ensurePanelDisplayed word testContext =
     testContext
         |> ensureView
@@ -58,7 +58,7 @@ ensurePanelDisplayed word testContext =
             )
 
 
-ensureOnlyOnePanelDisplayed : List String -> TestContext -> TestContext
+ensureOnlyOnePanelDisplayed : List String -> ProgramTest model msg effect -> ProgramTest model msg effect
 ensureOnlyOnePanelDisplayed panels testContext =
     testContext
         |> ensureView
@@ -71,7 +71,7 @@ ensureOnlyOnePanelDisplayed panels testContext =
             )
 
 
-ensureOnlyOneTabInSequence : List String -> TestContext -> TestContext
+ensureOnlyOneTabInSequence : List String -> ProgramTest model msg effect -> ProgramTest model msg effect
 ensureOnlyOneTabInSequence tabs testContext =
     testContext
         |> ensureView
@@ -84,13 +84,13 @@ ensureOnlyOneTabInSequence tabs testContext =
             )
 
 
-releaseRightArrow : TestContext -> TestContext
+releaseRightArrow : ProgramTest model msg effect -> ProgramTest model msg effect
 releaseRightArrow =
     KeyboardHelpers.releaseRightArrow { targetDetails = [] }
         [ Selector.attribute Role.tab, Selector.attribute (Key.tabbable True) ]
 
 
-releaseLeftArrow : TestContext -> TestContext
+releaseLeftArrow : ProgramTest model msg effect -> ProgramTest model msg effect
 releaseLeftArrow =
     KeyboardHelpers.releaseLeftArrow { targetDetails = [] }
         [ Selector.attribute Role.tab, Selector.attribute (Key.tabbable True) ]


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Implement new carousels types (previous/next and combined) using [w3c guided](https://www.w3.org/WAI/ARIA/apg/patterns/carousel/)
## :framed_picture: What does this change look like?
This component doesn't have styles attached to it, so no visual changes.
## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - [Growth issue to migrate landing](https://linear.app/noredink/issue/GRO-1375/migrate-landing-page-carousel-to-nriuicarouselv2)
  - [Quokka issue for short response](https://linear.app/noredink/issue/WR-208/adapt-and-use-nriuicarousel-to-view-supporting-materials)
