### PR TITLE
Revert elm dependencies change due to #1526

### DIFF
--- a/component-catalog/tests/SwitchExampleSpec.elm
+++ b/component-catalog/tests/SwitchExampleSpec.elm
@@ -7,7 +7,9 @@ import Nri.Test.MouseHelpers.V1 as MouseHelpers
 import ProgramTest exposing (..)
 import Routes exposing (Route)
 import Test exposing (..)
-import Test.Html.Selector exposing (..)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector exposing (..)
 import TestApp exposing (app)
 
 
@@ -36,8 +38,20 @@ suite =
 switchIt : String -> ProgramTest a b c -> ProgramTest a b c
 switchIt name =
     MouseHelpers.click
-        ProgramTest.simulateDomEvent
+        mhConfig
         [ attribute Role.switch
         , containing [ text name ]
         , id "view-switch-example"
         ]
+
+
+mhConfig : MouseHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+mhConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_click = Event.click
+    , event_mouseDown = Event.mouseDown
+    , event_mouseUp = Event.mouseUp
+    , event_mouseOver = Event.mouseOver
+    , event_custom = Event.custom
+    }

--- a/component-catalog/tests/SwitchExampleSpec.elm
+++ b/component-catalog/tests/SwitchExampleSpec.elm
@@ -36,6 +36,7 @@ suite =
 switchIt : String -> ProgramTest a b c -> ProgramTest a b c
 switchIt name =
     MouseHelpers.click
+        ProgramTest.simulateDomEvent
         [ attribute Role.switch
         , containing [ text name ]
         , id "view-switch-example"

--- a/elm.json
+++ b/elm.json
@@ -101,7 +101,6 @@
     "dependencies": {
         "BrianHicks/elm-particle": "1.5.0 <= v < 2.0.0",
         "Gizra/elm-keyboard-event": "1.0.1 <= v < 2.0.0",
-        "avh4/elm-program-test": "4.0.0 <= v < 5.0.0",
         "elm/browser": "1.0.2 <= v < 2.0.0",
         "elm/core": "1.0.1 <= v < 2.0.0",
         "elm/http": "2.0.0 <= v < 3.0.0",
@@ -123,6 +122,7 @@
         "tesk9/palette": "3.0.1 <= v < 4.0.0"
     },
     "test-dependencies": {
+        "avh4/elm-program-test": "4.0.0 <= v < 5.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
         "tesk9/accessible-html": "5.0.0 <= v < 6.0.0"
     }

--- a/elm.json
+++ b/elm.json
@@ -113,7 +113,6 @@
         "elm-community/maybe-extra": "5.3.0 <= v < 6.0.0",
         "elm-community/random-extra": "3.2.0 <= v < 4.0.0",
         "elm-community/string-extra": "4.0.1 <= v < 5.0.0",
-        "elm-explorations/test": "2.0.0 <= v < 3.0.0",
         "pablohirafuji/elm-markdown": "2.0.5 <= v < 3.0.0",
         "rtfeldman/elm-css": "17.0.1 <= v < 19.0.0",
         "rtfeldman/elm-iso8601-date-strings": "1.1.4 <= v < 2.0.0",
@@ -124,6 +123,7 @@
     "test-dependencies": {
         "avh4/elm-program-test": "4.0.0 <= v < 5.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
+        "elm-explorations/test": "2.0.0 <= v < 3.0.0",
         "tesk9/accessible-html": "5.0.0 <= v < 6.0.0"
     }
 }

--- a/src/Nri/Test/KeyboardHelpers/V1.elm
+++ b/src/Nri/Test/KeyboardHelpers/V1.elm
@@ -1,6 +1,7 @@
 module Nri.Test.KeyboardHelpers.V1 exposing
     ( pressKey, releaseKey
     , pressTab, pressTabBack, pressEsc, pressSpace, pressDownArrow, pressRightArrow, pressLeftArrow, pressShiftRight, pressShiftLeft, releaseRightArrow, releaseLeftArrow, releaseShiftRight, releaseShiftLeft
+    , Config
     )
 
 {-| `KeyboardHelpers` provides a set of functions to simulate keyboard events for testing Elm programs.
@@ -15,34 +16,41 @@ module Nri.Test.KeyboardHelpers.V1 exposing
 
 @docs pressTab, pressTabBack, pressEsc, pressSpace, pressDownArrow, pressRightArrow, pressLeftArrow, pressShiftRight, pressShiftLeft, releaseRightArrow, releaseLeftArrow, releaseShiftRight, releaseShiftLeft
 
+
+# Config
+
+@docs Config
+
 -}
 
 import Json.Encode as Encode
-import Test.Html.Event as Event
-import Test.Html.Query as Query
-import Test.Html.Selector exposing (Selector)
 
 
-type alias SimulateDomEvent msg programTest =
-    (Query.Single msg -> Query.Single msg) -> ( String, Encode.Value ) -> programTest -> programTest
+{-| A `Config` allow us to not depend strictly on elm-explorations/test and avh4/elm-program-test packages.
+-}
+type alias Config programTest selector querySingle =
+    { programTest_simulateDomEvent : (querySingle -> querySingle) -> ( String, Encode.Value ) -> programTest -> programTest
+    , query_find : List selector -> querySingle -> querySingle
+    , event_custom : String -> Encode.Value -> ( String, Encode.Value )
+    }
 
 
 {-| Simulate a "keydown" event on the given element.
 -}
 pressKey :
-    SimulateDomEvent msg programTest
+    Config programTest selector querySingle
     ->
         { targetDetails : List ( String, Encode.Value )
         , keyCode : Int
         , shiftKey : Bool
         }
-    -> List Selector
+    -> List selector
     -> programTest
     -> programTest
-pressKey simulateDomEvent { targetDetails, keyCode, shiftKey } selectors =
-    simulateDomEvent
-        (Query.find selectors)
-        (Event.custom
+pressKey config { targetDetails, keyCode, shiftKey } selectors =
+    config.programTest_simulateDomEvent
+        (config.query_find selectors)
+        (config.event_custom
             "keydown"
             (Encode.object
                 [ ( "keyCode", Encode.int keyCode )
@@ -58,19 +66,19 @@ pressKey simulateDomEvent { targetDetails, keyCode, shiftKey } selectors =
 {-| Simulate a "keyup" event on the given element.
 -}
 releaseKey :
-    SimulateDomEvent msg programTest
+    Config programTest selector querySingle
     ->
         { targetDetails : List ( String, Encode.Value )
         , keyCode : Int
         , shiftKey : Bool
         }
-    -> List Selector
+    -> List selector
     -> programTest
     -> programTest
-releaseKey simulateDomEvent { targetDetails, keyCode, shiftKey } selectors =
-    simulateDomEvent
-        (Query.find selectors)
-        (Event.custom
+releaseKey config { targetDetails, keyCode, shiftKey } selectors =
+    config.programTest_simulateDomEvent
+        (config.query_find selectors)
+        (config.event_custom
             "keyup"
             (Encode.object
                 [ ( "keyCode", Encode.int keyCode )
@@ -86,154 +94,154 @@ releaseKey simulateDomEvent { targetDetails, keyCode, shiftKey } selectors =
 {-| Simulate a tab key press on the given element.
 -}
 pressTab :
-    SimulateDomEvent msg programTest
+    Config programTest selector querySingle
     -> { targetDetails : List ( String, Encode.Value ) }
-    -> List Selector
+    -> List selector
     -> programTest
     -> programTest
-pressTab simulateDomEvent { targetDetails } =
-    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 9, shiftKey = False }
+pressTab config { targetDetails } =
+    pressKey config { targetDetails = targetDetails, keyCode = 9, shiftKey = False }
 
 
 {-| Simulate a shift-tab key press on the given element.
 -}
 pressTabBack :
-    SimulateDomEvent msg programTest
+    Config programTest selector querySingle
     -> { targetDetails : List ( String, Encode.Value ) }
-    -> List Selector
+    -> List selector
     -> programTest
     -> programTest
-pressTabBack simulateDomEvent { targetDetails } =
-    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 9, shiftKey = True }
+pressTabBack config { targetDetails } =
+    pressKey config { targetDetails = targetDetails, keyCode = 9, shiftKey = True }
 
 
 {-| Simulate an escape key press on the given element.
 -}
 pressEsc :
-    SimulateDomEvent msg programTest
+    Config programTest selector querySingle
     -> { targetDetails : List ( String, Encode.Value ) }
-    -> List Selector
+    -> List selector
     -> programTest
     -> programTest
-pressEsc simulateDomEvent { targetDetails } =
-    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 27, shiftKey = False }
+pressEsc config { targetDetails } =
+    pressKey config { targetDetails = targetDetails, keyCode = 27, shiftKey = False }
 
 
 {-| Simulate a spacebar key press on the given element.
 -}
 pressSpace :
-    SimulateDomEvent msg programTest
+    Config programTest selector querySingle
     -> { targetDetails : List ( String, Encode.Value ) }
-    -> List Selector
+    -> List selector
     -> programTest
     -> programTest
-pressSpace simulateDomEvent { targetDetails } =
-    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 32, shiftKey = False }
+pressSpace config { targetDetails } =
+    pressKey config { targetDetails = targetDetails, keyCode = 32, shiftKey = False }
 
 
 {-| Simulate a down arrow key press on the given element.
 -}
 pressDownArrow :
-    SimulateDomEvent msg programTest
+    Config programTest selector querySingle
     -> { targetDetails : List ( String, Encode.Value ) }
-    -> List Selector
+    -> List selector
     -> programTest
     -> programTest
-pressDownArrow simulateDomEvent { targetDetails } =
-    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 40, shiftKey = False }
+pressDownArrow config { targetDetails } =
+    pressKey config { targetDetails = targetDetails, keyCode = 40, shiftKey = False }
 
 
 {-| Simulate a right arrow key press on the given element.
 -}
 pressRightArrow :
-    SimulateDomEvent msg programTest
+    Config programTest selector querySingle
     -> { targetDetails : List ( String, Encode.Value ) }
-    -> List Selector
+    -> List selector
     -> programTest
     -> programTest
-pressRightArrow simulateDomEvent { targetDetails } =
-    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 39, shiftKey = False }
+pressRightArrow config { targetDetails } =
+    pressKey config { targetDetails = targetDetails, keyCode = 39, shiftKey = False }
 
 
 {-| Simulate a left arrow key press on the given element.
 -}
 pressLeftArrow :
-    SimulateDomEvent msg programTest
+    Config programTest selector querySingle
     -> { targetDetails : List ( String, Encode.Value ) }
-    -> List Selector
+    -> List selector
     -> programTest
     -> programTest
-pressLeftArrow simulateDomEvent { targetDetails } =
-    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 37, shiftKey = False }
+pressLeftArrow config { targetDetails } =
+    pressKey config { targetDetails = targetDetails, keyCode = 37, shiftKey = False }
 
 
 {-| Simulate a right arrow key press with the shift key held down on the given element.
 -}
 pressShiftRight :
-    SimulateDomEvent msg programTest
+    Config programTest selector querySingle
     -> { targetDetails : List ( String, Encode.Value ) }
-    -> List Selector
+    -> List selector
     -> programTest
     -> programTest
-pressShiftRight simulateDomEvent { targetDetails } =
-    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 39, shiftKey = True }
+pressShiftRight config { targetDetails } =
+    pressKey config { targetDetails = targetDetails, keyCode = 39, shiftKey = True }
 
 
 {-| Simulate a left arrow key press with the shift key held down on the given element.
 -}
 pressShiftLeft :
