### PR TITLE
Add a smidge of spacing between checkbox label and guidance

### DIFF
--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -298,7 +298,13 @@ view { label, selected } attributes =
                     |> Maybe.withDefault []
                 )
                 [ viewIcon [] icon ]
-        , span []
+        , span
+            [ css
+                [ displayFlex
+                , flexDirection column
+                , property "gap" "2px"
+                ]
+            ]
             (viewCheckboxLabel config_
                 (if config.isDisabled then
                     disabledLabelCss


### PR DESCRIPTION
<img width="517" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/13528834/b20c9e1b-4c15-49ad-92d2-acbfbe8900da">