### PR TITLE
🏷️  Bump for version `25.2.0` `Add highlightable initializer fromMarkdownInlines`

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "25.1.0",
+    "version": "25.2.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `25.2.0`

## What changes does this release include?
- #1542
## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```
---- Nri.Ui.Highlightable.V3 - MINOR ----

    Added:
        fromMarkdownInlines :
            List.List (Markdown.Inline.Inline i)
            -> List.List (Nri.Ui.Highlightable.V3.Highlightable ())

```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).
