### PR TITLE
A11-3558 Fix button hover contrast

### DIFF
--- a/src/Nri/Ui/Button/V10.elm
+++ b/src/Nri/Ui/Button/V10.elm
@@ -1084,6 +1084,7 @@ type alias ColorPalette =
     , hoverBackground : Css.Color
     , text : Css.Color
     , hoverText : Css.Color
+    , visitedHoverText : Css.Color
     , border : Maybe Css.Color
     , shadow : Css.Color
     }
@@ -1095,6 +1096,7 @@ primaryColors =
     , hoverBackground = Colors.azureDark
     , text = Colors.white
     , hoverText = Colors.white
+    , visitedHoverText = Colors.white
     , border = Nothing
     , shadow = Colors.azureDark
     }
@@ -1106,6 +1108,7 @@ secondaryColors =
     , hoverBackground = Colors.glacier
     , text = Colors.azure
     , hoverText = Colors.azureDark
+    , visitedHoverText = Colors.azure
     , border = Just <| Colors.azure
     , shadow = Colors.azure
     }
@@ -1117,6 +1120,7 @@ tertiaryColors =
     , hoverBackground = Colors.frost
     , text = Colors.navy
     , hoverText = Colors.navy
+    , visitedHoverText = Colors.navy
     , border = Just <| Colors.gray75
     , shadow = Colors.gray75
     }
@@ -1128,6 +1132,7 @@ dangerSecondaryColors =
     , hoverBackground = Colors.redLight
     , text = Colors.red
     , hoverText = Colors.redDark
+    , visitedHoverText = Colors.red
     , border = Just <| Colors.red
     , shadow = Colors.red
     }
@@ -1139,6 +1144,7 @@ dangerColors =
     , hoverBackground = Colors.redDark
     , text = Colors.white
     , hoverText = Colors.white
+    , visitedHoverText = Colors.white
     , border = Nothing
     , shadow = Colors.redDark
     }
@@ -1149,7 +1155,8 @@ premiumColors =
     { background = Colors.yellow
     , hoverBackground = Colors.ochre
     , text = Colors.navy
-    , hoverText = Colors.navy
+    , hoverText = Colors.gray20
+    , visitedHoverText = Colors.gray20
     , border = Nothing
     , shadow = Colors.ochre
     }
@@ -1166,6 +1173,7 @@ colorStyle defaultStyle state =
             , hoverBackground = Colors.gray92
             , text = Colors.gray45
             , hoverText = Colors.gray45
+            , visitedHoverText = Colors.gray45
             , border = Just <| Colors.gray75
             , shadow = Colors.gray75
             }
@@ -1175,6 +1183,7 @@ colorStyle defaultStyle state =
             , hoverBackground = Colors.purple
             , text = Colors.white
             , hoverText = Colors.white
+            , visitedHoverText = Colors.white
             , border = Nothing
             , shadow = Colors.purple
             }
@@ -1184,6 +1193,7 @@ colorStyle defaultStyle state =
             , hoverBackground = Colors.glacier
             , text = Colors.azure
             , hoverText = Colors.azureDark
+            , visitedHoverText = Colors.azure
             , border = Just <| Colors.gray75
             , shadow = Colors.gray75
             }
@@ -1193,6 +1203,7 @@ colorStyle defaultStyle state =
             , hoverBackground = Colors.glacier
             , text = Colors.navy
             , hoverText = Colors.navy
+            , visitedHoverText = Colors.navy
             , border = Nothing
             , shadow = Colors.glacier
             }
@@ -1202,6 +1213,7 @@ colorStyle defaultStyle state =
             , hoverBackground = Colors.greenDarkest
             , text = Colors.white
             , hoverText = Colors.white
+            , visitedHoverText = Colors.white
             , border = Nothing
             , shadow = Colors.greenDarkest
             }
@@ -1234,7 +1246,10 @@ applyColorStyle colorPalette =
             , Css.disabled [ Css.backgroundColor colorPalette.background ]
             , Css.Global.withAttribute "aria-disabled=true" [ Css.backgroundColor colorPalette.background ]
             ]
-        , Css.visited [ Css.color colorPalette.text ]
+        , Css.visited
+            [ Css.color colorPalette.text
+            , Css.hover [ Css.color colorPalette.visitedHoverText ]
+            ]
         ]
 
 


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

- Fixes [A11-3558 : \[A11yAud-0396\] Sign up button low contrast](https://linear.app/noredink/issue/A11-3558/[a11yaud-0396]-sign-up-button-low-contrast)

## :framed_picture: What does this change look like?

<img width="252" alt="large premium button hover styles" src="https://github.com/NoRedInk/noredink-ui/assets/5647344/3a228024-97fa-46e6-8928-6d3c278e0dfb">
<img width="220" alt="large premium link hover styles" src="https://github.com/NoRedInk/noredink-ui/assets/5647344/5bc6049d-64e0-4996-96ab-bf72eed51f4e">

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
