### PR TITLE
Add new syntax for `Highlightable.fromMarkdown` to add highlights with custom colors

### DIFF
--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -304,6 +304,16 @@ example =
                             , highlightables = Highlightable.fromMarkdown "Select your [favorite phrase]() in **your** writing."
                             }
                   }
+                , { viewName = "staticMarkdown"
+                  , tool = "buildMarker"
+                  , highlightable = "fromMarkdown"
+                  , description = "Interpreting highlight tags with a custom color."
+                  , example =
+                        Highlighter.staticMarkdown
+                            { id = "example-6"
+                            , highlightables = Highlightable.fromMarkdown "Select your <nri-highlight color=\"cyan\">favorite phrase with favorite color</nri-highlight> in **your** writing."
+                            }
+                  }
                 ]
             ]
     , categories = [ Instructional ]

--- a/src/Nri/Ui/Highlightable/V3.elm
+++ b/src/Nri/Ui/Highlightable/V3.elm
@@ -14,6 +14,11 @@ Highlighter is initialized, it's very possible for a Highlightable to consist of
 just a single whitespace.
 
 
+## Patch
+
+  - add new syntax for highlight on markdown parse, which support custom colors
+
+
 ## Changes from V2
 
   - move the uIState out of the Highlightable
@@ -48,7 +53,9 @@ just a single whitespace.
 -}
 
 import Html.Styled exposing (Attribute)
+import List.Extra
 import Markdown.Block
+import Markdown.Config exposing (defaultOptions, defaultSanitizeOptions)
 import Markdown.Inline
 import Maybe.Extra
 import Nri.Ui.Colors.V1 as Colors
@@ -142,9 +149,30 @@ initFragments text_ =
         |> List.indexedMap spaceOrInit
 
 
