### PR TITLE
A11-3052 Add helpfully disabled tooltip

### DIFF
--- a/component-catalog/src/Examples/Tooltip.elm
+++ b/component-catalog/src/Examples/Tooltip.elm
@@ -7,7 +7,6 @@ module Examples.Tooltip exposing (example, State, Msg)
 -}
 
 import Accessibility.Styled as Html exposing (Html)
-import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Key as Key
 import Category exposing (Category(..))
 import Code

--- a/component-catalog/src/Examples/Tooltip.elm
+++ b/component-catalog/src/Examples/Tooltip.elm
@@ -7,6 +7,7 @@ module Examples.Tooltip exposing (example, State, Msg)
 -}
 
 import Accessibility.Styled as Html exposing (Html)
+import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Key as Key
 import Category exposing (Category(..))
 import Code
@@ -20,6 +21,7 @@ import Example exposing (Example)
 import Html.Styled.Attributes exposing (css, href, id)
 import KeyboardSupport exposing (Key(..))
 import Markdown
+import Nri.Ui.Button.V10 as Button
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
@@ -122,6 +124,7 @@ type alias PageSettings =
 type TooltipId
     = PrimaryLabel
     | AuxillaryDescription
+    | HelpfullyDisabled
     | LearnMore
     | Disclosure
 
@@ -223,8 +226,26 @@ Examples:
 - We might show an icon to indicate that a link opens in a new tab. This icon would have a tooltip to explain ***how*** the link will open.
 - On a Quick Write teacher preview, we use Tooltip.auxiliaryDescription on the Save button to let teachers know that the Save button will not actually save in the preview.
 """
-          , example = viewAuxillaryDescriptionToolip model.openTooltip
+          , example = viewAuxillaryDescriptionTooltip model.openTooltip
           , tooltipId = AuxillaryDescription
+          }
+        , { name = "Tooltip.helpfullyDisabled"
+          , usage = """
+Use when all of the following are true:
+- the tooltip trigger is disabled
+- the content of the tooltip provides information explaining why the tooltip trigger is disabled
+- the tooltip trigger will become enabled through user interactions
+- the content of the tooltip doesn't contain interactive elements, such as links
+"""
+          , description =
+                """
+Tooltip.helpfullyDisabled provides information about ***why*** the tooltip trigger is disabled.
+
+Example:
+- A tooltip might appear on a disabled button to inform the user that the button will become enabled once they've filled out a required form.
+"""
+          , example = viewHelpfullyDisabledTooltip model.openTooltip
+          , tooltipId = HelpfullyDisabled
           }
         , { name = "Tooltip.disclosure"
           , usage = """
@@ -242,7 +263,7 @@ This type may contain interactive elements such as links.
                 , ")."
                 ]
                     |> String.join ""
-          , example = viewDisclosureToolip model.openTooltip
+          , example = viewDisclosureTooltip model.openTooltip
           , tooltipId = Disclosure
           }
         , { name = "Tooltip.viewToggleTip"
@@ -289,8 +310,8 @@ viewPrimaryLabelTooltip openTooltip =
         ]
 
 
-viewAuxillaryDescriptionToolip : Maybe TooltipId -> Html Msg
-viewAuxillaryDescriptionToolip openTooltip =
+viewAuxillaryDescriptionTooltip : Maybe TooltipId -> Html Msg
+viewAuxillaryDescriptionTooltip openTooltip =
     Tooltip.view
         { id = "tooltip__auxiliaryDescription"
         , trigger =
@@ -311,8 +332,28 @@ viewAuxillaryDescriptionToolip openTooltip =
         ]
 
 
-viewDisclosureToolip : Maybe TooltipId -> Html Msg
-viewDisclosureToolip openTooltip =
+viewHelpfullyDisabledTooltip : Maybe TooltipId -> Html Msg
+viewHelpfullyDisabledTooltip openTooltip =
+    Tooltip.view
+        { id = "tooltip__helpfullyDisabled"
+        , trigger =
+            \attrs ->
+                Button.button "Save"
+                    [ Button.custom attrs
+                    , Button.onClick (Log "")
+                    , Button.disabled
+                    ]
+        }
+        [ Tooltip.plaintext "Fill out the required fields before saving."
+        , Tooltip.helpfullyDisabled
+        , Tooltip.onToggle (ToggleTooltip HelpfullyDisabled)
+        , Tooltip.open (openTooltip == Just HelpfullyDisabled)
+        , Tooltip.onLeftForMobile
+        ]
+
+
+viewDisclosureTooltip : Maybe TooltipId -> Html Msg
+viewDisclosureTooltip openTooltip =
     let
         triggerId =
             "tooltip__disclosure-trigger"

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -835,7 +835,11 @@ auxiliaryDescription =
     Attribute (\config -> { config | purpose = AuxillaryDescription })
 
 
