### PR TITLE
[PHX-1215] Create `renderReadaloud` on the Block API

### DIFF
--- a/src/Nri/Ui/Block/V6.elm
+++ b/src/Nri/Ui/Block/V6.elm
@@ -1,5 +1,5 @@
 module Nri.Ui.Block.V6 exposing
-    ( view, Attribute
+    ( view, renderReadaloud, Attribute
     , plaintext
     , Content, content
     , phrase, space, bold, italic
@@ -20,7 +20,12 @@ module Nri.Ui.Block.V6 exposing
     - Set a maximum blank width of ~60 characters as blanks won't line break
     - Remove `labelState` as we are shifting reposibility to consumers to animate labels via `labelCss`
 
-@docs view, Attribute
+
+## Patch changes
+
+    Add renderReadaloud
+
+@docs view, renderReadaloud, Attribute
 
 
 ## Content
@@ -83,6 +88,26 @@ view attributes =
     attributes
         |> List.foldl (\(Attribute attribute) b -> attribute b) defaultConfig
         |> render
+
+
+renderReadaloud : List (Attribute msg) -> String
+renderReadaloud attributes =
+    let
+        renderContentReadAloud c =
+            case c of
+                Word string ->
+                    [ string ]
+
+                Blank _ ->
+                    [ "blank" ]
+
+                Markdown _ subContent ->
+                    List.concatMap renderContentReadAloud subContent
+    in
+    List.foldl (\(Attribute attribute) b -> attribute b) defaultConfig attributes
+        |> .content
+        |> List.concatMap renderContentReadAloud
+        |> String.join ""
 
 
 

--- a/src/Nri/Ui/Block/V6.elm
+++ b/src/Nri/Ui/Block/V6.elm
@@ -89,7 +89,7 @@ view attributes =
         |> List.foldl (\(Attribute attribute) b -> attribute b) defaultConfig
         |> render
 
-
+{-| Render a block to a ReadAloud friendly string.  -}
 renderReadaloud : List (Attribute msg) -> String
 renderReadaloud attributes =
     let

--- a/src/Nri/Ui/Block/V6.elm
+++ b/src/Nri/Ui/Block/V6.elm
@@ -1,5 +1,5 @@
 module Nri.Ui.Block.V6 exposing
-    ( view, renderReadaloud, Attribute
+    ( view, renderReadAloud, Attribute
     , plaintext
     , Content, content
     , phrase, space, bold, italic
@@ -23,9 +23,9 @@ module Nri.Ui.Block.V6 exposing
 
 ## Patch changes
 
-    Add renderReadaloud
+    Add renderReadAloud
 
-@docs view, renderReadaloud, Attribute
+@docs view, renderReadAloud, Attribute
 
 
 ## Content
@@ -89,9 +89,11 @@ view attributes =
         |> List.foldl (\(Attribute attribute) b -> attribute b) defaultConfig
         |> render
 
-{-| Render a block to a ReadAloud friendly string.  -}
-renderReadaloud : List (Attribute msg) -> String
-renderReadaloud attributes =
+
+{-| Render a block to a ReadAloud friendly string.
+-}
+renderReadAloud : List (Attribute msg) -> String
+renderReadAloud attributes =
     let
         renderContentReadAloud c =
             case c of

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -20,6 +20,7 @@ spec =
         , describe "labelId" labelIdSpec
         , describe "labelMarkdown" labelMarkdownSpec
         , describe "getLabelPositions" getLabelPositionsSpec
+        , describe "renderReadAloud" renderReadAloudTests
         ]
 
 
@@ -636,6 +637,67 @@ getLabelPositionsSpec =
                      ]
                         |> Dict.fromList
                     )
+    ]
+
+
+renderReadAloudTests : List Test
+renderReadAloudTests =
+    [ test "Simple Text" <|
+        \_ ->
+            Block.renderReadAloud [ Block.plaintext "Simple Text" ]
+                |> Expect.equal "Simple Text"
+    , test "Simple emphasize block" <|
+        \_ ->
+            Block.renderReadAloud [ Block.emphasize, Block.content (Block.phrase "Simple Text") ]
+                |> Expect.equal "Simple Text"
+    , test "Simple blank" <|
+        \_ ->
+            Block.renderReadAloud []
+                |> Expect.equal "blank"
+    , test "Bold markup is ignored" <|
+        \_ ->
+            Block.renderReadAloud
+                [ Block.content
+                    (List.concat
+                        [ Block.phrase "Hello there "
+                        , [ Block.bold (Block.phrase "Mr.") ]
+                        , Block.phrase " President"
+                        ]
+                    )
+                ]
+                |> Expect.equal "Hello there Mr. President"
+    , test "Italic markup is ignored" <|
+        \_ ->
+            Block.renderReadAloud
+                [ Block.content
+                    (List.concat
+                        [ Block.phrase "Hello there "
+                        , [ Block.italic (Block.phrase "Mr.") ]
+                        , Block.phrase " President"
+                        ]
+                    )
+                ]
+                |> Expect.equal "Hello there Mr. President"
+    , test "Blanks in content are read" <|
+        \_ ->
+            Block.renderReadAloud
+                [ Block.content
+                    (List.concat
+                        [ Block.phrase "Hello there "
+                        , [ Block.blank { widthInChars = 5 } ]
+                        , Block.phrase " President"
+                        ]
+                    )
+                ]
+                |> Expect.equal "Hello there blank President"
+    , test "Label text is ignored" <|
+        \_ ->
+            Block.renderReadAloud
+                [ Block.emphasize
+                , Block.plaintext "Hello there Mr. President"
+                , Block.label "Read this"
+                ]
+                |> Expect.equal "Hello there Mr. President"
     ]
 
 


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

We're trying to firm up our ReadAloud support for places that use the Block API.  The easiest way to do this is to allow the `Block` model to be processed to a read aloud friendly string. So this PR adds a `renderReadAloud` function to that effect. 

[PHX-1215](https://linear.app/noredink/issue/PHX-1215/improve-readaloud-for-new-scaffolding-markdown-in-questionbox)

## :framed_picture: What does this change look like?

No visible changes to the component. 

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
