### PR TITLE
A11-3345 Helpfully disabled checkbox

### DIFF
--- a/component-catalog/src/Examples/Button.elm
+++ b/component-catalog/src/Examples/Button.elm
@@ -6,7 +6,6 @@ module Examples.Button exposing (Msg, State, example)
 
 -}
 
-import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Key as Key
 import Category exposing (Category(..))
 import Code
@@ -272,11 +271,6 @@ initDebugControls =
             )
 
 
-tooltipId : String
-tooltipId =
-    "tooltip"
-
-
 viewButtonExamples : EllieLink.Config -> State -> Html Msg
 viewButtonExamples ellieLinkConfig state =
     let
@@ -367,11 +361,12 @@ viewButtonExamples ellieLinkConfig state =
             \attrs ->
                 Button.button "Save"
                     [ Button.disabled
-                    , Button.custom (Aria.describedBy [ tooltipId ] :: attrs)
+                    , Button.custom attrs
                     ]
-        , id = tooltipId
+        , id = "tooltip"
         }
-        [ Tooltip.open True
+        [ Tooltip.helpfullyDisabled
+        , Tooltip.open True
         , Tooltip.paragraph "Reasons why you can't save"
         , Tooltip.onRight
         , Tooltip.fitToContent

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -26,6 +26,7 @@ import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Html.Attributes.V2 exposing (safeIdWithPrefix)
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Tooltip.V3 as Tooltip
 
 
 moduleName : String
@@ -36,6 +37,15 @@ moduleName =
 version : Int
 version =
     7
+
+
+tooltipId : String
+tooltipId =
+    "tooltip"
+
+
+type TooltipType
+    = HelpfullyDisabled
 
 
 {-| -}
@@ -150,6 +160,30 @@ example =
                             ]
                   }
                 ]
+            , Heading.h2
+                [ Heading.plaintext "Tooltip Example"
+                , Heading.css [ Css.marginTop (Css.px 30) ]
+                ]
+            , Tooltip.view
+                { trigger =
+                    \attrs ->
+                        Checkbox.view
+                            { label = "Enable Text-to-Speech"
+                            , selected = Checkbox.NotSelected
+                            }
+                            [ Checkbox.id "tooltip-example"
+                            , Checkbox.disabled
+                            , Checkbox.custom attrs
+                            ]
+                , id = tooltipId
+                }
+                [ Tooltip.helpfullyDisabled
+                , Tooltip.open (state.openTooltip == Just HelpfullyDisabled)
+                , Tooltip.onToggle (ToggleTooltip HelpfullyDisabled)
+                , Tooltip.paragraph "Reasons why you can't enable Text-to-Speech"
+                , Tooltip.onRight
+                , Tooltip.fitToContent
+                ]
             ]
     , categories = [ Inputs ]
     , keyboardSupport =
@@ -219,6 +253,7 @@ preview =
 type alias State =
     { isChecked : Checkbox.IsSelected
     , settings : Control Settings
+    , openTooltip : Maybe TooltipType
     }
 
 
@@ -227,6 +262,7 @@ init : State
 init =
     { isChecked = Checkbox.PartiallySelected
     , settings = controlSettings
+    , openTooltip = Nothing
     }
 
 
@@ -315,6 +351,7 @@ type Msg
     = ToggleCheck Id Bool
     | UpdateControls (Control Settings)
     | Swallow
+    | ToggleTooltip TooltipType Bool
 
 
 {-| -}
@@ -337,6 +374,13 @@ update msg state =
 
         Swallow ->
             ( state, Cmd.none )
+
+        ToggleTooltip type_ isOpen ->
+            if isOpen then
+                ( { state | openTooltip = Just type_ }, Cmd.none )
+
+            else
+                ( { state | openTooltip = Nothing }, Cmd.none )
 
 
 type alias Id =

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -39,11 +39,6 @@ version =
     7
 
 
-tooltipId : String
-tooltipId =
-    "tooltip"
-
-
 type TooltipType
     = HelpfullyDisabled
 
@@ -175,7 +170,7 @@ example =
                             , Checkbox.disabled
                             , Checkbox.custom attrs
                             ]
