### PR TITLE
A11-2660 refactor and add ClickableText tests

### DIFF
--- a/tests/Spec/Nri/Ui/ClickableText.elm
+++ b/tests/Spec/Nri/Ui/ClickableText.elm
@@ -1,4 +1,4 @@
-module Spec.Nri.Ui.ClickableText exposing (..)
+module Spec.Nri.Ui.ClickableText exposing (spec)
 
 import Accessibility.Aria as Aria
 import Accessibility.Role as Role

--- a/tests/Spec/Nri/Ui/ClickableText.elm
+++ b/tests/Spec/Nri/Ui/ClickableText.elm
@@ -36,6 +36,8 @@ elementTests =
     [ testAsButton
     , testAsAnchor
     , testIconAsSvg
+    , testRightIconAsSvg
+    , testLinkExternalIconAsSvg
     ]
 
 
@@ -62,6 +64,24 @@ testIconAsSvg =
     test "renders an svg element when an icon is provided" <|
         \() ->
             program Button [ ClickableText.icon UiIcon.arrowLeft ]
+                |> ensureViewHas [ tag "svg" ]
+                |> done
+
+
+testRightIconAsSvg : Test
+testRightIconAsSvg =
+    test "renders an svg element when a right icon is provided" <|
+        \() ->
+            program Button [ ClickableText.rightIcon UiIcon.arrowLeft ]
+                |> ensureViewHas [ tag "svg" ]
+                |> done
+
+
+testLinkExternalIconAsSvg : Test
+testLinkExternalIconAsSvg =
+    test "renders an svg element when an external link is provided" <|
+        \() ->
+            program Link [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHas [ tag "svg" ]
                 |> done
 

--- a/tests/Spec/Nri/Ui/ClickableText.elm
+++ b/tests/Spec/Nri/Ui/ClickableText.elm
@@ -1,72 +1,391 @@
-module Spec.Nri.Ui.ClickableText exposing (spec)
+module Spec.Nri.Ui.ClickableText exposing (..)
 
 import Accessibility.Aria as Aria
-import Html.Styled exposing (Html, toUnstyled)
+import Accessibility.Role as Role
+import Html.Attributes as Attributes
+import Html.Styled exposing (..)
+import Nri.Test.KeyboardHelpers.V1 as KeyboardHelpers
+import Nri.Test.MouseHelpers.V1 as MouseHelpers
 import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.UiIcon.V1 as UiIcon
 import ProgramTest exposing (..)
 import Spec.Helpers exposing (expectFailure)
 import Test exposing (..)
-import Test.Html.Selector exposing (..)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector exposing (..)
 
 
 spec : Test
 spec =
     describe "Nri.Ui.ClickableText.V3"
-        [ describe "helpfullyDisabledClickableText" helpfullyDisabledClickableText
+        [ describe "elements" elementTests
+        , describe "attributes" attributeTests
+        , describe "icon accessibility" iconAccessibilityTests
+        , describe "disabled behavior and attributes" disabledStateTests
         ]
 
 
-helpfullyDisabledClickableText : List Test
-helpfullyDisabledClickableText =
-    [ test "does not have `aria-disabled=\"true\" when not disabled" <|
-        \() ->
-            program ()
-                (\_ ->
-                    ClickableText.button "Text"
-                        []
-                )
-                |> ensureViewHasNot [ attribute (Aria.disabled True) ]
-                |> done
-    , test "has `aria-disabled=\"true\" when disabled" <|
-        \() ->
-            program ()
-                (\_ ->
-                    ClickableText.button "Text"
-                        [ ClickableText.disabled True
-                        ]
-                )
-                |> ensureViewHas [ attribute (Aria.disabled True) ]
-                |> done
-    , test "is clickable when not disabled" <|
-        \() ->
-            program ()
-                (\_ ->
-                    ClickableText.button "Text"
-                        [ ClickableText.onClick ()
-                        ]
-                )
-                |> clickButton "Text"
-                |> done
-    , test "is not clickable when disabled" <|
-        \() ->
-            program ()
-                (\_ ->
-                    ClickableText.button "Text"
-                        [ ClickableText.onClick ()
-                        , ClickableText.disabled True
-                        ]
-                )
-                |> clickButton "Text"
-                |> done
-                |> expectFailure "Event.expectEvent: I found a node, but it does not listen for \"click\" events like I expected it would."
+type Type_
+    = Button
+    | Link
+
+
+elementTests : List Test
+elementTests =
+    [ testAsButton
+    , testAsAnchor
+    , testIconAsSvg
     ]
 
 
-program : model -> (model -> Html model) -> ProgramTest model model ()
-program init view =
+testAsButton : Test
+testAsButton =
+    test "the `button` type renders as a button element" <|
+        \() ->
+            program Button []
+                |> ensureViewHas [ tag "button" ]
+                |> done
+
+
+testAsAnchor : Test
+testAsAnchor =
+    test "the `link` type renders as an anchor element" <|
+        \() ->
+            program Link []
+                |> ensureViewHas [ tag "a" ]
+                |> done
+
+
+testIconAsSvg : Test
+testIconAsSvg =
+    test "renders an svg element when an icon is provided" <|
+        \() ->
+            program Button [ ClickableText.icon UiIcon.arrowLeft ]
+                |> ensureViewHas [ tag "svg" ]
+                |> done
+
+
+attributeTests : List Test
+attributeTests =
+    [ testHref
+    , testLinkExternalHref
+    , testTarget
+    , testLinkExternalTarget
+    , testLinkExternalRel
+    ]
+
+
+testHref : Test
+testHref =
+    test "a link has the `href` attribute set to the provided value" <|
+        \() ->
+            program Link [ ClickableText.href "https://example.com" ]
+                |> ensureViewHas
+                    [ attribute (Attributes.href "https://example.com")
+                    ]
+                |> done
+
+
+testLinkExternalHref : Test
+testLinkExternalHref =
+    test "an external link has the `href` attribute set to the provided value" <|
+        \() ->
+            program Link [ ClickableText.linkExternal "https://example.com" ]
+                |> ensureViewHas
+                    [ attribute (Attributes.href "https://example.com")
+                    ]
+                |> done
+
+
+testTarget : Test
+testTarget =
+    test "a default link has the `target` attribute set to `\"_self\"`" <|
+        \() ->
+            program Link [ ClickableText.href "https://example.com" ]
+                |> ensureViewHas
+                    [ attribute (Attributes.target "_self")
+                    ]
+                |> done
+
+
+testLinkExternalTarget : Test
+testLinkExternalTarget =
+    test "an external link has the `target` attribute set to `\"_blank\"`" <|
+        \() ->
+            program Link [ ClickableText.linkExternal "https://example.com" ]
+                |> ensureViewHas
+                    [ attribute (Attributes.target "_blank")
+                    ]
+                |> done
+
+
+testLinkExternalRel : Test
+testLinkExternalRel =
+    test "an external link has the `rel` attribute set to `\"noopener noreferrer\"`" <|
+        \() ->
+            program Link [ ClickableText.linkExternal "https://example.com" ]
+                |> ensureViewHas
+                    [ attribute (Attributes.rel "noopener noreferrer")
+                    ]
+                |> done
+
+
+iconAccessibilityTests : List Test
+iconAccessibilityTests =
+    [ testIconAriaHidden
+    , testIconRole
+    , testIconFocusable
+    , testRightIconAriaHidden
+    , testRightIconRole
+    , testRightIconFocusable
+    , testLinkExternalIconAriaHiddenAbsence
+    , testLinkExternalIconRole
+    , testLinkExternalIconFocusable
+    , testLinkExternalIconSvgTitle
+    ]
+
+
+testIconAriaHidden : Test
+testIconAriaHidden =
+    test "the icon has the `aria-hidden` attribute set to `\"true\"`" <|
+        \() ->
+            program Button [ ClickableText.icon UiIcon.arrowLeft ]
+                |> ensureViewHas
+                    [ attribute (Aria.hidden True)
+                    ]
+                |> done
+
+
+testIconRole : Test
+testIconRole =
+    test "the icon has the `role` attribute set to `\"img\"`" <|
+        \() ->
+            program Button [ ClickableText.icon UiIcon.arrowLeft ]
+                |> ensureViewHas
+                    [ attribute Role.img
+                    ]
+                |> done
+
+
+testIconFocusable : Test
+testIconFocusable =
+    test "the icon has the `focusable` attribute set to `\"false\"`" <|
+        \() ->
+            program Button [ ClickableText.icon UiIcon.arrowLeft ]
+                |> ensureViewHas
+                    [ attribute (Attributes.attribute "focusable" "false")
+                    ]
+                |> done
+
+
+testRightIconAriaHidden : Test
+testRightIconAriaHidden =
+    test "the right icon has the `aria-hidden` attribute set to `\"true\"`" <|
+        \() ->
+            program Button [ ClickableText.rightIcon UiIcon.arrowLeft ]
+                |> ensureViewHas
+                    [ attribute (Aria.hidden True)
+                    ]
+                |> done
+
+
+testRightIconRole : Test
+testRightIconRole =
+    test "the right icon has the `role` attribute set to `\"img\"`" <|
+        \() ->
+            program Button [ ClickableText.rightIcon UiIcon.arrowLeft ]
+                |> ensureViewHas
+                    [ attribute Role.img
+                    ]
+                |> done
+
+
+testRightIconFocusable : Test
+testRightIconFocusable =
+    test "the right icon has the `focusable` attribute set to `\"false\"`" <|
+        \() ->
+            program Button [ ClickableText.rightIcon UiIcon.arrowLeft ]
+                |> ensureViewHas
+                    [ attribute (Attributes.attribute "focusable" "false")
+                    ]
+                |> done
+
+
+testLinkExternalIconAriaHiddenAbsence : Test
+testLinkExternalIconAriaHiddenAbsence =
+    test "the `aria-hidden` attribute is not present for an external link icon" <|
+        \() ->
+            program Link [ ClickableText.linkExternal "https://example.com" ]
+                |> ensureViewHasNot
+                    [ attribute (Aria.hidden True)
+                    ]
+                |> done
+
+
+testLinkExternalIconRole : Test
+testLinkExternalIconRole =
+    test "the external link icon has the `role` attribute set to `\"img\"`" <|
+        \() ->
+            program Link [ ClickableText.linkExternal "https://example.com" ]
+                |> ensureViewHas
+                    [ attribute Role.img
+                    ]
+                |> done
+
+
+testLinkExternalIconFocusable : Test
+testLinkExternalIconFocusable =
+    test "the external link icon has the `focusable` attribute set to `\"false\"`" <|
+        \() ->
+            program Link [ ClickableText.linkExternal "https://example.com" ]
+                |> ensureViewHas
+                    [ attribute (Attributes.attribute "focusable" "false")
+                    ]
+                |> done
+
+
+testLinkExternalIconSvgTitle : Test
+testLinkExternalIconSvgTitle =
+    test "the external link icon has the `title` tag set to `\"Opens in a new tab\"`" <|
+        \() ->
+            program Link [ ClickableText.linkExternal "https://example.com" ]
+                |> ensureViewHas
+                    [ tag "title"
+                    , containing [ Selector.text "Opens in a new tab" ]
+                    ]
+                |> done
+
+
+disabledStateTests : List Test
+disabledStateTests =
+    [ testAriaDisabledAbsence
+    , testAriaDisabled
+    , testClickable
+    , testNotClickable
+    ]
+
+
+testAriaDisabledAbsence : Test
+testAriaDisabledAbsence =
+    test "the `aria-disabled` attribute is not present for an enabled ClickableText" <|
+        \() ->
+            program Button []
+                |> ensureViewHasNot [ attribute (Aria.disabled True) ]
+                |> done
+
+
+testAriaDisabled : Test
+testAriaDisabled =
+    test "the `aria-disabled` attribute is present and set to `\"true\"` for a disabled ClickableText" <|
+        \() ->
+            program Button [ ClickableText.disabled True ]
+                |> ensureViewHas [ attribute (Aria.disabled True) ]
+                |> done
+
+
+testClickable : Test
+testClickable =
+    test "is clickable when enabled" <|
+        \() ->
+            program Button
+                [ ClickableText.onClick NoOp
+                ]
+                |> clickOnButton
+                |> done
+
+
+testNotClickable : Test
+testNotClickable =
+    test "is not clickable when disabled" <|
+        \() ->
+            program Button
+                [ ClickableText.disabled True
+                ]
+                |> clickOnButton
+                |> done
+                |> expectFailure "Event.expectEvent: I found a node, but it does not listen for \"click\" events like I expected it would."
+
+
+buttonSelectors : List Selector
+buttonSelectors =
+    [ tag "button"
+    ]
+
+
+type alias TestContext =
+    ProgramTest Model Msg ()
+
+
+pressSpaceOnButton : TestContext -> TestContext
+pressSpaceOnButton =
+    KeyboardHelpers.pressSpace keyboardHelperConfig { targetDetails = [] } buttonSelectors
+
+
+clickOnButton : TestContext -> TestContext
+clickOnButton =
+    MouseHelpers.click mouseHelperConfig buttonSelectors
+
+
+type alias Model =
+    ()
+
+
+init : Model
+init =
+    ()
+
+
+type Msg
+    = NoOp
+
+
+update : Msg -> Model -> Model
+update msg state =
+    case msg of
+        NoOp ->
+            state
+
+
+view : Type_ -> List (ClickableText.Attribute Msg) -> Model -> Html Msg
+view type_ attributes _ =
+    div []
+        (case type_ of
+            Button ->
+                [ ClickableText.button "Accessible name" attributes
+                ]
+
+            Link ->
+                [ ClickableText.link "Accessible name" attributes
+                ]
+        )
+
+
+program : Type_ -> List (ClickableText.Attribute Msg) -> TestContext
+program type_ attributes =
     ProgramTest.createSandbox
         { init = init
-        , update = \msg model -> msg
-        , view = \model -> Html.Styled.div [] [ view model ] |> toUnstyled
+        , update = update
+        , view = view type_ attributes >> toUnstyled
         }
         |> ProgramTest.start ()
+
+
+keyboardHelperConfig : KeyboardHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+keyboardHelperConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_custom = Event.custom
+    }
+
+
+mouseHelperConfig : MouseHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
+mouseHelperConfig =
+    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
+    , query_find = Query.find
+    , event_click = Event.click
+    , event_mouseDown = Event.mouseDown
+    , event_mouseUp = Event.mouseUp
+    , event_mouseOver = Event.mouseOver
+    , event_custom = Event.custom
+    }

--- a/tests/Spec/Nri/Ui/ClickableText.elm
+++ b/tests/Spec/Nri/Ui/ClickableText.elm
@@ -26,36 +26,31 @@ spec =
         ]
 
 