-{-| -}
+{-| Used when the tooltip trigger is disabled.
+
+Provides information about why the tooltip trigger is disabled.
+
+-}
 helpfullyDisabled : Attribute msg
 helpfullyDisabled =
     Attribute (\config -> { config | purpose = AuxillaryDescription })

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -809,7 +809,6 @@ onToggle msg =
 type Purpose
     = PrimaryLabel
     | AuxillaryDescription
-    | HelpfullyDisabled
     | Disclosure { triggerId : String, lastId : Maybe String }
 
 
@@ -839,7 +838,7 @@ auxiliaryDescription =
 {-| -}
 helpfullyDisabled : Attribute msg
 helpfullyDisabled =
-    Attribute (\config -> { config | purpose = HelpfullyDisabled })
+    Attribute (\config -> { config | purpose = AuxillaryDescription })
 
 
 {-| Sometimes a "tooltip" only _looks_ like a tooltip, but is really more about hiding and showing extra information when the user asks for it.
@@ -990,9 +989,6 @@ viewTooltip_ { trigger, id } tooltip =
                         ]
 
                     AuxillaryDescription ->
-                        [ Aria.describedBy [ id ] ]
-
-                    HelpfullyDisabled ->
                         [ Aria.describedBy [ id ] ]
 
                     Disclosure _ ->

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -18,7 +18,7 @@ module Nri.Ui.Tooltip.V3 exposing
     , css, notMobileCss, mobileCss, quizEngineMobileCss, narrowMobileCss, containerCss
     , custom
     , nriDescription, testId
-    , primaryLabel, auxiliaryDescription, disclosure
+    , primaryLabel, auxiliaryDescription, helpfullyDisabled, disclosure
     )
 
 {-| Patch changes:
@@ -76,7 +76,7 @@ These tooltips aim to follow the accessibility recommendations from:
 @docs css, notMobileCss, mobileCss, quizEngineMobileCss, narrowMobileCss, containerCss
 @docs custom
 @docs nriDescription, testId
-@docs primaryLabel, auxiliaryDescription, disclosure
+@docs primaryLabel, auxiliaryDescription, helpfullyDisabled, disclosure
 
 -}
 
@@ -809,6 +809,7 @@ onToggle msg =
 type Purpose
     = PrimaryLabel
     | AuxillaryDescription
+    | HelpfullyDisabled
     | Disclosure { triggerId : String, lastId : Maybe String }
 
 
@@ -833,6 +834,12 @@ An auxiliary description is used when the tooltip content provides supplementary
 auxiliaryDescription : Attribute msg
 auxiliaryDescription =
     Attribute (\config -> { config | purpose = AuxillaryDescription })
+
+
+{-| -}
+helpfullyDisabled : Attribute msg
+helpfullyDisabled =
+    Attribute (\config -> { config | purpose = HelpfullyDisabled })
 
 
 {-| Sometimes a "tooltip" only _looks_ like a tooltip, but is really more about hiding and showing extra information when the user asks for it.
@@ -983,6 +990,9 @@ viewTooltip_ { trigger, id } tooltip =
                         ]
 
                     AuxillaryDescription ->
+                        [ Aria.describedBy [ id ] ]
+
+                    HelpfullyDisabled ->
                         [ Aria.describedBy [ id ] ]
 
                     Disclosure _ ->

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -34,6 +34,7 @@ module Nri.Ui.Tooltip.V3 exposing
   - add partially-transparent white border around tooltips
   - Use Nri.Ui.WhenFocusLeaves.V2
   - prevent default and stop propagation on click for disclosure tooltips
+  - adds `helpfullyDisabled` option
 
 Changes from V2:
 


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Adds `helpfullyDisabled` option to the Tooltip's API. The behavior is the same as `auxiliaryDescription`.

[A11-3052 : Add a new Tooltip type name like Tooltip.helpfullyDisabled](https://linear.app/noredink/issue/A11-3052/add-a-new-tooltip-type-name-like-tooltiphelpfullydisabled)

## :framed_picture: What does this change look like?

<img width="1431" alt="helpfully disabled tooltip docs" src="https://github.com/NoRedInk/noredink-ui/assets/5647344/87690535-019f-4253-af3d-9dbbe311ac7e">


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
