### PR TITLE
Add *lightest variant for highlight background colors

### DIFF
--- a/component-catalog/src/Examples/Colors.elm
+++ b/component-catalog/src/Examples/Colors.elm
@@ -169,18 +169,25 @@ uncategorizedColors =
 backgroundHighlightColors : List ColorExample
 backgroundHighlightColors =
     [ ( "highlightYellow", Colors.highlightYellow, "Yellow background highlights" )
+    , ( "highlightYellowLightest", Colors.highlightYellowLightest, "Lightest yellow background highlights" )
     , ( "highlightYellowDark", Colors.highlightYellowDark, "Dark yellow background highlights" )
     , ( "highlightCyan", Colors.highlightCyan, "Cyan background highlights" )
+    , ( "highlightCyanLightest", Colors.highlightCyanLightest, "Lightest cyan background highlights" )
     , ( "highlightCyanDark", Colors.highlightCyanDark, "Dark cyan background highlights" )
     , ( "highlightMagenta", Colors.highlightMagenta, "Magenta background highlights" )
+    , ( "highlightMagentaLightest", Colors.highlightMagentaLightest, "Lightest magenta background highlights" )
     , ( "highlightMagentaDark", Colors.highlightMagentaDark, "Dark magenta background highlights" )
     , ( "highlightGreen", Colors.highlightGreen, "Green background highlights" )
+    , ( "highlightGreenLightest", Colors.highlightGreenLightest, "Lightest green background highlights" )
     , ( "highlightGreenDark", Colors.highlightGreenDark, "Dark green background highlights" )
     , ( "highlightBlue", Colors.highlightBlue, "Blue background highlights" )
+    , ( "highlightBlueLightest", Colors.highlightBlueLightest, "Lightest blue background highlights" )
     , ( "highlightBlueDark", Colors.highlightBlueDark, "Dark blue background highlights" )
     , ( "highlightPurple", Colors.highlightPurple, "Purple background highlights" )
+    , ( "highlightPurpleLightest", Colors.highlightPurpleLightest, "Lightest purple background highlights" )
     , ( "highlightPurpleDark", Colors.highlightPurpleDark, "Dark purple background highlights" )
     , ( "highlightBrown", Colors.highlightBrown, "Brown background highlights" )
+    , ( "highlightBrownLightest", Colors.highlightBrownLightest, "Lightest brown background highlights" )
     , ( "highlightBrownDark", Colors.highlightBrownDark, "Dark brown background highlights" )
     ]
 

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -611,8 +611,8 @@ controlMarker =
             )
         )
         |> Control.field "highlightColor" (backgroundHighlightColors 0)
-        |> Control.field "hoverColor" (backgroundHighlightColors 2)
-        |> Control.field "hoverHighlightColor" (backgroundHighlightColors 4)
+        |> Control.field "hoverColor" (backgroundHighlightColors 3)
+        |> Control.field "hoverHighlightColor" (backgroundHighlightColors 6)
         |> Control.field "name" (Control.maybe True (Control.string "Claim"))
 
 

