### PR TITLE
Add highlightable initializer `fromMarkdownInlines`

### DIFF
--- a/src/Nri/Ui/Highlightable/V3.elm
+++ b/src/Nri/Ui/Highlightable/V3.elm
@@ -258,9 +258,10 @@ fromMarkdown markdownString =
             |> List.indexedMap (\i highlightable -> { highlightable | index = i })
 
 
-{-| Same as `fromMarkdown`, but receives a list of inlines parsed markdown instead of a string.
+{-| Same as [`fromMarkdown`](#fromMarkdown), but receives a list of inlines parsed markdown instead of a string.
 
 You might want to use this if you are parsing highlightables out of lists or in other block contexts that [`fromMarkdown`](#fromMarkdown) does not support.
+
 -}
 fromMarkdownInlines : List (Markdown.Inline.Inline i) -> List (Highlightable ())
 fromMarkdownInlines inlines =

--- a/src/Nri/Ui/Highlightable/V3.elm
+++ b/src/Nri/Ui/Highlightable/V3.elm
@@ -1,11 +1,10 @@
 module Nri.Ui.Highlightable.V3 exposing
     ( Highlightable, Type(..)
     , initStatic, initInteractive, initFragments
-    , fromMarkdown
+    , fromMarkdown, fromMarkdownInlines
     , set
     , joinAdjacentInteractiveHighlights
     , asFragmentTuples, usedMarkers, text, byId
-    , fromMarkdownInlines
     )
 
 {-| A Highlightable represents a span of text, typically a word, and its state.

--- a/src/Nri/Ui/Highlightable/V3.elm
+++ b/src/Nri/Ui/Highlightable/V3.elm
@@ -258,7 +258,9 @@ fromMarkdown markdownString =
             |> List.indexedMap (\i highlightable -> { highlightable | index = i })
 
 
-{-| Same as `fromMarkdown`, but receives a list of inlines parsed markdown instead of a string
+{-| Same as `fromMarkdown`, but receives a list of inlines parsed markdown instead of a string.
+
+You might want to use this if you are parsing highlightables out of lists or in other block contexts that [`fromMarkdown`](#fromMarkdown) does not support.
 -}
 fromMarkdownInlines : List (Markdown.Inline.Inline i) -> List (Highlightable ())
 fromMarkdownInlines inlines =


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Adds a new constructor for highlightable, using markdown inlines. This will be useful for quo-301, because we will be able to parse the markdown ourselves and mix list and highlightables using a custom markdown parser.

Part of quo-301

## :framed_picture: What does this change look like?
No visual changes

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer:
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
