### PR TITLE
Hover state for assignment library premium content tooltip

### DIFF
--- a/src/CheckboxIcons.elm
+++ b/src/CheckboxIcons.elm
@@ -67,7 +67,7 @@ unchecked idSuffix =
             , SvgAttributes.css
                 [ Css.hover
                     [ Css.Global.descendants
-                        [ Css.Global.typeSelector "rect"
+                        [ Css.Global.rect
                             [ Css.fill Colors.frost
                             , Css.property "stroke" (toCssString Colors.azure)
                             ]

--- a/src/CheckboxIcons.elm
+++ b/src/CheckboxIcons.elm
@@ -9,6 +9,7 @@ module CheckboxIcons exposing
     )
 
 import Css
+import Css.Global
 import Nri.Ui.Colors.Extra exposing (toCssString)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Svg.V1 exposing (Svg)
@@ -63,6 +64,16 @@ unchecked idSuffix =
             , SvgAttributes.strokeWidth "1"
             , SvgAttributes.fill "none"
             , SvgAttributes.fillRule "evenodd"
+            , SvgAttributes.css
+                [ Css.hover
+                    [ Css.Global.descendants
+                        [ Css.Global.typeSelector "rect"
+                            [ Css.fill Colors.frost
+                            , Css.property "stroke" (toCssString Colors.azure)
+                            ]
+                        ]
+                    ]
+                ]
             ]
             [ Svg.g
                 []

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -300,7 +300,7 @@ view { label, selected } attributes =
                     |> Maybe.map
                         (\msg ->
                             [ EventExtras.onClickStopPropagation msg
-                            , css [ cursor pointer ]
+                            , css [ cursor pointer, zIndex (int 1) ]
                             ]
                         )
                     |> Maybe.withDefault []
@@ -535,6 +535,7 @@ viewIcon styles icon =
                 , backgroundColor Colors.white
                 , height (Css.px checkboxIconHeight)
                 , borderRadius (px 4)
+                , zIndex (int 2)
                 ]
             ]
             [ Nri.Ui.Svg.V1.toHtml (Nri.Ui.Svg.V1.withCss styles icon)

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -395,7 +395,6 @@ enabledLabelCss : List Style
 enabledLabelCss =
     [ textStyle
     , cursor pointer
-    , color Colors.gray20
     ]
 
 

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -535,6 +535,7 @@ viewIcon styles icon =
                 , height (Css.px checkboxIconHeight)
                 , borderRadius (px 4)
                 , zIndex (int 2)
+                , position relative -- for z index to work
                 ]
             ]
             [ Nri.Ui.Svg.V1.toHtml (Nri.Ui.Svg.V1.withCss styles icon)


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

This PR updates the styling of the unselected checkbox on hover.

## :framed_picture: What does this change look like?

No hover:
<img width="113" alt="Screenshot 2023-10-06 at 13 40 24" src="https://github.com/NoRedInk/noredink-ui/assets/99652839/c7bc25b9-77e2-4b89-8900-05756a9a1613">

On hover:
<img width="114" alt="Screenshot 2023-10-06 at 13 40 55" src="https://github.com/NoRedInk/noredink-ui/assets/99652839/4c961e23-4f2b-4c90-a108-271d00f919e9">

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer:
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
