### PR TITLE
Replace lock icon with disabled checkbox in locked state of premium checkbox

### DIFF
--- a/component-catalog/src/Examples/PremiumCheckbox.elm
+++ b/component-catalog/src/Examples/PremiumCheckbox.elm
@@ -93,7 +93,7 @@ example =
 preview : List (Html Never)
 preview =
     let
-        renderPreview ( icon, label_ ) =
+        renderPreview ( icon, label_, labelCss ) =
             span
                 [ css
                     [ Css.color Colors.navy
@@ -110,12 +110,12 @@ preview =
                     |> Svg.withHeight (Css.px 30)
                     |> Svg.toHtml
                 , Svg.toHtml (Svg.withCss [ Css.marginRight (Css.px 8) ] icon)
-                , text label_
+                , span [ css labelCss ] [ text label_ ]
                 ]
     in
-    [ ( CheckboxIcons.lockOnInside "lockOnInside-preview-lockOnInside", "Locked" )
-    , ( CheckboxIcons.unchecked "unchecked-preview-unchecked", "Unchecked" )
-    , ( CheckboxIcons.checked "checkbox-preview-checked", "Checked" )
+    [ ( CheckboxIcons.uncheckedDisabled, "Locked", [ Css.color Colors.gray45 ] )
+    , ( CheckboxIcons.unchecked "unchecked-preview-unchecked", "Unchecked", [ Css.color Colors.gray20 ] )
+    , ( CheckboxIcons.checked "checkbox-preview-checked", "Checked", [] )
     ]
         |> List.map renderPreview
 

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -56,6 +56,7 @@ import Css exposing (..)
 import Html.Styled.Attributes as Attributes exposing (class, css)
 import Html.Styled.Events as Events
 import Nri.Ui.Checkbox.V7 as Checkbox
+import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Data.PremiumDisplay as PremiumDisplay exposing (PremiumDisplay)
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
@@ -302,14 +303,20 @@ viewLockedButton { idValue, label, containerCss, onLockedMsg } =
                 , css
                     [ displayFlex
                     , alignItems center
+                    , cursor notAllowed
                     , position relative
                     , Fonts.baseFont
                     , fontSize (px 15)
                     , Css.outline3 (Css.px 2) Css.solid Css.transparent
                     ]
                 ]
-                [ Checkbox.viewIcon [] (CheckboxIcons.lockOnInside idValue)
-                , Html.span [] [ Html.text label ]
+                [ Checkbox.viewIcon [] CheckboxIcons.uncheckedDisabled
+                , Html.span
+                    [ css
+                        [ color Colors.gray45
+                        ]
+                    ]
+                    [ Html.text label ]
                 ]
             ]
         ]

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -16,6 +16,7 @@ module Nri.Ui.PremiumCheckbox.V8 exposing
 ## Patch changes:
 
   - Added vouchered state for premium vouchers with gift pennant
+  - Replaced lock icon with disabled checkbox for locked state
 
 
 ## Changes from V7:


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

- GRO-1416

## :framed_picture: What does this change look like?

Before:
![Screenshot 2023-10-02 at 11 11 13](https://github.com/NoRedInk/noredink-ui/assets/99652839/577d9c77-d503-4cee-af56-ad850c7ff637)

After:
![Screenshot 2023-10-02 at 11 14 06](https://github.com/NoRedInk/noredink-ui/assets/99652839/2563ad19-aa3b-449f-a836-66b57e158591)

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [-] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer:
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
