### PR TITLE
🔧 Support ATAC in new Modal.V12

### DIFF
--- a/component-catalog/src/Examples/Modal.elm
+++ b/component-catalog/src/Examples/Modal.elm
@@ -17,7 +17,7 @@ import Debug.Control.View as ControlView
 import EventExtras exposing (onClickStopPropagation)
 import Example exposing (Example)
 import Guidance
-import Html.Styled exposing (Html, div, text)
+import Html.Styled as Html exposing (Html, div, text)
 import Html.Styled.Attributes as Attributes exposing (css)
 import KeyboardSupport
 import Nri.Ui.Button.V10 as Button
@@ -26,6 +26,7 @@ import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Modal.V12 as Modal
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -57,6 +58,7 @@ type alias ViewSettings =
     , showSecondary : Bool
     , dismissOnEscAndOverlayClick : Bool
     , content : String
+    , atac : Bool
     }
 
 
@@ -79,6 +81,7 @@ initViewSettings =
                     , "Candy cake danish gingerbread. Caramels toffee cupcake toffee sweet. Gummi bears candy cheesecake sweet. Pie gingerbread sugar plum halvah muffin icing marzipan wafer icing. Candy fruitcake gummies icing marzipan. Halvah jelly beans candy candy canes biscuit bonbon sesame snaps. Biscuit carrot cake croissant cake chocolate lollipop candy biscuit croissant. Topping jujubes apple pie croissant chocolate cake. Liquorice cookie dragée gummies cotton candy fruitcake lemon drops candy canes. Apple pie lemon drops gummies cake chocolate bar cake jelly-o tiramisu. Chocolate bar icing pudding marshmallow cake soufflé soufflé muffin. Powder lemon drops biscuit sugar plum cupcake carrot cake powder cake dragée. Bear claw gummi bears liquorice sweet roll."
                     ]
             )
+        |> Control.field "Show ATAC" (Control.bool False)
 
 
 controlTitleVisibility : Control ( String, Modal.Attribute )
@@ -241,6 +244,17 @@ example =
                                      , Maybe.map Tuple.first settings.titleVisibility
                                      , Maybe.map Tuple.first settings.theme
                                      , Maybe.map Tuple.first settings.customCss
+                                     , if settings.atac then
+                                        (Code.fromModule moduleName "atac"
+                                            ++ Code.withParens
+                                                ("text "
+                                                    ++ Code.string "Fake ATAC -- use the real one in real code!"
+                                                )
+                                        )
+                                            |> Just
+
+                                       else
+                                        Nothing
                                      ]
                                         |> List.filterMap identity
                                     )
@@ -298,6 +312,11 @@ example =
                  , Maybe.map Tuple.second settings.titleVisibility
                  , Maybe.map Tuple.second settings.theme
                  , Maybe.map Tuple.second settings.customCss
+                 , if settings.atac then
+                    Just (Modal.atac fakeATAC)
+
+                   else
+                    Nothing
                  ]
                     |> List.filterMap identity
                 )
@@ -306,6 +325,38 @@ example =
                 |> div [ onClickStopPropagation SwallowEvent ]
             ]
     }
+
+
+fakeATAC : Html msg
+fakeATAC =
+    Html.aside
+        [ Attributes.css
+            [ Css.position Css.fixed
+            , Css.bottom Css.zero
+            , Css.left Css.zero
+            , Css.maxWidth (Css.px 480)
+            , Css.backgroundColor Colors.gray96
+            , Css.borderTop3 (Css.px 1) Css.solid Colors.gray75
+            , Css.borderRight3 (Css.px 1) Css.solid Colors.gray75
+            , Css.minHeight (Css.px 80)
+            , Css.padding (Css.px 8)
+            , Fonts.baseFont
+            , Css.zIndex (Css.int 1)
+            ]
+        ]
+        [ Heading.h2
+            [ Heading.plaintext "(Fake) Announcement history"
+            ]
+        , Text.smallBody
+            [ Text.html
+                [ text "NRI employees can learn more about the real ATAC in "
+                , ClickableText.link "HERE"
+                    [ ClickableText.appearsInline
+                    , ClickableText.linkExternal ""
+                    ]
+                ]
+            ]
+        ]
 
 
 launchModalButton : ViewSettings -> Html Msg

--- a/component-catalog/src/Examples/Modal.elm
+++ b/component-catalog/src/Examples/Modal.elm
@@ -207,9 +207,8 @@ example =
                                 , "\n\t-- Use elements with Button.modal and ClickableText.modal for standardized footer elements"
                                 , "\n\t-- Remember to add an id to the first and final focusable element!"
                                 , "\n\t, footer = [] "
-                                , "\n\t, focusTrap ="
-                                , "\n\t\t{ focus = Focus"
-                                , "\n\t\t, firstId = "
+                                , "\n\t, focus = Focus"
+                                , "\n\t, firstId = "
                                     ++ (if settings.showX then
                                             Code.string Modal.closeButtonId
 
@@ -219,7 +218,7 @@ example =
                                         else
                                             Code.string closeClickableTextId
                                        )
-                                , "\n\t\t, lastId ="
+                                , "\n\t, lastId ="
                                     ++ (if settings.showSecondary then
                                             Code.string closeClickableTextId
 
@@ -229,7 +228,6 @@ example =
                                         else
                                             Code.string Modal.closeButtonId
                                        )
-                                , "\n\t\t}"
                                 , "\n\t}"
                                 , [ if settings.showX then
                                         Just "Modal.closeButton"
@@ -267,27 +265,25 @@ example =
                           else
                             Nothing
                         ]