-    SimulateDomEvent msg programTest
+    Config programTest selector querySingle
     -> { targetDetails : List ( String, Encode.Value ) }
-    -> List Selector
+    -> List selector
     -> programTest
     -> programTest
-pressShiftLeft simulateDomEvent { targetDetails } =
-    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 37, shiftKey = True }
+pressShiftLeft config { targetDetails } =
+    pressKey config { targetDetails = targetDetails, keyCode = 37, shiftKey = True }
 
 
 {-| Simulate a right arrow key release on the given element.
 -}
 releaseRightArrow :
-    SimulateDomEvent msg programTest
+    Config programTest selector querySingle
     -> { targetDetails : List ( String, Encode.Value ) }
-    -> List Selector
+    -> List selector
     -> programTest
     -> programTest
-releaseRightArrow simulateDomEvent { targetDetails } =
-    releaseKey simulateDomEvent { targetDetails = targetDetails, keyCode = 39, shiftKey = False }
+releaseRightArrow config { targetDetails } =
+    releaseKey config { targetDetails = targetDetails, keyCode = 39, shiftKey = False }
 
 
 {-| Simulate a left arrow key release on the given element.
 -}
 releaseLeftArrow :
-    SimulateDomEvent msg programTest
+    Config programTest selector querySingle
     -> { targetDetails : List ( String, Encode.Value ) }
-    -> List Selector
+    -> List selector
     -> programTest
     -> programTest
-releaseLeftArrow simulateDomEvent { targetDetails } =
-    releaseKey simulateDomEvent { targetDetails = targetDetails, keyCode = 37, shiftKey = False }
+releaseLeftArrow config { targetDetails } =
+    releaseKey config { targetDetails = targetDetails, keyCode = 37, shiftKey = False }
 
 
 {-| Simulate a right arrow key release with the shift key held down on the given element.
 -}
 releaseShiftRight :
-    SimulateDomEvent msg programTest
+    Config programTest selector querySingle
     -> { targetDetails : List ( String, Encode.Value ) }
-    -> List Selector
+    -> List selector
     -> programTest
     -> programTest
-releaseShiftRight simulateDomEvent { targetDetails } =
-    releaseKey simulateDomEvent { targetDetails = targetDetails, keyCode = 39, shiftKey = True }
+releaseShiftRight config { targetDetails } =
+    releaseKey config { targetDetails = targetDetails, keyCode = 39, shiftKey = True }
 
 
 {-| Simulate a left arrow key release with the shift key held down on the given element.
 -}
 releaseShiftLeft :
-    SimulateDomEvent msg programTest
+    Config programTest selector querySingle
     -> { targetDetails : List ( String, Encode.Value ) }
-    -> List Selector
+    -> List selector
     -> programTest
     -> programTest
-releaseShiftLeft simulateDomEvent { targetDetails } =
-    releaseKey simulateDomEvent { targetDetails = targetDetails, keyCode = 37, shiftKey = True }
+releaseShiftLeft config { targetDetails } =
+    releaseKey config { targetDetails = targetDetails, keyCode = 37, shiftKey = True }

--- a/src/Nri/Test/KeyboardHelpers/V1.elm
+++ b/src/Nri/Test/KeyboardHelpers/V1.elm
@@ -18,24 +18,29 @@ module Nri.Test.KeyboardHelpers.V1 exposing
 -}
 
 import Json.Encode as Encode
-import ProgramTest exposing (ProgramTest)
 import Test.Html.Event as Event
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (Selector)
 
 
+type alias SimulateDomEvent msg programTest =
+    (Query.Single msg -> Query.Single msg) -> ( String, Encode.Value ) -> programTest -> programTest
+
+
 {-| Simulate a "keydown" event on the given element.
 -}
 pressKey :
-    { targetDetails : List ( String, Encode.Value )
-    , keyCode : Int
-    , shiftKey : Bool
-    }
+    SimulateDomEvent msg programTest
+    ->
+        { targetDetails : List ( String, Encode.Value )
+        , keyCode : Int
+        , shiftKey : Bool
+        }
     -> List Selector
-    -> ProgramTest model msg effect
-    -> ProgramTest model msg effect
-pressKey { targetDetails, keyCode, shiftKey } selectors =
-    ProgramTest.simulateDomEvent
+    -> programTest
+    -> programTest
+pressKey simulateDomEvent { targetDetails, keyCode, shiftKey } selectors =
+    simulateDomEvent
         (Query.find selectors)
         (Event.custom
             "keydown"
@@ -53,15 +58,17 @@ pressKey { targetDetails, keyCode, shiftKey } selectors =
 {-| Simulate a "keyup" event on the given element.
 -}
 releaseKey :
-    { targetDetails : List ( String, Encode.Value )
-    , keyCode : Int
-    , shiftKey : Bool
-    }
+    SimulateDomEvent msg programTest
+    ->
+        { targetDetails : List ( String, Encode.Value )
+        , keyCode : Int
+        , shiftKey : Bool
+        }
     -> List Selector
-    -> ProgramTest model msg effect
-    -> ProgramTest model msg effect
-releaseKey { targetDetails, keyCode, shiftKey } selectors =
-    ProgramTest.simulateDomEvent
+    -> programTest
+    -> programTest
+releaseKey simulateDomEvent { targetDetails, keyCode, shiftKey } selectors =
+    simulateDomEvent
         (Query.find selectors)
         (Event.custom
             "keyup"
@@ -79,141 +86,154 @@ releaseKey { targetDetails, keyCode, shiftKey } selectors =
 {-| Simulate a tab key press on the given element.
 -}
 pressTab :
-    { targetDetails : List ( String, Encode.Value ) }
+    SimulateDomEvent msg programTest
+    -> { targetDetails : List ( String, Encode.Value ) }
     -> List Selector
-    -> ProgramTest model msg effect
-    -> ProgramTest model msg effect
-pressTab { targetDetails } =
-    pressKey { targetDetails = targetDetails, keyCode = 9, shiftKey = False }
+    -> programTest
+    -> programTest
+pressTab simulateDomEvent { targetDetails } =
+    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 9, shiftKey = False }
 
 
 {-| Simulate a shift-tab key press on the given element.
 -}
 pressTabBack :
-    { targetDetails : List ( String, Encode.Value ) }
+    SimulateDomEvent msg programTest
+    -> { targetDetails : List ( String, Encode.Value ) }
     -> List Selector
-    -> ProgramTest model msg effect
-    -> ProgramTest model msg effect
-pressTabBack { targetDetails } =
-    pressKey { targetDetails = targetDetails, keyCode = 9, shiftKey = True }
+    -> programTest
+    -> programTest
+pressTabBack simulateDomEvent { targetDetails } =
+    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 9, shiftKey = True }
 
 
 {-| Simulate an escape key press on the given element.
 -}
 pressEsc :
