### PR TITLE
Improve examples' heading formatting

### DIFF
--- a/component-catalog/src/Examples/AnimatedIcon.elm
+++ b/component-catalog/src/Examples/AnimatedIcon.elm
@@ -18,6 +18,7 @@ import Html.Styled exposing (..)
 import Nri.Ui.AnimatedIcon.V1 as AnimatedIcon
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Table.V7 as Table
 
@@ -89,7 +90,10 @@ example =
                           }
                         ]
                 }
-            , Heading.h2 [ Heading.plaintext "Example" ]
+            , Heading.h2
+                [ Heading.plaintext "Examples"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , Table.view []
                 [ Table.custom
                     { header = text "Rendered"

--- a/component-catalog/src/Examples/Balloon.elm
+++ b/component-catalog/src/Examples/Balloon.elm
@@ -20,6 +20,8 @@ import Guidance
 import Html.Styled exposing (Html)
 import Nri.Ui.Balloon.V2 as Balloon
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Spacing.V1 as Spacing
 
 
 moduleName : String
@@ -186,5 +188,9 @@ view ellieLinkConfig state =
                   }
                 ]
         }
+    , Heading.h2
+        [ Heading.plaintext "Customizable Example"
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+        ]
     , Balloon.view (List.map Tuple.second attributes)
     ]

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -125,7 +125,7 @@ example =
                         ]
                 }
             , Heading.h2
-                [ Heading.plaintext "Interactive example"
+                [ Heading.plaintext "Customizable example"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
             , [ Block.view [ Block.plaintext "I like " ]

--- a/component-catalog/src/Examples/BreadCrumbs.elm
+++ b/component-catalog/src/Examples/BreadCrumbs.elm
@@ -22,6 +22,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Html.V3 exposing (viewJust)
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Table.V7 as Table
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -165,13 +166,23 @@ example =
                           }
                         ]
                 }