-                , focusTrap =
-                    { focus = Focus
-                    , firstId =
-                        if settings.showX then
-                            Modal.closeButtonId
+                , focus = Focus
+                , firstId =
+                    if settings.showX then
+                        Modal.closeButtonId
 
-                        else if settings.showFocusOnTitle then
-                            continueButtonId
+                    else if settings.showFocusOnTitle then
+                        continueButtonId
 
-                        else
-                            closeClickableTextId
-                    , lastId =
-                        if settings.showSecondary then
-                            closeClickableTextId
+                    else
+                        closeClickableTextId
+                , lastId =
+                    if settings.showSecondary then
+                        closeClickableTextId
 
-                        else if settings.showFocusOnTitle then
-                            continueButtonId
+                    else if settings.showFocusOnTitle then
+                        continueButtonId
 
-                        else
-                            Modal.closeButtonId
-                    }
+                    else
+                        Modal.closeButtonId
                 }
                 ([ if settings.showX then
                     Just Modal.closeButton

--- a/component-catalog/src/Examples/Modal.elm
+++ b/component-catalog/src/Examples/Modal.elm
@@ -401,27 +401,29 @@ update msg state =
     case msg of
         OpenModal config ->
             let
-                ( newState, cmd ) =
+                ( newState, startFocusOn ) =
                     Modal.open config
             in
             ( { state | state = newState }
-            , Cmd.map ModalMsg cmd
+            , Task.attempt Focused (Dom.focus startFocusOn)
             )
 
         ModalMsg modalMsg ->
             case Modal.update updateConfig modalMsg state.state of
-                ( newState, cmd ) ->
+                ( newState, maybeFocus ) ->
                     ( { state | state = newState }
-                    , Cmd.map ModalMsg cmd
+                    , Maybe.map (Task.attempt Focused << Dom.focus) maybeFocus
+                        |> Maybe.withDefault Cmd.none
                     )
 
         CloseModal ->
             let
-                ( newState, cmd ) =
+                ( newState, maybeFocus ) =
                     Modal.close state.state
             in
             ( { state | state = newState }
-            , Cmd.map ModalMsg cmd
+            , Maybe.map (Task.attempt Focused << Dom.focus) maybeFocus
+                |> Maybe.withDefault Cmd.none
             )
 
         UpdateSettings value ->

--- a/component-catalog/src/Examples/Modal.elm
+++ b/component-catalog/src/Examples/Modal.elm
@@ -200,48 +200,53 @@ example =
                     \_ ->
                         let
                             code =
-                                [ "Modal.view"
-                                , "\n\t{ title = " ++ Code.string settings.title
-                                , "\n\t, wrapMsg = ModalMsg"
-                                , "\n\t, content = [] -- The body of the modal goes in here"
-                                , "\n\t-- Use elements with Button.modal and ClickableText.modal for standardized footer elements"
-                                , "\n\t-- Remember to add an id to the first and final focusable element!"
-                                , "\n\t, footer = [] "
-                                , "\n\t, focus = Focus"
-                                , "\n\t, firstId = "
-                                    ++ (if settings.showX then
-                                            Code.string Modal.closeButtonId
+                                [ Code.fromModule moduleName "view"
+                                    ++ Code.record
+                                        [ ( "title", Code.string settings.title )
+                                        , ( "wrapMsg", "ModalMsg" )
+                                        , ( "content", "[] -- The body of the modal goes in here" )
+                                        , ( "footer", "[] -- Use Button.modal and ClickableText.modal for standard styles" )
+                                        , ( "focus", "Focus" )
+                                        , ( "firstId"
+                                          , Code.string
+                                                (if settings.showX then
+                                                    Modal.closeButtonId
 
-                                        else if settings.showFocusOnTitle then
-                                            Code.string continueButtonId
+                                                 else if settings.showFocusOnTitle then
+                                                    continueButtonId
 
-                                        else
-                                            Code.string closeClickableTextId
-                                       )
-                                , "\n\t, lastId ="
-                                    ++ (if settings.showSecondary then
-                                            Code.string closeClickableTextId
+                                                 else
+                                                    closeClickableTextId
+                                                )
+                                          )
+                                        , ( "lastId"
+                                          , Code.string
+                                                (if settings.showSecondary then
+                                                    closeClickableTextId
 
-                                        else if settings.showFocusOnTitle then
-                                            Code.string continueButtonId
+                                                 else if settings.showFocusOnTitle then
+                                                    continueButtonId
 
-                                        else
-                                            Code.string Modal.closeButtonId
-                                       )
-                                , "\n\t}"
-                                , [ if settings.showX then
+                                                 else
+                                                    Modal.closeButtonId
+                                                )
+                                          )
+                                        ]
+                                , Code.listMultiline
+                                    ([ if settings.showX then
                                         Just "Modal.closeButton"
 
-                                    else
+                                       else
                                         Nothing
-                                  , Maybe.map Tuple.first settings.titleVisibility
-                                  , Maybe.map Tuple.first settings.theme
-                                  , Maybe.map Tuple.first settings.customCss
-                                  ]
-                                    |> List.filterMap identity
-                                    |> Code.list
-                                , "\n\t-- you should use the actual state, NEVER hardcode it open like this:"
-                                , "\n\t(Modal.open { startFocusOn = \"\", returnFocusTo = \"\"} |> Tuple.first)"
+                                     , Maybe.map Tuple.first settings.titleVisibility
+                                     , Maybe.map Tuple.first settings.theme
+                                     , Maybe.map Tuple.first settings.customCss
+                                     ]
+                                        |> List.filterMap identity
+                                    )
+                                    1
+                                , Code.newlineWithIndent 1
+                                , "modalState"
                                 ]
                                     |> String.join ""
                         in

--- a/component-catalog/src/Examples/Modal.elm
+++ b/component-catalog/src/Examples/Modal.elm
@@ -26,7 +26,7 @@ import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
-import Nri.Ui.Modal.V11 as Modal
+import Nri.Ui.Modal.V12 as Modal
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Task

--- a/component-catalog/src/Examples/Modal.elm
+++ b/component-catalog/src/Examples/Modal.elm
@@ -115,7 +115,7 @@ moduleName =
 
 version : Int
 version =
-    11
+    12
 
 
 {-| -}

--- a/component-catalog/src/Examples/Modal.elm
+++ b/component-catalog/src/Examples/Modal.elm
@@ -350,9 +350,10 @@ fakeATAC =
         , Text.smallBody
             [ Text.html
                 [ text "NRI employees can learn more about the real ATAC in "
-                , ClickableText.link "HERE"
+                , ClickableText.link "Assistive Technology Announcement Center (“ATAC”)"
                     [ ClickableText.appearsInline
-                    , ClickableText.linkExternal ""
+                    , ClickableText.linkExternal "https://paper.dropbox.com/doc/Assistive-Technology-Announcement-Center-ATAC--B_GuqwWltzU432ueq7p6Z42mAg-bOnmcnzOj631NRls1IBe3"
+                    , ClickableText.small
                     ]
                 ]
             ]

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -167,11 +167,9 @@ view ellieLinkConfig state =
                 , Button.id "close-premium-modal"
                 ]
             ]
-        , focusTrap =
-            { focus = Focus
-            , firstId = Modal.closeButtonId
-            , lastId = "close-premium-modal"
-            }
+        , focus = Focus
+        , firstId = Modal.closeButtonId
+        , lastId = "close-premium-modal"
         }
         [ Modal.closeButton ]
         state.modal

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -30,7 +30,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Data.PremiumDisplay as PremiumDisplay
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Message.V4 as Message
-import Nri.Ui.Modal.V11 as Modal
+import Nri.Ui.Modal.V12 as Modal
 import Nri.Ui.RadioButton.V4 as RadioButton
 import Nri.Ui.Text.V6 as Text
 import Routes

--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -6,6 +6,7 @@ Nri.Ui.Mark.V2,upgrade to V5
 Nri.Ui.Mark.V3,upgrade to V5
 Nri.Ui.Mark.V4,upgrade to V5
 Nri.Ui.Message.V3,upgrade to V4
+Nri.Ui.Modal.V11,upgrade to V12
 Nri.Ui.SideNav.V4,upgrade to V5
 Nri.Ui.Switch.V2,upgrade to V3
 Nri.Ui.Table.V6,upgrade to V7

--- a/elm.json
+++ b/elm.json
@@ -57,6 +57,7 @@
         "Nri.Ui.Message.V3",
         "Nri.Ui.Message.V4",
         "Nri.Ui.Modal.V11",
+        "Nri.Ui.Modal.V12",
         "Nri.Ui.Page.V3",
         "Nri.Ui.Pagination.V1",
         "Nri.Ui.Palette.V1",

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -169,6 +169,9 @@ hint = 'upgrade to V4'
 hint = 'upgrade to V11'
 usages = ['component-catalog-app/Examples/RadioButton.elm']
 
+[forbidden."Nri.Ui.Modal.V11"]
+hint = 'upgrade to V12'
+
 [forbidden."Nri.Ui.Modal.V3"]
 hint = 'upgrade to V11'
 

