### PR TITLE
Expose Nri.Ui

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -8,6 +8,7 @@
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",
         "Nri.Test.MouseHelpers.V1",
+        "Nri.Ui",
         "Nri.Ui.Accordion.V3",
         "Nri.Ui.AnimatedIcon.V1",
         "Nri.Ui.AssignmentIcon.V2",


### PR DESCRIPTION
I missed [this breaking change that removed Nri.Ui](https://github.com/NoRedInk/noredink-ui/pull/1526/files/eaf95a4b2f178b9fc011031a488b843ac6847976#diff-d4b4331a1a542ce28ac90a7d59d1cf6f04eb34df3ae695d33c4f740c2c6c19c6), seems unintentional?

This re-instates `Nri.Ui` an an exposed module