-    { targetDetails : List ( String, Encode.Value ) }
+    SimulateDomEvent msg programTest
+    -> { targetDetails : List ( String, Encode.Value ) }
     -> List Selector
-    -> ProgramTest model msg effect
-    -> ProgramTest model msg effect
-pressEsc { targetDetails } =
-    pressKey { targetDetails = targetDetails, keyCode = 27, shiftKey = False }
+    -> programTest
+    -> programTest
+pressEsc simulateDomEvent { targetDetails } =
+    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 27, shiftKey = False }
 
 
 {-| Simulate a spacebar key press on the given element.
 -}
 pressSpace :
-    { targetDetails : List ( String, Encode.Value ) }
+    SimulateDomEvent msg programTest
+    -> { targetDetails : List ( String, Encode.Value ) }
     -> List Selector
-    -> ProgramTest model msg effect
-    -> ProgramTest model msg effect
-pressSpace { targetDetails } =
-    pressKey { targetDetails = targetDetails, keyCode = 32, shiftKey = False }
+    -> programTest
+    -> programTest
+pressSpace simulateDomEvent { targetDetails } =
+    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 32, shiftKey = False }
 
 
 {-| Simulate a down arrow key press on the given element.
 -}
 pressDownArrow :
-    { targetDetails : List ( String, Encode.Value ) }
+    SimulateDomEvent msg programTest
+    -> { targetDetails : List ( String, Encode.Value ) }
     -> List Selector
-    -> ProgramTest model msg effect
-    -> ProgramTest model msg effect
-pressDownArrow { targetDetails } =
-    pressKey { targetDetails = targetDetails, keyCode = 40, shiftKey = False }
+    -> programTest
+    -> programTest
+pressDownArrow simulateDomEvent { targetDetails } =
+    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 40, shiftKey = False }
 
 
 {-| Simulate a right arrow key press on the given element.
 -}
 pressRightArrow :
-    { targetDetails : List ( String, Encode.Value ) }
+    SimulateDomEvent msg programTest
+    -> { targetDetails : List ( String, Encode.Value ) }
     -> List Selector
-    -> ProgramTest model msg effect
-    -> ProgramTest model msg effect
-pressRightArrow { targetDetails } =
-    pressKey { targetDetails = targetDetails, keyCode = 39, shiftKey = False }
+    -> programTest
+    -> programTest
+pressRightArrow simulateDomEvent { targetDetails } =
+    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 39, shiftKey = False }
 
 
 {-| Simulate a left arrow key press on the given element.
 -}
 pressLeftArrow :
-    { targetDetails : List ( String, Encode.Value ) }
+    SimulateDomEvent msg programTest
+    -> { targetDetails : List ( String, Encode.Value ) }
     -> List Selector
-    -> ProgramTest model msg effect
-    -> ProgramTest model msg effect
-pressLeftArrow { targetDetails } =
-    pressKey { targetDetails = targetDetails, keyCode = 37, shiftKey = False }
+    -> programTest
+    -> programTest
+pressLeftArrow simulateDomEvent { targetDetails } =
+    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 37, shiftKey = False }
 
 
 {-| Simulate a right arrow key press with the shift key held down on the given element.
 -}
 pressShiftRight :
-    { targetDetails : List ( String, Encode.Value ) }
+    SimulateDomEvent msg programTest
+    -> { targetDetails : List ( String, Encode.Value ) }
     -> List Selector
-    -> ProgramTest model msg effect
-    -> ProgramTest model msg effect
-pressShiftRight { targetDetails } =
-    pressKey { targetDetails = targetDetails, keyCode = 39, shiftKey = True }
+    -> programTest
+    -> programTest
+pressShiftRight simulateDomEvent { targetDetails } =
+    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 39, shiftKey = True }
 
 
 {-| Simulate a left arrow key press with the shift key held down on the given element.
 -}
 pressShiftLeft :
-    { targetDetails : List ( String, Encode.Value ) }
+    SimulateDomEvent msg programTest
+    -> { targetDetails : List ( String, Encode.Value ) }
     -> List Selector
-    -> ProgramTest model msg effect
-    -> ProgramTest model msg effect
-pressShiftLeft { targetDetails } =
-    pressKey { targetDetails = targetDetails, keyCode = 37, shiftKey = True }
+    -> programTest
+    -> programTest
+pressShiftLeft simulateDomEvent { targetDetails } =
+    pressKey simulateDomEvent { targetDetails = targetDetails, keyCode = 37, shiftKey = True }
 
 
 {-| Simulate a right arrow key release on the given element.
 -}
 releaseRightArrow :
-    { targetDetails : List ( String, Encode.Value ) }
+    SimulateDomEvent msg programTest
+    -> { targetDetails : List ( String, Encode.Value ) }
     -> List Selector
-    -> ProgramTest model msg effect
-    -> ProgramTest model msg effect
-releaseRightArrow { targetDetails } =
-    releaseKey { targetDetails = targetDetails, keyCode = 39, shiftKey = False }
+    -> programTest
+    -> programTest
+releaseRightArrow simulateDomEvent { targetDetails } =
+    releaseKey simulateDomEvent { targetDetails = targetDetails, keyCode = 39, shiftKey = False }
 
 
 {-| Simulate a left arrow key release on the given element.
 -}
 releaseLeftArrow :
-    { targetDetails : List ( String, Encode.Value ) }
+    SimulateDomEvent msg programTest
+    -> { targetDetails : List ( String, Encode.Value ) }
     -> List Selector
-    -> ProgramTest model msg effect
-    -> ProgramTest model msg effect
-releaseLeftArrow { targetDetails } =
-    releaseKey { targetDetails = targetDetails, keyCode = 37, shiftKey = False }
+    -> programTest
+    -> programTest
+releaseLeftArrow simulateDomEvent { targetDetails } =
+    releaseKey simulateDomEvent { targetDetails = targetDetails, keyCode = 37, shiftKey = False }
 
 
 {-| Simulate a right arrow key release with the shift key held down on the given element.
 -}
 releaseShiftRight :
-    { targetDetails : List ( String, Encode.Value ) }
+    SimulateDomEvent msg programTest
+    -> { targetDetails : List ( String, Encode.Value ) }
     -> List Selector
-    -> ProgramTest model msg effect
-    -> ProgramTest model msg effect
-releaseShiftRight { targetDetails } =
-    releaseKey { targetDetails = targetDetails, keyCode = 39, shiftKey = True }
+    -> programTest
+    -> programTest
+releaseShiftRight simulateDomEvent { targetDetails } =
+    releaseKey simulateDomEvent { targetDetails = targetDetails, keyCode = 39, shiftKey = True }
 
 
 {-| Simulate a left arrow key release with the shift key held down on the given element.
 -}
 releaseShiftLeft :
-    { targetDetails : List ( String, Encode.Value ) }
+    SimulateDomEvent msg programTest
+    -> { targetDetails : List ( String, Encode.Value ) }
     -> List Selector
-    -> ProgramTest model msg effect
-    -> ProgramTest model msg effect
-releaseShiftLeft { targetDetails } =
-    releaseKey { targetDetails = targetDetails, keyCode = 37, shiftKey = True }
+    -> programTest
+    -> programTest
+releaseShiftLeft simulateDomEvent { targetDetails } =
+    releaseKey simulateDomEvent { targetDetails = targetDetails, keyCode = 37, shiftKey = True }

--- a/src/Nri/Test/MouseHelpers/V1.elm
+++ b/src/Nri/Test/MouseHelpers/V1.elm
@@ -18,53 +18,56 @@ module Nri.Test.MouseHelpers.V1 exposing
 -}
 
 import Json.Encode as Encode
-import ProgramTest exposing (ProgramTest)
 import Test.Html.Event as Event
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (Selector)
 
 
+type alias SimulateDomEvent msg programTest =
+    (Query.Single msg -> Query.Single msg) -> ( String, Encode.Value ) -> programTest -> programTest
+
+
 {-| Simulate a click event on elements that match the given selectors.
 -}
-click : List Selector -> ProgramTest model msg effect -> ProgramTest model msg effect
-click selectors =
-    ProgramTest.simulateDomEvent
+click : SimulateDomEvent msg programTest -> List Selector -> programTest -> programTest
+click simulateDomEvent selectors =
+    simulateDomEvent
         (Query.find selectors)
         Event.click
 
 
 {-| Simulate a mouse down event on elements that match the given selectors.
 -}