--- a/src/Nri/Ui/Modal/V11.elm
+++ b/src/Nri/Ui/Modal/V11.elm
@@ -43,7 +43,7 @@ import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (id)
 import Html.Styled.Events as Events
 import Nri.Ui.FocusTrap.V1 as FocusTrap exposing (FocusTrap)
-import Nri.Ui.Modal.V11 as Modal
+import Nri.Ui.Modal.V12 as Modal
 import Task
 
 main : Program () Modal.Model Msg

--- a/src/Nri/Ui/Modal/V12.elm
+++ b/src/Nri/Ui/Modal/V12.elm
@@ -1,0 +1,788 @@
+module Nri.Ui.Modal.V11 exposing
+    ( view, closeButton, closeButtonId
+    , Model, init, open, close
+    , Msg, update, subscriptions
+    , Attribute
+    , info, warning
+    , showTitle, hideTitle
+    , testId, css, custom
+    , isOpen, titleId
+    )
+
+{-|
+
+
+# TODO for next major version:
+
+  - remove use of FocusTrap type alias (not using the alias causes a major version change)
+
+
+# Patch changes:
+
+  - adds `testId` helper
+  - adds data-nri-descriptions to the header, content, and footer
+  - use `Shadows`
+  - exposes `titleId`
+  - makes the title programmatically focusable
+  - use WhenFocusLeaves directly, instead of using FocusTrap as an intermediary
+
+
+# Changes from V10:
+
+  - remove `initOpen`
+  - change `open`, `close` to return `(Model, Cmd Msg)` rather than `Msg`
+  - make info and warning themes
+  - adds `custom` helper for adding arbitrary html attributes (primarily useful to make limiting the scope of selectors in tests easier by adding ids to modals)
+  - tab and tabback events stop propagation and prevent default
+
+```
+import Browser exposing (element)
+import Browser.Dom as Dom
+import Css exposing (padding, px)
+import Html.Styled exposing (..)
+import Html.Styled.Attributes exposing (id)
+import Html.Styled.Events as Events
+import Nri.Ui.FocusTrap.V1 as FocusTrap exposing (FocusTrap)
+import Nri.Ui.Modal.V11 as Modal
+import Task
+
+main : Program () Modal.Model Msg
+main =
+    Browser.element
+        { init = \_ -> init
+        , view = toUnstyled << view
+        , update = update
+        , subscriptions = \model -> Sub.map ModalMsg (Modal.subscriptions model)
+        }
+
+init : ( Modal.Model, Cmd Msg )
+init =
+    let
+        ( model, cmd ) =
+            -- When we load the page with a modal already open, we should return
+            -- the focus someplace sensible when the modal closes.
+            -- [This article](https://developer.paciellogroup.com/blog/2018/06/the-current-state-of-modal-dialog-accessibility/) recommends
+            -- focusing the main or body.
+            Modal.open
+                { startFocusOn = Modal.closeButtonId
+                , returnFocusTo = "maincontent"
+                }
+    in
+    ( model, Cmd.map ModalMsg cmd )
+
+type Msg
+    = OpenModal String
+    | ModalMsg Modal.Msg
+    | CloseModal
+    | Focus String
+    | Focused (Result Dom.Error ())
+
+update : Msg -> Modal.Model -> ( Modal.Model, Cmd Msg )
+update msg model =
+    case msg of
+        OpenModal returnFocusTo ->
+            let
+                ( newModel, cmd ) =
+                    Modal.open
+                        { startFocusOn = Modal.closeButtonId
+                        , returnFocusTo = returnFocusTo
+                        }
+            in
+            ( newModel, Cmd.map ModalMsg cmd )
+
+        ModalMsg modalMsg ->
+            let
+                ( newModel, cmd ) =
+                    Modal.update
+                        { dismissOnEscAndOverlayClick = True }
+                        modalMsg
+                        model
+            in
+            ( newModel, Cmd.map ModalMsg cmd )
+
+        CloseModal ->
+            let
+                ( newModel, cmd ) =
+                    Modal.close model
+            in
+            ( newModel, Cmd.map ModalMsg cmd )
+
+        Focus id ->
+            ( model, Task.attempt Focused (Dom.focus id) )
+
+        Focused _ ->
+            ( model, Cmd.none )
+
+view : Modal.Model -> Html Msg
+view model =
+    main_ [ id "maincontent" ]
+        [ button
+            [ id "open-modal"
+            , Events.onClick (OpenModal "open-modal")
+            ]
+            [ text "Open Modal" ]
+        , Modal.view
+            { title = "First kind of modal"
+            , wrapMsg = ModalMsg
+            , content = [ text "Modal Content" ]
+            , footer =
+                [ button
+                    [ Events.onClick CloseModal
+                    , id "last-element-id"
+                    ]
+                    [ text "Close" ]
+                ]
+            , focusTrap =
+                { focus = Focus
+                , firstId = Modal.closeButtonId
+                , lastId = "last-element-id"
+                }
+            }
+            [ Modal.hideTitle
+            , Modal.css [ padding (px 10) ]
+            , Modal.custom [ id "first-modal" ]
+            , Modal.closeButton
+            ]
+            model
+        ]
+```
+
+@docs view, closeButton, closeButtonId
+@docs Model, init, open, close
+@docs Msg, update, subscriptions
+
+
+### Attributes
+
+@docs Attribute
+@docs info, warning
+@docs showTitle, hideTitle
+@docs testId, css, custom
+
+
+### State checks and accessors
+
+@docs isOpen, titleId
+
+-}
+
+import Accessibility.Styled as Html exposing (..)
+import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Key as Key
+import Accessibility.Styled.Role as Role
+import Browser.Dom as Dom
+import Browser.Events.Extra
+import Css exposing (..)
+import Css.Media
+import Css.Transitions
+import Html.Styled as Root
+import Html.Styled.Attributes as Attrs exposing (id)
+import Html.Styled.Events exposing (onClick)
+import Nri.Ui.ClickableSvg.V2 as ClickableSvg
+import Nri.Ui.Colors.Extra
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.FocusTrap.V1 exposing (FocusTrap)
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
+import Nri.Ui.MediaQuery.V1 exposing (mobile)
+import Nri.Ui.Shadows.V1 as Shadows
+import Nri.Ui.UiIcon.V1 as UiIcon
+import Nri.Ui.WhenFocusLeaves.V2 as WhenFocusLeaves
+import Task
+
+
+{-| -}
+type Model
+    = Opened String
+    | Closed
+
+
+{-| -}
+init : Model
+init =
+    Closed
+
+
+{-| Pass the id of the element that should receive focus when the modal closes.
+
+> ...if a dialog was opened on page load, then focus could be placed on either the body or main element.
+> If the trigger was removed from the DOM, then placing focus as close to the trigger’s DOM location would be ideal.
+
+<https://developer.paciellogroup.com/blog/2018/06/the-current-state-of-modal-dialog-accessibility/>
+
+-}
+open : { startFocusOn : String, returnFocusTo : String } -> ( Model, Cmd Msg )
+open { startFocusOn, returnFocusTo } =
+    ( Opened returnFocusTo
+    , Task.attempt Focused (Dom.focus startFocusOn)
+    )
+
+
+{-| -}
+close : Model -> ( Model, Cmd Msg )
+close model =
+    case model of
+        Opened returnFocusTo ->
+            ( Closed, Task.attempt Focused (Dom.focus returnFocusTo) )
+
+        Closed ->
+            ( Closed, Cmd.none )
+
+
+{-| -}
+isOpen : Model -> Bool
+isOpen model =
+    case model of
+        Opened _ ->
+            True
+
+        Closed ->
+            False
+
+
+{-| -}
+type Msg
+    = CloseButtonClicked
+    | EscOrOverlayClicked
+    | Focused (Result Dom.Error ())
+
+
+{-| Include the subscription if you want the modal to dismiss on `Esc`.
+-}
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    case model of
+        Opened _ ->
+            Browser.Events.Extra.escape EscOrOverlayClicked
+
+        Closed ->
+            Sub.none
+
+
+{-| -}
+update : { dismissOnEscAndOverlayClick : Bool } -> Msg -> Model -> ( Model, Cmd Msg )
+update { dismissOnEscAndOverlayClick } msg model =
+    case msg of
+        CloseButtonClicked ->
+            close model
+
+        EscOrOverlayClicked ->
+            if dismissOnEscAndOverlayClick then
+                close model
+
+            else
+                ( model, Cmd.none )
+
+        Focused _ ->
+            -- TODO: consider adding error handling when we didn't successfully
+            -- fous an element
+            ( model, Cmd.none )
+
+
+
+-- ATTRIBUTES
+
+
+{-| This is the default theme.
+-}
+info : Attribute
+info =
+    Batch []
+
+
+{-| -}
+warning : Attribute
+warning =
+    Batch
+        [ overlayColor (Nri.Ui.Colors.Extra.withAlpha 0.9 Colors.gray20)
+        , titleColor Colors.red
+        ]
+
+
+{-| Include the close button.
+-}
+closeButton : Attribute
+closeButton =
+    Attribute (\attrs -> { attrs | closeButton = True })
+
+
+{-| This is the default setting.
+-}
+showTitle : Attribute
+showTitle =
+    Attribute (\attrs -> { attrs | visibleTitle = True })
+
+
+{-| -}
+hideTitle : Attribute
+hideTitle =
+    Attribute (\attrs -> { attrs | visibleTitle = False })
+
+
+{-| Do NOT use this function for attaching styles -- use the `css` helper instead.
+
+    import Html.Styled.Attribute exposing (id)
+
+    Modal.view
+        { title = "Some Great Modal"
+        , wrapMsg = ModalMsg
+        , content = []
+        , footer = []
+        }
+        [ Modal.custom [ id "my-modal" ]]
+        modalState
+
+-}
+custom : List (Html.Attribute Never) -> Attribute
+custom customAttributes =
+    Attribute
+        (\attrs ->
+            { attrs
+                | customAttributes =
+                    List.append attrs.customAttributes customAttributes
+            }
+        )
+
+
+{-| -}
+testId : String -> Attribute
+testId id_ =
+    Attribute
+        (\attrs ->
+            { attrs
+                | customAttributes =
+                    ExtraAttributes.testId id_ :: attrs.customAttributes
+            }
+        )
+
+
+{-| -}
+css : List Style -> Attribute
+css styles =
+    Attribute
+        (\attrs ->
+            { attrs
+                | customStyles =
+                    List.append attrs.customStyles styles
+            }
+        )
+
+
+{-| -}
+type Attribute
+    = Attribute (Attributes -> Attributes)
+    | Batch (List Attribute)
+
+
+
+-- ATTRIBUTES (INTERNAL)
+
+
+type alias Attributes =
+    { overlayColor : Color
+    , titleColor : Color
+    , visibleTitle : Bool
+    , customStyles : List Style
+    , customAttributes : List (Html.Attribute Never)
+    , closeButton : Bool
+    }
+
+
+defaultAttributes : Attributes
+defaultAttributes =
+    { overlayColor = Nri.Ui.Colors.Extra.withAlpha 0.9 Colors.navy
+    , titleColor = Colors.navy
+    , visibleTitle = True
+    , customStyles = []
+    , customAttributes = []
+    , closeButton = False
+    }
+
+
+titleColor : Color -> Attribute
+titleColor color =
+    Attribute (\attrs -> { attrs | titleColor = color })
+
+
+overlayColor : Color -> Attribute
+overlayColor color =
+    Attribute (\attrs -> { attrs | overlayColor = color })
+
+
+buildAttributes : List Attribute -> Attributes
+buildAttributes attrs =
+    let
+        applyAttrs attribute acc =
+            case attribute of
+                Attribute fun ->
+                    fun acc
+
+                Batch functions ->
+                    List.foldl applyAttrs acc functions
+    in
+    List.foldl applyAttrs defaultAttributes attrs
+
+
+modalStyles : List Style
+modalStyles =
+    [ position relative
+
+    -- Border
+    , borderRadius (px 20)
+    , Shadows.high
+    , Css.Media.withMedia [ mobile ]
+        [ borderRadius zero
+        ]
+
+    -- Spacing
+    , margin2 (px 20) auto
+
+    -- Size
+    , width (px 600)
+    , backgroundColor Colors.white
+    ]
+
+
+titleStyles : { a | titleColor : Color, visibleTitle : Bool, closeButton : Maybe msg } -> List Style
+titleStyles config =
+    if config.visibleTitle then
+        let
+            titleSidePadding =
+                Css.px <|
+                    case config.closeButton of
+                        Just _ ->
+                            60
+
+                        Nothing ->
+                            40
+        in
+        [ Fonts.baseFont
+        , Css.fontWeight (Css.int 700)
+        , Css.padding3
+            (Css.px 40)
+            titleSidePadding
+            (Css.px 20)
+        , Css.margin Css.zero
+        , Css.fontSize (Css.px 20)
+        , Css.textAlign Css.center
+        , Css.color config.titleColor
+        , Css.Media.withMedia [ mobile ]
+            [ Css.padding3 (Css.px 20) (Css.px 20) Css.zero
+            ]
+        ]
+
+    else
+        [ -- https://snook.ca/archives/html_and_css/hiding-content-for-accessibility
+          Css.property "clip" "rect(1px, 1px, 1px, 1px)"
+        , Css.position Css.absolute
+        , Css.height (Css.px 1)
+        , Css.width (Css.px 1)
+        , Css.overflow Css.hidden
+        , Css.margin (Css.px -1)
+        , Css.padding Css.zero
+        , Css.border Css.zero
+        ]
+
+
+
+-- VIEW
+
+
+{-| `FocusTrap` comes from `Nri.Ui.FocusTrap.V1`.
+-}
+view :
+    { title : String
+    , wrapMsg : Msg -> msg
+    , focusTrap : FocusTrap msg
+    , content : List (Html msg)
+    , footer : List (Html msg)
+    }
+    -> List Attribute
+    -> Model
+    -> Html msg
+view config attrsList model =
+    let
+        attrs =
+            buildAttributes attrsList
+    in
+    case model of
+        Opened _ ->
+            div
+                [ Attrs.css
+                    [ position fixed
+                    , top zero
+                    , left zero
+                    , width (pct 100)
+                    , height (pct 100)
+                    , displayFlex
+                    , alignItems center
+                    ]
+                ]
+                [ viewBackdrop config.wrapMsg attrs.overlayColor
+                , div [ Attrs.css (List.append modalStyles attrs.customStyles) ]
+                    [ viewModal
+                        { title = config.title
+                        , titleColor = attrs.titleColor
+                        , visibleTitle = attrs.visibleTitle
+                        , customAttributes = attrs.customAttributes
+                        , closeButton =
+                            if attrs.closeButton then
+                                Just (config.wrapMsg CloseButtonClicked)
+
+                            else
+                                Nothing
+                        , content = config.content
+                        , footer = config.footer
+                        }
+                    ]
+                , Root.node "style" [] [ Root.text "body {overflow: hidden;} " ]
+                ]
+                |> List.singleton
+                |> Root.div
+                    [ WhenFocusLeaves.onKeyDownPreventDefault
+                        []
+                        { firstIds = [ config.focusTrap.firstId, titleId ]
+                        , lastIds = [ config.focusTrap.lastId ]
+                        , -- if the user tabs back while on the first id or the modal heading's id,
+                          -- we want to wrap around to the last id.
+                          tabBackAction = config.focusTrap.focus config.focusTrap.lastId
+                        , -- if the user tabs forward while on the last id,
+                          -- we want to wrap around to the first id.
+                          tabForwardAction = config.focusTrap.focus config.focusTrap.firstId
+                        }
+                    , ExtraAttributes.testId "focus-trap-node"
+                    , Attrs.css [ Css.position Css.relative, Css.zIndex (Css.int 100) ]
+                    ]
+
+        Closed ->
+            text ""
+
+
+viewBackdrop : (Msg -> msg) -> Color -> Html msg
+viewBackdrop wrapMsg color =
+    Root.div
+        -- We use Root html here in order to allow clicking to exit out of
+        -- the overlay. This behavior is available to non-mouse users as
+        -- well via the ESC key, so imo it's fine to have this div
+        -- be clickable but not focusable.
+        [ Attrs.css
+            [ position absolute
+            , width (pct 100)
+            , height (pct 100)
+            , backgroundColor color
+            ]
+        , onClick (wrapMsg EscOrOverlayClicked)
+        , ExtraAttributes.nriDescription "modal-backdrop"
+        ]
+        []
+
+
+{-| Id used for the `h1` that labels the modal.
+
+Useful if you're changing the modal contents and want to move the user's focus to the new modal's updated title to re-orient them.
+
+-}
+titleId : String
+titleId =
+    "modal__title"
+
+
+viewModal :
+    { title : String
+    , titleColor : Color
+    , visibleTitle : Bool
+    , customAttributes : List (Html.Attribute Never)
+    , closeButton : Maybe msg
+    , content : List (Html msg)
+    , footer : List (Html msg)
+    }
+    -> Html msg
+viewModal config =
+    section
+        ([ Role.dialog
+         , Aria.modal True
+         , Aria.labeledBy titleId
+         ]
+            ++ config.customAttributes
+        )
+        [ h1
+            [ id titleId
+            , Attrs.css (titleStyles config)
+            , ExtraAttributes.nriDescription "modal-title"
+            , Key.tabbable False
+            ]
+            [ text config.title ]
+        , div
+            []
+            [ viewInnerContent config
+            , viewFooter config.footer
+            ]
+        ]
+
+
+{-| -}
+viewInnerContent :
+    { config
+        | content : List (Html msg)
+        , visibleTitle : Bool
+        , closeButton : Maybe msg
+        , footer : List (Html msg)
+    }
+    -> Html msg
+viewInnerContent ({ visibleTitle } as config) =
+    let
+        children =
+            case config.closeButton of
+                Just msg ->
+                    viewCloseButton msg :: config.content
+
+                Nothing ->
+                    config.content
+
+        visibleFooter =
+            not (List.isEmpty config.footer)
+
+        ( titleDesktopHeight, titleMobileHeight ) =
+            if visibleTitle then
+                ( 85, 45 )
+
+            else
+                ( 0, 0 )
+
+        ( footerDesktopHeight, footerMobileHeight ) =
+            if visibleFooter then
+                ( 160, 137 )
+
+            else
+                ( 0, 0 )
+
+        modalTitleStyles =
+            if visibleTitle then
+                []
+
+            else
+                [ Css.borderTopLeftRadius (Css.px 20)
+                , Css.borderTopRightRadius (Css.px 20)
+                , Css.overflowY Css.hidden
+                ]
+
+        modalFooterStyles =
+            if visibleFooter then
+                []
+
+            else
+                [ Css.borderBottomLeftRadius (Css.px 20)
+                , Css.borderBottomRightRadius (Css.px 20)
+                , Css.overflowY Css.hidden
+                ]
+    in
+    div
+        [ Attrs.css (modalTitleStyles ++ modalFooterStyles)
+        , ExtraAttributes.nriDescription "modal-content"
+        ]
+        [ div
+            [ Attrs.css
+                [ Css.overflowY Css.auto
+                , Css.overflowX Css.hidden
+                , Css.minHeight (Css.px 50)
+                , Css.maxHeight
+                    (Css.calc (Css.vh 100)
+                        Css.minus
+                        (Css.px (footerDesktopHeight + titleDesktopHeight + 40))
+                    )
+                , Css.width (Css.pct 100)
+                , Css.boxSizing Css.borderBox
+                , Css.paddingLeft (Css.px 40)
+                , Css.paddingRight (Css.px 40)
+                , Css.Media.withMedia [ mobile ]
+                    [ Css.padding (Css.px 20)
+                    , Css.maxHeight
+                        (Css.calc (Css.vh 100)
+                            Css.minus
+                            (Css.px (footerMobileHeight + titleMobileHeight + 80))
+                        )
+                    ]
+                , if visibleTitle then
+                    Css.paddingTop Css.zero
+
+                  else
+                    Css.paddingTop (Css.px 40)
+                , if visibleFooter then
+                    Css.paddingBottom (Css.px 30)
+
+                  else
+                    Css.paddingBottom (Css.px 40)
+                ]
+            ]
+            children
+        ]
+
+
+{-| -}
+viewFooter : List (Html msg) -> Html msg
+viewFooter children =
+    if List.isEmpty children then
+        Html.text ""
+
+    else
+        div
+            [ Attrs.css
+                [ Css.alignItems Css.center
+                , Css.displayFlex
+                , Css.flexDirection Css.column
+                , Css.flexGrow (Css.int 2)
+                , Css.flexWrap Css.noWrap
+                , Css.padding2 (Css.px 30) Css.zero
+                , Css.backgroundColor Colors.gray96
+                , Css.borderTop3 (Css.px 1) Css.solid Colors.gray92
+                , Css.borderRadius4 Css.zero Css.zero (Css.px 20) (Css.px 20)
+                , Css.Media.withMedia [ mobile ]
+                    [ Css.padding (Css.px 20)
+                    ]
+                ]
+            , ExtraAttributes.nriDescription "modal-footer"
+            ]
+            children
+
+
+
+--BUTTONS
+
+
+{-| -}
+closeButtonId : String
+closeButtonId =
+    "modal__close-button-x"
+
+
+{-| -}
+viewCloseButton : msg -> Html msg
+viewCloseButton closeModal =
+    ClickableSvg.button "Close modal"
+        UiIcon.x
+        [ ClickableSvg.id closeButtonId
+        , ClickableSvg.onClick closeModal
+        , -- TODO: trim down the unnecessary styles
+          ClickableSvg.css
+            [ -- in the upper-right corner of the modal
+              Css.position Css.absolute
+            , Css.top Css.zero
+            , Css.right Css.zero
+
+            -- make appear above lesson content
+            , Css.backgroundColor (rgba 255 255 255 0.5)
+            , Css.borderRadius (pct 50)
+
+            -- make the hitspace extend all the way around x
+            , Css.width (Css.px 60)
+            , Css.height (Css.px 60)
+            , Css.padding (Css.px 20)
+
+            -- apply button styles
+            , Css.borderWidth Css.zero
+            , Css.cursor Css.pointer
+            , Css.color Colors.azure
+            , Css.hover [ Css.color Colors.azureDark ]
+            , Css.Transitions.transition [ Css.Transitions.color 0.1 ]
+            ]
+        ]

