### PR TITLE
A11-3344 A11-3592 Add helpfully disabled ClickableSvg and ClickableText

### DIFF
--- a/src/ClickableAttributes.elm
+++ b/src/ClickableAttributes.elm
@@ -41,7 +41,7 @@ import Html.Styled exposing (Attribute)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Json.Decode
-import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (targetBlank)
+import Nri.Ui.Html.Attributes.V2 as ExtraAttributes exposing (targetBlank)
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.UiIcon.V1 as UiIcon
 
@@ -178,16 +178,22 @@ linkExternalWithTrackingInternal { track, url } ({ clickableAttributes } as conf
 {-| -}
 toButtonAttributes : ClickableAttributes route msg -> { disabled : Bool } -> List (Attribute msg)
 toButtonAttributes clickableAttributes { disabled } =
-    [ AttributesExtra.maybe Events.onClick clickableAttributes.onClick
-    , Attributes.type_ clickableAttributes.buttonType
-    , -- why "aria-haspopup=true" instead of "aria-haspopup=dialog"?
-      -- AT support for aria-haspopup=dialog is currently (Nov 2022) limited.
-      -- See https://html5accessibility.com/stuff/2021/02/02/haspopup-haspoop/
-      -- If time has passed, feel free to revisit and see if dialog support has improved!
-      AttributesExtra.includeIf clickableAttributes.opensModal
+    ExtraAttributes.includeIf clickableAttributes.opensModal
         (Attributes.attribute "aria-haspopup" "true")
-    , Attributes.disabled disabled
-    ]
+        :: (if disabled then
+                Aria.disabled True
+                    :: (if clickableAttributes.buttonType == "submit" then
+                            [ Attributes.type_ "button" ]
+
+                        else
+                            [ Attributes.type_ clickableAttributes.buttonType ]
+                       )
+
+            else
+                [ Attributes.type_ clickableAttributes.buttonType
+                , ExtraAttributes.maybe Events.onClick clickableAttributes.onClick
+                ]
+           )
 
 
 {-| -}

--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -761,22 +761,8 @@ renderButton ((ButtonOrLink config) as button_) =
     Nri.Ui.styled Html.button
         (styledName "customButton")
         (buttonStyles config)
-        (ExtraAttributes.includeIf config.clickableAttributes.opensModal
-            (Attributes.attribute "aria-haspopup" "true")
-            :: (if isDisabled config.state then
-                    Aria.disabled True
-                        :: (if config.clickableAttributes.buttonType == "submit" then
-                                [ Attributes.type_ "button" ]
-
-                            else
-                                [ Attributes.type_ config.clickableAttributes.buttonType ]
-                           )
-
-                else
-                    [ Attributes.type_ config.clickableAttributes.buttonType
-                    , ExtraAttributes.maybe Events.onClick config.clickableAttributes.onClick
-                    ]
-               )
+        (ClickableAttributes.toButtonAttributes config.clickableAttributes
+            { disabled = isDisabled config.state }
             ++ Attributes.class FocusRing.customClass
             :: ExtraAttributes.maybe (Just >> Aria.pressed) config.pressed
             :: config.customAttributes

--- a/src/Nri/Ui/ClickableSvg/V2.elm
+++ b/src/Nri/Ui/ClickableSvg/V2.elm
@@ -22,6 +22,9 @@ module Nri.Ui.ClickableSvg.V2 exposing
     - adds `nriDescription`, `testId`, and `id` helpers
     - adds `iconForMobile`, `iconForQuizEngineMobile`, `iconForNarrowMobile`
     - adds `submit` and `opensModal`
+    - replaces the `disabled` attribute with `aria-disabled="true"`
+    - removes click handler from disabled buttons
+    - prevents default behavior for disabled submit buttons by setting `type="button"`
 
 
 # Create a button or link

--- a/src/Nri/Ui/ClickableText/V3.elm
+++ b/src/Nri/Ui/ClickableText/V3.elm
@@ -18,6 +18,9 @@ module Nri.Ui.ClickableText.V3 exposing
 
   - Remove the -v2- from dataDescriptor to avoid version specific
   - Use dataDescriptor for clickable-text-label
+  - replaces the `disabled` attribute with `aria-disabled="true"`
+  - removes click handler from disabled buttons
+  - prevents default behavior for disabled submit buttons by setting `type="button"`
 
 
 # Post-release patches

--- a/tests/Spec/Nri/Ui/ClickableSvg.elm
+++ b/tests/Spec/Nri/Ui/ClickableSvg.elm
@@ -1,0 +1,77 @@
+module Spec.Nri.Ui.ClickableSvg exposing (spec)
+
+import Accessibility.Aria as Aria
+import Html.Styled exposing (Html, toUnstyled)
+import Nri.Ui.ClickableSvg.V2 as ClickableSvg
+import Nri.Ui.UiIcon.V1 as UiIcon
+import ProgramTest exposing (..)
+import Spec.Helpers exposing (expectFailure)
+import Test exposing (..)
+import Test.Html.Selector exposing (..)
+
+
+spec : Test
+spec =
+    describe "Nri.Ui.ClickableSvg.V2"
+        [ describe "helpfullyDisabledClickableSvg" helpfullyDisabledClickableSvg
+        ]
+
+
+helpfullyDisabledClickableSvg : List Test
+helpfullyDisabledClickableSvg =
+    [ test "does not have `aria-disabled=\"true\" when not disabled" <|
+        \() ->
+            program ()
+                (\_ ->
+                    ClickableSvg.button "Next"
+                        UiIcon.arrowRight
+                        []
+                )
+                |> ensureViewHasNot [ attribute (Aria.disabled True) ]
+                |> done
+    , test "has `aria-disabled=\"true\" when disabled" <|
+        \() ->
+            program ()
+                (\_ ->
+                    ClickableSvg.button "Next"
+                        UiIcon.arrowRight
+                        [ ClickableSvg.disabled True
+                        ]
+                )
+                |> ensureViewHas [ attribute (Aria.disabled True) ]
+                |> done
+    , test "is clickable when not disabled" <|
+        \() ->
+            program ()
+                (\_ ->
+                    ClickableSvg.button "Next"
+                        UiIcon.arrowRight
+                        [ ClickableSvg.onClick ()
+                        ]
+                )
+                |> clickButton "Next"
+                |> done
+    , test "is not clickable when disabled" <|
+        \() ->
+            program ()
+                (\_ ->
+                    ClickableSvg.button "Next"
+                        UiIcon.arrowRight
+                        [ ClickableSvg.onClick ()
+                        , ClickableSvg.disabled True
+                        ]
+                )
+                |> clickButton "Next"
+                |> done
+                |> expectFailure "Event.expectEvent: I found a node, but it does not listen for \"click\" events like I expected it would."
+    ]
+
+
+program : model -> (model -> Html model) -> ProgramTest model model ()
+program init view =
+    ProgramTest.createSandbox
+        { init = init
+        , update = \msg model -> msg
+        , view = \model -> Html.Styled.div [] [ view model ] |> toUnstyled
+        }
+        |> ProgramTest.start ()

--- a/tests/Spec/Nri/Ui/ClickableText.elm
+++ b/tests/Spec/Nri/Ui/ClickableText.elm
@@ -1,0 +1,72 @@
+module Spec.Nri.Ui.ClickableText exposing (spec)
+
+import Accessibility.Aria as Aria
+import Html.Styled exposing (Html, toUnstyled)
+import Nri.Ui.ClickableText.V3 as ClickableText
+import ProgramTest exposing (..)
+import Spec.Helpers exposing (expectFailure)
+import Test exposing (..)
+import Test.Html.Selector exposing (..)
+
+
+spec : Test
+spec =
+    describe "Nri.Ui.ClickableText.V3"
+        [ describe "helpfullyDisabledClickableText" helpfullyDisabledClickableText
+        ]
+
+
+helpfullyDisabledClickableText : List Test
+helpfullyDisabledClickableText =
+    [ test "does not have `aria-disabled=\"true\" when not disabled" <|
+        \() ->
+            program ()
+                (\_ ->
+                    ClickableText.button "Text"
+                        []
+                )
+                |> ensureViewHasNot [ attribute (Aria.disabled True) ]
+                |> done
+    , test "has `aria-disabled=\"true\" when disabled" <|
+        \() ->
+            program ()
+                (\_ ->
+                    ClickableText.button "Text"
+                        [ ClickableText.disabled True
+                        ]
+                )
+                |> ensureViewHas [ attribute (Aria.disabled True) ]
+                |> done
+    , test "is clickable when not disabled" <|
+        \() ->
+            program ()
+                (\_ ->
+                    ClickableText.button "Text"
+                        [ ClickableText.onClick ()
+                        ]
+                )
+                |> clickButton "Text"
+                |> done
+    , test "is not clickable when disabled" <|
+        \() ->
+            program ()
+                (\_ ->
+                    ClickableText.button "Text"
+                        [ ClickableText.onClick ()
+                        , ClickableText.disabled True
+                        ]
+                )
+                |> clickButton "Text"
+                |> done
+                |> expectFailure "Event.expectEvent: I found a node, but it does not listen for \"click\" events like I expected it would."
+    ]
+
+
+program : model -> (model -> Html model) -> ProgramTest model model ()
+program init view =
+    ProgramTest.createSandbox
+        { init = init
+        , update = \msg model -> msg
+        , view = \model -> Html.Styled.div [] [ view model ] |> toUnstyled
+        }
+        |> ProgramTest.start ()


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

[A11-3344 : Add helpfully disabled version of Clickable SVG](https://linear.app/noredink/issue/A11-3344/add-helpfully-disabled-version-of-clickable-svg)
[A11-3592 : Add helpfully disabled version of Clickable Text](https://linear.app/noredink/issue/A11-3592/add-helpfully-disabled-version-of-clickable-text)

- Replaces the `disabled` attribute with `aria-disabled="true"`.
- Ensures that the disabled styles remain the same.
- Removes click event handlers.
- Prevents disabled buttons from submitting a form.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
    - [x] Component docs include a changelog
    - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
    - [x] The Component Catalog is updated to use the newest version, if appropriate
    - [x] The Component Catalog example version number is updated, if appropriate
    - [x] Any new customizations are available from the Component Catalog
    - [x] The component example still has:
        - an accurate preview
        - valid sample code
        - correct keyboard behavior
        - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
    - e.g., as a dev, I can conveniently add an `nriDescription`
    - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
