### PR TITLE
Assignment Library disabled checklist and radio button styling

### DIFF
--- a/src/CheckboxIcons.elm
+++ b/src/CheckboxIcons.elm
@@ -52,7 +52,7 @@ unchecked idSuffix =
                     ]
                     []
                 , Svg.feColorMatrix
-                    [ SvgAttributes.values "0 0 0 0 0.2 0 0 0 0 0.2 0 0 0 0 0.2 0 0 0 0.1 0"
+                    [ SvgAttributes.values "0 0 0 0 0.1 0 0 0 0 0.1 0 0 0 0 0.1 0 0 0 0.1 0"
                     , SvgAttributes.in_ "shadowInnerInner1"
                     ]
                     []
@@ -67,7 +67,7 @@ unchecked idSuffix =
             [ Svg.g
                 []
                 [ checkboxBackground
-                    [ SvgAttributes.fill "#EBEBEB"
+                    [ SvgAttributes.fill "#F5F5F5"
                     , SvgAttributes.fillRule "evenodd"
                     , SvgAttributes.stroke (toCssString Colors.gray75)
                     ]
@@ -89,9 +89,9 @@ uncheckedDisabled =
         [ Svg.g
             []
             [ checkboxBackground
-                [ SvgAttributes.fill (toCssString Colors.gray75)
+                [ SvgAttributes.fill (toCssString Colors.gray85)
                 , SvgAttributes.fillRule "evenodd"
-                , SvgAttributes.stroke (toCssString Colors.gray75)
+                , SvgAttributes.stroke (toCssString Colors.gray85)
                 ]
             ]
         ]
@@ -149,7 +149,7 @@ checked idSuffix =
             ]
             [ -- Blue background
               checkboxBackground
-                [ SvgAttributes.fill "#D4F0FF"
+                [ SvgAttributes.fill (toCssString Colors.frost)
                 , SvgAttributes.fillRule "evenodd"
                 , SvgAttributes.stroke (toCssString Colors.azure)
                 ]
@@ -169,12 +169,12 @@ checked idSuffix =
 checkedDisabled : Svg
 checkedDisabled =
     Nri.Ui.Svg.V1.init viewBox
-        [ -- Dark gray background
+        [ -- Light gray background
           checkboxBackground
-            [ SvgAttributes.fill (toCssString Colors.gray45)
-            , SvgAttributes.stroke (toCssString Colors.gray45)
+            [ SvgAttributes.fill (toCssString Colors.gray85)
+            , SvgAttributes.stroke (toCssString Colors.gray85)
             ]
-        , checkmark Colors.white
+        , checkmark Colors.gray45
         ]
         |> Nri.Ui.Svg.V1.withWidth (Css.px 27)
         |> Nri.Ui.Svg.V1.withHeight (Css.px 27)
@@ -246,7 +246,7 @@ checkedPartially idSuffix =
                 [ Svg.g
                     []
                     [ checkboxBackground
-                        [ SvgAttributes.fill "#EBEBEB"
+                        [ SvgAttributes.fill (toCssString Colors.frost)
                         , SvgAttributes.fillRule "evenodd"
                         , SvgAttributes.stroke (toCssString Colors.azure)
                         ]
@@ -269,10 +269,10 @@ checkedPartiallyDisabled =
     Nri.Ui.Svg.V1.init viewBox
         [ -- Dark gray background
           checkboxBackground
-            [ SvgAttributes.fill (toCssString Colors.gray45)
-            , SvgAttributes.stroke (toCssString Colors.gray45)
+            [ SvgAttributes.fill (toCssString Colors.gray85)
+            , SvgAttributes.stroke (toCssString Colors.gray85)
             ]
-        , tilde Colors.white
+        , tilde Colors.gray45
         ]
         |> Nri.Ui.Svg.V1.withWidth (Css.px 27)
         |> Nri.Ui.Svg.V1.withHeight (Css.px 27)

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -21,6 +21,7 @@ module Nri.Ui.Checkbox.V7 exposing
   - fix duplicative focus ring issue
   - apply custom attributes to the element with the `"checkbox"` role
   - set cursor to not-allowed when disabled
+  - update color styling
 
 
 ## Changes from V6:

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -588,7 +588,7 @@ unselectedSvg =
             [ Svg.g []
                 [ Svg.g []
                     [ Svg.use
-                        [ SvgAttributes.fill "#EBEBEB"
+                        [ SvgAttributes.fill "#F5F5F5"
                         , SvgAttributes.fillRule "evenodd"
                         , SvgAttributes.xlinkHref "#unselected-path-1"
                         ]
@@ -625,7 +625,7 @@ selectedSvg =
             [ Svg.g []
                 [ Svg.g []
                     [ Svg.use
-                        [ SvgAttributes.fill "#D4F0FF"
+                        [ SvgAttributes.fill "#EEF9FF"
                         , SvgAttributes.fillRule "evenodd"
                         , SvgAttributes.xlinkHref "#selected-path-1"
                         ]
@@ -639,7 +639,7 @@ selectedSvg =
                         []
                     ]
                 , Svg.circle
-                    [ SvgAttributes.fill "#146AFF"
+                    [ SvgAttributes.fill "#0A64FF"
                     , SvgAttributes.cx "13.5"
                     , SvgAttributes.cy "13.5"
                     , SvgAttributes.r "6.3"
@@ -655,7 +655,7 @@ unselectedDisabledSvg : Svg
 unselectedDisabledSvg =
     Nri.Ui.Svg.V1.init "0 0 27 27"
         [ Svg.circle
-            [ SvgAttributes.fill Colors.gray75.value
+            [ SvgAttributes.fill Colors.gray85.value
             , SvgAttributes.cx "13.5"
             , SvgAttributes.cy "13.5"
             , SvgAttributes.r "13.5"
@@ -668,14 +668,14 @@ selectedDisabledSvg : Svg
 selectedDisabledSvg =
     Nri.Ui.Svg.V1.init "0 0 27 27"
         [ Svg.circle
-            [ SvgAttributes.fill Colors.gray45.value
+            [ SvgAttributes.fill Colors.gray85.value
             , SvgAttributes.cx "13.5"
             , SvgAttributes.cy "13.5"
             , SvgAttributes.r "13.5"
             ]
             []
         , Svg.circle
-            [ SvgAttributes.fill Colors.white.value
+            [ SvgAttributes.fill Colors.gray45.value
             , SvgAttributes.cx "13.5"
             , SvgAttributes.cy "13.5"
             , SvgAttributes.r "6.5"
@@ -699,7 +699,7 @@ lockedSvg =
             ]
             [ Svg.g []
                 [ Svg.use
-                    [ SvgAttributes.fill "#EBEBEB"
+                    [ SvgAttributes.fill "#F5F5F5"
                     , SvgAttributes.fillRule "evenodd"
                     , SvgAttributes.xlinkHref "#locked-path-1"
                     ]

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -16,6 +16,7 @@ module Nri.Ui.RadioButton.V4 exposing
 
   - replace `height` use with `minHeight` to prevent vertical text overflow issues
   - use `break-word` to prevent horiztonal text overflow issues
+  - update color styling
 
 
 ### Changes from V3:


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

This PR updates the check box and radio button styling as per [GRO-1390](https://linear.app/noredink/issue/GRO-1390/assignment-library-disabled-checklist-styling).

## :framed_picture: What does this change look like?

![](https://files.slack.com/files-pri/T032HH80H-F05T72PAATB/image.png)

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [-] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [-] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer:
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