--- a/src/Nri/Ui/Modal/V12.elm
+++ b/src/Nri/Ui/Modal/V12.elm
@@ -18,6 +18,7 @@ module Nri.Ui.Modal.V12 exposing
 
   - remove use of FocusTrap type alias
   - return ids to focus on instead of cmds (in order to make modals more testable via the effect pattern with program-test)
+  - use tesk9/accessible-html-with-css for SR-only content
 
 ```
 import Browser exposing (element)
@@ -154,6 +155,7 @@ import Accessibility.Styled as Html exposing (..)
 import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Key as Key
 import Accessibility.Styled.Role as Role
+import Accessibility.Styled.Style as Style
 import Browser.Events.Extra
 import Css exposing (..)
 import Css.Media
@@ -466,16 +468,7 @@ titleStyles config =
         ]
 
     else
-        [ -- https://snook.ca/archives/html_and_css/hiding-content-for-accessibility
-          Css.property "clip" "rect(1px, 1px, 1px, 1px)"
-        , Css.position Css.absolute
-        , Css.height (Css.px 1)
-        , Css.width (Css.px 1)
-        , Css.overflow Css.hidden
-        , Css.margin (Css.px -1)
-        , Css.padding Css.zero
-        , Css.border Css.zero
-        ]
+        [ Style.invisibleStyle ]
 
 
 

--- a/src/Nri/Ui/Modal/V12.elm
+++ b/src/Nri/Ui/Modal/V12.elm
@@ -21,6 +21,7 @@ module Nri.Ui.Modal.V12 exposing
   - return ids to focus on instead of cmds (in order to make modals more testable via the effect pattern with program-test)
   - use tesk9/accessible-html-with-css for SR-only content
   - simplify internal attributes pattern
+  - adds Modal.atac to make a hole for the ATAC to render inside the modal
 
 ```
 import Browser exposing (element)