-                , id = tooltipId
+                , id = "tooltip"
                 }
                 [ Tooltip.helpfullyDisabled
                 , Tooltip.open (state.openTooltip == Just HelpfullyDisabled)

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -284,7 +284,10 @@ view { label, selected } attributes =
     in
     checkboxContainer config_
         [ if config.isDisabled then
-            div [] [ viewIcon [] disabledIcon ]
+            div
+                [ css [ cursor notAllowed ]
+                ]
+                [ viewIcon [] disabledIcon ]
 
           else
             -- ensure the entire checkbox icon is always clickable
@@ -379,7 +382,7 @@ enabledLabelCss =
 disabledLabelCss : List Style
 disabledLabelCss =
     [ textStyle
-    , cursor auto
+    , cursor notAllowed
     , color Colors.gray45
     ]
 

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -19,6 +19,7 @@ module Nri.Ui.Checkbox.V7 exposing
   - fix the disabled styles
   - fix "checkboxes can’t be clicked in the lower half when there’s guidance" issue
   - fix duplicative focus ring issue
+  - apply custom attributes to the element with the `"checkbox"` role
 
 
 ## Changes from V6:

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -159,7 +159,7 @@ you want/expect if underlying styles change.
 Instead, please use the `css` helper.
 
 -}
-custom : List (Html.Attribute Never) -> Attribute msg
+custom : List (Html.Attribute msg) -> Attribute msg
 custom attributes =
     Attribute <| \config -> { config | custom = config.custom ++ attributes }
 
@@ -190,7 +190,7 @@ type alias Config msg =
     , onCheck : Maybe (Bool -> msg)
     , isDisabled : Bool
     , guidance : Guidance msg
-    , custom : List (Html.Attribute Never)
+    , custom : List (Html.Attribute msg)
     , containerCss : List Css.Style
     , labelCss : List Css.Style
     }
@@ -260,6 +260,7 @@ view { label, selected } attributes =
             , selected = selected
             , disabled = config.isDisabled
             , guidance = config.guidance
+            , custom = config.custom
             , error = InputErrorAndGuidanceInternal.noError
             }
 
@@ -393,6 +394,7 @@ viewCheckboxLabel :
         , labelCss : List Style
         , error : InputErrorAndGuidanceInternal.ErrorState
         , guidance : Guidance msg
+        , custom : List (Html.Attribute msg)
     }
     -> List Style
     -> Html.Html msg
@@ -429,6 +431,7 @@ viewCheckboxLabel config styles =
                   , InputErrorAndGuidanceInternal.describedBy config.identifier config
                   , Aria.checked (selectedToMaybe config.selected)
                   ]
+                    ++ config.custom
                 , if config.disabled then
                     [ Aria.disabled True ]
 

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -20,6 +20,7 @@ module Nri.Ui.Checkbox.V7 exposing
   - fix "checkboxes can’t be clicked in the lower half when there’s guidance" issue
   - fix duplicative focus ring issue
   - apply custom attributes to the element with the `"checkbox"` role
+  - set cursor to not-allowed when disabled
 
 
 ## Changes from V6:

--- a/tests/Spec/Nri/Ui/Checkbox.elm
+++ b/tests/Spec/Nri/Ui/Checkbox.elm
@@ -7,6 +7,7 @@ import InputErrorAndGuidanceInternal exposing (guidanceId)
 import Nri.Test.KeyboardHelpers.V1 as KeyboardHelpers
 import Nri.Ui.Checkbox.V7 as Checkbox
 import ProgramTest exposing (..)
+import Spec.Helpers exposing (expectFailure)
 import Test exposing (..)
 import Test.Html.Event as Event
 import Test.Html.Query as Query
@@ -33,6 +34,7 @@ spec =
                         , attribute (Aria.describedBy [ guidanceId checkboxId ])
                         ]
                     |> done
+        , describe "helpfullyDisabledCheckbox" helpfullyDisabledCheckbox
         ]
 
 
@@ -89,6 +91,34 @@ stateSpec =
                 |> clickIt
                 |> ensureViewHas [ attribute (Aria.checked (Just False)) ]
                 |> done
+    ]
+
+
+helpfullyDisabledCheckbox : List Test
+helpfullyDisabledCheckbox =
+    [ test "does not have `aria-disabled=\"true\" when not disabled" <|
+        \() ->
+            program []
+                |> ensureViewHasNot [ attribute (Aria.disabled True) ]
+                |> done
+    , test "has `aria-disabled=\"true\" when disabled" <|
+        \() ->
+            program [ Checkbox.disabled ]
+                |> ensureViewHas [ attribute (Aria.disabled True) ]
+                |> done
+    , test "is clickable when not disabled" <|
+        \() ->
+            program []
+                |> clickIt
+                |> done
+    , test "is not clickable when disabled" <|
+        \() ->
+            program
+                [ Checkbox.disabled
+                ]
+                |> clickIt
+                |> done
+                |> expectFailure "Event.expectEvent: I found a node, but it does not listen for \"click\" events like I expected it would."
     ]
 
 


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

[A11-3345 : Add helpfully disabled version of Checkbox](https://linear.app/noredink/issue/A11-3345/add-helpfully-disabled-version-of-checkbox)

- apply custom attributes to the element with the `"checkbox"` role, enabling it to receive tooltip attributes
- set the cursor to `not-allowed` for disabled checkboxes
- add an example showcasing how tooltips can be used with helpfully disabled checkboxes
- add tests

## :framed_picture: What does this change look like?

<img width="626" alt="disabled checkbox with tooltip" src="https://github.com/NoRedInk/noredink-ui/assets/5647344/5b4a1113-6a55-4547-845d-bece378b97e8">

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer:
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
