### PR TITLE
Quo 274/identify tabs container

### DIFF
--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -16,6 +16,7 @@ module Nri.Ui.Tabs.V8 exposing
   - Adds sticky positioning
   - Adds background color in the tab list (for use with sticky positioning)
   - Adds the ability to make the background of the active tab fade into the background of the panel below it
+  - Adds an `data-nri-description='Nri-Ui__tabs'` attribute to the tabs container
 
 
 ### Attributes

--- a/src/TabsInternal/V2.elm
+++ b/src/TabsInternal/V2.elm
@@ -21,7 +21,7 @@ import Html.Styled.Events as Events
 import Html.Styled.Keyed as Keyed
 import Nri.Ui.FocusLoop.V1 as FocusLoop
 import Nri.Ui.FocusRing.V1 as FocusRing
-import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (safeId, safeIdWithPrefix)
+import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (nriDescription, safeId, safeIdWithPrefix)
 import Nri.Ui.Tooltip.V3 as Tooltip
 
 
@@ -95,6 +95,13 @@ viewTabs config =
                     , upDown = False
                     }
                 |> List.indexedMap (viewTab_ config)
+
+        tabsAttribute =
+            -- used to identify the actual container of the tabs. we should
+            -- ideally be able to target `[role=tablist]` when needed but that
+            -- won't work because the markup changes slightly in the presence of
+            -- tooltips (see comment below!).
+            nriDescription "Nri-Ui__tabs"
     in
     if anyTooltips then
         -- if any tooltip setup is present, we use aria-owns to associate the
@@ -108,7 +115,10 @@ viewTabs config =
                 , Aria.owns (List.map (safeId << .idString) config.tabs)
                 ]
                 []
-            , Html.div [ Attributes.css config.tabListStyles ]
+            , Html.div
+                [ tabsAttribute
+                , Attributes.css config.tabListStyles
+                ]
                 tabs
             ]
 
@@ -116,6 +126,7 @@ viewTabs config =
         -- if no tooltips are present, we can rely on the DOM structure to set up the relationships correctly.
         Html.div
             [ Role.tabList
+            , tabsAttribute
             , Attributes.css config.tabListStyles
             ]
             tabs

--- a/tests/Spec/Nri/Ui/Tabs.elm
+++ b/tests/Spec/Nri/Ui/Tabs.elm
@@ -9,7 +9,7 @@ import Spec.Helpers exposing (nriDescription)
 import Spec.TabsInternalHelpers exposing (..)
 import Task
 import Test exposing (..)
-import Test.Html.Selector as Selector exposing (all, containing)
+import Test.Html.Selector as Selector exposing (Selector, all, containing)
 
 
 spec : Test
@@ -33,46 +33,36 @@ panelRenderingTests =
             program (\_ -> [])
                 |> ensureOnlyOnePanelDisplayed [ "Panel 0", "Panel 1", "Panel 2" ]
                 |> done
