### PR TITLE
A11-3347 Helpfully Disabled RadioButton

### DIFF
--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -144,13 +144,14 @@ view ellieLinkConfig state =
         , mainType = Nothing
         , extraCode =
             [ Code.newlines
-            , Code.unionType "Animals" [ "Dogs", "Cats" ]
+            , Code.unionType "Animals" [ "Dogs", "Cats", "Rabbits" ]
             , Code.newlines
             , "toString : Animals -> String"
             , "toString animals ="
                 ++ Code.caseExpression "animals"
                     [ ( "Dogs", Code.string selectionSettings.dogsLabel )
                     , ( "Cats", Code.string selectionSettings.catsLabel )
+                    , ( "Rabbits", Code.string selectionSettings.rabbitsLabel )
                     ]
                     1
             ]
@@ -188,25 +189,43 @@ view ellieLinkConfig state =
         [ Heading.plaintext "Tooltip Example"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
-    , Tooltip.view
-        { trigger =
-            \attrs ->
-                RadioButton.view
-                    { label = "Rabbits"
-                    , name = "pets"
-                    , value = "Rabbits"
-                    , selectedValue = Just "Selected"
-                    , valueToString = identity
-                    }
-                    [ RadioButton.disabled, RadioButton.custom attrs ]
-        , id = "tooltip"
-        }
-        [ Tooltip.helpfullyDisabled
-        , Tooltip.open (state.openTooltip == Just HelpfullyDisabled)
-        , Tooltip.onToggle (ToggleTooltip HelpfullyDisabled)
-        , Tooltip.paragraph "Reasons why you can't select this option"
-        , Tooltip.onRight
-        , Tooltip.fitToContent
+    , div []
+        [ RadioButton.view
+            { label = "Dogs"
+            , name = "pets-2"
+            , value = Dogs
+            , selectedValue = state.selectedValue2
+            , valueToString = selectionToString selectionSettings
+            }
+            [ RadioButton.onSelect Select2 ]
+        , RadioButton.view
+            { label = "Cats"
+            , name = "pets-2"
+            , value = Cats
+            , selectedValue = state.selectedValue2
+            , valueToString = selectionToString selectionSettings
+            }
+            [ RadioButton.onSelect Select2 ]
+        , Tooltip.view
+            { trigger =
+                \attrs ->
+                    RadioButton.view
+                        { label = "Rabbits"
+                        , name = "pets-2"
+                        , value = Rabbits
+                        , selectedValue = state.selectedValue2
+                        , valueToString = selectionToString selectionSettings
+                        }
+                        [ RadioButton.disabled, RadioButton.custom attrs ]
+            , id = "tooltip"
+            }
+            [ Tooltip.helpfullyDisabled
+            , Tooltip.open (state.openTooltip == Just HelpfullyDisabled)
+            , Tooltip.onToggle (ToggleTooltip HelpfullyDisabled)
+            , Tooltip.paragraph "Reasons why you can't select this option"
+            , Tooltip.onRight
+            , Tooltip.fitToContent
+            ]
         ]
     ]
 
@@ -254,16 +273,18 @@ examples :
 examples selectionSettings =
     [ ( Dogs, selectionSettings.dogs )
     , ( Cats, selectionSettings.cats )
+    , ( Rabbits, selectionSettings.rabbits )
     ]
 
 
 type Selection
     = Dogs
     | Cats
+    | Rabbits
 
 
 selectionToString : SelectionSettings -> Selection -> String
-selectionToString { dogsLabel, catsLabel } selection =
+selectionToString { dogsLabel, catsLabel, rabbitsLabel } selection =
     case selection of
         Dogs ->
             dogsLabel
@@ -271,10 +292,14 @@ selectionToString { dogsLabel, catsLabel } selection =
         Cats ->
             catsLabel
 
+        Rabbits ->
+            rabbitsLabel
+
 
 {-| -}
 type alias State =
     { selectedValue : Maybe Selection
+    , selectedValue2 : Maybe Selection
     , modal : Modal.Model
     , selectionSettings : Control SelectionSettings
     , openTooltip : Maybe TooltipType
@@ -285,6 +310,7 @@ type alias State =
 init : State
 init =
     { selectedValue = Nothing
+    , selectedValue2 = Nothing
     , modal = Modal.init
     , selectionSettings = initSelectionSettings
     , openTooltip = Nothing
@@ -296,6 +322,8 @@ type alias SelectionSettings =
     , dogs : List ( String, RadioButton.Attribute Selection Msg )
     , catsLabel : String
     , cats : List ( String, RadioButton.Attribute Selection Msg )
+    , rabbitsLabel : String
+    , rabbits : List ( String, RadioButton.Attribute Selection Msg )
     }
 
 
@@ -306,6 +334,8 @@ initSelectionSettings =
         |> Control.field "Dogs" controlAttributes
         |> Control.field "Cats label" (Control.string "Cats")
         |> Control.field "Cats" controlAttributes
+        |> Control.field "Rabbits label" (Control.string "Rabbits")
+        |> Control.field "Rabbits" controlAttributes
 
 
 controlAttributes : Control (List ( String, RadioButton.Attribute Selection Msg ))
@@ -412,6 +442,7 @@ type Msg
     | ModalMsg Modal.Msg
     | CloseModal
     | Select Selection
+    | Select2 Selection
     | SetSelectionSettings (Control SelectionSettings)
     | Focus String
     | Focused (Result Dom.Error ())
@@ -458,6 +489,9 @@ update msg model =
 
         Select value ->
             ( { model | selectedValue = Just value }, Cmd.none )
+
+        Select2 value ->
+            ( { model | selectedValue2 = Just value }, Cmd.none )
 
         SetSelectionSettings selectionSettings ->
             ( { model | selectionSettings = selectionSettings }

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -34,6 +34,7 @@ import Nri.Ui.Modal.V12 as Modal
 import Nri.Ui.RadioButton.V4 as RadioButton
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Text.V6 as Text
+import Nri.Ui.Tooltip.V3 as Tooltip
 import Routes
 import Task
 
@@ -46,6 +47,10 @@ moduleName =
 version : Int
 version =
     4
+
+
+type TooltipType
+    = HelpfullyDisabled
 
 
 {-| -}
@@ -179,6 +184,30 @@ view ellieLinkConfig state =
         }
         [ Modal.closeButton ]
         state.modal
+    , Heading.h2
+        [ Heading.plaintext "Tooltip Example"
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+        ]
+    , Tooltip.view
+        { trigger =
+            \attrs ->
+                RadioButton.view
+                    { label = "Dogs"
+                    , name = "pets"
+                    , value = "Dogs"
+                    , selectedValue = Just "Selected"
+                    , valueToString = identity
+                    }
+                    [ RadioButton.disabled, RadioButton.custom attrs ]
+        , id = "tooltip"
+        }
+        [ Tooltip.helpfullyDisabled
+        , Tooltip.open (state.openTooltip == Just HelpfullyDisabled)
+        , Tooltip.onToggle (ToggleTooltip HelpfullyDisabled)
+        , Tooltip.paragraph "Reasons why you can't select this option"
+        , Tooltip.onRight
+        , Tooltip.fitToContent
+        ]
     ]
 
 
@@ -248,6 +277,7 @@ type alias State =
     { selectedValue : Maybe Selection
     , modal : Modal.Model
     , selectionSettings : Control SelectionSettings
+    , openTooltip : Maybe TooltipType
     }
 
 
@@ -257,6 +287,7 @@ init =
     { selectedValue = Nothing
     , modal = Modal.init
     , selectionSettings = initSelectionSettings
+    , openTooltip = Nothing
     }
 
 
@@ -384,6 +415,7 @@ type Msg
     | SetSelectionSettings (Control SelectionSettings)
     | Focus String
     | Focused (Result Dom.Error ())
+    | ToggleTooltip TooltipType Bool
 
 
 {-| -}
@@ -437,6 +469,13 @@ update msg model =
 
         Focused _ ->
             ( model, Cmd.none )
+
+        ToggleTooltip type_ isOpen ->
+            if isOpen then
+                ( { model | openTooltip = Just type_ }, Cmd.none )
+
+            else
+                ( { model | openTooltip = Nothing }, Cmd.none )
 
 
 subscriptions : State -> Sub Msg

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -192,9 +192,9 @@ view ellieLinkConfig state =
         { trigger =
             \attrs ->
                 RadioButton.view
-                    { label = "Dogs"
+                    { label = "Rabbits"
                     , name = "pets"
-                    , value = "Dogs"
+                    , value = "Rabbits"
                     , selectedValue = Just "Selected"
                     , valueToString = identity
                     }

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -345,7 +345,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
                      , Aria.label label
                      , Key.tabbable True
                      , Aria.checked (Just isChecked)
-                     , Aria.disabled config.isDisabled
+                     , Aria.disabled True
                      , InputErrorAndGuidanceInternal.describedBy idValue config
                      , class "Nri-RadioButton-HiddenRadioInput"
                      , if List.length disclosureIds > 0 then
@@ -370,7 +370,6 @@ view { label, name, value, valueToString, selectedValue } attributes =
                     stringValue
                     isChecked
                     ([ Attributes.id idValue
-                     , Aria.disabled config.isDisabled
                      , InputErrorAndGuidanceInternal.describedBy idValue config
                      , case config.onSelect of
                         Just onSelect_ ->

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -198,7 +198,7 @@ you want/expect if underlying styles change.
 Instead, please use the `css` helper.
 
 -}
-custom : List (Html.Attribute Never) -> Attribute value msg
+custom : List (Html.Attribute msg) -> Attribute value msg
 custom attributes =
     Attribute <| \config -> { config | custom = config.custom ++ attributes }
 
@@ -233,7 +233,7 @@ type alias Config value msg =
     , hideLabel : Bool
     , containerCss : List Css.Style
     , labelCss : List Css.Style
-    , custom : List (Html.Attribute Never)
+    , custom : List (Html.Attribute msg)
     , onSelect : Maybe (value -> msg)
     , onLockedMsg : Maybe msg
     , disclosedContent : List (Html msg)
@@ -360,7 +360,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
                         , opacity zero
                         ]
                      ]
-                        ++ List.map (Attributes.map never) config.custom
+                        ++ config.custom
                     )
                     []
                 ]
