### PR TITLE
Bump noredink-ui to 27.4.0 to include Block API ReadAloud

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "27.3.0",
+    "version": "27.4.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `27.4.0`

## What changes does this release include?

- #1567

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```
This is a MINOR change.

---- Nri.Ui.Block.V6 - MINOR ----

    Added:
        renderReadAloud :
            List.List (Nri.Ui.Block.V6.Attribute msg) -> String.String


```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).