### PR TITLE
A11-3348 Helpfully disabled select

### DIFF
--- a/src/Nri/Ui/Select/V9.elm
+++ b/src/Nri/Ui/Select/V9.elm
@@ -491,7 +491,7 @@ viewSelect config_ config =
             -- Interaction
             , Css.cursor
                 (if config.disabled then
-                    Css.default
+                    Css.notAllowed
 
                  else
                     Css.pointer

--- a/src/Nri/Ui/Select/V9.elm
+++ b/src/Nri/Ui/Select/V9.elm
@@ -21,6 +21,10 @@ module Nri.Ui.Select.V9 exposing
       This is not a breaking change to the API, but affects automated tests
       that are looking for this prefix.
     - adds `icon` support
+    - when disabled, the select element is now replaced by a div element with
+      `aria-disabled="true"` and `tabindex="0"`. This change prevents user
+      interactions while maintaining the element in the tab order.
+    - sets cursor to `not-allowed` when disabled`
 
 @docs view, generateId
 

--- a/tests/Spec/Nri/Ui/Select.elm
+++ b/tests/Spec/Nri/Ui/Select.elm
@@ -1,5 +1,8 @@
 module Spec.Nri.Ui.Select exposing (spec)
 
+import Accessibility.Aria as Aria
+import Accessibility.Key as Key
+import Accessibility.Role as Role
 import Html.Attributes as Attributes
 import Html.Styled
 import Nri.Ui.Select.V9 as Select
@@ -61,6 +64,23 @@ spec =
                         , attribute (Attributes.value "My favorite animal is something else")
                         ]
                     |> done
+        , test "has the correct attributes when disabled" <|
+            \() ->
+                disabled
+                    |> ensureViewHas
+                        [ attribute (Aria.disabled True)
+                        , attribute Role.listBox
+                        , attribute (Key.tabbable True)
+                        ]
+                    |> done
+
+        {- Attempted to simulate click and keydown events on the enabled select element,
+           similar to the approach in tests/Spec/Nri/Ui/Switch.elm
+           Got the following error:
+
+           simulateDomEvent "keydown":
+           Event.expectEvent: I found a node, but it does not listen for "keydown" events like I expected it would.
+        -}
         ]
 
 
@@ -112,6 +132,33 @@ grouped =
                         ]
                     , Select.value model.favoriteAnimal
                     , Select.id selectId
+                    ]
+                    |> Html.Styled.map SelectFavorite
+                    |> Html.Styled.toUnstyled
+        }
+        |> ProgramTest.start ()
+
+
+disabled : ProgramTest Model Msg ()
+disabled =
+    ProgramTest.createSandbox
+        { init = { favoriteAnimal = Nothing }
+        , update = update
+        , view =
+            \model ->
+                Select.view "Favorite type of animal"
+                    [ Select.choices toString
+                        (List.map
+                            (\animal ->
+                                { label = toString animal
+                                , value = animal
+                                }
+                            )
+                            (mammals ++ amphibians ++ [ Other ])
+                        )
+                    , Select.value model.favoriteAnimal
+                    , Select.id selectId
+                    , Select.disabled
                     ]
                     |> Html.Styled.map SelectFavorite
                     |> Html.Styled.toUnstyled


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

[A11-3348 : Add helpfully disabled version of Select](https://linear.app/noredink/issue/A11-3348/add-helpfully-disabled-version-of-select)

The purpose of this PR is to replace `disabled` with `aria-disabled="true"` to keep the element in the tab order. Unlike `disabled`, `aria-disabled` does not remove event listeners from the element, so we need to remove these interactions programmatically.

The initial attempt was to prevent default on `mousedown` and some `keydown` events when the select element is disabled. However, this would require passing a `NoOp` msg to `Select.disabled` since `Events.preventDefaultOn` needs a msg. This would also require an `Attribute msg` type, which would conflict with the existing `Attribute a` type.

To avoid changes in the API, the current solution is to replace the `select` element with a `div` element with `aria-disabled="true"` and `tabindex="0"`. This change prevents user interactions while keeping the element in the tab order.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer:
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
