### PR TITLE
Added vouchered icon to premiumcheckbox and fixed unchecked radio button and checkbox label

### DIFF
--- a/component-catalog/src/CommonControls.elm
+++ b/component-catalog/src/CommonControls.elm
@@ -62,6 +62,7 @@ premiumDisplay =
         [ ( "Free", Control.value ( "PremiumDisplay.Free", PremiumDisplay.Free ) )
         , ( "Premium Locked", Control.value ( "PremiumDisplay.PremiumLocked", PremiumDisplay.PremiumLocked ) )
         , ( "Premium Unlocked", Control.value ( "PremiumDisplay.PremiumUnlocked", PremiumDisplay.PremiumUnlocked ) )
+        , ( "Premium Vouchered", Control.value ( "PremiumDisplay.PremiumVouchered", PremiumDisplay.PremiumVouchered ) )
         ]
 
 

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -22,6 +22,7 @@ module Nri.Ui.Checkbox.V7 exposing
   - apply custom attributes to the element with the `"checkbox"` role
   - set cursor to not-allowed when disabled
   - update color styling
+  - update unselected enabled label color
 
 
 ## Changes from V6:

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -316,8 +316,11 @@ view { label, selected } attributes =
                 (if config.isDisabled then
                     disabledLabelCss
 
-                 else
+                 else if selected == NotSelected then
                     enabledLabelCss
+
+                 else
+                    selectedLabelCss
                 )
                 :: inputGuidance config_
             )
@@ -380,10 +383,18 @@ onCheckMsg selected msg =
         |> msg
 
 
+selectedLabelCss : List Style
+selectedLabelCss =
+    [ textStyle
+    , cursor pointer
+    ]
+
+
 enabledLabelCss : List Style
 enabledLabelCss =
     [ textStyle
     , cursor pointer
+    , color Colors.gray20
     ]
 
 

--- a/src/Nri/Ui/Data/PremiumDisplay.elm
+++ b/src/Nri/Ui/Data/PremiumDisplay.elm
@@ -12,3 +12,4 @@ type PremiumDisplay
     = Free
     | PremiumLocked
     | PremiumUnlocked
+    | PremiumVouchered

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -10,7 +10,15 @@ module Nri.Ui.PremiumCheckbox.V8 exposing
     , setCheckboxDisabledLabelCss
     )
 
-{-| Changes from V7:
+{-|
+
+
+## Patch changes:
+
+  - Added vouchered state for premium vouchers with gift pennant
+
+
+## Changes from V7:
 
   - Use PremiumDisplay instead of PremiumLevel
   - Rename showPennant to onLockedClick

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -51,7 +51,7 @@ import Nri.Ui.Checkbox.V7 as Checkbox
 import Nri.Ui.Data.PremiumDisplay as PremiumDisplay exposing (PremiumDisplay)
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
-import Nri.Ui.Pennant.V3 exposing (contentPremiumFlag)
+import Nri.Ui.Pennant.V3 exposing (contentPremiumFlag, giftPremiumFlag)
 import Nri.Ui.Svg.V1 as Svg
 
 
@@ -209,6 +209,9 @@ view { label, onChange } attributes =
 
         isLocked =
             config.premiumDisplay == PremiumDisplay.PremiumLocked
+
+        isVouchered =
+            config.premiumDisplay == PremiumDisplay.PremiumVouchered
     in
     if isLocked then
         viewLockedButton
@@ -220,8 +223,11 @@ view { label, onChange } attributes =
 
     else
         Html.div [ css config.containerCss ]
-            [ if isPremium then
-                viewPremiumFlag
+            [ if isVouchered then
+                viewPremiumFlag giftPremiumFlag
+
+              else if isPremium then
+                viewPremiumFlag contentPremiumFlag
 
               else
                 -- left-align the checkbox with checkboxes that _do_ have the premium pennant
@@ -269,7 +275,7 @@ viewLockedButton { idValue, label, containerCss, onLockedMsg } =
             Nothing ->
                 Extra.none
         ]
-        [ viewPremiumFlag
+        [ viewPremiumFlag contentPremiumFlag
         , Html.span
             [ css
                 [ outline Css.none
@@ -301,9 +307,9 @@ viewLockedButton { idValue, label, containerCss, onLockedMsg } =
         ]
 
 
-viewPremiumFlag : Html msg
-viewPremiumFlag =
-    contentPremiumFlag
+viewPremiumFlag : Svg.Svg -> Html msg
+viewPremiumFlag icon =
+    icon
         |> Svg.withLabel "Premium"
         |> Svg.withWidth (Css.px iconWidth)
         |> Svg.withHeight (Css.px 30)

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -17,6 +17,7 @@ module Nri.Ui.RadioButton.V4 exposing
   - replace `height` use with `minHeight` to prevent vertical text overflow issues
   - use `break-word` to prevent horiztonal text overflow issues
   - update color styling
+  - update unselected enabled label color
 
 
 ### Changes from V3:

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -374,6 +374,11 @@ view { label, name, value, valueToString, selectedValue } attributes =
                             , cursor notAllowed
                             ]
 
+                         else if not isChecked then
+                            [ color Colors.gray20
+                            , cursor pointer
+                            ]
+
                          else if isInError then
                             [ color Colors.purple
                             , cursor pointer


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

This PR extends the PremiumCheckbox component to include a vouchered state for premium vouchers as per this [ticket](https://linear.app/noredink/issue/GRO-1412/extend-premiumcheckbox-noredink-ui-component).

It also fixes the issue raised in [this PR comment](https://github.com/NoRedInk/noredink-ui/pull/1539#issuecomment-1736456634).

## :framed_picture: What does this change look like?

PremiumCheckbox
![Screenshot 2023-09-28 at 11 45 04](https://github.com/NoRedInk/noredink-ui/assets/99652839/3b94a186-5bfa-44c1-b216-cad5b99a94ea)

Checkbox (notselected enabled):
![Screenshot 2023-09-28 at 11 48 40](https://github.com/NoRedInk/noredink-ui/assets/99652839/87734c53-01f9-4df0-a9c0-10da1b3d0a85)

Radio Button (notSelected enabled):
![Screenshot 2023-09-28 at 11 49 00](https://github.com/NoRedInk/noredink-ui/assets/99652839/0a5a7071-92de-4ae2-b029-39687faedb21)

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [-] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer:
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
