### PR TITLE
[PHX-1127] Bump to 24.8.2 to fix label vertical line spacing

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "24.8.1",
+    "version": "24.8.2",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Ui",


### PR DESCRIPTION
# :label: Bump for version `24.8.2`

This bump is primarily to make the label vertical spacing available on production - most of the other included changes are improvements to the component catalog. 

## What changes does this release include?

- #1487
- #1510
- #1512
- #1513
- #1509
- #1511

## How has the API changed?

```
No API changes detected, so this is a PATCH change.
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).