-type Type_
-    = Button
-    | Link
-
-
 elementTests : List Test
 elementTests =
     [ test "the `button` type renders as a button element" <|
         \() ->
-            program Button []
+            programButton []
                 |> ensureViewHas [ tag "button" ]
                 |> done
     , test "the `link` type renders as an anchor element" <|
         \() ->
-            program Link []
+            programLink []
                 |> ensureViewHas [ tag "a" ]
                 |> done
     , test "renders an svg element when an icon is provided" <|
         \() ->
-            program Button [ ClickableText.icon UiIcon.arrowLeft ]
+            programButton [ ClickableText.icon UiIcon.arrowLeft ]
                 |> ensureViewHas [ tag "svg" ]
                 |> done
     , test "renders an svg element when a right icon is provided" <|
         \() ->
-            program Button [ ClickableText.rightIcon UiIcon.arrowLeft ]
+            programButton [ ClickableText.rightIcon UiIcon.arrowLeft ]
                 |> ensureViewHas [ tag "svg" ]
                 |> done
     , test "renders an svg element when an external link is provided" <|
         \() ->
-            program Link [ ClickableText.linkExternal "https://example.com" ]
+            programLink [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHas [ tag "svg" ]
                 |> done
     ]
@@ -65,35 +60,35 @@ attributeTests : List Test
 attributeTests =
     [ test "a link has the `href` attribute set to the provided value" <|
         \() ->
-            program Link [ ClickableText.href "https://example.com" ]
+            programLink [ ClickableText.href "https://example.com" ]
                 |> ensureViewHas
                     [ attribute (Attributes.href "https://example.com")
                     ]
                 |> done
     , test "an external link has the `href` attribute set to the provided value" <|
         \() ->
-            program Link [ ClickableText.linkExternal "https://example.com" ]
+            programLink [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHas
                     [ attribute (Attributes.href "https://example.com")
                     ]
                 |> done
     , test "a default link has the `target` attribute set to `\"_self\"`" <|
         \() ->
-            program Link [ ClickableText.href "https://example.com" ]
+            programLink [ ClickableText.href "https://example.com" ]
                 |> ensureViewHas
                     [ attribute (Attributes.target "_self")
                     ]
                 |> done
     , test "an external link has the `target` attribute set to `\"_blank\"`" <|
         \() ->
-            program Link [ ClickableText.linkExternal "https://example.com" ]
+            programLink [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHas
                     [ attribute (Attributes.target "_blank")
                     ]
                 |> done
     , test "an external link has the `rel` attribute set to `\"noopener noreferrer\"`" <|
         \() ->
-            program Link [ ClickableText.linkExternal "https://example.com" ]
+            programLink [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHas
                     [ attribute (Attributes.rel "noopener noreferrer")
                     ]
@@ -105,70 +100,70 @@ iconAccessibilityTests : List Test
 iconAccessibilityTests =
     [ test "the icon has the `aria-hidden` attribute set to `\"true\"`" <|
         \() ->
-            program Button [ ClickableText.icon UiIcon.arrowLeft ]
+            programButton [ ClickableText.icon UiIcon.arrowLeft ]
                 |> ensureViewHas
                     [ attribute (Aria.hidden True)
                     ]
                 |> done
     , test "the icon has the `role` attribute set to `\"img\"`" <|
         \() ->
-            program Button [ ClickableText.icon UiIcon.arrowLeft ]
+            programButton [ ClickableText.icon UiIcon.arrowLeft ]
                 |> ensureViewHas
                     [ attribute Role.img
                     ]
                 |> done
     , test "the icon has the `focusable` attribute set to `\"false\"`" <|
         \() ->
-            program Button [ ClickableText.icon UiIcon.arrowLeft ]
+            programButton [ ClickableText.icon UiIcon.arrowLeft ]
                 |> ensureViewHas
                     [ attribute (Attributes.attribute "focusable" "false")
                     ]
                 |> done
     , test "the right icon has the `aria-hidden` attribute set to `\"true\"`" <|
         \() ->
-            program Button [ ClickableText.rightIcon UiIcon.arrowLeft ]
+            programButton [ ClickableText.rightIcon UiIcon.arrowLeft ]
                 |> ensureViewHas
                     [ attribute (Aria.hidden True)
                     ]
                 |> done
     , test "the right icon has the `role` attribute set to `\"img\"`" <|
         \() ->
-            program Button [ ClickableText.rightIcon UiIcon.arrowLeft ]
+            programButton [ ClickableText.rightIcon UiIcon.arrowLeft ]
                 |> ensureViewHas
                     [ attribute Role.img
                     ]
                 |> done
     , test "the right icon has the `focusable` attribute set to `\"false\"`" <|
         \() ->
-            program Button [ ClickableText.rightIcon UiIcon.arrowLeft ]
+            programButton [ ClickableText.rightIcon UiIcon.arrowLeft ]
                 |> ensureViewHas
                     [ attribute (Attributes.attribute "focusable" "false")
                     ]
                 |> done
     , test "the `aria-hidden` attribute is not present for an external link icon" <|
         \() ->
-            program Link [ ClickableText.linkExternal "https://example.com" ]
+            programLink [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHasNot
                     [ attribute (Aria.hidden True)
                     ]
                 |> done
     , test "the external link icon has the `role` attribute set to `\"img\"`" <|
         \() ->
-            program Link [ ClickableText.linkExternal "https://example.com" ]
+            programLink [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHas
                     [ attribute Role.img
                     ]
                 |> done
     , test "the external link icon has the `focusable` attribute set to `\"false\"`" <|
         \() ->
-            program Link [ ClickableText.linkExternal "https://example.com" ]
+            programLink [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHas
                     [ attribute (Attributes.attribute "focusable" "false")
                     ]
                 |> done
     , test "the external link icon has the `title` tag set to `\"Opens in a new tab\"`" <|
         \() ->
-            program Link [ ClickableText.linkExternal "https://example.com" ]
+            programLink [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHas
                     [ tag "title"
                     , containing [ Selector.text "Opens in a new tab" ]
@@ -181,24 +176,24 @@ disabledStateTests : List Test
 disabledStateTests =
     [ test "the `aria-disabled` attribute is not present for an enabled ClickableText" <|
         \() ->
-            program Button []
+            programButton []
                 |> ensureViewHasNot [ attribute (Aria.disabled True) ]
                 |> done
     , test "the `aria-disabled` attribute is present and set to `\"true\"` for a disabled ClickableText" <|
         \() ->
-            program Button [ ClickableText.disabled True ]
+            programButton [ ClickableText.disabled True ]
                 |> ensureViewHas [ attribute (Aria.disabled True) ]
                 |> done
     , test "is clickable when enabled" <|
         \() ->
-            program Button
+            programButton
                 [ ClickableText.onClick NoOp
                 ]
                 |> clickOnButton
                 |> done
     , test "is not clickable when disabled" <|
         \() ->
-            program Button
+            programButton
                 [ ClickableText.disabled True
                 ]
                 |> clickOnButton
@@ -247,26 +242,36 @@ update msg state =
             state
 
 
-view : Type_ -> List (ClickableText.Attribute Msg) -> Model -> Html Msg
-view type_ attributes _ =
+viewLink : List (ClickableText.Attribute Msg) -> Model -> Html Msg
+viewLink attributes _ =
     div []
-        (case type_ of
-            Button ->
-                [ ClickableText.button "Accessible name" attributes
-                ]
-
-            Link ->
-                [ ClickableText.link "Accessible name" attributes
-                ]
-        )
+        [ ClickableText.link "Accessible name" attributes
+        ]
 
 
-program : Type_ -> List (ClickableText.Attribute Msg) -> TestContext
-program type_ attributes =
+viewButton : List (ClickableText.Attribute Msg) -> Model -> Html Msg
+viewButton attributes _ =
+    div []
+        [ ClickableText.button "Accessible name" attributes
+        ]
+
+
+programLink : List (ClickableText.Attribute Msg) -> TestContext
+programLink attributes =
     ProgramTest.createSandbox
         { init = init
         , update = update
-        , view = view type_ attributes >> toUnstyled
+        , view = viewLink attributes >> toUnstyled
+        }
+        |> ProgramTest.start ()
+
+
+programButton : List (ClickableText.Attribute Msg) -> TestContext
+programButton attributes =
+    ProgramTest.createSandbox
+        { init = init
+        , update = update
+        , view = viewButton attributes >> toUnstyled
         }
         |> ProgramTest.start ()
 

--- a/tests/Spec/Nri/Ui/ClickableText.elm
+++ b/tests/Spec/Nri/Ui/ClickableText.elm
@@ -212,11 +212,6 @@ type alias TestContext =
     ProgramTest Model Msg ()
 
 
-pressSpaceOnButton : TestContext -> TestContext
-pressSpaceOnButton =
-    KeyboardHelpers.pressSpace keyboardHelperConfig { targetDetails = [] } buttonSelectors
-
-
 clickOnButton : TestContext -> TestContext
 clickOnButton =
     MouseHelpers.click mouseHelperConfig buttonSelectors

--- a/tests/Spec/Nri/Ui/ClickableText.elm
+++ b/tests/Spec/Nri/Ui/ClickableText.elm
@@ -33,241 +33,140 @@ type Type_
 
 elementTests : List Test
 elementTests =
-    [ testAsButton
-    , testAsAnchor
-    , testIconAsSvg
-    , testRightIconAsSvg
-    , testLinkExternalIconAsSvg
-    ]
-
-
-testAsButton : Test
-testAsButton =
-    test "the `button` type renders as a button element" <|
+    [ test "the `button` type renders as a button element" <|
         \() ->
             program Button []
                 |> ensureViewHas [ tag "button" ]
                 |> done
-
-
-testAsAnchor : Test
-testAsAnchor =
-    test "the `link` type renders as an anchor element" <|
+    , test "the `link` type renders as an anchor element" <|
         \() ->
             program Link []
                 |> ensureViewHas [ tag "a" ]
                 |> done
-
-
-testIconAsSvg : Test
-testIconAsSvg =
-    test "renders an svg element when an icon is provided" <|
+    , test "renders an svg element when an icon is provided" <|
         \() ->
             program Button [ ClickableText.icon UiIcon.arrowLeft ]
                 |> ensureViewHas [ tag "svg" ]
                 |> done
-
-
-testRightIconAsSvg : Test
-testRightIconAsSvg =
-    test "renders an svg element when a right icon is provided" <|
+    , test "renders an svg element when a right icon is provided" <|
         \() ->
             program Button [ ClickableText.rightIcon UiIcon.arrowLeft ]
                 |> ensureViewHas [ tag "svg" ]
                 |> done
-
-
-testLinkExternalIconAsSvg : Test
-testLinkExternalIconAsSvg =
-    test "renders an svg element when an external link is provided" <|
+    , test "renders an svg element when an external link is provided" <|
         \() ->
             program Link [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHas [ tag "svg" ]
                 |> done
+    ]
 
 
 attributeTests : List Test
 attributeTests =
-    [ testHref
-    , testLinkExternalHref
-    , testTarget
-    , testLinkExternalTarget
-    , testLinkExternalRel
-    ]
-
-
-testHref : Test
-testHref =
-    test "a link has the `href` attribute set to the provided value" <|
+    [ test "a link has the `href` attribute set to the provided value" <|
         \() ->
             program Link [ ClickableText.href "https://example.com" ]
                 |> ensureViewHas
                     [ attribute (Attributes.href "https://example.com")
                     ]
                 |> done
-
-
-testLinkExternalHref : Test
-testLinkExternalHref =
-    test "an external link has the `href` attribute set to the provided value" <|
+    , test "an external link has the `href` attribute set to the provided value" <|
         \() ->
             program Link [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHas
                     [ attribute (Attributes.href "https://example.com")
                     ]
                 |> done
-
-
-testTarget : Test
-testTarget =
-    test "a default link has the `target` attribute set to `\"_self\"`" <|
+    , test "a default link has the `target` attribute set to `\"_self\"`" <|
         \() ->
             program Link [ ClickableText.href "https://example.com" ]
                 |> ensureViewHas
                     [ attribute (Attributes.target "_self")
                     ]
                 |> done
-
-
-testLinkExternalTarget : Test
-testLinkExternalTarget =
-    test "an external link has the `target` attribute set to `\"_blank\"`" <|
+    , test "an external link has the `target` attribute set to `\"_blank\"`" <|
         \() ->
             program Link [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHas
                     [ attribute (Attributes.target "_blank")
                     ]
                 |> done
-
-
-testLinkExternalRel : Test
-testLinkExternalRel =
-    test "an external link has the `rel` attribute set to `\"noopener noreferrer\"`" <|
+    , test "an external link has the `rel` attribute set to `\"noopener noreferrer\"`" <|
         \() ->
             program Link [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHas
                     [ attribute (Attributes.rel "noopener noreferrer")
                     ]
                 |> done
+    ]
 
 
 iconAccessibilityTests : List Test
 iconAccessibilityTests =
-    [ testIconAriaHidden
-    , testIconRole
-    , testIconFocusable
-    , testRightIconAriaHidden
-    , testRightIconRole
-    , testRightIconFocusable
-    , testLinkExternalIconAriaHiddenAbsence
-    , testLinkExternalIconRole
-    , testLinkExternalIconFocusable
-    , testLinkExternalIconSvgTitle
-    ]
-
-
-testIconAriaHidden : Test
-testIconAriaHidden =
-    test "the icon has the `aria-hidden` attribute set to `\"true\"`" <|
+    [ test "the icon has the `aria-hidden` attribute set to `\"true\"`" <|
         \() ->
             program Button [ ClickableText.icon UiIcon.arrowLeft ]
                 |> ensureViewHas
                     [ attribute (Aria.hidden True)
                     ]
                 |> done
-
-
-testIconRole : Test
-testIconRole =
-    test "the icon has the `role` attribute set to `\"img\"`" <|
+    , test "the icon has the `role` attribute set to `\"img\"`" <|
         \() ->
             program Button [ ClickableText.icon UiIcon.arrowLeft ]
                 |> ensureViewHas
                     [ attribute Role.img
                     ]
                 |> done
-
-
-testIconFocusable : Test
-testIconFocusable =
-    test "the icon has the `focusable` attribute set to `\"false\"`" <|
+    , test "the icon has the `focusable` attribute set to `\"false\"`" <|
         \() ->
             program Button [ ClickableText.icon UiIcon.arrowLeft ]
                 |> ensureViewHas
                     [ attribute (Attributes.attribute "focusable" "false")
                     ]
                 |> done
-
-
-testRightIconAriaHidden : Test
-testRightIconAriaHidden =
-    test "the right icon has the `aria-hidden` attribute set to `\"true\"`" <|
+    , test "the right icon has the `aria-hidden` attribute set to `\"true\"`" <|
         \() ->
             program Button [ ClickableText.rightIcon UiIcon.arrowLeft ]
                 |> ensureViewHas
                     [ attribute (Aria.hidden True)
                     ]
                 |> done
-
-
-testRightIconRole : Test
-testRightIconRole =
-    test "the right icon has the `role` attribute set to `\"img\"`" <|
+    , test "the right icon has the `role` attribute set to `\"img\"`" <|
         \() ->
             program Button [ ClickableText.rightIcon UiIcon.arrowLeft ]
                 |> ensureViewHas
                     [ attribute Role.img
                     ]
                 |> done
-
-
-testRightIconFocusable : Test
-testRightIconFocusable =
-    test "the right icon has the `focusable` attribute set to `\"false\"`" <|
+    , test "the right icon has the `focusable` attribute set to `\"false\"`" <|
         \() ->
             program Button [ ClickableText.rightIcon UiIcon.arrowLeft ]
                 |> ensureViewHas
                     [ attribute (Attributes.attribute "focusable" "false")
                     ]
                 |> done
-
-
-testLinkExternalIconAriaHiddenAbsence : Test
-testLinkExternalIconAriaHiddenAbsence =
-    test "the `aria-hidden` attribute is not present for an external link icon" <|
+    , test "the `aria-hidden` attribute is not present for an external link icon" <|
         \() ->
             program Link [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHasNot
                     [ attribute (Aria.hidden True)
                     ]
                 |> done
-
-
-testLinkExternalIconRole : Test
-testLinkExternalIconRole =
-    test "the external link icon has the `role` attribute set to `\"img\"`" <|
+    , test "the external link icon has the `role` attribute set to `\"img\"`" <|
         \() ->
             program Link [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHas
                     [ attribute Role.img
                     ]
                 |> done
-
-
-testLinkExternalIconFocusable : Test
-testLinkExternalIconFocusable =
-    test "the external link icon has the `focusable` attribute set to `\"false\"`" <|
+    , test "the external link icon has the `focusable` attribute set to `\"false\"`" <|
         \() ->
             program Link [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHas
                     [ attribute (Attributes.attribute "focusable" "false")
                     ]
                 |> done
-
-
-testLinkExternalIconSvgTitle : Test
-testLinkExternalIconSvgTitle =
-    test "the external link icon has the `title` tag set to `\"Opens in a new tab\"`" <|
+    , test "the external link icon has the `title` tag set to `\"Opens in a new tab\"`" <|
         \() ->
             program Link [ ClickableText.linkExternal "https://example.com" ]
                 |> ensureViewHas
@@ -275,49 +174,29 @@ testLinkExternalIconSvgTitle =
                     , containing [ Selector.text "Opens in a new tab" ]
                     ]
                 |> done
+    ]
 
 
 disabledStateTests : List Test
 disabledStateTests =
-    [ testAriaDisabledAbsence
-    , testAriaDisabled
-    , testClickable
-    , testNotClickable
-    ]
-
-
-testAriaDisabledAbsence : Test
-testAriaDisabledAbsence =
-    test "the `aria-disabled` attribute is not present for an enabled ClickableText" <|
+    [ test "the `aria-disabled` attribute is not present for an enabled ClickableText" <|
         \() ->
             program Button []
                 |> ensureViewHasNot [ attribute (Aria.disabled True) ]
                 |> done
-
-
-testAriaDisabled : Test
-testAriaDisabled =
-    test "the `aria-disabled` attribute is present and set to `\"true\"` for a disabled ClickableText" <|
+    , test "the `aria-disabled` attribute is present and set to `\"true\"` for a disabled ClickableText" <|
         \() ->
             program Button [ ClickableText.disabled True ]
                 |> ensureViewHas [ attribute (Aria.disabled True) ]
                 |> done
-
-
-testClickable : Test
-testClickable =
-    test "is clickable when enabled" <|
+    , test "is clickable when enabled" <|
         \() ->
             program Button
                 [ ClickableText.onClick NoOp
                 ]
                 |> clickOnButton
                 |> done
-
-
-testNotClickable : Test
-testNotClickable =
-    test "is not clickable when disabled" <|
+    , test "is not clickable when disabled" <|
         \() ->
             program Button
                 [ ClickableText.disabled True
@@ -325,6 +204,7 @@ testNotClickable =
                 |> clickOnButton
                 |> done
                 |> expectFailure "Event.expectEvent: I found a node, but it does not listen for \"click\" events like I expected it would."
+    ]
 
 
 buttonSelectors : List Selector

--- a/tests/Spec/Nri/Ui/ClickableText.elm
+++ b/tests/Spec/Nri/Ui/ClickableText.elm
@@ -4,7 +4,6 @@ import Accessibility.Aria as Aria
 import Accessibility.Role as Role
 import Html.Attributes as Attributes
 import Html.Styled exposing (..)
-import Nri.Test.KeyboardHelpers.V1 as KeyboardHelpers
 import Nri.Test.MouseHelpers.V1 as MouseHelpers
 import Nri.Ui.ClickableText.V3 as ClickableText
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -269,14 +268,6 @@ programButton attributes =
         , view = viewButton attributes >> toUnstyled
         }
         |> ProgramTest.start ()
-
-
-keyboardHelperConfig : KeyboardHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)
-keyboardHelperConfig =
-    { programTest_simulateDomEvent = ProgramTest.simulateDomEvent
-    , query_find = Query.find
-    , event_custom = Event.custom
-    }
 
 
 mouseHelperConfig : MouseHelpers.Config (ProgramTest model msg effect) Selector.Selector (Query.Single msg)


### PR DESCRIPTION
Restructures the ClickableText spec, improves the descriptions for better understanding, adds tests.