### PR TITLE
[PHX-1127] Fix vertical spacing above labels

### DIFF
--- a/src/Nri/Ui/Mark/V5.elm
+++ b/src/Nri/Ui/Mark/V5.elm
@@ -7,6 +7,11 @@ module Nri.Ui.Mark.V5 exposing
 {-|
 
 
+### Patch changes:
+
+    - Fix line-height for spacer element reducing the amount of vertical space consumed by the balloons
+
+
 ### Changes from V4
 
     - Remove `LabelState` from API, the consumer will manage animations through `labelCss`

--- a/src/Nri/Ui/Mark/V5.elm
+++ b/src/Nri/Ui/Mark/V5.elm
@@ -598,7 +598,7 @@ viewBalloonSpacer config =
                             Css.lineHeight (Css.num 0)
 
                         Just _ ->
-                            Css.lineHeight Css.unset
+                            Css.lineHeight Css.initial
                     ]
                 ]
             ]


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

- https://github.com/NoRedInk/NoRedInk/pull/45661

I've noticed for a while (and we've had mild complaints from curriculum) that labels in scaffolding appear to consume more vertical space than they need to.  I finally tracked down the root cause... see the image below (where I've tweaked the child of the `balloon-spacer` element to have `width: 10px`.

<img width=400 src="https://github.com/NoRedInk/noredink-ui/assets/12899207/7277c696-a5ce-41bd-8d52-0ed1a826eec6">

The spacers line height is greater than than of the text it is beside!  This is due to us setting the `line-height` to `unset` which opens the child up to inherit an ancestors line height.  If we set the `line-height` to `initial` instead (which defaults to `normal`) then all is well in the world. 

This change doesn't really affect the example catalog as much as scaffolding due to the ancestor line height issue. 

## :framed_picture: What does this change look like?

| Before | After |
| --- | --- |
| ![image](https://github.com/NoRedInk/NoRedInk/assets/12899207/95c9726b-0659-4057-b36d-c7f2655b3550) | ![image](https://github.com/NoRedInk/NoRedInk/assets/12899207/d5257c99-e393-45da-b4da-d7444d0f9e78) |

(Note: these are what the hack fix looks like on scaffolding)

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
