### PR TITLE
:wrench: Fix checkbox hit area and focus indication

### DIFF
--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -289,7 +289,12 @@ view { label, selected } attributes =
             div
                 (config.onCheck
                     |> Maybe.map (onCheckMsg config_.selected)
-                    |> Maybe.map (\msg -> [ EventExtras.onClickStopPropagation msg ])
+                    |> Maybe.map
+                        (\msg ->
+                            [ EventExtras.onClickStopPropagation msg
+                            , css [ cursor pointer ]
+                            ]
+                        )
                     |> Maybe.withDefault []
                 )
                 [ viewIcon [] icon ]

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -17,6 +17,8 @@ module Nri.Ui.Checkbox.V7 exposing
   - reposition the guidance to be right below the label text
   - fix the hiddenLabel checkbox behavior
   - fix the disabled styles
+  - fix "checkboxes can’t be clicked in the lower half when there’s guidance" issue
+  - fix duplicative focus ring issue
 
 
 ## Changes from V6:

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -55,7 +55,6 @@ module Nri.Ui.Checkbox.V7 exposing
 
 -}
 
-import Accessibility.Styled exposing (..)
 import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Key as Key
 import Accessibility.Styled.Role as Role
@@ -63,7 +62,8 @@ import Accessibility.Styled.Style
 import CheckboxIcons
 import Css exposing (..)
 import Css.Global
-import Html.Styled as Html
+import EventExtras
+import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes as Attributes exposing (css)
 import Html.Styled.Events as Events
 import InputErrorAndGuidanceInternal exposing (Guidance)
@@ -279,15 +279,20 @@ view { label, selected } attributes =
                     )
     in
     checkboxContainer config_
-        [ viewIcon []
-            (if config.isDisabled then
-                disabledIcon
+        [ if config.isDisabled then
+            div [] [ viewIcon [] disabledIcon ]
 
-             else
-                icon
-            )
+          else
+            -- ensure the entire checkbox icon is always clickable
+            div
+                (config.onCheck
+                    |> Maybe.map (onCheckMsg config_.selected)
+                    |> Maybe.map (\msg -> [ EventExtras.onClickStopPropagation msg ])
+                    |> Maybe.withDefault []
+                )
+                [ viewIcon [] icon ]
         , span []
-            (viewCheckbox config_
+            (viewCheckboxLabel config_
                 (if config.isDisabled then
                     disabledLabelCss
 
@@ -371,7 +376,7 @@ disabledLabelCss =
     ]
 
 
-viewCheckbox :
+viewCheckboxLabel :
     { a
         | identifier : String
         , selected : IsSelected
@@ -385,7 +390,7 @@ viewCheckbox :
     }
     -> List Style
     -> Html.Html msg
-viewCheckbox config styles =
+viewCheckboxLabel config styles =
     let
         marginTopAdjustment =
             case config.guidance of
@@ -440,9 +445,7 @@ viewCheckbox config styles =
             else
                 Html.text config.label
     in
-    Html.div attributes
-        [ viewLabel
-        ]
+    Html.div attributes [ viewLabel ]
 
 
 checkboxIconWidth : Float

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -370,7 +370,6 @@ enabledLabelCss =
 disabledLabelCss : List Style
 disabledLabelCss =
     [ textStyle
-    , Css.outline3 (Css.px 2) Css.solid Css.transparent
     , cursor auto
     , color Colors.gray45
     ]
@@ -412,6 +411,7 @@ viewCheckboxLabel config styles =
                                 else
                                     Css.batch []
                                )
+                            :: outline none
                             :: styles
                             ++ config.labelCss
                         )


### PR DESCRIPTION
Fixes A11-3464
Fixes A11-3542

- ensures checkbox is fully clickable, including when guidance is present
- removes redundant default focus ring from "label"

## :framed_picture: What does this change look like?

<img width="259" alt="Screen Shot 2023-09-07 at 3 19 03 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/b8e7b1be-e6b5-4cf9-94b3-e355dd08f9e4">

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  -  this is not a new major version