-            , section [ css [ Css.margin2 (Css.px 20) Css.zero ] ]
-                [ Heading.h2 [ Heading.plaintext "view Example" ]
+            , section []
+                [ Heading.h2
+                    [ Heading.plaintext "Customizable view Example"
+                    , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                    ]
                 , viewJust (Tuple.second >> viewExample settings.currentRoute) breadCrumbs
                 ]
-            , section [ css [ Css.margin2 (Css.px 20) Css.zero ] ]
-                [ Heading.h2 [ Heading.plaintext "viewSecondary Example" ]
+            , section []
+                [ Heading.h2
+                    [ Heading.plaintext "Customizable viewSecondary Example"
+                    , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                    ]
                 , viewJust (Tuple.second >> viewSecondaryExample settings.currentRoute) breadCrumbs
+                ]
+            , Heading.h2
+                [ Heading.plaintext "Other Helpers"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
             , Table.view []
                 [ Table.string

--- a/component-catalog/src/Examples/Button.elm
+++ b/component-catalog/src/Examples/Button.elm
@@ -310,9 +310,9 @@ viewButtonExamples ellieLinkConfig state =
                 ]
         }
     , Heading.h2
-        [ Heading.plaintext "Interactive example"
+        [ Heading.plaintext "Customizable example"
         , Heading.css
-            [ Css.margin2 Spacing.verticalSpacerPx Css.zero
+            [ Css.marginTop Spacing.verticalSpacerPx
             , Css.marginBottom (Css.px 10)
             ]
         ]

--- a/component-catalog/src/Examples/ClickableSvg.elm
+++ b/component-catalog/src/Examples/ClickableSvg.elm
@@ -20,6 +20,8 @@ import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 exposing (Svg)
 import Nri.Ui.Tooltip.V3 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -88,7 +90,15 @@ example =
                           }
                         ]
                 }
+            , Heading.h2
+                [ Heading.plaintext "Customizable Examples"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , viewExampleTable (Control.currentValue state.settings)
+            , Heading.h2
+                [ Heading.plaintext "Tooltip Example"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , viewExample
                 """
 Tooltip.view

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -20,6 +20,7 @@ import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 
@@ -176,10 +177,14 @@ viewExamples ellieLinkConfig (State control) =
                   }
                 ]
         }
+    , Heading.h2
+        [ Heading.plaintext "Customizable Examples"
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+        ]
     , buttons settings
     , Heading.h2
-        [ Heading.plaintext "Inline ClickableTexts"
-        , Heading.css [ Css.marginTop (Css.px 30) ]
+        [ Heading.plaintext "Inline ClickableText Examples"
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
     , Text.caption (inlineExample "Text.caption" ClickableText.caption)
     , Text.smallBody (inlineExample "Text.smallBody" ClickableText.small)

--- a/component-catalog/src/Examples/Confetti.elm
+++ b/component-catalog/src/Examples/Confetti.elm
@@ -19,7 +19,9 @@ import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.Extra as ColorsExtra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Confetti.V2 as Confetti
+import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Html.V3 exposing (viewJust)
+import Nri.Ui.Spacing.V1 as Spacing
 import Svg.Styled as Svg exposing (Svg)
 import Svg.Styled.Attributes as SvgAttrs
 
@@ -113,6 +115,10 @@ example =
                           }
                         ]
                 }
+            , Heading.h2
+                [ Heading.plaintext "Example"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , Button.button "Launch confetti!"
                 [ Button.onClick LaunchConfetti
                 , Button.small

--- a/component-catalog/src/Examples/Container.elm
+++ b/component-catalog/src/Examples/Container.elm
@@ -18,6 +18,7 @@ import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Spacing.V1 as Spacing
 
 
 moduleName : String
@@ -86,6 +87,10 @@ example =
                           }
                         ]
                 }
+            , Heading.h2
+                [ Heading.plaintext "Customizable Examples"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , viewExample
                 { name = "Default Container"
                 , description = "Your go-to container."

--- a/component-catalog/src/Examples/Fonts.elm
+++ b/component-catalog/src/Examples/Fonts.elm
@@ -14,6 +14,7 @@ import Html.Styled.Attributes exposing (css)
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V7 as Table
 
 
@@ -65,7 +66,10 @@ example =
                 dd =
                     Html.dd [ css [ Css.marginLeft Css.zero, Css.marginBottom (Css.px 8) ] ]
             in
-            [ Heading.h2 [ Heading.plaintext "Fonts" ]
+            [ Heading.h2
+                [ Heading.plaintext "Fonts"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , Html.dl [ css [ Fonts.baseFont ] ]
                 [ dt [ Html.text "quizFont" ]
                 , dd [ Html.text "Use for exercise content. Georgia" ]
@@ -74,7 +78,10 @@ example =
                 , dt [ Html.text "baseFont" ]
                 , dd [ Html.text "Use  for everything else! Mulish" ]
                 ]
-            , Heading.h2 [ Heading.plaintext "Font failure patterns" ]
+            , Heading.h2
+                [ Heading.plaintext "Font failure patterns"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , viewFontFailurePatterns
             ]
     }

--- a/component-catalog/src/Examples/Header.elm
+++ b/component-catalog/src/Examples/Header.elm
@@ -23,6 +23,7 @@ import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Header.V1 as Header
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Select.V9 as Select
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.UiIcon.V1 as UiIcon
 
@@ -92,7 +93,10 @@ example =
                           }
                         ]
                 }
-            , Heading.h2 [ Heading.plaintext "Example" ]
+            , Heading.h2
+                [ Heading.plaintext "Customizable Example"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , Header.view
                 (Header.breadCrumbsLabel "header example breadcrumbs" :: attributes)
                 { breadCrumbs =

--- a/component-catalog/src/Examples/Heading.elm
+++ b/component-catalog/src/Examples/Heading.elm
@@ -9,11 +9,13 @@ module Examples.Heading exposing (example, State, Msg)
 import Category exposing (Category(..))
 import Code
 import CommonControls
+import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Spacing.V1 as Spacing
 import ViewHelpers exposing (viewExamples)
 
 
@@ -83,6 +85,10 @@ example =
                         in
                         List.map toExampleCode examples
                 }
+            , Heading.h2
+                [ Heading.plaintext "Customizable Examples"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , examples
                 |> List.map (\( name, view ) -> ( name, view attributes ))
                 |> viewExamples

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -26,6 +26,7 @@ import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Highlightable.V3 as Highlightable exposing (Highlightable)
 import Nri.Ui.Highlighter.V5 as Highlighter
 import Nri.Ui.HighlighterTool.V1 as Tool
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V7 as Table
 import Nri.Ui.Text.V6 as Text
 import Sort exposing (Sorter)
@@ -131,7 +132,10 @@ example =
                           }
                         ]
                 }
-            , Heading.h2 [ Heading.plaintext "Interactive example" ]
+            , Heading.h2
+                [ Heading.plaintext "Customizable example"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , Text.mediumBody [ Text.plaintext "This example updates based on the settings you configure on this page." ]
             , Button.button "Clear all highlights"
                 [ Button.onClick ClearHighlights
@@ -148,7 +152,10 @@ example =
                 [ Tuple.second (view state)
                     |> map HighlighterMsg
                 ]
-            , Heading.h2 [ Heading.plaintext "Overlapping highlights example" ]
+            , Heading.h2
+                [ Heading.plaintext "Overlapping highlights example"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , Text.mediumBody [ Text.plaintext "Supporting overlapping highlights, as in inline comments, requires a lot of extra set-up. Generally, you won't need this." ]
             , Text.mediumBody [ Text.plaintext "This example does not support removing highlights. This is to enable you to create highlights that overlap." ]
             , div
@@ -161,7 +168,10 @@ example =
                 [ Highlighter.viewWithOverlappingHighlights state.overlappingHighlightsState
                     |> map OverlappingHighlighterMsg
                 ]
-            , Heading.h2 [ Heading.plaintext "Non-interactive examples" ]
+            , Heading.h2
+                [ Heading.plaintext "Non-interactive examples"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , Text.mediumBody [ Text.plaintext "These are examples of some different ways the highlighter can appear to users." ]
             , Table.view []
                 [ Table.rowHeader

--- a/component-catalog/src/Examples/HighlighterToolbar.elm
+++ b/component-catalog/src/Examples/HighlighterToolbar.elm
@@ -18,6 +18,7 @@ import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.HighlighterToolbar.V3 as HighlighterToolbar
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -78,7 +79,10 @@ example =
                           }
                         ]
                 }
-            , Heading.h2 [ Heading.plaintext "Example" ]
+            , Heading.h2
+                [ Heading.plaintext "Example"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , HighlighterToolbar.view
                 { onSelect = SelectTag
                 , getNameAndColor = identity

--- a/component-catalog/src/Examples/IconExamples.elm
+++ b/component-catalog/src/Examples/IconExamples.elm
@@ -372,7 +372,8 @@ viewResults state =
             [ Css.displayFlex
             , Css.property "gap" "20px"
             , Css.marginTop Spacing.verticalSpacerPx
-            , Css.maxWidth (Css.px 600)
+            , Css.maxWidth (Css.px 700)
+            , Css.flexWrap Css.wrap
             ]
         ]
         [ Html.pre [ Attributes.css [ Css.maxWidth (Css.px 400) ] ]
@@ -386,7 +387,11 @@ viewResults state =
                          , Just <| "Svg.withWidth (Css.px " ++ String.fromFloat state.width ++ ")"
                          , Just <| "Svg.withHeight (Css.px " ++ String.fromFloat state.height ++ ")"
                          , if state.showBorder then
-                            Just "Svg.withCss [ Css.border3 (Css.px 1) Css.solid Colors.gray20 ]"
+                            Just
+                                ("Svg.withCss"
+                                    ++ Code.newlineWithIndent 3
+                                    ++ "[ Css.border3 (Css.px 1) Css.solid Colors.gray20 ]"
+                                )
 
                            else
                             Nothing

--- a/component-catalog/src/Examples/IconExamples.elm
+++ b/component-catalog/src/Examples/IconExamples.elm
@@ -27,6 +27,7 @@ import Nri.Ui.Colors.Extra exposing (fromCssColor, toCssColor)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Select.V9 as Select
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.TextInput.V7 as TextInput
@@ -199,10 +200,14 @@ view settings groups =
         viewExampleSection ( group, values ) =
             viewWithCustomStyles settings group values
     in
-    viewSettings settings
+    Heading.h2 [ Heading.plaintext "Grouped Icons" ]
+        :: viewSettings settings
         :: List.map viewExampleSection groups
-        ++ [ Html.section [ css [ Css.margin2 (Css.px 30) Css.zero ] ]
-                [ Heading.h3 [ Heading.plaintext "Example Usage" ]
+        ++ [ Html.section []
+                [ Heading.h2
+                    [ Heading.plaintext "Example Usage"
+                    , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                    ]
                 , viewSingularExampleSettings groups settings
                 , viewResults settings
                 ]

--- a/component-catalog/src/Examples/IconExamples.elm
+++ b/component-catalog/src/Examples/IconExamples.elm
@@ -367,13 +367,15 @@ viewResults state =
         ( red, green, blue ) =
             SolidColor.toRGB state.color
     in
-    Html.div [ Attributes.css [ Css.displayFlex ] ]
-        [ Html.pre
-            [ Attributes.css
-                [ Css.width (Css.px 400)
-                , Css.marginRight (Css.px 20)
-                ]
+    Html.div
+        [ Attributes.css
+            [ Css.displayFlex
+            , Css.property "gap" "20px"
+            , Css.marginTop Spacing.verticalSpacerPx
+            , Css.maxWidth (Css.px 600)
             ]
+        ]
+        [ Html.pre [ Attributes.css [ Css.maxWidth (Css.px 400) ] ]
             [ [ Code.varWithTypeAnnotation "color" "Css.Color" <|
                     ("Css.rgb " ++ String.fromFloat red ++ " " ++ String.fromFloat green ++ " " ++ String.fromFloat blue)
               , Code.newlines

--- a/component-catalog/src/Examples/Loading.elm
+++ b/component-catalog/src/Examples/Loading.elm
@@ -18,6 +18,7 @@ import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Loading.V1 as Loading
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
 
 
@@ -105,7 +106,10 @@ example =
         \ellieLinkConfig { showLoadingFadeIn, showLoading, showSpinners } ->
             [ Heading.h2
                 [ Heading.plaintext "Examples"
-                , Heading.css [ Css.marginBottom (Css.px 30) ]
+                , Heading.css
+                    [ Css.marginTop Spacing.verticalSpacerPx
+                    , Css.marginBottom (Css.px 10)
+                    ]
                 ]
             , if showLoading then
                 Loading.page

--- a/component-catalog/src/Examples/Message.elm
+++ b/component-catalog/src/Examples/Message.elm
@@ -15,6 +15,7 @@ import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Message.V4 as Message
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V7 as Table
 import ViewHelpers exposing (viewExamples)
 
@@ -199,8 +200,8 @@ example =
                         ]
                 }
             , Heading.h2
-                [ Heading.plaintext "Customizable example"
-                , Heading.css [ Css.marginTop (Css.px 30) ]
+                [ Heading.plaintext "Customizable Examples"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
             , orDismiss <|
                 viewExamples
@@ -210,7 +211,7 @@ example =
                     ]
             , Heading.h2
                 [ Heading.css
-                    [ Css.marginTop (Css.px 20)
+                    [ Css.marginTop Spacing.verticalSpacerPx
                     , Css.borderTop3 (Css.px 2) Css.solid Colors.gray96
                     , Css.paddingTop (Css.px 20)
                     ]
@@ -218,8 +219,8 @@ example =
                 ]
             , Message.somethingWentWrong exampleRailsError
             , Heading.h2
-                [ Heading.plaintext "Content type variations"
-                , Heading.css [ Css.marginTop (Css.px 30) ]
+                [ Heading.plaintext "Content Type Variations"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
             , viewContentTable "Message.tiny" Message.tiny ClickableText.caption
             , viewContentTable "Message.large" Message.large ClickableText.medium

--- a/component-catalog/src/Examples/Modal.elm
+++ b/component-catalog/src/Examples/Modal.elm
@@ -28,6 +28,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Modal.V12 as Modal
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Task
@@ -266,6 +267,10 @@ example =
                         in
                         [ { sectionName = "Example", code = code } ]
                 }
+            , Heading.h2
+                [ Heading.plaintext "Customizable Example"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , launchModalButton settings
             , Modal.view
                 { title = settings.title

--- a/component-catalog/src/Examples/Page.elm
+++ b/component-catalog/src/Examples/Page.elm
@@ -20,6 +20,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Page.V3 as Page exposing (DefaultPage, RecoveryText(..))
+import Nri.Ui.Spacing.V1 as Spacing
 
 
 {-| -}
@@ -118,7 +119,10 @@ example =
                           }
                         ]
                 }
-            , Heading.h2 [ Heading.plaintext "Example" ]
+            , Heading.h2
+                [ Heading.plaintext "Customizable Example"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , Tuple.second settings.page
                 { link = ShowItWorked
                 , recoveryText = settings.recoveryText

--- a/component-catalog/src/Examples/Pagination.elm
+++ b/component-catalog/src/Examples/Pagination.elm
@@ -19,6 +19,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Pagination.V1 as Pagination
+import Nri.Ui.Spacing.V1 as Spacing
 
 
 moduleName : String
@@ -100,7 +101,10 @@ example =
                           }
                         ]
                 }
-            , Heading.h2 [ Heading.plaintext "Example" ]
+            , Heading.h2
+                [ Heading.plaintext "Customizable Example"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , Pagination.view (Tuple.second pages) model.currentPage
             ]
     }

--- a/component-catalog/src/Examples/Panel.elm
+++ b/component-catalog/src/Examples/Panel.elm
@@ -20,6 +20,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Panel.V1 as Panel
+import Nri.Ui.Spacing.V1 as Spacing
 
 
 moduleName : String
@@ -74,7 +75,13 @@ example =
                           }
                         ]
                 }
-            , Heading.h2 [ Heading.plaintext "Example" ]
+            , Heading.h2
+                [ Heading.plaintext "Customizable Example"
+                , Heading.css
+                    [ Css.marginTop Spacing.verticalSpacerPx
+                    , Css.marginBottom (Css.px 10)
+                    ]
+                ]
             , Panel.view attributes
             ]
     }

--- a/component-catalog/src/Examples/PremiumCheckbox.elm
+++ b/component-catalog/src/Examples/PremiumCheckbox.elm
@@ -23,6 +23,7 @@ import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Pennant.V2 as Pennant
 import Nri.Ui.PremiumCheckbox.V8 as PremiumCheckbox
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
 import Set exposing (Set)
 
@@ -74,7 +75,10 @@ example =
                 , renderExample = Code.unstyledView
                 , toExampleCode = \_ -> [ { sectionName = "view", code = exampleCode } ]
                 }
-            , Heading.h2 [ Heading.plaintext "Example" ]
+            , Heading.h2
+                [ Heading.plaintext "Customizable Example"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , exampleView
             ]
     , categories = [ Inputs ]

--- a/component-catalog/src/Examples/QuestionBox.elm
+++ b/component-catalog/src/Examples/QuestionBox.elm
@@ -98,7 +98,7 @@ view ellieLinkConfig state =
                 ]
         }
     , Heading.h2
-        [ Heading.plaintext "Interactive example"
+        [ Heading.plaintext "Customizable example"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
     , div [ css [ Css.minHeight (Css.px 350) ] ]
@@ -125,7 +125,7 @@ view ellieLinkConfig state =
             ]
         ]
     , Heading.h2
-        [ Heading.plaintext "Non-interactive examples"
+        [ Heading.plaintext "Non-customizable examples"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
     , Table.view []

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -32,6 +32,7 @@ import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Message.V4 as Message
 import Nri.Ui.Modal.V12 as Modal
 import Nri.Ui.RadioButton.V4 as RadioButton
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Text.V6 as Text
 import Routes
 import Task
@@ -156,7 +157,10 @@ view ellieLinkConfig state =
                   }
                 ]
         }
-    , Heading.h2 [ Heading.plaintext "Example" ]
+    , Heading.h2
+        [ Heading.plaintext "Customizable Example"
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+        ]
     , viewExamples selectionSettings state.selectedValue
     , Modal.view
         { title = "Go Premium!"

--- a/component-catalog/src/Examples/RadioButtonDotless.elm
+++ b/component-catalog/src/Examples/RadioButtonDotless.elm
@@ -263,11 +263,7 @@ view ellieLinkConfig state =
         selectionSettings =
             Control.currentValue state.selectionSettings
     in
-    [ Heading.h2
-        [ Heading.plaintext "Interactive example"
-        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
-        ]
-    , ControlView.view
+    [ ControlView.view
         { ellieLinkConfig = ellieLinkConfig
         , name = moduleName
         , version = version
@@ -294,6 +290,10 @@ view ellieLinkConfig state =
                   }
                 ]
         }
+    , Heading.h2
+        [ Heading.plaintext "Interactive example"
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+        ]
     , viewExamples selectionSettings state.selectedValue
     , Heading.h2
         [ Heading.plaintext "Layout Configurations"

--- a/component-catalog/src/Examples/RingGauge.elm
+++ b/component-catalog/src/Examples/RingGauge.elm
@@ -19,6 +19,7 @@ import Nri.Ui.Colors.Extra exposing (fromCssColor)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.RingGauge.V1 as RingGauge
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Table.V7 as Table
 import Round
@@ -93,7 +94,10 @@ example =
                           }
                         ]
                 }
-            , Heading.h2 [ Heading.plaintext "Example" ]
+            , Heading.h2
+                [ Heading.plaintext "Customizable example"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , RingGauge.view
                 { backgroundColor = Tuple.second settings.backgroundColor
                 , emptyColor = Tuple.second settings.emptyColor

--- a/component-catalog/src/Examples/SegmentedControl.elm
+++ b/component-catalog/src/Examples/SegmentedControl.elm
@@ -25,7 +25,9 @@ import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Colors.Extra exposing (withAlpha)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.SegmentedControl.V14 as SegmentedControl
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Tooltip.V3 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -114,8 +116,10 @@ example =
                           }
                         ]
                 }
-            , Html.h3 [ css [ Css.marginBottom Css.zero ] ]
-                [ Html.code [] [ Html.text "view" ] ]
+            , Heading.h2
+                [ Heading.html [ Html.code [] [ Html.text "view" ], Html.text " Example" ]
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , Html.p [ css [ Css.marginTop (Css.px 1) ] ]
                 [ Html.text "Use in cases where it would also be reasonable to use Tabs." ]
             , SegmentedControl.view
@@ -125,8 +129,10 @@ example =
                 , toUrl = Nothing
                 , options = List.map Tuple.second pageOptions
                 }
-            , Html.h3 [ css [ Css.marginBottom Css.zero ] ]
-                [ Html.code [] [ Html.text "viewRadioGroup" ] ]
+            , Heading.h2
+                [ Heading.html [ Html.code [] [ Html.text "viewRadioGroup" ], Html.text " Example" ]
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , Html.p [ css [ Css.marginTop (Css.px 1) ] ]
                 [ Html.text "Use in cases where it would be reasonable to use radio buttons for the same purpose." ]
             , SegmentedControl.viewRadioGroup

--- a/component-catalog/src/Examples/Select.elm
+++ b/component-catalog/src/Examples/Select.elm
@@ -20,6 +20,7 @@ import Html.Styled
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Select.V9 as Select
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Text.V6 as Text
 
 
@@ -95,7 +96,10 @@ example =
                           }
                         ]
                 }
-            , Heading.h2 [ Heading.plaintext "Example" ]
+            , Heading.h2
+                [ Heading.plaintext "Customizable Example"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , Select.view label (Select.value state.selectedValue :: attributes)
                 |> Html.Styled.map ChangedTheSelectorValue
             , Text.smallBody

--- a/component-catalog/src/Examples/SideNav.elm
+++ b/component-catalog/src/Examples/SideNav.elm
@@ -20,6 +20,7 @@ import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.SideNav.V5 as SideNav
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Text.V6 as Text
 
 
@@ -116,7 +117,7 @@ view ellieLinkConfig state =
         }
     , Heading.h2
         [ Heading.plaintext "Interactive example"
-        , Heading.css [ Css.marginTop (Css.px 30) ]
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
     , SideNav.view
         { isCurrentRoute = (==) settings.currentRoute
@@ -127,7 +128,7 @@ view ellieLinkConfig state =
         (List.map Tuple.second settings.entries)
     , Heading.h2
         [ Heading.plaintext "Complex example"
-        , Heading.css [ Css.marginTop (Css.px 30) ]
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
     , SideNav.view
         { isCurrentRoute = \route -> route == "complex-example__child-2"
@@ -165,7 +166,7 @@ view ellieLinkConfig state =
         ]
     , Heading.h2
         [ Heading.plaintext "Compact Groups example"
-        , Heading.css [ Css.marginTop (Css.px 30) ]
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
     , SideNav.view
         { isCurrentRoute = \route -> route == "complex-example__child-2"

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -18,6 +18,7 @@ import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.SortableTable.V4 as SortableTable exposing (Column)
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Table.V7 as Table
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -190,7 +191,10 @@ example =
                 , renderExample = Code.unstyledView
                 , toExampleCode = \_ -> [ toExampleCode "view" (Code.list dataCode), toExampleCode "viewLoading" "" ]
                 }
-            , Heading.h2 [ Heading.plaintext "Example" ]
+            , Heading.h2
+                [ Heading.plaintext "Customizable Example"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , if settings.loading then
                 SortableTable.viewLoading attrs columns
 

--- a/component-catalog/src/Examples/Table.elm
+++ b/component-catalog/src/Examples/Table.elm
@@ -15,6 +15,7 @@ import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V7 as Table exposing (Column)
 
 
@@ -110,7 +111,10 @@ example =
                         , toExampleCode "viewLoadingWithoutHeader" ""
                         ]
                 }
-            , Heading.h2 [ Heading.plaintext "Example" ]
+            , Heading.h2
+                [ Heading.plaintext "Example"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , case ( showHeader, isLoading ) of
                 ( True, False ) ->
                     Table.view [] columns data

--- a/component-catalog/src/Examples/Text.elm
+++ b/component-catalog/src/Examples/Text.elm
@@ -17,6 +17,7 @@ import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Text.V6 as Text
 
 
@@ -85,7 +86,10 @@ example =
                         , toExampleCode "ugSmallBody"
                         ]
                 }
-            , Heading.h2 [ Heading.plaintext "Examples" ]
+            , Heading.h2
+                [ Heading.plaintext "Examples"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , Text.caption [ Text.plaintext "NOTE: When using these styles, please read the documentation in the Elm module about \"Understanding spacing\"" ]
             , Heading.h3 [ Heading.plaintext "Paragraph styles" ]
             , viewExamples
@@ -96,7 +100,10 @@ example =
                 , ( "footnote", Text.footnote )
                 ]
                 attributes
-            , Heading.h3 [ Heading.plaintext "Paragraph styles for user-authored content" ]
+            , Heading.h3
+                [ Heading.plaintext "Paragraph styles for user-authored content"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , viewExamples
                 [ ( "ugMediumBody", Text.ugMediumBody )
                 , ( "ugSmallBody", Text.ugSmallBody )

--- a/component-catalog/src/Examples/TextArea.elm
+++ b/component-catalog/src/Examples/TextArea.elm
@@ -20,6 +20,7 @@ import Html.Styled.Attributes as Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.InputStyles.V4 as InputStyles exposing (Theme(..))
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.TextArea.V5 as TextArea
 
 
@@ -100,7 +101,10 @@ example =
                           }
                         ]
                 }
-            , Heading.h2 [ Heading.plaintext "Example" ]
+            , Heading.h2
+                [ Heading.plaintext "Customizable Example"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , TextArea.view label
                 (TextArea.value state.value
                     :: TextArea.onInput UpdateValue

--- a/component-catalog/src/Examples/TextInput.elm
+++ b/component-catalog/src/Examples/TextInput.elm
@@ -21,6 +21,7 @@ import Guidance
 import Iso8601
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.TextInput.V7 as TextInput
 import ViewHelpers exposing (viewExamples)
 
@@ -92,7 +93,10 @@ example =
                             )
                             examples
                 }
-            , Heading.h2 [ Heading.plaintext "Example" ]
+            , Heading.h2
+                [ Heading.plaintext "Customizable Examples"
+                , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                ]
             , viewExamples (List.map (\( name, _, ex ) -> ( name, ex )) examples)
             ]
     }


### PR DESCRIPTION
Component catalog change only -- consistently adds the standard amount of whitespace between the Settings and Code example containers and the "Customizable Example" Heading. Also slightly adjusts the spacing on all of the icon examples.

I'm not going to include screenshots in this PR description because the majority of the examples changed. Please see Percy for a complete diff!