-    , describe "identifying tabs container"
-        [ test "uses an attribute to identify the tabs container (without tooltips)" <|
-            \() ->
-                program (\_ -> [])
-                    |> ensureViewHas
-                        [ all
-                            [ nriDescription "Nri-Ui__tabs"
-                            , containing [ Selector.text "Tab 0" ]
-                            , containing [ Selector.text "Tab 1" ]
-                            , containing [ Selector.text "Tab 2" ]
-                            ]
+    , describe "identifying tabs container" <|
+        let
+            ensureTabContainerHas : List Selector -> TestContext -> TestContext
+            ensureTabContainerHas attrs =
+                ensureViewHas
+                    [ all
+                        [ all attrs
+                        , containing [ Selector.text "Tab 0" ]
+                        , containing [ Selector.text "Tab 1" ]
+                        , containing [ Selector.text "Tab 2" ]
                         ]
-                    |> ensureViewHasNot
+                    ]
+                    >> ensureViewHasNot
                         [ all
-                            [ nriDescription "Nri-Ui__tabs"
+                            [ all attrs
                             , containing [ Selector.text "Panel 0" ]
                             , containing [ Selector.text "Panel 1" ]
                             , containing [ Selector.text "Panel 2" ]
                             ]
                         ]
+        in
+        [ test "uses an attribute to identify the tabs container (without tooltips)" <|
+            \() ->
+                program (\_ -> [])
+                    |> ensureTabContainerHas [ nriDescription "Nri-Ui__tabs" ]
                     |> done
         , test "uses an attribute to identify the tabs container (with tooltips)" <|
             \() ->
                 program (\tabId -> [ Tabs.withTooltip [ Tooltip.plaintext (Debug.toString tabId) ] ])
-                    |> ensureViewHas
-                        [ all
-                            [ nriDescription "Nri-Ui__tabs"
-                            , containing [ Selector.text "Tab 0" ]
-                            , containing [ Selector.text "Tab 1" ]
-                            , containing [ Selector.text "Tab 2" ]
-                            ]
-                        ]
-                    |> ensureViewHasNot
-                        [ all
-                            [ nriDescription "Nri-Ui__tabs"
-                            , containing [ Selector.text "Panel 0" ]
-                            , containing [ Selector.text "Panel 1" ]
-                            , containing [ Selector.text "Panel 2" ]
-                            ]
-                        ]
+                    |> ensureTabContainerHas [ nriDescription "Nri-Ui__tabs" ]
                     |> done
         ]
     ]

--- a/tests/Spec/Nri/Ui/Tabs.elm
+++ b/tests/Spec/Nri/Ui/Tabs.elm
@@ -61,7 +61,7 @@ panelRenderingTests =
                     |> done
         , test "uses an attribute to identify the tabs container (with tooltips)" <|
             \() ->
-                program (\tabId -> [ Tabs.withTooltip [ Tooltip.plaintext (Debug.toString tabId) ] ])
+                program (\tabId -> [ Tabs.withTooltip [ Tooltip.plaintext (String.fromInt tabId) ] ])
                     |> ensureTabContainerHas [ nriDescription "Nri-Ui__tabs" ]
                     |> done
         ]

--- a/tests/Spec/Nri/Ui/Tabs.elm
+++ b/tests/Spec/Nri/Ui/Tabs.elm
@@ -4,9 +4,11 @@ import Browser.Dom as Dom
 import Html.Styled as Html exposing (..)
 import Nri.Ui.Tabs.V8 as Tabs
 import ProgramTest exposing (..)
+import Spec.Helpers exposing (nriDescription)
 import Spec.TabsInternalHelpers exposing (..)
 import Task
 import Test exposing (..)
+import Test.Html.Selector as Selector exposing (all, containing)
 
 
 spec : Test
@@ -29,6 +31,26 @@ panelRenderingTests =
         \() ->
             program
                 |> ensureOnlyOnePanelDisplayed [ "Panel 0", "Panel 1", "Panel 2" ]
+                |> done
+    , test "uses an attribute to identify the tabs container" <|
+        \() ->
+            program
+                |> ensureViewHas
+                    [ all
+                        [ nriDescription "Nri-Ui__tabs"
+                        , containing [ Selector.text "Tab 0" ]
+                        , containing [ Selector.text "Tab 1" ]
+                        , containing [ Selector.text "Tab 2" ]
+                        ]
+                    ]
+                |> ensureViewHasNot
+                    [ all
+                        [ nriDescription "Nri-Ui__tabs"
+                        , containing [ Selector.text "Panel 0" ]
+                        , containing [ Selector.text "Panel 1" ]
+                        , containing [ Selector.text "Panel 2" ]
+                        ]
+                    ]
                 |> done
     ]
 


### PR DESCRIPTION
## Context

Part of [QUO-274](https://linear.app/noredink/issue/QUO-274/gd-preview-userflow-tour-attachment-point-is-no-longer-spotlighting).

We have a Userflow tour that at some point is meant to target the tabs in the Writing sidebar:
<img width="545" alt="userflow" src="https://github.com/NoRedInk/noredink-ui/assets/753421/b3923710-b8a7-4536-8da3-ffdb29cf4636">

Recent [changes](https://github.com/NoRedInk/noredink-ui/pull/1288) to `Nri.Ui.Tabs` broke it, as we are using a modified HTML structure in the case where any tab has tooltips. This PR adds an `data-nri-description='Nri-Ui__tabs'` attribute to the container, letting us target it in a robust way when needed regardless of how the component is structured.

See [this conversation](https://noredink.slack.com/archives/C02NVG4M45U/p1695826087337389) with @charbelrami for more details!

## :framed_picture: What does this change look like?

### Without tooltips
<img width="1083" alt="Screenshot 2023-09-27 at 14 17 44" src="https://github.com/NoRedInk/noredink-ui/assets/753421/fc7baa96-5b74-4732-b6e4-c871049e0952">

### With tooltips
<img width="1095" alt="Screenshot 2023-09-27 at 14 17 36" src="https://github.com/NoRedInk/noredink-ui/assets/753421/0232f110-2452-44cb-9c5e-b27fe6fb497c">


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer:
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
