### PR TITLE
A11-3346 Add tests and docs for Helpfully Disabled Switch

### DIFF
--- a/component-catalog/src/Examples/Switch.elm
+++ b/component-catalog/src/Examples/Switch.elm
@@ -21,6 +21,7 @@ import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Switch.V3 as Switch
 import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Tooltip.V3 as Tooltip
 
 
 moduleName : String
@@ -31,6 +32,10 @@ moduleName =
 version : Int
 version =
     3
+
+
+type TooltipType
+    = HelpfullyDisabled
 
 
 example : Example State Msg
@@ -163,6 +168,29 @@ example =
                             ]
                   }
                 ]
+            , Heading.h2
+                [ Heading.plaintext "Tooltip example"
+                , Heading.css
+                    [ Css.marginTop Spacing.verticalSpacerPx
+                    , Css.marginBottom (Css.px 10)
+                    ]
+                ]
+            , Tooltip.view
+                { trigger =
+                    \attrs ->
+                        Switch.view { id = "tooltip-example", label = "Show pandas in results" }
+                            [ Switch.disabled True
+                            , Switch.custom attrs
+                            ]
+                , id = "tooltip"
+                }
+                [ Tooltip.helpfullyDisabled
+                , Tooltip.open (state.openTooltip == Just HelpfullyDisabled)
+                , Tooltip.onToggle (ToggleTooltip HelpfullyDisabled)
+                , Tooltip.paragraph "Reasons why you can't toggle this switch"
+                , Tooltip.onRight
+                , Tooltip.fitToContent
+                ]
             ]
     , categories = [ Category.Inputs ]
     , keyboardSupport =
@@ -177,6 +205,7 @@ example =
 type alias State =
     { selected : Bool
     , settings : Control Settings
+    , openTooltip : Maybe TooltipType
     }
 
 
@@ -184,6 +213,7 @@ init : State
 init =
     { selected = True
     , settings = controlSettings
+    , openTooltip = Nothing
     }
 
 
@@ -211,6 +241,7 @@ type Msg
     = Switch Bool
     | UpdateSettings (Control Settings)
     | Swallow
+    | ToggleTooltip TooltipType Bool
 
 
 update : Msg -> State -> ( State, Cmd Msg )
@@ -230,3 +261,10 @@ update msg state =
             ( state
             , Cmd.none
             )
+
+        ToggleTooltip type_ isOpen ->
+            if isOpen then
+                ( { state | openTooltip = Just type_ }, Cmd.none )
+
+            else
+                ( { state | openTooltip = Nothing }, Cmd.none )

--- a/component-catalog/tests/SwitchExampleSpec.elm
+++ b/component-catalog/tests/SwitchExampleSpec.elm
@@ -3,11 +3,10 @@ module SwitchExampleSpec exposing (suite)
 import Accessibility.Aria as Aria
 import Accessibility.Role as Role
 import Examples.Switch exposing (example)
+import Nri.Test.MouseHelpers.V1 as MouseHelpers
 import ProgramTest exposing (..)
 import Routes exposing (Route)
 import Test exposing (..)
-import Test.Html.Event as Event
-import Test.Html.Query as Query
 import Test.Html.Selector exposing (..)
 import TestApp exposing (app)
 
@@ -36,10 +35,8 @@ suite =
 
 switchIt : String -> ProgramTest a b c -> ProgramTest a b c
 switchIt name =
-    simulateDomEvent
-        (Query.find
-            [ attribute Role.switch
-            , containing [ text name ]
-            ]
-        )
-        Event.click
+    MouseHelpers.click
+        [ attribute Role.switch
+        , containing [ text name ]
+        , id "view-switch-example"
+        ]

--- a/tests/Spec/Nri/Ui/Switch.elm
+++ b/tests/Spec/Nri/Ui/Switch.elm
@@ -3,17 +3,20 @@ module Spec.Nri.Ui.Switch exposing (..)
 import Accessibility.Aria as Aria
 import Accessibility.Role as Role
 import Html.Styled exposing (..)
+import Nri.Test.KeyboardHelpers.V1 as KeyboardHelpers
+import Nri.Test.MouseHelpers.V1 as MouseHelpers
 import Nri.Ui.Switch.V3 as Switch
+import ProgramTest exposing (..)
+import Spec.Helpers exposing (expectFailure)
 import Test exposing (..)
