### PR TITLE
Question Box Tip Theme background color change

### DIFF
--- a/src/Nri/Ui/QuestionBox/V6.elm
+++ b/src/Nri/Ui/QuestionBox/V6.elm
@@ -337,7 +337,7 @@ themeToColor theme =
             { backgroundColor = Colors.purpleLight, shadowColor = Colors.purple }
 
         Tip ->
-            { backgroundColor = Colors.white, shadowColor = Colors.white }
+            { backgroundColor = Colors.sunshine, shadowColor = Colors.white }
 
 
 viewGuidance :

--- a/src/Nri/Ui/QuestionBox/V6.elm
+++ b/src/Nri/Ui/QuestionBox/V6.elm
@@ -9,7 +9,11 @@ module Nri.Ui.QuestionBox.V6 exposing
     , guidanceId
     )
 
-{-| Changes from V5:
+{-| Patch Changes
+
+  - Background color in Tip theme changed from white to sunshine yellow
+
+Changes from V5:
 
   - ???
 


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

[PHX-1141](https://linear.app/noredink/issue/PHX-1141/modify-background-color-for-tip-questionbox) requests that we change the background of the QuestionBox's Tip Theme to sunshine yellow.
We know that changing the background color from white to yellow lowers the contrast ratio, but we think it is still within acceptable limits of this [contrast ratio checker](https://www.siegemedia.com/contrast-ratio#hsla%28200%2C0%25%2C0%25%2C.7%29-on-%23fffadc)
## :framed_picture: What does this change look like?
<img width="1552" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/22882922/c0a63145-f988-412c-895d-d9dbc044d4a0">

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer:
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