--- a/src/Nri/Ui/Colors/V1.elm
+++ b/src/Nri/Ui/Colors/V1.elm
@@ -61,504 +61,504 @@ import Css exposing (hex)
 import Nri.Ui.Colors.Extra exposing (withAlpha)
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 aqua : Css.Color
 aqua =
     hex "#00cbeb"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 aquaDark : Css.Color
 aquaDark =
     hex "#008da3"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 aquaLight : Css.Color
 aquaLight =
     hex "#e6fcff"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 azure : Css.Color
 azure =
     hex "#0A64FF"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 azureDark : Css.Color
 azureDark =
     hex "#004cc9"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 cornflower : Css.Color
 cornflower =
     hex "#00aaff"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 cornflowerDark : Css.Color
 cornflowerDark =
     hex "#0074ad"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 cornflowerLight : Css.Color
 cornflowerLight =
     hex "#e6f7ff"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 cyan : Css.Color
 cyan =
     hex "#43dcff"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 frost : Css.Color
 frost =
     hex "#eef9ff"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 glacier : Css.Color
 glacier =
     hex "#d4f0ff"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 grassland : Css.Color
 grassland =
     hex "#56bf74"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 gray20 : Css.Color
 gray20 =
     hex "#333333"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 gray45 : Css.Color
 gray45 =
     hex "#707070"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 gray75 : Css.Color
 gray75 =
     hex "#bfbfbf"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 gray85 : Css.Color
 gray85 =
     hex "#d9d9d9"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 gray92 : Css.Color
 gray92 =
     hex "#ebebeb"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 gray96 : Css.Color
 gray96 =
     hex "#f5f5f5"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 green : Css.Color
 green =
     hex "#00d93e"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 greenDark : Css.Color
 greenDark =
     hex "#28ab00"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 greenDarkest : Css.Color
 greenDarkest =
     hex "#228000"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 greenLight : Css.Color
 greenLight =
     hex "#b3ffc9"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 greenLightest : Css.Color
 greenLightest =
     hex "#e6ffed"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightLightBlue : Css.Color
 highlightLightBlue =
     withAlpha 0.75 cyan
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightLightMagenta : Css.Color
 highlightLightMagenta =
     withAlpha 0.5 magenta
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightLightYellow : Css.Color
 highlightLightYellow =
     withAlpha 0.75 yellow
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightYellow : Css.Color
 highlightYellow =
     hex "#fee798"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightYellowLightest : Css.Color
 highlightYellowLightest =
     hex "#fffdf5"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightYellowDark : Css.Color
 highlightYellowDark =
     hex "#795d01"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 textHighlightYellow : Css.Color
 textHighlightYellow =
     hex "#ab8403"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightCyan : Css.Color
 highlightCyan =
     hex "#9BFFF4"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightCyanLightest : Css.Color
 highlightCyanLightest =
     hex "#f5fffe"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightCyanDark : Css.Color
 highlightCyanDark =
     hex "#006156"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 textHighlightCyan : Css.Color
 textHighlightCyan =
     hex "#009e8e"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightMagenta : Css.Color
 highlightMagenta =
     hex "#ffb8f3"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightMagentaLightest : Css.Color
 highlightMagentaLightest =
     hex "#fff8fe"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightMagentaDark : Css.Color
 highlightMagentaDark =
     hex "#a30088"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 textHighlightMagenta : Css.Color
 textHighlightMagenta =
     hex "#ff33dd"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightGreen : Css.Color
 highlightGreen =
     hex "#8fffb3"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightGreenLightest : Css.Color
 highlightGreenLightest =
     hex "#f4fff7"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightGreenDark : Css.Color
 highlightGreenDark =
     hex "#007025"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 textHighlightGreen : Css.Color
 textHighlightGreen =
     hex "#00a336"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightBlue : Css.Color
 highlightBlue =
     hex "#ccdeff"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightBlueLightest : Css.Color
 highlightBlueLightest =
     hex "#fafcff"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightBlueDark : Css.Color
 highlightBlueDark =
     hex "#002e85"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 textHighlightBlue : Css.Color
 textHighlightBlue =
     hex "#3d81ff"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightPurple : Css.Color
 highlightPurple =
     hex "#e3d6ff"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightPurpleLightest : Css.Color
 highlightPurpleLightest =
     hex "#fcfbff"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightPurpleDark : Css.Color
 highlightPurpleDark =
     hex "#3c00bd"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 textHighlightPurple : Css.Color
 textHighlightPurple =
     hex "#702eff"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightBrown : Css.Color
 highlightBrown =
     hex "#ffc6a1"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightBrownLightest : Css.Color
 highlightBrownLightest =
     hex "#fff9f6"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 highlightBrownDark : Css.Color
 highlightBrownDark =
     hex "#943b00"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 textHighlightBrown : Css.Color
 textHighlightBrown =
     hex "#e05a00"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 lichen : Css.Color
 lichen =
     hex "#99bfa4"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 magenta : Css.Color
 magenta =
     hex "#ff00bd"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 navy : Css.Color
 navy =
     hex "#004e95"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 orange : Css.Color
 orange =
     hex "#f5a623"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 ochre : Css.Color
 ochre =
     hex "#f28f00"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 ochreDark : Css.Color
 ochreDark =
     hex "#ad6500"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 purple : Css.Color
 purple =
     hex "#a839e7"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 purpleLight : Css.Color
 purpleLight =
     hex "#f7ebff"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 purpleDark : Css.Color
 purpleDark =
     hex "#7721a7"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 red : Css.Color
 red =
     hex "#e70d4f"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 redLight : Css.Color
 redLight =
     hex "#ffe0e6"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 redDark : Css.Color
 redDark =
     hex "#c2003a"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 sunshine : Css.Color
 sunshine =
     hex "#fffadc"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 turquoise : Css.Color
 turquoise =
     hex "#00cfbe"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 turquoiseDark : Css.Color
 turquoiseDark =
     hex "#00a39b"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 turquoiseLight : Css.Color
 turquoiseLight =
     hex "#e0fffe"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 white : Css.Color
 white =
     hex "#ffffff"
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 
 DEPRECATED: use [`mustard`](#mustard) instead. `yellow` will be removed in V2.
 
@@ -568,7 +568,7 @@ yellow =
     mustard
 
 
-{-| See <https://noredink-ui.netlify.com/#category/Colors>
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
 -}
 mustard : Css.Color
 mustard =

--- a/src/Nri/Ui/Colors/V1.elm
+++ b/src/Nri/Ui/Colors/V1.elm
@@ -6,13 +6,13 @@ module Nri.Ui.Colors.V1 exposing
     , gray20, gray45, gray75, gray85, gray92, gray96
     , glacier, grassland, green, greenDark, greenDarkest, greenLight, greenLightest
     , highlightLightBlue, highlightLightMagenta, highlightLightYellow
-    , highlightBlue, highlightBlueDark
-    , highlightCyan, highlightCyanDark
-    , highlightGreen, highlightGreenDark
-    , highlightMagenta, highlightMagentaDark
-    , highlightPurple, highlightPurpleDark
-    , highlightYellow, highlightYellowDark
-    , highlightBrown, highlightBrownDark
+    , highlightBlue, highlightBlueLightest, highlightBlueDark
+    , highlightCyan, highlightCyanLightest, highlightCyanDark
+    , highlightGreen, highlightGreenLightest, highlightGreenDark
+    , highlightMagenta, highlightMagentaLightest, highlightMagentaDark
+    , highlightPurple, highlightPurpleLightest, highlightPurpleDark
+    , highlightYellow, highlightYellowLightest, highlightYellowDark
+    , highlightBrown, highlightBrownLightest, highlightBrownDark
     , textHighlightYellow, textHighlightCyan, textHighlightMagenta, textHighlightGreen, textHighlightBlue, textHighlightPurple, textHighlightBrown
     , lichen
     , magenta
@@ -37,13 +37,13 @@ consider [elm-color-extra](http://package.elm-lang.org/packages/eskimoblood/elm-
 @docs gray20, gray45, gray75, gray85, gray92, gray96
 @docs glacier, grassland, green, greenDark, greenDarkest, greenLight, greenLightest
 @docs highlightLightBlue, highlightLightMagenta, highlightLightYellow
-@docs highlightBlue, highlightBlueDark
-@docs highlightCyan, highlightCyanDark
-@docs highlightGreen, highlightGreenDark
-@docs highlightMagenta, highlightMagentaDark
-@docs highlightPurple, highlightPurpleDark
-@docs highlightYellow, highlightYellowDark
-@docs highlightBrown, highlightBrownDark
+@docs highlightBlue, highlightBlueLightest, highlightBlueDark
+@docs highlightCyan, highlightCyanLightest, highlightCyanDark
+@docs highlightGreen, highlightGreenLightest, highlightGreenDark
+@docs highlightMagenta, highlightMagentaLightest, highlightMagentaDark
+@docs highlightPurple, highlightPurpleLightest, highlightPurpleDark
+@docs highlightYellow, highlightYellowLightest, highlightYellowDark
+@docs highlightBrown, highlightBrownLightest, highlightBrownDark
 @docs textHighlightYellow, textHighlightCyan, textHighlightMagenta, textHighlightGreen, textHighlightBlue, textHighlightPurple, textHighlightBrown
 @docs lichen
 @docs magenta
@@ -252,6 +252,13 @@ highlightYellow =
 
 {-| See <https://noredink-ui.netlify.com/#category/Colors>
 -}
+highlightYellowLightest : Css.Color
+highlightYellowLightest =
+    hex "#fffdf5"
+
+
+{-| See <https://noredink-ui.netlify.com/#category/Colors>
+-}
 highlightYellowDark : Css.Color
 highlightYellowDark =
     hex "#795d01"
@@ -269,6 +276,13 @@ textHighlightYellow =
 highlightCyan : Css.Color
 highlightCyan =
     hex "#9BFFF4"
+
+
+{-| See <https://noredink-ui.netlify.com/#category/Colors>
+-}
+highlightCyanLightest : Css.Color
+highlightCyanLightest =
+    hex "#f5fffe"
 
 
 {-| See <https://noredink-ui.netlify.com/#category/Colors>
@@ -294,6 +308,13 @@ highlightMagenta =
 
 {-| See <https://noredink-ui.netlify.com/#category/Colors>
 -}
+highlightMagentaLightest : Css.Color
+highlightMagentaLightest =
+    hex "#fff8fe"
+
+
+{-| See <https://noredink-ui.netlify.com/#category/Colors>
+-}
 highlightMagentaDark : Css.Color
 highlightMagentaDark =
     hex "#a30088"
@@ -311,6 +332,13 @@ textHighlightMagenta =
 highlightGreen : Css.Color
 highlightGreen =
     hex "#8fffb3"
+
+
+{-| See <https://noredink-ui.netlify.com/#category/Colors>
+-}
+highlightGreenLightest : Css.Color
+highlightGreenLightest =
+    hex "#f4fff7"
 
 
 {-| See <https://noredink-ui.netlify.com/#category/Colors>
@@ -336,6 +364,13 @@ highlightBlue =
 
 {-| See <https://noredink-ui.netlify.com/#category/Colors>
 -}
+highlightBlueLightest : Css.Color
+highlightBlueLightest =
+    hex "#fafcff"
+
+
+{-| See <https://noredink-ui.netlify.com/#category/Colors>
+-}
 highlightBlueDark : Css.Color
 highlightBlueDark =
     hex "#002e85"
@@ -357,6 +392,13 @@ highlightPurple =
 
 {-| See <https://noredink-ui.netlify.com/#category/Colors>
 -}
+highlightPurpleLightest : Css.Color
+highlightPurpleLightest =
+    hex "#fcfbff"
+
+
+{-| See <https://noredink-ui.netlify.com/#category/Colors>
+-}
 highlightPurpleDark : Css.Color
 highlightPurpleDark =
     hex "#3c00bd"
@@ -374,6 +416,13 @@ textHighlightPurple =
 highlightBrown : Css.Color
 highlightBrown =
     hex "#ffc6a1"
+
+
+{-| See <https://noredink-ui.netlify.com/#category/Colors>
+-}
+highlightBrownLightest : Css.Color
+highlightBrownLightest =
+    hex "#fff9f6"
 
 
 {-| See <https://noredink-ui.netlify.com/#category/Colors>


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Part of QUO-219.

Add new "lightest" variant for highlight background colors as specified in the Linear ticket linked above. These will be used for color-coded UI elements in the short response GD UI.


## :framed_picture: What does this change look like?

<img width="1526" alt="Screenshot 2023-11-28 at 17 32 23" src="https://github.com/NoRedInk/noredink-ui/assets/753421/d3a3b957-8cc6-4d8a-8f06-33abc24d1267">

## Component completion checklist

- [X] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [X] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [X] Changes extend to the Component Catalog
  - [X] The Component Catalog is updated to use the newest version, if appropriate
  - [X] The Component Catalog example version number is updated, if appropriate
  - [X] Any new customizations are available from the Component Catalog
  - [X] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [X] Changes to the component are tested/the new version of the component is tested
- [X] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [X] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
