### PR TITLE
Added html function to QuestionBox

### DIFF
--- a/component-catalog/src/Examples/QuestionBox.elm
+++ b/component-catalog/src/Examples/QuestionBox.elm
@@ -349,10 +349,10 @@ initAttributes =
                                 [ p []
                                     [ text "Let's remember the rules "
                                     , ul []
-                                        [ li [] [text "Always capitalize the first word of a title"]
-                                        , li [] [text "Capitalize all words except small words like “and,” “of” and “an.”"]
+                                        [ li [] [ text "Always capitalize the first word of a title" ]
+                                        , li [] [ text "Capitalize all words except small words like “and,” “of” and “an.”" ]
                                         ]
-                                    , strong [] [text "How should this be capitalized?"]
+                                    , strong [] [ text "How should this be capitalized?" ]
                                     ]
                                 ]
                             )

--- a/component-catalog/src/Examples/QuestionBox.elm
+++ b/component-catalog/src/Examples/QuestionBox.elm
@@ -335,7 +335,7 @@ initAttributes =
                 [ ( "markdown"
                   , Control.map
                         (\str ->
-                            ( Code.fromModule moduleName "content " ++ Code.stringMultiline str
+                            ( Code.fromModule moduleName "markdown " ++ Code.stringMultiline str
                             , QuestionBox.markdown str
                             )
                         )

--- a/component-catalog/src/Examples/QuestionBox.elm
+++ b/component-catalog/src/Examples/QuestionBox.elm
@@ -330,14 +330,35 @@ type alias State =
 initAttributes : Control (List ( String, QuestionBox.Attribute Msg ))
 initAttributes =
     ControlExtra.list
-        |> ControlExtra.listItem "markdown"
-            (Control.map
-                (\str ->
-                    ( Code.fromModule moduleName "markdown " ++ Code.stringMultiline str
-                    , QuestionBox.markdown str
-                    )
-                )
-                (Control.stringTextarea initialMarkdown)
+        |> ControlExtra.listItem "content"
+            (Control.choice
+                [ ( "markdown"
+                  , Control.map
+                        (\str ->
+                            ( Code.fromModule moduleName "content " ++ Code.stringMultiline str
+                            , QuestionBox.markdown str
+                            )
+                        )
+                        (Control.stringTextarea initialMarkdown)
+                  )
+                , ( "html"
+                  , Control.value
+                        ( "QuestionBox.html = ... "
+                        , QuestionBox.html
+                            (div []
+                                [ p []
+                                    [ text "Let's remember the rules "
+                                    , ul []
+                                        [ li [] [text "Always capitalize the first word of a title"]
+                                        , li [] [text "Capitalize all words except small words like “and,” “of” and “an.”"]
+                                        ]
+                                    , strong [] [text "How should this be capitalized?"]
+                                    ]
+                                ]
+                            )
+                        )
+                  )
+                ]
             )
         |> ControlExtra.optionalListItem "leftButton"
             ([ ( "Play button"

--- a/src/Nri/Ui/QuestionBox/V6.elm
+++ b/src/Nri/Ui/QuestionBox/V6.elm
@@ -12,6 +12,7 @@ module Nri.Ui.QuestionBox.V6 exposing
 {-| Patch Changes
 
   - Background color in Tip theme changed from white to sunshine yellow
+  - added html function
 
 Changes from V5:
 


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

[PHX-1151](https://linear.app/noredink/issue/PHX-1151/support-passing-html-to-noredink-ui-questionbox) requires us to add a html function to the QuestionBox to allow us to render DisplayElements within the question box.

## :framed_picture: What does this change look like?
Here's a screenshot of the component catalogue using the new `html` function
<img width="1448" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/22882922/0af59843-421f-4b47-800d-5f66c453ad73">
## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer:
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
