### PR TITLE
fix character headshot zoom in safari

### DIFF
--- a/src/Nri/Ui/CharacterIcon/V2.elm
+++ b/src/Nri/Ui/CharacterIcon/V2.elm
@@ -1292,7 +1292,13 @@ lindyHeadshot =
 {-| -}
 lindyHeadshotFacingRight : Nri.Ui.Svg.V1.Svg
 lindyHeadshotFacingRight =
-    lindyHeadshot_ "lindyHeadshotFacingRight" [ Css.transforms [ Css.scaleX -1, Css.translate (Css.pct -100) ] ] [ Css.transforms [ Css.scaleX -1, Css.translate (Css.pct -110) ] ]
+    lindyHeadshot_ "lindyHeadshotFacingRight"
+        [ Css.transforms [ Css.scaleX -1 ]
+        , Css.property "transform-origin" "1.88rem 0"
+        ]
+        [ Css.transforms [ Css.scaleX -1 ]
+        , Css.property "transform-origin" "2.1rem 0"
+        ]
 
 
 redPalette =

--- a/src/Nri/Ui/CharacterIcon/V2.elm
+++ b/src/Nri/Ui/CharacterIcon/V2.elm
@@ -1644,4 +1644,8 @@ salHeadshot =
 {-| -}
 salHeadshotFacingRight : Nri.Ui.Svg.V1.Svg
 salHeadshotFacingRight =
-    salHeadshot_ "salHeadshotFacingRight" [ Css.transforms [ Css.scaleX -1, Css.translate (Css.pct -100) ] ]
+    salHeadshot_ "salHeadshotFacingRight" 
+        [ Css.transforms [ Css.scaleX -1 ]
+        , Css.property "transform-origin" "1.88rem 0"
+        ]
+

--- a/src/Nri/Ui/CharacterIcon/V2.elm
+++ b/src/Nri/Ui/CharacterIcon/V2.elm
@@ -1477,7 +1477,10 @@ redHeadshot =
 {-| -}
 redHeadshotFacingRight : Nri.Ui.Svg.V1.Svg
 redHeadshotFacingRight =
-    redHeadshot_ "redHeadshotFacingRight" [ Css.transforms [ Css.scaleX -1, Css.translate (Css.pct -100) ] ]
+    redHeadshot_ "redHeadshotFacingRight" 
+        [ Css.transforms [ Css.scaleX -1 ]
+        , Css.property "transform-origin" "1.88rem 0"
+        ]
 
 
 salPalette =

--- a/src/Nri/Ui/CharacterIcon/V2.elm
+++ b/src/Nri/Ui/CharacterIcon/V2.elm
@@ -9,6 +9,7 @@ module Nri.Ui.CharacterIcon.V2 exposing
 {-| Patch changes:
 
   - added missing headshots
+  - made flipped headshots scale correctly in Safari
 
 TODO: There was a bunch of work on <https://github.com/NoRedInk/noredink-ui/pull/1403>
 towards reusing code in the SVGs to make them smaller. We should do the same for headshots.

--- a/src/Nri/Ui/CharacterIcon/V2.elm
+++ b/src/Nri/Ui/CharacterIcon/V2.elm
@@ -1478,7 +1478,7 @@ redHeadshot =
 {-| -}
 redHeadshotFacingRight : Nri.Ui.Svg.V1.Svg
 redHeadshotFacingRight =
-    redHeadshot_ "redHeadshotFacingRight" 
+    redHeadshot_ "redHeadshotFacingRight"
         [ Css.transforms [ Css.scaleX -1 ]
         , Css.property "transform-origin" "1.88rem 0"
         ]
@@ -1645,8 +1645,7 @@ salHeadshot =
 {-| -}
 salHeadshotFacingRight : Nri.Ui.Svg.V1.Svg
 salHeadshotFacingRight =
-    salHeadshot_ "salHeadshotFacingRight" 
+    salHeadshot_ "salHeadshotFacingRight"
         [ Css.transforms [ Css.scaleX -1 ]
         , Css.property "transform-origin" "1.88rem 0"
         ]
-


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Once applied, you should be able to adjust text zoom in Safari without beheading Lindy.

The beheading happened because we were flipping Lindy's head and then moving it back into place by pixels. Chrome zooms these, but Safari apparently does not. I fixed it by setting the transformation origin where I wanted it using rem (which explicitly scale with text.) Ems might have worked as well, but I think rems are safer since this issue was caused by device zoom instead of page styles.

On release in the monolith, this will fix WR-246.

## :framed_picture: What does this change look like?

- [x] Follow the the [Guidelines for an optimal design ping](https://paper.dropbox.com/doc/Guidelines-for-Sharing-User-Facing-Changes-with-Design--BpL8hpJLMugy6033aT5m0JdaAg-bdKGQtYH9qO9I00hUkA6k) to add helpful screenshots/videos for design.
- [x] @ mention the design team on this PR to request approval on your changes. A designer will "thumbs up" react to your PR if they approve it, or will leave comments if it's not quite approved yet.

https://github.com/NoRedInk/noredink-ui/assets/355401/e58dc0d4-1a71-4fb2-835d-3b51aa28dba6

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