-mouseDown : List Selector -> ProgramTest model msg effect -> ProgramTest model msg effect
-mouseDown selectors =
-    ProgramTest.simulateDomEvent
+mouseDown : SimulateDomEvent msg programTest -> List Selector -> programTest -> programTest
+mouseDown simulateDomEvent selectors =
+    simulateDomEvent
         (Query.find selectors)
         Event.mouseDown
 
 
 {-| Simulate a mouse up event on elements that match the given selectors.
 -}
-mouseUp : List Selector -> ProgramTest model msg effect -> ProgramTest model msg effect
-mouseUp selectors =
-    ProgramTest.simulateDomEvent
+mouseUp : SimulateDomEvent msg programTest -> List Selector -> programTest -> programTest
+mouseUp simulateDomEvent selectors =
+    simulateDomEvent
         (Query.find selectors)
         Event.mouseUp
 
 
 {-| Simulate a mouse over event on elements that match the given selectors.
 -}
-mouseOver : List Selector -> ProgramTest model msg effect -> ProgramTest model msg effect
-mouseOver selectors =
-    ProgramTest.simulateDomEvent
+mouseOver : SimulateDomEvent msg programTest -> List Selector -> programTest -> programTest
+mouseOver simulateDomEvent selectors =
+    simulateDomEvent
         (Query.find selectors)
         Event.mouseOver
 
 
 {-| Simulate a cancelable mouse down event on elements that match the given selectors.
 -}
