### PR TITLE
bump patch change for circular AssignmentIcon

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "27.4.0",
+    "version": "27.4.1",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION


# :label: Bump for version `27.4.1` 

## What changes does this release include?

Updates `AssignmentIcon` to use `<circle>` instead of `<path>` elements #1575

## How has the API changed?

```
No API changes detected, so this is a PATCH change.
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).