### PR TITLE
Bump version 25.0.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "24.9.0",
+    "version": "25.0.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `25.0.0`

## What changes does this release include?

- #1526
- #1527
- #1528
- #1529
- #1530 
- #1531 
- #1532 
- #1533 
- #1535 


## How has the API changed?

```
This is a MAJOR change.

---- ADDED MODULES - MINOR ----

    Nri.Test.KeyboardHelpers.V1
    Nri.Test.MouseHelpers.V1
    Nri.Ui.FocusLoop.Lazy.V1


---- REMOVED MODULES - MAJOR ----

    Nri.Ui


---- Nri.Ui.Checkbox.V7 - MAJOR ----

    Changed:
      - custom : List (Attribute Never) -> Attribute msg
      + custom :
            List.List (Html.Styled.Attribute msg)
            -> Nri.Ui.Checkbox.V7.Attribute msg
    


---- Nri.Ui.FocusLoop.V1 - MINOR ----

    Added:
        view :
            { toId : item -> id
            , focus : id -> msg
            , view :
                  List.List (Accessibility.Styled.Key.Event msg)
                  -> item
                  -> Accessibility.Styled.Html msg
            , leftRight : Basics.Bool
            , upDown : Basics.Bool
            }
            -> List.List item
            -> List.List (Accessibility.Styled.Html msg)


---- Nri.Ui.QuestionBox.V6 - MINOR ----

    Added:
        html :
            Html.Styled.Html Basics.Never -> Nri.Ui.QuestionBox.V6.Attribute msg


---- Nri.Ui.Tooltip.V3 - MINOR ----

    Added:
        onTriggerKeyDown :
            List.List (Accessibility.Styled.Key.Event msg)
            -> Nri.Ui.Tooltip.V3.Attribute msg
```

**NOTE:** the "breaking" change here is a false alarm. An exposed signature was changed from `Attribute Never` -> `Attribute msg`; this is less restrictive than before, but still triggers a major version in Elm tooling. [#Ask-A11ybats Slack](https://noredink.slack.com/archives/C02NVG4M45U/p1695677579865589)

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).