-cancelableMouseDown : List Selector -> ProgramTest model msg effect -> ProgramTest model msg effect
-cancelableMouseDown selectors =
-    ProgramTest.simulateDomEvent
+cancelableMouseDown : SimulateDomEvent msg programTest -> List Selector -> programTest -> programTest
+cancelableMouseDown simulateDomEvent selectors =
+    simulateDomEvent
         (Query.find selectors)
         (Event.custom
             "mousedown"
@@ -74,9 +77,9 @@ cancelableMouseDown selectors =
 
 {-| Simulate a cancelable mouse up event on elements that match the given selectors.
 -}
-cancelableMouseUp : List Selector -> ProgramTest model msg effect -> ProgramTest model msg effect
-cancelableMouseUp selectors =
-    ProgramTest.simulateDomEvent
+cancelableMouseUp : SimulateDomEvent msg programTest -> List Selector -> programTest -> programTest
+cancelableMouseUp simulateDomEvent selectors =
+    simulateDomEvent
         (Query.find selectors)
         (Event.custom
             "mouseup"
@@ -86,9 +89,9 @@ cancelableMouseUp selectors =
 
 {-| Simulate a cancelable mouse over event on elements that match the given selectors.
 -}
-cancelableMouseOver : List Selector -> ProgramTest model msg effect -> ProgramTest model msg effect
-cancelableMouseOver selectors =
-    ProgramTest.simulateDomEvent
+cancelableMouseOver : SimulateDomEvent msg programTest -> List Selector -> programTest -> programTest
+cancelableMouseOver simulateDomEvent selectors =
+    simulateDomEvent
         (Query.find selectors)
         (Event.custom
             "mouseover"

--- a/src/Nri/Test/MouseHelpers/V1.elm
+++ b/src/Nri/Test/MouseHelpers/V1.elm
@@ -1,6 +1,7 @@
 module Nri.Test.MouseHelpers.V1 exposing
     ( click, mouseDown, mouseUp, mouseOver
     , cancelableMouseDown, cancelableMouseUp, cancelableMouseOver
+    , Config
     )
 
 {-| `MouseHelpers` provides a set of functions to simulate mouse events for testing Elm programs.
@@ -15,61 +16,72 @@ module Nri.Test.MouseHelpers.V1 exposing
 
 @docs cancelableMouseDown, cancelableMouseUp, cancelableMouseOver
 
+
+# Config
+
+@docs Config
+
 -}
 
 import Json.Encode as Encode
-import Test.Html.Event as Event
-import Test.Html.Query as Query
-import Test.Html.Selector exposing (Selector)
 
 
-type alias SimulateDomEvent msg programTest =
-    (Query.Single msg -> Query.Single msg) -> ( String, Encode.Value ) -> programTest -> programTest
+{-| A `Config` allow us to not depend strictly on elm-explorations/test and avh4/elm-program-test packages.
+-}
+type alias Config programTest selector querySingle =
+    { programTest_simulateDomEvent : (querySingle -> querySingle) -> ( String, Encode.Value ) -> programTest -> programTest
+    , query_find : List selector -> querySingle -> querySingle
+    , event_click : ( String, Encode.Value )
+    , event_mouseDown : ( String, Encode.Value )
+    , event_mouseUp : ( String, Encode.Value )
+    , event_mouseOver : ( String, Encode.Value )
+    , event_custom : String -> Encode.Value -> ( String, Encode.Value )
+    }
 
 
 {-| Simulate a click event on elements that match the given selectors.
 -}
-click : SimulateDomEvent msg programTest -> List Selector -> programTest -> programTest
-click simulateDomEvent selectors =
-    simulateDomEvent
-        (Query.find selectors)
-        Event.click
+click : Config programTest selector querySingle -> List selector -> programTest -> programTest
+click config selectors =
+    config.programTest_simulateDomEvent
+        (config.query_find selectors)
+        config.event_click
 
 
 {-| Simulate a mouse down event on elements that match the given selectors.
 -}
-mouseDown : SimulateDomEvent msg programTest -> List Selector -> programTest -> programTest
-mouseDown simulateDomEvent selectors =
-    simulateDomEvent
-        (Query.find selectors)
-        Event.mouseDown
+mouseDown : Config programTest selector querySingle -> List selector -> programTest -> programTest
+mouseDown config selectors =
+    config.programTest_simulateDomEvent
+        (config.query_find selectors)
+        config.event_mouseDown
 
 
 {-| Simulate a mouse up event on elements that match the given selectors.
 -}
-mouseUp : SimulateDomEvent msg programTest -> List Selector -> programTest -> programTest
-mouseUp simulateDomEvent selectors =
-    simulateDomEvent
-        (Query.find selectors)
-        Event.mouseUp
+mouseUp : Config programTest selector querySingle -> List selector -> programTest -> programTest
+mouseUp config selectors =
+    config.programTest_simulateDomEvent
+        (config.query_find selectors)
+        config.event_mouseUp
 
 
 {-| Simulate a mouse over event on elements that match the given selectors.
 -}
-mouseOver : SimulateDomEvent msg programTest -> List Selector -> programTest -> programTest
-mouseOver simulateDomEvent selectors =
-    simulateDomEvent
-        (Query.find selectors)
-        Event.mouseOver
+mouseOver : Config programTest selector querySingle -> List selector -> programTest -> programTest
+mouseOver config selectors =
+    config.programTest_simulateDomEvent
+        (config.query_find selectors)
+        config.event_mouseOver
 
 
 {-| Simulate a cancelable mouse down event on elements that match the given selectors.
 -}
-cancelableMouseDown : SimulateDomEvent msg programTest -> List Selector -> programTest -> programTest
-cancelableMouseDown simulateDomEvent selectors =
-    simulateDomEvent
-        (Query.find selectors)
-        (Event.custom
+cancelableMouseDown : Config programTest selector querySingle -> List selector -> programTest -> programTest
+cancelableMouseDown config selectors =
+    config.programTest_simulateDomEvent
+        (config.query_find selectors)
+        (config.event_custom
             "mousedown"
             (Encode.object [ ( "cancelable", Encode.bool True ) ])
         )
@@ -77,11 +89,11 @@ cancelableMouseDown simulateDomEvent selectors =
 
 {-| Simulate a cancelable mouse up event on elements that match the given selectors.
 -}
-cancelableMouseUp : SimulateDomEvent msg programTest -> List Selector -> programTest -> programTest
-cancelableMouseUp simulateDomEvent selectors =
-    simulateDomEvent
-        (Query.find selectors)
-        (Event.custom
+cancelableMouseUp : Config programTest selector querySingle -> List selector -> programTest -> programTest
+cancelableMouseUp config selectors =
+    config.programTest_simulateDomEvent
+        (config.query_find selectors)
+        (config.event_custom
             "mouseup"
             (Encode.object [ ( "cancelable", Encode.bool True ) ])
         )
@@ -89,11 +101,11 @@ cancelableMouseUp simulateDomEvent selectors =
 
 {-| Simulate a cancelable mouse over event on elements that match the given selectors.
 -}
-cancelableMouseOver : SimulateDomEvent msg programTest -> List Selector -> programTest -> programTest
-cancelableMouseOver simulateDomEvent selectors =
-    simulateDomEvent
-        (Query.find selectors)
-        (Event.custom
+cancelableMouseOver : Config programTest selector querySingle -> List selector -> programTest -> programTest
+cancelableMouseOver config selectors =
+    config.programTest_simulateDomEvent
+        (config.query_find selectors)
+        (config.event_custom
             "mouseover"
             (Encode.object [ ( "cancelable", Encode.bool True ) ])
         )

--- a/tests/Spec/Nri/Ui/Checkbox.elm
+++ b/tests/Spec/Nri/Ui/Checkbox.elm
@@ -124,7 +124,7 @@ helpfullyDisabledCheckbox =
 
 pressSpace : TestContext -> TestContext
 pressSpace =
-    KeyboardHelpers.pressSpace { targetDetails = [] } checkbox
+    KeyboardHelpers.pressSpace ProgramTest.simulateDomEvent { targetDetails = [] } checkbox
 
 
 clickIt : TestContext -> TestContext

--- a/tests/Spec/Nri/Ui/Checkbox.elm
+++ b/tests/Spec/Nri/Ui/Checkbox.elm
@@ -11,7 +11,7 @@ import Spec.Helpers exposing (expectFailure)
 import Test exposing (..)
 import Test.Html.Event as Event
 import Test.Html.Query as Query
-import Test.Html.Selector exposing (..)
+import Test.Html.Selector as Selector exposing (..)
 
 
 spec : Test
@@ -124,7 +124,7 @@ helpfullyDisabledCheckbox =
 
 pressSpace : TestContext -> TestContext
 pressSpace =
-    KeyboardHelpers.pressSpace ProgramTest.simulateDomEvent { targetDetails = [] } checkbox
+    KeyboardHelpers.pressSpace khConfig { targetDetails = [] } checkbox
 
 
 clickIt : TestContext -> TestContext
@@ -188,3 +188,11 @@ program attributes =
         , view = view attributes >> toUnstyled
         }
         |> ProgramTest.start ()
+
+
+khConfig : KeyboardHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+khConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_custom = Event.custom
+    }

--- a/tests/Spec/Nri/Ui/FocusLoop.elm
+++ b/tests/Spec/Nri/Ui/FocusLoop.elm
@@ -182,7 +182,8 @@ viewSpec =
         [ test "moves focus right on right arrow" <|
             \() ->
                 program
-                    |> pressRightArrow { targetDetails = [] }
+                    |> pressRightArrow ProgramTest.simulateDomEvent
+                        { targetDetails = [] }
                         [ Selector.all
                             [ Selector.tag "button"
                             , Selector.containing
@@ -194,7 +195,8 @@ viewSpec =
         , test "moves focus left on left arrow" <|
             \() ->
                 program
-                    |> pressLeftArrow { targetDetails = [] }
+                    |> pressLeftArrow ProgramTest.simulateDomEvent
+                        { targetDetails = [] }
                         [ Selector.all
                             [ Selector.tag "button"
                             , Selector.containing
@@ -206,7 +208,8 @@ viewSpec =
         , test "loops to end" <|
             \() ->
                 program
-                    |> pressLeftArrow { targetDetails = [] }
+                    |> pressLeftArrow ProgramTest.simulateDomEvent
+                        { targetDetails = [] }
                         [ Selector.all
                             [ Selector.tag "button"
                             , Selector.containing
@@ -218,7 +221,8 @@ viewSpec =
         , test "loops to beginning" <|
             \() ->
                 program
-                    |> pressRightArrow { targetDetails = [] }
+                    |> pressRightArrow ProgramTest.simulateDomEvent
+                        { targetDetails = [] }
                         [ Selector.all
                             [ Selector.tag "button"
                             , Selector.containing

--- a/tests/Spec/Nri/Ui/FocusLoop.elm
+++ b/tests/Spec/Nri/Ui/FocusLoop.elm
@@ -3,10 +3,12 @@ module Spec.Nri.Ui.FocusLoop exposing (spec)
 import Accessibility.Styled.Key as Key exposing (Event)
 import Expect
 import Html.Styled as Html exposing (Html)
-import Nri.Test.KeyboardHelpers.V1 exposing (pressLeftArrow, pressRightArrow)
+import Nri.Test.KeyboardHelpers.V1 as KeyboardHelpers
 import Nri.Ui.FocusLoop.V1 as FocusLoop
 import ProgramTest exposing (..)
 import Test exposing (..)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
 import Test.Html.Selector as Selector
 
 
@@ -182,7 +184,7 @@ viewSpec =
         [ test "moves focus right on right arrow" <|
             \() ->
                 program
-                    |> pressRightArrow ProgramTest.simulateDomEvent
+                    |> KeyboardHelpers.pressRightArrow khConfig
                         { targetDetails = [] }
                         [ Selector.all
                             [ Selector.tag "button"
@@ -195,7 +197,7 @@ viewSpec =
         , test "moves focus left on left arrow" <|
             \() ->
                 program
-                    |> pressLeftArrow ProgramTest.simulateDomEvent
+                    |> KeyboardHelpers.pressLeftArrow khConfig
                         { targetDetails = [] }
                         [ Selector.all
                             [ Selector.tag "button"
@@ -208,7 +210,7 @@ viewSpec =
         , test "loops to end" <|
             \() ->
                 program
-                    |> pressLeftArrow ProgramTest.simulateDomEvent
+                    |> KeyboardHelpers.pressLeftArrow khConfig
                         { targetDetails = [] }
                         [ Selector.all
                             [ Selector.tag "button"
@@ -221,7 +223,7 @@ viewSpec =
         , test "loops to beginning" <|
             \() ->
                 program
-                    |> pressRightArrow ProgramTest.simulateDomEvent
+                    |> KeyboardHelpers.pressRightArrow khConfig
                         { targetDetails = [] }
                         [ Selector.all
                             [ Selector.tag "button"
@@ -278,3 +280,11 @@ program =
         , view = view >> Html.div [] >> Html.toUnstyled
         }
         |> ProgramTest.start ()
+
+
+khConfig : KeyboardHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+khConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_custom = Event.custom
+    }

--- a/tests/Spec/Nri/Ui/FocusLoopLazy.elm
+++ b/tests/Spec/Nri/Ui/FocusLoopLazy.elm
@@ -9,10 +9,12 @@ module Spec.Nri.Ui.FocusLoopLazy exposing (spec)
 import Accessibility.Styled.Key as Key
 import Expect
 import Html.Styled as Html exposing (Html)
-import Nri.Test.KeyboardHelpers.V1 exposing (pressLeftArrow, pressRightArrow)
+import Nri.Test.KeyboardHelpers.V1 as KeyboardHelpers
 import Nri.Ui.FocusLoop.Lazy.V1 as FocusLoop
 import ProgramTest exposing (..)
 import Test exposing (..)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
 import Test.Html.Selector as Selector
 
 
@@ -29,7 +31,7 @@ viewSpec =
         [ test "moves focus right on right arrow" <|
             \() ->
                 program
-                    |> pressRightArrow ProgramTest.simulateDomEvent
+                    |> KeyboardHelpers.pressRightArrow khConfig
                         { targetDetails = [] }
                         [ Selector.all
                             [ Selector.tag "button"
@@ -42,7 +44,7 @@ viewSpec =
         , test "moves focus left on left arrow" <|
             \() ->
                 program
-                    |> pressLeftArrow ProgramTest.simulateDomEvent
+                    |> KeyboardHelpers.pressLeftArrow khConfig
                         { targetDetails = [] }
                         [ Selector.all
                             [ Selector.tag "button"
@@ -55,7 +57,7 @@ viewSpec =
         , test "loops to end" <|
             \() ->
                 program
-                    |> pressLeftArrow ProgramTest.simulateDomEvent
+                    |> KeyboardHelpers.pressLeftArrow khConfig
                         { targetDetails = [] }
                         [ Selector.all
                             [ Selector.tag "button"
@@ -68,7 +70,7 @@ viewSpec =
         , test "loops to beginning" <|
             \() ->
                 program
-                    |> pressRightArrow ProgramTest.simulateDomEvent
+                    |> KeyboardHelpers.pressRightArrow khConfig
                         { targetDetails = [] }
                         [ Selector.all
                             [ Selector.tag "button"
@@ -126,3 +128,11 @@ program =
         , view = view >> Html.div [] >> Html.toUnstyled
         }
         |> ProgramTest.start ()
+
+
+khConfig : KeyboardHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+khConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_custom = Event.custom
+    }

--- a/tests/Spec/Nri/Ui/FocusLoopLazy.elm
+++ b/tests/Spec/Nri/Ui/FocusLoopLazy.elm
@@ -29,7 +29,8 @@ viewSpec =
         [ test "moves focus right on right arrow" <|
             \() ->
                 program
-                    |> pressRightArrow { targetDetails = [] }
+                    |> pressRightArrow ProgramTest.simulateDomEvent
+                        { targetDetails = [] }
                         [ Selector.all
                             [ Selector.tag "button"
                             , Selector.containing
@@ -41,7 +42,8 @@ viewSpec =
         , test "moves focus left on left arrow" <|
             \() ->
                 program
-                    |> pressLeftArrow { targetDetails = [] }
+                    |> pressLeftArrow ProgramTest.simulateDomEvent
+                        { targetDetails = [] }
                         [ Selector.all
                             [ Selector.tag "button"
                             , Selector.containing
@@ -53,7 +55,8 @@ viewSpec =
         , test "loops to end" <|
             \() ->
                 program
-                    |> pressLeftArrow { targetDetails = [] }
+                    |> pressLeftArrow ProgramTest.simulateDomEvent
+                        { targetDetails = [] }
                         [ Selector.all
                             [ Selector.tag "button"
                             , Selector.containing
@@ -65,7 +68,8 @@ viewSpec =
         , test "loops to beginning" <|
             \() ->
                 program
-                    |> pressRightArrow { targetDetails = [] }
+                    |> pressRightArrow ProgramTest.simulateDomEvent
+                        { targetDetails = [] }
                         [ Selector.all
                             [ Selector.tag "button"
                             , Selector.containing

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -15,6 +15,7 @@ import ProgramTest exposing (..)
 import Sort
 import Spec.PseudoElements exposing (..)
 import Test exposing (..)
+import Test.Html.Event as Event
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector exposing (Selector)
 
@@ -519,49 +520,49 @@ highlightable index selector =
 
 space : TestContext -> TestContext
 space =
-    KeyboardHelpers.pressSpace ProgramTest.simulateDomEvent
+    KeyboardHelpers.pressSpace khConfig
         { targetDetails = [] }
         [ Selector.attribute (Key.tabbable True) ]
 
 
 rightArrow : TestContext -> TestContext
 rightArrow =
-    KeyboardHelpers.pressRightArrow ProgramTest.simulateDomEvent
+    KeyboardHelpers.pressRightArrow khConfig
         { targetDetails = [] }
         [ Selector.attribute (Key.tabbable True) ]
 
 
 leftArrow : TestContext -> TestContext
 leftArrow =
-    KeyboardHelpers.pressLeftArrow ProgramTest.simulateDomEvent
+    KeyboardHelpers.pressLeftArrow khConfig
         { targetDetails = [] }
         [ Selector.attribute (Key.tabbable True) ]
 
 
 shiftRight : TestContext -> TestContext
 shiftRight =
-    KeyboardHelpers.pressShiftRight ProgramTest.simulateDomEvent
+    KeyboardHelpers.pressShiftRight khConfig
         { targetDetails = [] }
         [ Selector.attribute (Key.tabbable True) ]
 
 
 shiftLeft : TestContext -> TestContext
 shiftLeft =
-    KeyboardHelpers.pressShiftLeft ProgramTest.simulateDomEvent
+    KeyboardHelpers.pressShiftLeft khConfig
         { targetDetails = [] }
         [ Selector.attribute (Key.tabbable True) ]
 
 
 releaseShiftRight : TestContext -> TestContext
 releaseShiftRight =
-    KeyboardHelpers.releaseShiftRight ProgramTest.simulateDomEvent
+    KeyboardHelpers.releaseShiftRight khConfig
         { targetDetails = [] }
         [ Selector.attribute (Key.tabbable True) ]
 
 
 releaseShiftLeft : TestContext -> TestContext
 releaseShiftLeft =
-    KeyboardHelpers.releaseShiftLeft ProgramTest.simulateDomEvent
+    KeyboardHelpers.releaseShiftLeft khConfig
         { targetDetails = [] }
         [ Selector.attribute (Key.tabbable True) ]
 
@@ -937,3 +938,11 @@ overlappingHighlightTests =
     in
     [ describe "viewWithOverlappingHighlights" (staticAssertions Highlighter.viewWithOverlappingHighlights)
     ]
+
+
+khConfig : KeyboardHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+khConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_custom = Event.custom
+    }

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -519,54 +519,61 @@ highlightable index selector =
 
 space : TestContext -> TestContext
 space =
-    KeyboardHelpers.pressSpace { targetDetails = [] }
+    KeyboardHelpers.pressSpace ProgramTest.simulateDomEvent
+        { targetDetails = [] }
         [ Selector.attribute (Key.tabbable True) ]
 
 
 rightArrow : TestContext -> TestContext
 rightArrow =
-    KeyboardHelpers.pressRightArrow { targetDetails = [] }
+    KeyboardHelpers.pressRightArrow ProgramTest.simulateDomEvent
+        { targetDetails = [] }
         [ Selector.attribute (Key.tabbable True) ]
 
 
 leftArrow : TestContext -> TestContext
 leftArrow =
-    KeyboardHelpers.pressLeftArrow { targetDetails = [] }
+    KeyboardHelpers.pressLeftArrow ProgramTest.simulateDomEvent
+        { targetDetails = [] }
         [ Selector.attribute (Key.tabbable True) ]
 
 
 shiftRight : TestContext -> TestContext
 shiftRight =
-    KeyboardHelpers.pressShiftRight { targetDetails = [] }
+    KeyboardHelpers.pressShiftRight ProgramTest.simulateDomEvent
+        { targetDetails = [] }
         [ Selector.attribute (Key.tabbable True) ]
 
 
 shiftLeft : TestContext -> TestContext
 shiftLeft =
-    KeyboardHelpers.pressShiftLeft { targetDetails = [] }
+    KeyboardHelpers.pressShiftLeft ProgramTest.simulateDomEvent
+        { targetDetails = [] }
         [ Selector.attribute (Key.tabbable True) ]
 
 
 releaseShiftRight : TestContext -> TestContext
 releaseShiftRight =
-    KeyboardHelpers.releaseShiftRight { targetDetails = [] }
+    KeyboardHelpers.releaseShiftRight ProgramTest.simulateDomEvent
+        { targetDetails = [] }
         [ Selector.attribute (Key.tabbable True) ]
 
 
 releaseShiftLeft : TestContext -> TestContext
 releaseShiftLeft =
-    KeyboardHelpers.releaseShiftLeft { targetDetails = [] }
+    KeyboardHelpers.releaseShiftLeft ProgramTest.simulateDomEvent
+        { targetDetails = [] }
         [ Selector.attribute (Key.tabbable True) ]
 
 
 mouseDown : String -> TestContext -> TestContext
 mouseDown word =
-    MouseHelpers.cancelableMouseDown [ Selector.tag "span", Selector.containing [ Selector.text word ] ]
+    MouseHelpers.cancelableMouseDown ProgramTest.simulateDomEvent [ Selector.tag "span", Selector.containing [ Selector.text word ] ]
 
 
 mouseUp : String -> TestContext -> TestContext
 mouseUp word =
-    MouseHelpers.cancelableMouseUp [ Selector.tag "span", Selector.containing [ Selector.text word ] ]
+    MouseHelpers.cancelableMouseUp ProgramTest.simulateDomEvent [ Selector.tag "span", Selector.containing [ Selector.text word ] ]
 
 
 click : String -> TestContext -> TestContext
@@ -576,7 +583,7 @@ click word =
 
 mouseOver : String -> TestContext -> TestContext
 mouseOver word =
-    MouseHelpers.cancelableMouseOver [ Selector.tag "span", Selector.containing [ Selector.text word ] ]
+    MouseHelpers.cancelableMouseOver ProgramTest.simulateDomEvent [ Selector.tag "span", Selector.containing [ Selector.text word ] ]
 
 
 markerModel : Maybe String -> Tool String

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -569,12 +569,12 @@ releaseShiftLeft =
 
 mouseDown : String -> TestContext -> TestContext
 mouseDown word =
-    MouseHelpers.cancelableMouseDown ProgramTest.simulateDomEvent [ Selector.tag "span", Selector.containing [ Selector.text word ] ]
+    MouseHelpers.cancelableMouseDown mhConfig [ Selector.tag "span", Selector.containing [ Selector.text word ] ]
 
 
 mouseUp : String -> TestContext -> TestContext
 mouseUp word =
-    MouseHelpers.cancelableMouseUp ProgramTest.simulateDomEvent [ Selector.tag "span", Selector.containing [ Selector.text word ] ]
+    MouseHelpers.cancelableMouseUp mhConfig [ Selector.tag "span", Selector.containing [ Selector.text word ] ]
 
 
 click : String -> TestContext -> TestContext
@@ -584,7 +584,7 @@ click word =
 
 mouseOver : String -> TestContext -> TestContext
 mouseOver word =
-    MouseHelpers.cancelableMouseOver ProgramTest.simulateDomEvent [ Selector.tag "span", Selector.containing [ Selector.text word ] ]
+    MouseHelpers.cancelableMouseOver mhConfig [ Selector.tag "span", Selector.containing [ Selector.text word ] ]
 
 
 markerModel : Maybe String -> Tool String
@@ -944,5 +944,17 @@ khConfig : KeyboardHelpers.Config (ProgramTest model msg effect) Selector.Select
 khConfig =
     { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
     , query_find = Query.find
+    , event_custom = Event.custom
+    }
+
+
+mhConfig : MouseHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+mhConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_click = Event.click
+    , event_mouseDown = Event.mouseDown
+    , event_mouseUp = Event.mouseUp
+    , event_mouseOver = Event.mouseOver
     , event_custom = Event.custom
     }

--- a/tests/Spec/Nri/Ui/Menu.elm
+++ b/tests/Spec/Nri/Ui/Menu.elm
@@ -57,14 +57,16 @@ spec =
         , test "Opens on down arrow" <|
             \() ->
                 program []
-                    |> KeyboardHelpers.pressDownArrow { targetDetails = targetDetails "hello-button" }
+                    |> KeyboardHelpers.pressDownArrow ProgramTest.simulateDomEvent
+                        { targetDetails = targetDetails "hello-button" }
                         [ Selector.tag "button", Selector.id "hello-button" ]
                     |> ensureViewHas (menuContentSelector menuContent)
                     |> ProgramTest.done
         , test "Opens on down arrow when there's a tooltip attached" <|
             \() ->
                 program [ Menu.withTooltip [ Tooltip.onToggle ToggleTooltip ] ]
-                    |> KeyboardHelpers.pressDownArrow { targetDetails = targetDetails "hello-button" }
+                    |> KeyboardHelpers.pressDownArrow ProgramTest.simulateDomEvent
+                        { targetDetails = targetDetails "hello-button" }
                         [ Selector.tag "button", Selector.id "hello-button" ]
                     |> ensureViewHas (menuContentSelector menuContent)
                     |> ProgramTest.done
@@ -225,20 +227,20 @@ targetDetails targetId =
 
 pressTab : { targetId : String } -> ProgramTest model msg effect -> ProgramTest model msg effect
 pressTab { targetId } =
-    KeyboardHelpers.pressTab
+    KeyboardHelpers.pressTab ProgramTest.simulateDomEvent
         { targetDetails = targetDetails targetId }
         [ Selector.class "Container" ]
 
 
 pressTabBack : { targetId : String } -> ProgramTest model msg effect -> ProgramTest model msg effect
 pressTabBack { targetId } =
-    KeyboardHelpers.pressTabBack
+    KeyboardHelpers.pressTabBack ProgramTest.simulateDomEvent
         { targetDetails = targetDetails targetId }
         [ Selector.class "Container" ]
 
 
 pressEsc : { targetId : String } -> ProgramTest model msg effect -> ProgramTest model msg effect
 pressEsc { targetId } =
-    KeyboardHelpers.pressEsc
+    KeyboardHelpers.pressEsc ProgramTest.simulateDomEvent
         { targetDetails = targetDetails targetId }
         [ Selector.class "Container" ]

--- a/tests/Spec/Nri/Ui/Menu.elm
+++ b/tests/Spec/Nri/Ui/Menu.elm
@@ -57,7 +57,7 @@ spec =
         , test "Opens on down arrow" <|
             \() ->
                 program []
-                    |> KeyboardHelpers.pressDownArrow ProgramTest.simulateDomEvent
+                    |> KeyboardHelpers.pressDownArrow khConfig
                         { targetDetails = targetDetails "hello-button" }
                         [ Selector.tag "button", Selector.id "hello-button" ]
                     |> ensureViewHas (menuContentSelector menuContent)
@@ -65,7 +65,7 @@ spec =
         , test "Opens on down arrow when there's a tooltip attached" <|
             \() ->
                 program [ Menu.withTooltip [ Tooltip.onToggle ToggleTooltip ] ]
-                    |> KeyboardHelpers.pressDownArrow ProgramTest.simulateDomEvent
+                    |> KeyboardHelpers.pressDownArrow khConfig
                         { targetDetails = targetDetails "hello-button" }
                         [ Selector.tag "button", Selector.id "hello-button" ]
                     |> ensureViewHas (menuContentSelector menuContent)
@@ -227,20 +227,28 @@ targetDetails targetId =
 
 pressTab : { targetId : String } -> ProgramTest model msg effect -> ProgramTest model msg effect
 pressTab { targetId } =
-    KeyboardHelpers.pressTab ProgramTest.simulateDomEvent
+    KeyboardHelpers.pressTab khConfig
         { targetDetails = targetDetails targetId }
         [ Selector.class "Container" ]
 
 
 pressTabBack : { targetId : String } -> ProgramTest model msg effect -> ProgramTest model msg effect
 pressTabBack { targetId } =
-    KeyboardHelpers.pressTabBack ProgramTest.simulateDomEvent
+    KeyboardHelpers.pressTabBack khConfig
         { targetDetails = targetDetails targetId }
         [ Selector.class "Container" ]
 
 
 pressEsc : { targetId : String } -> ProgramTest model msg effect -> ProgramTest model msg effect
 pressEsc { targetId } =
-    KeyboardHelpers.pressEsc ProgramTest.simulateDomEvent
+    KeyboardHelpers.pressEsc khConfig
         { targetDetails = targetDetails targetId }
         [ Selector.class "Container" ]
+
+
+khConfig : KeyboardHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+khConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_custom = Event.custom
+    }

--- a/tests/Spec/Nri/Ui/Modal.elm
+++ b/tests/Spec/Nri/Ui/Modal.elm
@@ -81,12 +81,12 @@ focusTests =
 
 tabBackWithinModal : String -> ProgramTest a b c -> ProgramTest a b c
 tabBackWithinModal onElementId =
-    pressTabBack { targetDetails = [ ( "id", Encode.string onElementId ) ] } focusTrapNode
+    pressTabBack ProgramTest.simulateDomEvent { targetDetails = [ ( "id", Encode.string onElementId ) ] } focusTrapNode
 
 
 tabForwardWithinModal : String -> ProgramTest a b c -> ProgramTest a b c
 tabForwardWithinModal onElementId =
-    pressTab { targetDetails = [ ( "id", Encode.string onElementId ) ] } focusTrapNode
+    pressTab ProgramTest.simulateDomEvent { targetDetails = [ ( "id", Encode.string onElementId ) ] } focusTrapNode
 
 
 focusTrapNode : List Selector

--- a/tests/Spec/Nri/Ui/Modal.elm
+++ b/tests/Spec/Nri/Ui/Modal.elm
@@ -7,12 +7,14 @@ import Html.Styled as Html exposing (Html, toUnstyled)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Json.Encode as Encode
-import Nri.Test.KeyboardHelpers.V1 exposing (pressTab, pressTabBack)
+import Nri.Test.KeyboardHelpers.V1 as KeyboardHelpers
 import Nri.Ui.Modal.V12 as Modal
 import ProgramTest exposing (..)
 import SimulatedEffect.Cmd
 import Test exposing (..)
-import Test.Html.Selector exposing (..)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector exposing (..)
 
 
 spec : Test
@@ -81,12 +83,12 @@ focusTests =
 
 tabBackWithinModal : String -> ProgramTest a b c -> ProgramTest a b c
 tabBackWithinModal onElementId =
-    pressTabBack ProgramTest.simulateDomEvent { targetDetails = [ ( "id", Encode.string onElementId ) ] } focusTrapNode
+    KeyboardHelpers.pressTabBack khConfig { targetDetails = [ ( "id", Encode.string onElementId ) ] } focusTrapNode
 
 
 tabForwardWithinModal : String -> ProgramTest a b c -> ProgramTest a b c
 tabForwardWithinModal onElementId =
-    pressTab ProgramTest.simulateDomEvent { targetDetails = [ ( "id", Encode.string onElementId ) ] } focusTrapNode
+    KeyboardHelpers.pressTab khConfig { targetDetails = [ ( "id", Encode.string onElementId ) ] } focusTrapNode
 
 
 focusTrapNode : List Selector
@@ -197,3 +199,11 @@ modalTitle =
 ensureFocused : String -> ProgramTest a b Effect -> ProgramTest a b Effect
 ensureFocused id =
     ensureLastEffect (Expect.equal (FocusOn id))
+
+
+khConfig : KeyboardHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+khConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_custom = Event.custom
+    }

--- a/tests/Spec/Nri/Ui/SegmentedControl.elm
+++ b/tests/Spec/Nri/Ui/SegmentedControl.elm
@@ -10,6 +10,7 @@ import Nri.Ui.SegmentedControl.V14 as SegmentedControl
 import ProgramTest exposing (..)
 import Task
 import Test exposing (..)
+import Test.Html.Event as Event
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector
 
@@ -155,14 +156,14 @@ ensureOnlyOneTabInSequence tabs testContext =
 
 releaseRightArrow : TestContext -> TestContext
 releaseRightArrow =
-    KeyboardHelpers.releaseRightArrow ProgramTest.simulateDomEvent
+    KeyboardHelpers.releaseRightArrow khConfig
         { targetDetails = [] }
         [ Selector.attribute Role.tab, Selector.attribute (Key.tabbable True) ]
 
 
 releaseLeftArrow : TestContext -> TestContext
 releaseLeftArrow =
-    KeyboardHelpers.releaseLeftArrow ProgramTest.simulateDomEvent
+    KeyboardHelpers.releaseLeftArrow khConfig
         { targetDetails = [] }
         [ Selector.attribute Role.tab, Selector.attribute (Key.tabbable True) ]
 
@@ -248,3 +249,11 @@ program =
         , view = view >> Html.toUnstyled
         }
         |> ProgramTest.start ()
+
+
+khConfig : KeyboardHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+khConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_custom = Event.custom
+    }

--- a/tests/Spec/Nri/Ui/SegmentedControl.elm
+++ b/tests/Spec/Nri/Ui/SegmentedControl.elm
@@ -155,13 +155,15 @@ ensureOnlyOneTabInSequence tabs testContext =
 
 releaseRightArrow : TestContext -> TestContext
 releaseRightArrow =
-    KeyboardHelpers.releaseRightArrow { targetDetails = [] }
+    KeyboardHelpers.releaseRightArrow ProgramTest.simulateDomEvent
+        { targetDetails = [] }
         [ Selector.attribute Role.tab, Selector.attribute (Key.tabbable True) ]
 
 
 releaseLeftArrow : TestContext -> TestContext
 releaseLeftArrow =
-    KeyboardHelpers.releaseLeftArrow { targetDetails = [] }
+    KeyboardHelpers.releaseLeftArrow ProgramTest.simulateDomEvent
+        { targetDetails = [] }
         [ Selector.attribute Role.tab, Selector.attribute (Key.tabbable True) ]
 
 

--- a/tests/Spec/Nri/Ui/Switch.elm
+++ b/tests/Spec/Nri/Ui/Switch.elm
@@ -9,7 +9,9 @@ import Nri.Ui.Switch.V3 as Switch
 import ProgramTest exposing (..)
 import Spec.Helpers exposing (expectFailure)
 import Test exposing (..)
-import Test.Html.Selector exposing (..)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector exposing (..)
 
 
 spec : Test
@@ -74,7 +76,7 @@ helpfullyDisabledSwitch =
 
 pressSpace : TestContext -> TestContext
 pressSpace =
-    KeyboardHelpers.pressSpace ProgramTest.simulateDomEvent { targetDetails = [] } switch
+    KeyboardHelpers.pressSpace khConfig { targetDetails = [] } switch
 
 
 click : TestContext -> TestContext
@@ -132,3 +134,11 @@ program attributes =
         , view = view attributes >> toUnstyled
         }
         |> ProgramTest.start ()
+
+
+khConfig : KeyboardHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+khConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_custom = Event.custom
+    }

--- a/tests/Spec/Nri/Ui/Switch.elm
+++ b/tests/Spec/Nri/Ui/Switch.elm
@@ -74,12 +74,12 @@ helpfullyDisabledSwitch =
 
 pressSpace : TestContext -> TestContext
 pressSpace =
-    KeyboardHelpers.pressSpace { targetDetails = [] } switch
+    KeyboardHelpers.pressSpace ProgramTest.simulateDomEvent { targetDetails = [] } switch
 
 
 click : TestContext -> TestContext
 click =
-    MouseHelpers.click switch
+    MouseHelpers.click ProgramTest.simulateDomEvent switch
 
 
 switch : List Selector

--- a/tests/Spec/Nri/Ui/Switch.elm
+++ b/tests/Spec/Nri/Ui/Switch.elm
@@ -81,7 +81,7 @@ pressSpace =
 
 click : TestContext -> TestContext
 click =
-    MouseHelpers.click ProgramTest.simulateDomEvent switch
+    MouseHelpers.click mhConfig switch
 
 
 switch : List Selector
@@ -140,5 +140,17 @@ khConfig : KeyboardHelpers.Config (ProgramTest model msg effect) Selector.Select
 khConfig =
     { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
     , query_find = Query.find
+    , event_custom = Event.custom
+    }
+
+
+mhConfig : MouseHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+mhConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_click = Event.click
+    , event_mouseDown = Event.mouseDown
+    , event_mouseUp = Event.mouseUp
+    , event_mouseOver = Event.mouseOver
     , event_custom = Event.custom
     }

--- a/tests/Spec/Nri/Ui/Tooltip.elm
+++ b/tests/Spec/Nri/Ui/Tooltip.elm
@@ -155,7 +155,8 @@ spec =
                     , Tooltip.onTriggerKeyDown
                         [ Key.space SpaceKeyPressed ]
                     ]
-                    |> KeyboardHelpers.pressSpace { targetDetails = [] }
+                    |> KeyboardHelpers.pressSpace ProgramTest.simulateDomEvent
+                        { targetDetails = [] }
                         [ Selector.id triggerId
                         ]
                     |> ProgramTest.expectModel (\model -> Expect.equal (Just SpaceKeyPressed) model.lastMsg)

--- a/tests/Spec/Nri/Ui/Tooltip.elm
+++ b/tests/Spec/Nri/Ui/Tooltip.elm
@@ -155,7 +155,7 @@ spec =
                     , Tooltip.onTriggerKeyDown
                         [ Key.space SpaceKeyPressed ]
                     ]
-                    |> KeyboardHelpers.pressSpace ProgramTest.simulateDomEvent
+                    |> KeyboardHelpers.pressSpace khConfig
                         { targetDetails = [] }
                         [ Selector.id triggerId
                         ]
@@ -239,3 +239,11 @@ clickButtonByLabel label =
             ]
         )
         Event.click
+
+
+khConfig : KeyboardHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+khConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_custom = Event.custom
+    }

--- a/tests/Spec/TabsInternalHelpers.elm
+++ b/tests/Spec/TabsInternalHelpers.elm
@@ -86,11 +86,13 @@ ensureOnlyOneTabInSequence tabs testContext =
 
 releaseRightArrow : ProgramTest model msg effect -> ProgramTest model msg effect
 releaseRightArrow =
-    KeyboardHelpers.releaseRightArrow { targetDetails = [] }
+    KeyboardHelpers.releaseRightArrow ProgramTest.simulateDomEvent
+        { targetDetails = [] }
         [ Selector.attribute Role.tab, Selector.attribute (Key.tabbable True) ]
 
 
 releaseLeftArrow : ProgramTest model msg effect -> ProgramTest model msg effect
 releaseLeftArrow =
-    KeyboardHelpers.releaseLeftArrow { targetDetails = [] }
+    KeyboardHelpers.releaseLeftArrow ProgramTest.simulateDomEvent
+        { targetDetails = [] }
         [ Selector.attribute Role.tab, Selector.attribute (Key.tabbable True) ]

--- a/tests/Spec/TabsInternalHelpers.elm
+++ b/tests/Spec/TabsInternalHelpers.elm
@@ -7,6 +7,7 @@ import Expect
 import Html.Styled exposing (..)
 import Nri.Test.KeyboardHelpers.V1 as KeyboardHelpers
 import ProgramTest exposing (..)
+import Test.Html.Event as Event
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector
 
@@ -86,13 +87,21 @@ ensureOnlyOneTabInSequence tabs testContext =
 
 releaseRightArrow : ProgramTest model msg effect -> ProgramTest model msg effect
 releaseRightArrow =
-    KeyboardHelpers.releaseRightArrow ProgramTest.simulateDomEvent
+    KeyboardHelpers.releaseRightArrow khConfig
         { targetDetails = [] }
         [ Selector.attribute Role.tab, Selector.attribute (Key.tabbable True) ]
 
 
 releaseLeftArrow : ProgramTest model msg effect -> ProgramTest model msg effect
 releaseLeftArrow =
-    KeyboardHelpers.releaseLeftArrow ProgramTest.simulateDomEvent
+    KeyboardHelpers.releaseLeftArrow khConfig
         { targetDetails = [] }
         [ Selector.attribute Role.tab, Selector.attribute (Key.tabbable True) ]
+
+
+khConfig : KeyboardHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+khConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_custom = Event.custom
+    }

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -4,6 +4,7 @@
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",
         "Nri.Test.MouseHelpers.V1",
+        "Nri.Ui",
         "Nri.Ui.Accordion.V3",
         "Nri.Ui.AnimatedIcon.V1",
         "Nri.Ui.AssignmentIcon.V2",


### PR DESCRIPTION
Workaround the strict dependency introduced in #1526 .
Otherwise dependent projects are forced to match `avh4/elm-program-test` and `elm-explorations/test`.

Merging this will require a major release yet only Nri.Test.* modules are changed

It also reverts an unintended change in https://github.com/NoRedInk/noredink-ui/pull/1526/files#diff-b2798733fa48dc75a65aa2d774f9f5e1a294e46f04c1161290ae62755755f20dL5