@@ -372,7 +373,7 @@ css styles =
         )
 
 
-{-| Pass the Assistive Technology Announcement Center and Announcement Log.
+{-| Pass the [Assistive Technology Announcement Center and Announcement Log]("https://paper.dropbox.com/doc/Assistive-Technology-Announcement-Center-ATAC--B_GuqwWltzU432ueq7p6Z42mAg-bOnmcnzOj631NRls1IBe3").
 
 HTML passed here will render after the footer.
 

--- a/src/Nri/Ui/Modal/V12.elm
+++ b/src/Nri/Ui/Modal/V12.elm
@@ -1,39 +1,22 @@
 module Nri.Ui.Modal.V12 exposing
-    ( view, closeButton, closeButtonId
+    ( view
     , Model, init, open, close
     , Msg, update, subscriptions
     , Attribute
     , info, warning
+    , closeButton
     , showTitle, hideTitle
     , testId, css, custom
-    , isOpen, titleId
+    , closeButtonId, titleId
+    , isOpen
     )
 
 {-|
 
 
-# TODO for next major version:
+# Changes fro V11:
 
-  - remove use of FocusTrap type alias (not using the alias causes a major version change)
-
-
-# Patch changes:
-
-  - adds `testId` helper
-  - adds data-nri-descriptions to the header, content, and footer
-  - use `Shadows`
-  - exposes `titleId`
-  - makes the title programmatically focusable
-  - use WhenFocusLeaves directly, instead of using FocusTrap as an intermediary
-
-
-# Changes from V10:
-
-  - remove `initOpen`
-  - change `open`, `close` to return `(Model, Cmd Msg)` rather than `Msg`
-  - make info and warning themes
-  - adds `custom` helper for adding arbitrary html attributes (primarily useful to make limiting the scope of selectors in tests easier by adding ids to modals)
-  - tab and tabback events stop propagation and prevent default
+  - remove use of FocusTrap type alias
 
 ```
 import Browser exposing (element)
@@ -147,7 +130,7 @@ view model =
         ]
 ```
 
-@docs view, closeButton, closeButtonId
+@docs view
 @docs Model, init, open, close
 @docs Msg, update, subscriptions
 
@@ -156,13 +139,19 @@ view model =
 
 @docs Attribute
 @docs info, warning
+@docs closeButton
 @docs showTitle, hideTitle
 @docs testId, css, custom
 
 
-### State checks and accessors
+### Id accessors
 
-@docs isOpen, titleId
+@docs closeButtonId, titleId
+
+
+### State check
+
+@docs isOpen
 
 -}
 

--- a/src/Nri/Ui/Modal/V12.elm
+++ b/src/Nri/Ui/Modal/V12.elm
@@ -25,7 +25,6 @@ import Css exposing (padding, px)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (id)
 import Html.Styled.Events as Events
-import Nri.Ui.FocusTrap.V1 as FocusTrap exposing (FocusTrap)
 import Nri.Ui.Modal.V12 as Modal
 import Task
 
@@ -115,11 +114,9 @@ view model =
                     ]
                     [ text "Close" ]
                 ]
-            , focusTrap =
-                { focus = Focus
-                , firstId = Modal.closeButtonId
-                , lastId = "last-element-id"
-                }
+            , focus = Focus
+            , firstId = Modal.closeButtonId
+            , lastId = "last-element-id"
             }
             [ Modal.hideTitle
             , Modal.css [ padding (px 10) ]
@@ -170,7 +167,6 @@ import Html.Styled.Events exposing (onClick)
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.FocusTrap.V1 exposing (FocusTrap)
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
 import Nri.Ui.MediaQuery.V1 exposing (mobile)
@@ -477,12 +473,13 @@ titleStyles config =
 -- VIEW
 
 
-{-| `FocusTrap` comes from `Nri.Ui.FocusTrap.V1`.
--}
+{-| -}
 view :
     { title : String
     , wrapMsg : Msg -> msg
-    , focusTrap : FocusTrap msg
+    , firstId : String
+    , lastId : String
+    , focus : String -> msg
     , content : List (Html msg)
     , footer : List (Html msg)
     }
@@ -530,14 +527,14 @@ view config attrsList model =
                 |> Root.div
                     [ WhenFocusLeaves.onKeyDownPreventDefault
                         []
-                        { firstIds = [ config.focusTrap.firstId, titleId ]
-                        , lastIds = [ config.focusTrap.lastId ]
+                        { firstIds = [ config.firstId, titleId ]
+                        , lastIds = [ config.lastId ]
                         , -- if the user tabs back while on the first id or the modal heading's id,
                           -- we want to wrap around to the last id.
-                          tabBackAction = config.focusTrap.focus config.focusTrap.lastId
+                          tabBackAction = config.focus config.lastId
                         , -- if the user tabs forward while on the last id,
                           -- we want to wrap around to the first id.
-                          tabForwardAction = config.focusTrap.focus config.focusTrap.firstId
+                          tabForwardAction = config.focus config.firstId
                         }
                     , ExtraAttributes.testId "focus-trap-node"
                     , Attrs.css [ Css.position Css.relative, Css.zIndex (Css.int 100) ]

--- a/src/Nri/Ui/Modal/V12.elm
+++ b/src/Nri/Ui/Modal/V12.elm
@@ -19,6 +19,7 @@ module Nri.Ui.Modal.V12 exposing
   - remove use of FocusTrap type alias
   - return ids to focus on instead of cmds (in order to make modals more testable via the effect pattern with program-test)
   - use tesk9/accessible-html-with-css for SR-only content
+  - simplify internal attributes pattern
 
 ```
 import Browser exposing (element)
@@ -280,16 +281,20 @@ update { dismissOnEscAndOverlayClick } msg model =
 -}
 info : Attribute
 info =
-    Batch []
+    Attribute identity
 
 
 {-| -}
 warning : Attribute
 warning =
-    Batch
-        [ overlayColor (Nri.Ui.Colors.Extra.withAlpha 0.9 Colors.gray20)
-        , titleColor Colors.red
-        ]
+    Attribute
+        (\attrs ->
+            { attrs
+                | overlayColor =
+                    Nri.Ui.Colors.Extra.withAlpha 0.9 Colors.gray20
+                , titleColor = Colors.red
+            }
+        )
 
 
 {-| Include the close button.
@@ -367,7 +372,6 @@ css styles =
 {-| -}
 type Attribute
     = Attribute (Attributes -> Attributes)
-    | Batch (List Attribute)
 
 
 
@@ -395,16 +399,6 @@ defaultAttributes =
     }
 
 
-titleColor : Color -> Attribute
-titleColor color =
-    Attribute (\attrs -> { attrs | titleColor = color })
-
-
-overlayColor : Color -> Attribute
-overlayColor color =
-    Attribute (\attrs -> { attrs | overlayColor = color })
-
-
 buildAttributes : List Attribute -> Attributes
 buildAttributes attrs =
     let
@@ -412,9 +406,6 @@ buildAttributes attrs =
             case attribute of
                 Attribute fun ->
                     fun acc
-
-                Batch functions ->
-                    List.foldl applyAttrs acc functions
     in
     List.foldl applyAttrs defaultAttributes attrs
 

--- a/src/Nri/Ui/Modal/V12.elm
+++ b/src/Nri/Ui/Modal/V12.elm
@@ -1,4 +1,4 @@
-module Nri.Ui.Modal.V11 exposing
+module Nri.Ui.Modal.V12 exposing
     ( view, closeButton, closeButtonId
     , Model, init, open, close
     , Msg, update, subscriptions
@@ -43,7 +43,7 @@ import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (id)
 import Html.Styled.Events as Events
 import Nri.Ui.FocusTrap.V1 as FocusTrap exposing (FocusTrap)
-import Nri.Ui.Modal.V11 as Modal
+import Nri.Ui.Modal.V12 as Modal
 import Task
 
 main : Program () Modal.Model Msg

--- a/src/Nri/Ui/Modal/V12.elm
+++ b/src/Nri/Ui/Modal/V12.elm
@@ -7,6 +7,7 @@ module Nri.Ui.Modal.V12 exposing
     , closeButton
     , showTitle, hideTitle
     , testId, css, custom
+    , atac
     , closeButtonId, titleId
     , isOpen
     )
@@ -139,6 +140,7 @@ view model =
 @docs closeButton
 @docs showTitle, hideTitle
 @docs testId, css, custom
+@docs atac
 
 
 ### Id accessors
@@ -169,6 +171,7 @@ import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
+import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.MediaQuery.V1 exposing (mobile)
 import Nri.Ui.Shadows.V1 as Shadows
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -369,6 +372,16 @@ css styles =
         )
 
 
+{-| Pass the Assistive Technology Announcement Center and Announcement Log.
+
+HTML passed here will render after the footer.
+
+-}
+atac : Html Never -> Attribute
+atac atac_ =
+    Attribute (\attrs -> { attrs | atac = Just atac_ })
+
+
 {-| -}
 type Attribute
     = Attribute (Attributes -> Attributes)
@@ -385,6 +398,7 @@ type alias Attributes =
     , customStyles : List Style
     , customAttributes : List (Html.Attribute Never)
     , closeButton : Bool
+    , atac : Maybe (Html Never)
     }
 
 
@@ -396,6 +410,7 @@ defaultAttributes =
     , customStyles = []
     , customAttributes = []
     , closeButton = False
+    , atac = Nothing
     }
 
 
@@ -512,6 +527,7 @@ view config attrsList model =
                                 Nothing
                         , content = config.content
                         , footer = config.footer
+                        , atac = attrs.atac
                         }
                     ]
                 , Root.node "style" [] [ Root.text "body {overflow: hidden;} " ]
@@ -574,6 +590,7 @@ viewModal :
     , closeButton : Maybe msg
     , content : List (Html msg)
     , footer : List (Html msg)
+    , atac : Maybe (Html Never)
     }
     -> Html msg
 viewModal config =
@@ -595,6 +612,7 @@ viewModal config =
             []
             [ viewInnerContent config
             , viewFooter config.footer
+            , viewJust (map never) config.atac
             ]
         ]
 

--- a/tests/Spec/Nri/Ui/Modal.elm
+++ b/tests/Spec/Nri/Ui/Modal.elm
@@ -29,26 +29,39 @@ spec =
                         , attribute (Key.tabbable False)
                         ]
                     |> done
+        , test "focus starts on the specified element in the modal" <|
+            \() ->
+                start
+                    |> clickButton "Open Modal"
+                    |> ensureFocused Modal.closeButtonId
+                    |> done
+        , test "focus returns to the element that opened the modal" <|
+            \() ->
+                start
+                    |> clickButton "Open Modal"
+                    |> clickButton "Close modal"
+                    |> ensureFocused "open-modal"
+                    |> done
         , test "focus wraps from the modal title correctly" <|
             \() ->
                 start
                     |> clickButton "Open Modal"
                     |> tabBackWithinModal Modal.titleId
-                    |> ensureLastEffect (Expect.equal (FocusOn lastButtonId))
+                    |> ensureFocused lastButtonId
                     |> done
         , test "focus wraps from the close button correctly" <|
             \() ->
                 start
                     |> clickButton "Open Modal"
                     |> tabBackWithinModal Modal.closeButtonId
-                    |> ensureLastEffect (Expect.equal (FocusOn lastButtonId))
+                    |> ensureFocused lastButtonId
                     |> done
         , test "focus wraps from the last button correctly" <|
             \() ->
                 start
                     |> clickButton "Open Modal"
                     |> tabForwardWithinModal lastButtonId
-                    |> ensureLastEffect (Expect.equal (FocusOn Modal.closeButtonId))
+                    |> ensureFocused Modal.closeButtonId
                     |> done
         ]
 
@@ -167,3 +180,8 @@ lastButtonId =
 modalTitle : String
 modalTitle =
     "Modal Title"
+
+
+ensureFocused : String -> ProgramTest a b Effect -> ProgramTest a b Effect
+ensureFocused id =
+    ensureLastEffect (Expect.equal (FocusOn id))

--- a/tests/Spec/Nri/Ui/Modal.elm
+++ b/tests/Spec/Nri/Ui/Modal.elm
@@ -29,7 +29,14 @@ spec =
                         , attribute (Key.tabbable False)
                         ]
                     |> done
-        , test "focus starts on the specified element in the modal" <|
+        , focusTests
+        ]
+
+
+focusTests : Test
+focusTests =
+    describe "Focus management"
+        [ test "focus starts on the specified element in the modal" <|
             \() ->
                 start
                     |> clickButton "Open Modal"

--- a/tests/Spec/Nri/Ui/Modal.elm
+++ b/tests/Spec/Nri/Ui/Modal.elm
@@ -90,40 +90,39 @@ update msg model =
     case msg of
         OpenModal returnFocusTo ->
             let
-                ( newModel, cmd ) =
+                ( newModel, focusOn ) =
                     Modal.open
                         { startFocusOn = Modal.closeButtonId
                         , returnFocusTo = returnFocusTo
                         }
             in
-            ( newModel, ModalEffect cmd )
+            ( newModel, FocusOn focusOn )
 
         ModalMsg modalMsg ->
             let
-                ( newModel, cmd ) =
+                ( newModel, maybeFocus ) =
                     Modal.update
                         { dismissOnEscAndOverlayClick = True }
                         modalMsg
                         model
             in
-            ( newModel, ModalEffect cmd )
+            ( newModel
+            , Maybe.map FocusOn maybeFocus
+                |> Maybe.withDefault None
+            )
 
         Focus id ->
             ( model, FocusOn id )
 
 
 type Effect
-    = ModalEffect (Cmd Modal.Msg)
-    | FocusOn String
+    = FocusOn String
     | None
 
 
 perform : Effect -> SimulatedEffect Msg
 perform effect =
     case effect of
-        ModalEffect modalMsg ->
-            SimulatedEffect.Cmd.none
-
         FocusOn id ->
             SimulatedEffect.Cmd.none
 
@@ -150,11 +149,9 @@ view model =
                     [ Html.text "Last Button"
                     ]
                 ]
-            , focusTrap =
-                { focus = Focus
-                , firstId = Modal.closeButtonId
-                , lastId = lastButtonId
-                }
+            , focus = Focus
+            , firstId = Modal.closeButtonId
+            , lastId = lastButtonId
             }
             [ Modal.closeButton
             ]

--- a/tests/Spec/Nri/Ui/Modal.elm
+++ b/tests/Spec/Nri/Ui/Modal.elm
@@ -20,7 +20,7 @@ spec =
     describe "Nri.Ui.Modal"
         [ test "titleId is attached to the modal title" <|
             \() ->
-                start
+                start []
                     |> clickButton "Open Modal"
                     |> ensureViewHas
                         [ id Modal.titleId
@@ -30,6 +30,12 @@ spec =
                         ]
                     |> done
         , focusTests
+        , test "ATAC hole works" <|
+            \() ->
+                start [ Modal.atac (Html.text "ATAC content") ]
+                    |> clickButton "Open Modal"
+                    |> ensureViewHas [ text "ATAC content" ]
+                    |> done
         ]
 
 
@@ -38,34 +44,34 @@ focusTests =
     describe "Focus management"
         [ test "focus starts on the specified element in the modal" <|
             \() ->
-                start
+                start []
                     |> clickButton "Open Modal"
                     |> ensureFocused Modal.closeButtonId
                     |> done
         , test "focus returns to the element that opened the modal" <|
             \() ->
-                start
+                start []
                     |> clickButton "Open Modal"
                     |> clickButton "Close modal"
                     |> ensureFocused "open-modal"
                     |> done
         , test "focus wraps from the modal title correctly" <|
             \() ->
-                start
+                start []
                     |> clickButton "Open Modal"
                     |> tabBackWithinModal Modal.titleId
                     |> ensureFocused lastButtonId
                     |> done
         , test "focus wraps from the close button correctly" <|
             \() ->
-                start
+                start []
                     |> clickButton "Open Modal"
                     |> tabBackWithinModal Modal.closeButtonId
                     |> ensureFocused lastButtonId
                     |> done
         , test "focus wraps from the last button correctly" <|
             \() ->
-                start
+                start []
                     |> clickButton "Open Modal"
                     |> tabForwardWithinModal lastButtonId
                     |> ensureFocused Modal.closeButtonId
@@ -88,11 +94,11 @@ focusTrapNode =
     [ attribute (Html.Attributes.attribute "data-testid" "focus-trap-node") ]
 
 
-start : ProgramTest Modal.Model Msg Effect
-start =
+start : List Modal.Attribute -> ProgramTest Modal.Model Msg Effect
+start modalAttributes =
     createElement
         { init = \_ -> ( Modal.init, None )
-        , view = toUnstyled << view
+        , view = toUnstyled << view modalAttributes
         , update = update
         }
         |> withSimulatedEffects perform
@@ -150,8 +156,8 @@ perform effect =
             SimulatedEffect.Cmd.none
 
 
-view : Modal.Model -> Html Msg
-view model =
+view : List Modal.Attribute -> Modal.Model -> Html Msg
+view modalAttributes model =
     Html.main_ [ Attributes.id "maincontent" ]
         [ Html.button
             [ Attributes.id "open-modal"
@@ -173,8 +179,7 @@ view model =
             , firstId = Modal.closeButtonId
             , lastId = lastButtonId
             }
-            [ Modal.closeButton
-            ]
+            (Modal.closeButton :: modalAttributes)
             model
         ]
 

--- a/tests/Spec/Nri/Ui/Modal.elm
+++ b/tests/Spec/Nri/Ui/Modal.elm
@@ -7,7 +7,7 @@ import Html.Styled as Html exposing (Html, toUnstyled)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Json.Encode as Encode
-import Nri.Ui.Modal.V11 as Modal
+import Nri.Ui.Modal.V12 as Modal
 import ProgramTest exposing (..)
 import SimulatedEffect.Cmd
 import Spec.KeyboardHelpers exposing (pressTabBackKey, pressTabKey)

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -53,6 +53,7 @@
         "Nri.Ui.Message.V3",
         "Nri.Ui.Message.V4",
         "Nri.Ui.Modal.V11",
+        "Nri.Ui.Modal.V12",
         "Nri.Ui.Page.V3",
         "Nri.Ui.Pagination.V1",
         "Nri.Ui.Palette.V1",


### PR DESCRIPTION
towards A11-2116

Adds Modal.V12 which:
- removes use of FocusTrap type alias
- returns ids to focus on instead of cmds (in order to make modals more testable via the effect pattern with program-test)
- uses tesk9/accessible-html-with-css for SR-only content
- simplifies internal attributes pattern
- adds Modal.atac to make a hole for the ATAC to render inside the modal

## :framed_picture: What does this change look like?

<img width="1199" alt="Screen Shot 2023-08-31 at 11 57 12 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/858ba45b-263d-4687-a3b3-3885bfdf9ac3">
(Not pinging designers, as the visual changes are constrained to this example and are not particularly interesting.)

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - [A11-3504](https://linear.app/noredink/issue/A11-3504/update-modalv11-to-modalv12-everywhere)
