### PR TITLE
[PHX-1112] Bump up Tip QuestionBox `minHeight` so character always fits

### DIFF
--- a/src/Nri/Ui/QuestionBox/V6.elm
+++ b/src/Nri/Ui/QuestionBox/V6.elm
@@ -295,18 +295,19 @@ viewContainer config =
             , Css.displayFlex
             , Css.property "gap" "30px"
             , Css.flexDirection Css.column
-
-            -- Approximately one line of text
-            , Css.minHeight (Css.px 53)
             , case config.theme of
                 Tip ->
                     Css.batch
-                        [ Css.padding2 (Css.px 15) (Css.px 25)
+                        [ -- Enough space that the character circle fits in the box
+                          Css.minHeight (Css.px 80)
+                        , Css.padding2 (Css.px 15) (Css.px 25)
                         ]
 
                 _ ->
                     Css.batch
-                        [ Css.borderLeft3 (Css.px 1) Css.solid Colors.gray85
+                        [ -- Approximately one line of text
+                          Css.minHeight (Css.px 53)
+                        , Css.borderLeft3 (Css.px 1) Css.solid Colors.gray85
                         , Css.borderTop3 (Css.px 1) Css.solid Colors.gray85
                         , Css.borderRight3 (Css.px 1) Css.solid Colors.gray85
                         , Css.borderTopLeftRadius (Css.px borderRounding)

--- a/src/Nri/Ui/QuestionBox/V6.elm
+++ b/src/Nri/Ui/QuestionBox/V6.elm
@@ -13,6 +13,7 @@ module Nri.Ui.QuestionBox.V6 exposing
 
   - Background color in Tip theme changed from white to sunshine yellow
   - added html function
+  - Increase `minHeight` for tip question box so character fits
 
 Changes from V5:
 


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

[PHX-1112](https://linear.app/noredink/issue/PHX-1112/character-overflows-tip-message-box-with-only-one-line-of-text)

## :framed_picture: What does this change look like?

| Before | After |
| --- | --- |
| <img width="495" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/12899207/a91fc36a-8541-4b34-9f72-40d4cbe6c527"> | <img width="460" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/12899207/25d8ce19-5eeb-47c9-8347-73ddd6749ca2"> |
| <img width="474" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/12899207/c7774e3f-a9c2-4eda-9b2e-4e78e129b2d5"> | <img width="475" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/12899207/ec3a572f-394f-4308-ac67-9c0ddfda23bc"> |
| <img width="474" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/12899207/5599c7e8-e13e-400d-ae3e-669a351762d5"> | <img width="470" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/12899207/f4edd070-9d0a-4fc6-b4ec-7bc89d8b3216"> |

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
