### PR TITLE
bump to 27.3.0 - include new highlight colors and update sidenav lock icon

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "27.2.0",
+    "version": "27.3.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `27.3.0`

## What changes does this release include?

PRs included:
  - https://github.com/NoRedInk/noredink-ui/pull/1566, by @mandla-noredink
    - Not sure where this icon is used. May want to check with Mandla if you are verifying this!
  - https://github.com/NoRedInk/noredink-ui/pull/1568, by @juanedi
    - Should not have any impact on the site, as the new colors aren't used anywhere yet

## How has the API changed?

```
This is a MINOR change.

---- Nri.Ui.Colors.V1 - MINOR ----

    Added:
        highlightBlueLightest : Css.Color
        highlightBrownLightest : Css.Color
        highlightCyanLightest : Css.Color
        highlightGreenLightest : Css.Color
        highlightMagentaLightest : Css.Color
        highlightPurpleLightest : Css.Color
        highlightYellowLightest : Css.Color

```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).