-{-| How do we know which elements should be marked, if all we have is a markdown string?
+{-| Initialize highlightables from a markdown string.
+This will get all `nri-highlight` tags into markded elements, you can add a specific color
+using the `color` attribute. The default color used is yellow.
 
-We do some funky parsing to interpret empty anchor tags and tagged spans as highlighted!
+    fromMarkdown "for example, <nri-highlight>this phrase</nri-highlight> will show as highlighted"
+
+will result in a list of highlightables where "this phrase" is marked with the default marker.
+
+    fromMarkdown "for example, <nri-highlight color=" cyan ">this phrase</nri-highlight> will show as highlighted"
+
+will result in a list of highlightables where "this phrase" is marked with the cyan marker.
+
+The available are the highlight colors available on [Nri.Colors](https://noredink-ui.netlify.app/#/doodad/Colors),
+which are the following:
+
+  - `magenta` -> `Colors.highlightMagenta`
+  - `brown` -> `Colors.highlightBrown`
+  - `purple` -> `Colors.highlightPurple`
+  - `blue` -> `Colors.highlightBlue`
+  - `yellow` -> `Colors.highlightYellow`
+  - `green` -> `Colors.highlightGreen`
+  - `cyan` -> `Colors.highlightCyan`
+
+There is also the empty url syntax, which is currently being deprecated:
 
     fromMarkdown "for example, [this phrase]() will show as highlighted"
 
@@ -157,14 +185,17 @@ fromMarkdown markdownString =
         static maybeMark mapStrings c =
             initStatic (Maybe.Extra.toList maybeMark) -1 (mapStrings c)
 
-        defaultMark =
+        markFromColor color =
             Tool.buildMarker
-                { highlightColor = Colors.highlightYellow
-                , hoverColor = Colors.highlightYellow
-                , hoverHighlightColor = Colors.highlightYellow
+                { highlightColor = color
+                , hoverColor = color
+                , hoverHighlightColor = color
                 , kind = ()
                 , name = Nothing
                 }
+
+        defaultMark =
+            markFromColor Colors.highlightYellow
 
         highlightableFromInline : Maybe (Tool.MarkerModel ()) -> (String -> String) -> Markdown.Inline.Inline i -> List (Highlightable ())
         highlightableFromInline maybeMark mapStrings inline =
@@ -178,11 +209,11 @@ fromMarkdown markdownString =
                 Markdown.Inline.CodeInline text_ ->
                     [ static maybeMark mapStrings text_ ]
 
-                Markdown.Inline.Link "" maybeTitle inlines ->
+                Markdown.Inline.Link "" _ inlines ->
                     -- empty links should be interpreted as content that's supposed to be highlighted!
                     List.concatMap (highlightableFromInline (Just defaultMark) mapStrings) inlines
 
-                Markdown.Inline.Link url maybeTitle inlines ->
+                Markdown.Inline.Link url _ inlines ->
                     let
                         lastIndex =
                             List.length inlines - 1
@@ -211,6 +242,43 @@ fromMarkdown markdownString =
 
                 Markdown.Inline.Image _ _ inlines ->
                     List.concatMap (highlightableFromInline maybeMark mapStrings) inlines
+
+                Markdown.Inline.HtmlInline "nri-highlight" attrs inlines ->
+                    let
+                        color =
+                            case
+                                List.Extra.find (\( attrName, _ ) -> attrName == "color") attrs
+                                    |> Maybe.andThen Tuple.second
+                            of
+                                Just "magenta" ->
+                                    Colors.highlightMagenta
+
+                                Just "brown" ->
+                                    Colors.highlightBrown
+
+                                Just "purple" ->
+                                    Colors.highlightPurple
+
+                                Just "blue" ->
+                                    Colors.highlightBlue
+
+                                Just "yellow" ->
+                                    Colors.highlightYellow
+
+                                Just "green" ->
+                                    Colors.highlightGreen
+
+                                Just "cyan" ->
+                                    Colors.highlightCyan
+
+                                -- Default color
+                                Just _ ->
+                                    Colors.highlightYellow
+
+                                Nothing ->
+                                    Colors.highlightYellow
+                    in
+                    List.concatMap (highlightableFromInline (Just (markFromColor color)) mapStrings) inlines
 
                 Markdown.Inline.HtmlInline _ _ inlines ->
                     List.concatMap (highlightableFromInline maybeMark mapStrings) inlines
@@ -264,7 +332,18 @@ fromMarkdown markdownString =
         []
 
     else
-        Markdown.Block.parse Nothing markdownString
+        let
+            parseOptions =
+                { defaultOptions
+                    | rawHtml =
+                        Markdown.Config.Sanitize
+                            { allowedHtmlElements = "nri-highlight" :: defaultSanitizeOptions.allowedHtmlElements
+                            , allowedHtmlAttributes = "color" :: defaultSanitizeOptions.allowedHtmlElements
+                            }
+                }
+        in
+        Markdown.Block.parse (Just parseOptions)
+            markdownString
             |> List.concatMap highlightableFromBlock
             |> List.foldr
                 -- ensure that adjacent highlights are in a single mark element

--- a/src/Nri/Ui/Highlightable/V3.elm
+++ b/src/Nri/Ui/Highlightable/V3.elm
@@ -16,7 +16,7 @@ just a single whitespace.
 
 ## Patch
 
-  - add new syntax for highlight on markdown parse, which support custom colors
+  - add new syntax for highlight on markdown parse, which supports custom colors
 
 
 ## Changes from V2
@@ -151,7 +151,7 @@ initFragments text_ =
 
 {-| Initialize highlightables from a markdown string.
 This will get all `nri-highlight` tags into markded elements, you can add a specific color
-using the `color` attribute. The default color used is yellow.
+using the `color` attribute. The default color is yellow.
 
     fromMarkdown "for example, <nri-highlight>this phrase</nri-highlight> will show as highlighted"
 
@@ -161,7 +161,7 @@ will result in a list of highlightables where "this phrase" is marked with the d
 
 will result in a list of highlightables where "this phrase" is marked with the cyan marker.
 
-The available are the highlight colors available on [Nri.Colors](https://noredink-ui.netlify.app/#/doodad/Colors),
+The available highlight colors are listed in the [Nri.Colors docs](https://noredink-ui.netlify.app/#/doodad/Colors),
 which are the following:
 
   - `magenta` -> `Colors.highlightMagenta`


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

- [Slack thread](https://noredink.slack.com/archives/C02NVG4M45U/p1694629282622879)
- [Linear issue](https://linear.app/noredink/issue/QUO-261/allow-highlighting-subcomponent-names-in-the-examples-description-text)
## :framed_picture: What does this change look like?
No visual changes, just introduces new syntax.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer:
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
