### PR TITLE
25.1.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "25.0.0",
+    "version": "25.1.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `25.1.0`

## What changes does this release include?

This version re-instates `Nri.Ui` as an exposed module.

https://github.com/NoRedInk/noredink-ui/pull/1538

## How has the API changed?

```
This is a MINOR change.

---- ADDED MODULES - MINOR ----

    Nri.Ui

```

_This module was previously exposed and only removed (accidentally) for a single version of noredink-ui_

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).

