### PR TITLE
Darker purple text for tiny errors

### DIFF
--- a/src/Nri/Ui/Message/V4.elm
+++ b/src/Nri/Ui/Message/V4.elm
@@ -746,7 +746,7 @@ getColor size theme =
         Error ->
             case size of
                 Tiny ->
-                    Colors.purple
+                    Colors.purpleDark
 
                 _ ->
                     Colors.purpleDark


### PR DESCRIPTION
<img width="244" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/13528834/47118f2c-7624-4842-acf3-34d0e983cda1">