### PR TITLE
Use tabs for Usage Examples

### DIFF
--- a/component-catalog/src/App.elm
+++ b/component-catalog/src/App.elm
@@ -489,14 +489,14 @@ viewExamplePreviews containerId exampleNavConfig usageNavConfig examples usageEx
                 [ Tabs.alignment Tabs.Left
                 ]
                 [ Tabs.build { id = ComponentExamples, idString = "component-examples" }
-                    [ Tabs.tabString "Component examples"
+                    [ Tabs.tabString "Component Examples"
                     , examples
                         |> List.map (Example.preview exampleNavConfig)
                         |> examplesContainer [ Spacing.pageTopWhitespace ]
                         |> Tabs.panelHtml
                     ]
                 , Tabs.build { id = UsageExamples, idString = "usage-examples" }
-                    [ Tabs.tabString "Usage examples"
+                    [ Tabs.tabString "Usage Examples"
                     , usageExamples
                         |> List.map (UsageExample.preview usageNavConfig)
                         |> examplesContainer [ Spacing.pageTopWhitespace ]

--- a/component-catalog/src/App.elm
+++ b/component-catalog/src/App.elm
@@ -480,40 +480,55 @@ viewExamplePreviews :
     -> Content
     -> Html Msg
 viewExamplePreviews containerId exampleNavConfig usageNavConfig examples usageExamples selectedContent =
+    let
+        viewBothTabs =
+            [ Tabs.view
+                { focusAndSelect = SelectContent
+                , selected = selectedContent
+                }
+                [ Tabs.alignment Tabs.Left
+                ]
+                [ Tabs.build { id = ComponentExamples, idString = "component-examples" }
+                    [ Tabs.tabString "Component examples"
+                    , examples
+                        |> List.map (Example.preview exampleNavConfig)
+                        |> examplesContainer [ Spacing.pageTopWhitespace ]
+                        |> Tabs.panelHtml
+                    ]
+                , Tabs.build { id = UsageExamples, idString = "usage-examples" }
+                    [ Tabs.tabString "Usage examples"
+                    , usageExamples
+                        |> List.map (UsageExample.preview usageNavConfig)
+                        |> examplesContainer [ Spacing.pageTopWhitespace ]
+                        |> Tabs.panelHtml
+                    ]
+                ]
+            ]
+
+        viewJustComponents =
+            [ Heading.h2 [ Heading.plaintext "Components" ]
+            , examplesContainer []
+                (List.map (Example.preview exampleNavConfig) examples)
+            ]
+    in
     Html.div [ id containerId ]
-        [ Tabs.view
-            { focusAndSelect = SelectContent
-            , selected = selectedContent
-            }
-            [ Tabs.alignment Tabs.Left
-            ]
-            [ Tabs.build { id = ComponentExamples, idString = "component-examples" }
-                [ Tabs.tabString "Component examples"
-                , examples
-                    |> List.map (Example.preview exampleNavConfig)
-                    |> examplesContainer
-                    |> Tabs.panelHtml
-                ]
-            , Tabs.build { id = UsageExamples, idString = "usage-examples" }
-                [ Tabs.tabString "Usage examples"
-                , usageExamples
-                    |> List.map (UsageExample.preview usageNavConfig)
-                    |> examplesContainer
-                    |> Tabs.panelHtml
-                ]
-            ]
-        ]
+        (if List.isEmpty usageExamples then
+            viewJustComponents
+
+         else
+            viewBothTabs
+        )
 
 
-examplesContainer : List (Html msg) -> Html msg
-examplesContainer =
+examplesContainer : List Css.Style -> List (Html msg) -> Html msg
+examplesContainer extraStyles =
     Html.div
         [ css
-            [ Spacing.pageTopWhitespace
-            , Css.displayFlex
+            [ Css.displayFlex
             , Css.flexWrap Css.wrap
             , Css.property "row-gap" (.value Spacing.verticalSpacerPx)
             , Css.property "column-gap" (.value Spacing.horizontalSpacerPx)
+            , Css.batch extraStyles
             ]
         ]
 

--- a/component-catalog/src/App.elm
+++ b/component-catalog/src/App.elm
@@ -482,7 +482,7 @@ viewExamplePreviews :
 viewExamplePreviews containerId exampleNavConfig usageNavConfig examples usageExamples selectedContent =
     let
         viewBothTabs =
-            [ Tabs.view
+            Tabs.view
                 { focusAndSelect = SelectContent
                 , selected = selectedContent
                 }
@@ -503,21 +503,14 @@ viewExamplePreviews containerId exampleNavConfig usageNavConfig examples usageEx
                         |> Tabs.panelHtml
                     ]
                 ]
-            ]
-
-        viewJustComponents =
-            [ Heading.h2 [ Heading.plaintext "Components" ]
-            , examplesContainer []
-                (List.map (Example.preview exampleNavConfig) examples)
-            ]
     in
     Html.div [ id containerId ]
-        (if List.isEmpty usageExamples then
-            viewJustComponents
+        [ if List.isEmpty usageExamples then
+            examplesContainer [] (List.map (Example.preview exampleNavConfig) examples)
 
-         else
+          else
             viewBothTabs
-        )
+        ]
 
 
 examplesContainer : List Css.Style -> List (Html msg) -> Html msg

--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -1,5 +1,6 @@
 Nri.Ui.Block.V4,upgrade to V6
 Nri.Ui.Block.V5,upgrade to V6
+Nri.Ui.Carousel.V1,upgrade to V2
 Nri.Ui.WhenFocusLeaves.V1,upgrade to V2
 Nri.Ui.Highlighter.V4,upgrade to V5
 Nri.Ui.Mark.V2,upgrade to V5

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -63,6 +63,9 @@ hint = 'upgrade to V2'
 hint = 'upgrade to V10'
 usages = ['component-catalog-app/../src/Nri/Ui/SlideModal/V2.elm']
 
+[forbidden."Nri.Ui.Carousel.V1"]
+hint = 'upgrade to V2'
+
 [forbidden."Nri.Ui.CharacterIcon.V1"]
 hint = 'upgrade to V2'
 usages = [

--- a/script/puppeteer-tests.js
+++ b/script/puppeteer-tests.js
@@ -322,6 +322,10 @@ describe("UI tests", function () {
     await page.goto(`http://localhost:${PORT}`);
 
     await page.$("#maincontent");
+
+    const [usageTab] = await page.$x("//button[contains(., 'Usage Examples')]");
+    await usageTab.click();
+
     let links = await page.evaluate(() => {
       let nodes = Array.from(
         document.querySelectorAll("[data-nri-description='usage-example-link']")

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -13,6 +13,7 @@
         "Nri.Ui.BreadCrumbs.V2",
         "Nri.Ui.Button.V10",
         "Nri.Ui.Carousel.V1",
+        "Nri.Ui.Carousel.V2",
         "Nri.Ui.CharacterIcon.V2",
         "Nri.Ui.Checkbox.V7",
         "Nri.Ui.ClickableSvg.V2",


### PR DESCRIPTION
Component catalog change only. Addresses https://github.com/NoRedInk/noredink-ui/pull/1487#issuecomment-1703834962

Adds tabs to separate the Component-specific examples from the Usage examples.

When there's at least one Usage example, use tabs to divide the page content:
<img width="765" alt="Screen Shot 2023-09-11 at 11 37 56 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/a46f8b02-c04b-4d62-acf1-3e766f9711e1">

When there's just component examples, just show the component examples:
<img width="919" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/6a386854-42bf-4580-b21a-84946b914beb">