-import Test.Html.Query as Query
-import Test.Html.Selector as Selector
+import Test.Html.Selector exposing (..)
 
 
 spec : Test
 spec =
     describe "Nri.Ui.Switch.V2"
         [ describe "'switch' role" hasCorrectRole
-        , describe "has aria-disabled=true when disabled" hasCorrectAriaDisabled
+        , describe "helpfully disabled switch" helpfullyDisabledSwitch
         ]
 
 
@@ -21,27 +24,111 @@ hasCorrectRole : List Test
 hasCorrectRole =
     [ test "has role 'switch'" <|
         \() ->
-            Switch.view { id = "switch", label = "Switch" }
-                []
-                |> List.singleton
-                |> div []
-                |> toUnstyled
-                |> Query.fromHtml
-                |> Query.find [ Selector.id "switch" ]
-                |> Query.has [ Selector.attribute Role.switch ]
+            program []
+                |> ensureViewHas [ attribute Role.switch ]
+                |> done
     ]
 
 
-hasCorrectAriaDisabled : List Test
-hasCorrectAriaDisabled =
-    [ test "has 'aria-disabled=true' when disabled" <|
+helpfullyDisabledSwitch : List Test
+helpfullyDisabledSwitch =
+    [ test "does not have `aria-disabled=\"true\" when not disabled" <|
         \() ->
-            Switch.view { id = "switch", label = "Switch" }
-                [ Switch.disabled True ]
-                |> List.singleton
-                |> div []
-                |> toUnstyled
-                |> Query.fromHtml
-                |> Query.find [ Selector.id "switch" ]
-                |> Query.has [ Selector.attribute (Aria.disabled True) ]
+            program []
+                |> ensureViewHasNot [ attribute (Aria.disabled True) ]
+                |> done
+    , test "has `aria-disabled=\"true\" when disabled" <|
+        \() ->
+            program [ Switch.disabled True ]
+                |> ensureViewHas [ attribute (Aria.disabled True) ]
+                |> done
+    , test "is clickable when not disabled" <|
+        \() ->
+            program []
+                |> click
+                |> done
+    , test "is not clickable when disabled" <|
+        \() ->
+            program
+                [ Switch.disabled True
+                ]
+                |> click
+                |> done
+                |> expectFailure "Event.expectEvent: I found a node, but it does not listen for \"click\" events like I expected it would."
+    , test "allows pressing space when not disabled" <|
+        \() ->
+            program
+                []
+                |> pressSpace
+                |> done
+    , test "does not allow pressing space when disabled" <|
+        \() ->
+            program
+                [ Switch.disabled True
+                ]
+                |> pressSpace
+                |> done
+                |> expectFailure "Event.expectEvent: I found a node, but it does not listen for \"keydown\" events like I expected it would."
     ]
+
+
+pressSpace : TestContext -> TestContext
+pressSpace =
+    KeyboardHelpers.pressSpace { targetDetails = [] } switch
+
+
+click : TestContext -> TestContext
+click =
+    MouseHelpers.click switch
+
+
+switch : List Selector
+switch =
+    [ attribute Role.switch ]
+
+
+type alias Model =
+    { selected : Bool
+    }
+
+
+init : Model
+init =
+    { selected = False
+    }
+
+
+type Msg
+    = Toggle Bool
+
+
+update : Msg -> Model -> Model
+update msg state =
+    case msg of
+        Toggle selected ->
+            { state | selected = not selected }
+
+
+view : List (Switch.Attribute Msg) -> Model -> Html Msg
+view attributes state =
+    div []
+        [ Switch.view
+            { id = "switch"
+            , label = "Switch"
+            }
+            (Switch.selected state.selected :: Switch.onSwitch Toggle :: attributes)
+        ]
+
+
+type alias TestContext =
+    ProgramTest Model Msg ()
+
+
+program : List (Switch.Attribute Msg) -> TestContext
+program attributes =
+    ProgramTest.createSandbox
+        { init = init
+        , update = update
+        , view = view attributes >> toUnstyled
+        }
+        |> ProgramTest.start ()


### PR DESCRIPTION
## Context

The Switch already had the correct behavior and attributes and was functioning with a helpfully disabled tooltip, so there was no need to change its implementation. I have added documentation and tests to ensure that it works correctly.

[A11-3346 : Add helpfully disabled version of Switch](https://linear.app/noredink/issue/A11-3346/add-helpfully-disabled-version-of-switch)

## :framed_picture: What does this change look like?

<img width="584" alt="helpfully disabled switch with tooltip" src="https://github.com/NoRedInk/noredink-ui/assets/5647344/e99fcfaf-a35c-4f12-8655-6833ce40defa">
