### PR TITLE
Allow adding additional keydown handlers to tooltip triggers

### DIFF
--- a/component-catalog/src/UsageExamples/FocusLoop.elm
+++ b/component-catalog/src/UsageExamples/FocusLoop.elm
@@ -358,7 +358,7 @@ viewItem focusKeyEvents expensiveComputationIters id tooltipOpen =
     Html.li [ Attrs.class hash ]
         [ Tooltip.view
             { id = String.fromInt id |> Debug.log "vDOM evaluated for"
-            , trigger = viewTrigger id focusKeyEvents
+            , trigger = viewTrigger id
             }
             [ Tooltip.open tooltipOpen
             , Tooltip.primaryLabel
@@ -366,21 +366,16 @@ viewItem focusKeyEvents expensiveComputationIters id tooltipOpen =
             , Tooltip.fitToContent
             , Tooltip.plaintext "Remove me!"
             , Tooltip.onToggle (ToggleTooltip (ItemTooltip id))
+            , Tooltip.onTriggerKeyDown focusKeyEvents
             ]
         ]
 
 
-viewTrigger : Int -> List (Key.Event Msg) -> List (Attribute Msg) -> Html Msg
-viewTrigger id focusKeyEvents attrs =
+viewTrigger : Int -> List (Attribute Msg) -> Html Msg
+viewTrigger id attrs =
     Button.button (String.fromInt id)
         [ Button.id (buttonDomId id)
-        , Button.custom
-            (attrs
-                -- @TODO get rid of the conflict with the tooltip so that we can listen to all
-                -- key events (this is currently overriding the esc key handl/er from the tooltip
-                -- attrs on the line above)
-                ++ [ Key.onKeyDownPreventDefault focusKeyEvents ]
-            )
+        , Button.custom attrs
         , Button.onClick (RemoveItem id)
         ]
 


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Adds `Tooltip.onTriggerKeyDown` to allow attaching additional `keydown` event handlers to tooltip triggers. The issue this resolves is demonstrated in the changes to ./component-catalog/src/UsageExamples/FocusLoop.elm.

tl;dr: If you apply multiple `onKeyDown` handlers to an element, only the last one is applied. This meant that we could either have arrow-key navigation OR esc-key tooltip dismissal on a tooltip trigger, but not both. Now we can have both.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] ~If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:~
  - Not a major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