@@ -391,7 +391,7 @@ view { label, name, value, valueToString, selectedValue } attributes =
                         , opacity zero
                         ]
                      ]
-                        ++ List.map (Attributes.map never) config.custom
+                        ++ config.custom
                     )
                 ]
              )

--- a/tests/Spec/Nri/Ui/RadioButton.elm
+++ b/tests/Spec/Nri/Ui/RadioButton.elm
@@ -1,7 +1,6 @@
 module Spec.Nri.Ui.RadioButton exposing (..)
 
 import Accessibility.Aria as Aria
-import Accessibility.Role as Role
 import Html.Attributes exposing (type_)
 import Html.Styled exposing (..)
 import Nri.Test.KeyboardHelpers.V1 as KeyboardHelpers
@@ -27,7 +26,7 @@ hasCorrectTypeWhenEnabled : List Test
 hasCorrectTypeWhenEnabled =
     [ test "has type 'radio'" <|
         \() ->
-            program False []
+            program []
                 |> ensureViewHas [ attribute (type_ "radio") ]
                 |> done
     ]
@@ -37,44 +36,27 @@ helpfullyDisabledRadioButton : List Test
 helpfullyDisabledRadioButton =
     [ test "does not have `aria-disabled=\"true\" when not disabled" <|
         \() ->
-            program False []
+            program []
                 |> ensureViewHasNot [ attribute (Aria.disabled True) ]
                 |> done
     , test "does not have `aria-disabled=\"false\" when not disabled" <|
         \() ->
-            program False []
+            program []
                 |> ensureViewHasNot [ attribute (Aria.disabled False) ]
                 |> done
     , test "has `aria-disabled=\"true\" when disabled" <|
         \() ->
-            program False [ RadioButton.disabled ]
+            program [ RadioButton.disabled ]
                 |> ensureViewHas [ attribute (Aria.disabled True) ]
-                |> done
-    , test "has `role=\"radio\" when disabled" <|
-        \() ->
-            program False [ RadioButton.disabled ]
-                |> ensureViewHas [ attribute Role.radio ]
-                |> done
-    , test "has `aria-checked=\"true\" when disabled and not selected" <|
-        \() ->
-            program True [ RadioButton.disabled ]
-                |> ensureViewHas [ attribute (Aria.checked (Just True)) ]
-                |> done
-    , test "has `aria-checked=\"false\" when disabled and not selected" <|
-        \() ->
-            program False [ RadioButton.disabled ]
-                |> ensureViewHas [ attribute (Aria.checked (Just False)) ]
                 |> done
     , test "is clickable when not disabled" <|
         \() ->
-            program False []
+            program []
                 |> click
                 |> done
     , test "is not clickable when disabled" <|
         \() ->
-            program
-                False
-                [ RadioButton.disabled ]
+            program [ RadioButton.disabled ]
                 |> click
                 |> done
                 |> expectFailure "Event.expectEvent: I found a node, but it does not listen for \"click\" events like I expected it would."
@@ -129,19 +111,14 @@ update msg model =
             { model | selectedValue = Just value }
 
 
-view : Bool -> List (RadioButton.Attribute Selection Msg) -> Model -> Html Msg
-view selected attributes state =
+view : List (RadioButton.Attribute Selection Msg) -> Model -> Html Msg
+view attributes state =
     div []
         [ RadioButton.view
             { label = "Dogs"
             , name = "pets"
             , value = Dogs
-            , selectedValue =
-                if selected then
-                    Just Dogs
-
-                else
-                    state.selectedValue
+            , selectedValue = state.selectedValue
             , valueToString = selectionToString
             }
             (RadioButton.onSelect Select :: attributes)
@@ -152,12 +129,12 @@ type alias TestContext =
     ProgramTest Model Msg ()
 
 
-program : Bool -> List (RadioButton.Attribute Selection Msg) -> ProgramTest Model Msg ()
-program selected attributes =
+program : List (RadioButton.Attribute Selection Msg) -> ProgramTest Model Msg ()
+program attributes =
     ProgramTest.createSandbox
         { init = init
         , update = update
-        , view = view selected attributes >> toUnstyled
+        , view = view attributes >> toUnstyled
         }
         |> ProgramTest.start ()
 

--- a/tests/Spec/Nri/Ui/RadioButton.elm
+++ b/tests/Spec/Nri/Ui/RadioButton.elm
@@ -1,0 +1,182 @@
+module Spec.Nri.Ui.RadioButton exposing (..)
+
+import Accessibility.Aria as Aria
+import Accessibility.Role as Role
+import Html.Attributes exposing (type_)
+import Html.Styled exposing (..)
+import Nri.Test.KeyboardHelpers.V1 as KeyboardHelpers
+import Nri.Test.MouseHelpers.V1 as MouseHelpers
+import Nri.Ui.RadioButton.V4 as RadioButton
+import ProgramTest exposing (..)
+import Spec.Helpers exposing (expectFailure)
+import Test exposing (..)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector exposing (..)
+
+
+spec : Test
+spec =
+    describe "Nri.Ui.RadioButton.V4"
+        [ describe "'role' type when enabled" hasCorrectTypeWhenEnabled
+        , describe "helpfully disabled RadioButton" helpfullyDisabledRadioButton
+        ]
+
+
+hasCorrectTypeWhenEnabled : List Test
+hasCorrectTypeWhenEnabled =
+    [ test "has type 'radio'" <|
+        \() ->
+            program False []
+                |> ensureViewHas [ attribute (type_ "radio") ]
+                |> done
+    ]
+
+
+helpfullyDisabledRadioButton : List Test
+helpfullyDisabledRadioButton =
+    [ test "does not have `aria-disabled=\"true\" when not disabled" <|
+        \() ->
+            program False []
+                |> ensureViewHasNot [ attribute (Aria.disabled True) ]
+                |> done
+    , test "does not have `aria-disabled=\"false\" when not disabled" <|
+        \() ->
+            program False []
+                |> ensureViewHasNot [ attribute (Aria.disabled False) ]
+                |> done
+    , test "has `aria-disabled=\"true\" when disabled" <|
+        \() ->
+            program False [ RadioButton.disabled ]
+                |> ensureViewHas [ attribute (Aria.disabled True) ]
+                |> done
+    , test "has `role=\"radio\" when disabled" <|
+        \() ->
+            program False [ RadioButton.disabled ]
+                |> ensureViewHas [ attribute Role.radio ]
+                |> done
+    , test "has `aria-checked=\"true\" when disabled and not selected" <|
+        \() ->
+            program True [ RadioButton.disabled ]
+                |> ensureViewHas [ attribute (Aria.checked (Just True)) ]
+                |> done
+    , test "has `aria-checked=\"false\" when disabled and not selected" <|
+        \() ->
+            program False [ RadioButton.disabled ]
+                |> ensureViewHas [ attribute (Aria.checked (Just False)) ]
+                |> done
+    , test "is clickable when not disabled" <|
+        \() ->
+            program False []
+                |> click
+                |> done
+    , test "is not clickable when disabled" <|
+        \() ->
+            program
+                False
+                [ RadioButton.disabled ]
+                |> click
+                |> done
+                |> expectFailure "Event.expectEvent: I found a node, but it does not listen for \"click\" events like I expected it would."
+    ]
+
+
+pressSpace : TestContext -> TestContext
+pressSpace =
+    KeyboardHelpers.pressSpace khConfig { targetDetails = [] } radio
+
+
+click : TestContext -> TestContext
+click =
+    MouseHelpers.click mhConfig radio
+
+
+radio : List Selector
+radio =
+    [ id "id-pets-Dogs" ]
+
+
+type Selection
+    = Dogs
+
+
+selectionToString : Selection -> String
+selectionToString selection =
+    case selection of
+        Dogs ->
+            "Dogs"
+
+
+type alias Model =
+    { selectedValue : Maybe Selection
+    }
+
+
+init : Model
+init =
+    { selectedValue = Nothing
+    }
+
+
+type Msg
+    = Select Selection
+
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        Select value ->
+            { model | selectedValue = Just value }
+
+
+view : Bool -> List (RadioButton.Attribute Selection Msg) -> Model -> Html Msg
+view selected attributes state =
+    div []
+        [ RadioButton.view
+            { label = "Dogs"
+            , name = "pets"
+            , value = Dogs
+            , selectedValue =
+                if selected then
+                    Just Dogs
+
+                else
+                    state.selectedValue
+            , valueToString = selectionToString
+            }
+            (RadioButton.onSelect Select :: attributes)
+        ]
+
+
+type alias TestContext =
+    ProgramTest Model Msg ()
+
+
+program : Bool -> List (RadioButton.Attribute Selection Msg) -> ProgramTest Model Msg ()
+program selected attributes =
+    ProgramTest.createSandbox
+        { init = init
+        , update = update
+        , view = view selected attributes >> toUnstyled
+        }
+        |> ProgramTest.start ()
+
+
+khConfig : KeyboardHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+khConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_custom = Event.custom
+    }
+
+
+mhConfig : MouseHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+mhConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_click = Event.click
+    , event_mouseDown = Event.mouseDown
+    , event_mouseUp = Event.mouseUp
+    , event_mouseOver = Event.mouseOver
+    , event_custom = Event.custom
+    }


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

The purpose of this PR is to replace the `disabled` attribute with `aria-disabled="true"` to keep the disabled radio button in the tab order. When it is focused, we should be able to show a tooltip explaining why the element is disabled. Unlike `disabled`, `aria-disabled` does not remove event listeners from the element, so we need to remove these interactions programmatically.

## :framed_picture: What does this change look like?

<img width="462" alt="disabled radio button with tooltip" src="https://github.com/NoRedInk/noredink-ui/assets/5647344/20dbb745-10f8-41f3-8dbb-88a579e53054">

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer:
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
