### PR TITLE
Bump to 27.1.0 (minor update)

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "27.0.0",
+    "version": "27.1.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `27.1.0`

## What changes does this release include?

The easiest and most reliable way to find the changes that this release includes is to go through the changes between the last version number and master: https://github.com/NoRedInk/noredink-ui/compare/27.0.0...master

This is the only PR included in this release: https://github.com/NoRedInk/noredink-ui/pull/1559

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```
This is a MINOR change.

---- Nri.Ui.AssignmentIcon.V2 - MINOR ----

    Added:
        gradingAssistantCircled : Nri.Ui.Svg.V1.Svg


---- Nri.Ui.UiIcon.V1 - MINOR ----

    Added:
        gradingAssistant : Nri.Ui.Svg.V1.Svg
        manuallyGraded : Nri.Ui.Svg.V1.Svg
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).