### PR TITLE
V2s for focusloop

### DIFF
--- a/src/Nri/Ui/FocusLoop/InternalV2.elm
+++ b/src/Nri/Ui/FocusLoop/InternalV2.elm
@@ -1,0 +1,100 @@
+module Nri.Ui.FocusLoop.InternalV2 exposing (..)
+
+import Accessibility.Styled.Key as Key
+
+
+keyEvents :
+    { config
+        | focus : a -> msg
+        , leftRight : Bool
+        , upDown : Bool
+    }
+    -> ( Maybe a, Maybe a )
+    -> List (Key.Event msg)
+keyEvents config ( maybePrevious, maybeNext ) =
+    let
+        leftRightEvents =
+            if config.leftRight then
+                List.filterMap identity
+                    [ Maybe.map (\next -> Key.right (config.focus next)) maybeNext
+                    , Maybe.map (\prev -> Key.left (config.focus prev)) maybePrevious
+                    ]
+
+            else
+                []
+
+        upDownEvents =
+            if config.upDown then
+                List.filterMap identity
+                    [ Maybe.map (\next -> Key.down (config.focus next)) maybeNext
+                    , Maybe.map (\prev -> Key.up (config.focus prev)) maybePrevious
+                    ]
+
+            else
+                []
+    in
+    leftRightEvents ++ upDownEvents
+
+
+siblings : Bool -> List a -> List ( a, ( Maybe a, Maybe a ) )
+siblings wrappable items =
+    let
+        previousItems =
+            finalItem :: List.map Just items
+
+        finalItem =
+            List.head (List.reverse items)
+
+        init =
+            ( List.head items, [] )
+    in
+    case items of
+        [] ->
+            []
+
+        singleton :: [] ->
+            [ ( singleton, ( Nothing, Nothing ) ) ]
+
+        _ ->
+            if wrappable then
+                List.map2 Tuple.pair previousItems items
+                    |> List.foldr
+                        (\( previousId, item ) ( nextId, acc ) ->
+                            ( Just item
+                            , ( item, Tuple.pair previousId nextId ) :: acc
+                            )
+                        )
+                        init
+                    |> Tuple.second
+
+            else
+                List.map2 Tuple.pair previousItems items
+                    |> List.foldr
+                        (\( previousId, item ) ( nextId, acc ) ->
+                            let
+                                nextIsFirst =
+                                    Tuple.first init == nextId
+
+                                previousIsFinal =
+                                    previousId == finalItem
+
+                                previous =
+                                    if previousIsFinal then
+                                        Nothing
+
+                                    else
+                                        previousId
+
+                                next =
+                                    if nextIsFirst then
+                                        Nothing
+
+                                    else
+                                        nextId
+                            in
+                            ( Just item
+                            , ( item, Tuple.pair previous next ) :: acc
+                            )
+                        )
+                        init
+                    |> Tuple.second

--- a/src/Nri/Ui/FocusLoop/Lazy/V2.elm
+++ b/src/Nri/Ui/FocusLoop/Lazy/V2.elm
@@ -1,0 +1,332 @@
+module Nri.Ui.FocusLoop.Lazy.V2 exposing (..)
+
+{-| Like FocusLoop, but with lazy rendering. Prefer this when the set of items can change.
+
+@docs lazy, lazy2, lazy3, lazy4, lazy5
+
+-}
+
+import Accessibility.Styled exposing (Html)
+import Accessibility.Styled.Key as Key
+import Html.Styled.Lazy as Lazy
+import Nri.Ui.FocusLoop.Internal exposing (keyEvents, siblings)
+
+
+{-| Lazy version of FocusLoop.view
+
+As the name suggests, this function uses Html.Lazy.lazy to render your `view` function.
+
+There are special considerations to take into account when using this or the laziness will
+not actually work. It is very easy to get this wrong or to accidentally break it, so please
+read the following carefully.
+
+This function MUST be called with with a configuration and assigned to a TOP-LEVEL CONSTANT.
+
+Specifically, this works:
+
+    viewFocusLoop : List item -> List ( String, Html msg )
+    viewFocusLoop =
+        FocusLoop.lazy
+            { toId = .id
+            , focus = Focus
+            , view = \arrowKeyHandlers item -> ...
+            , leftRight = True
+            , upDown = True
+            }
+
+This does NOT work:
+
+    viewFocusLoop : List item -> List ( String, Html msg )
+    viewFocusLoop items =
+        FocusLoop.lazy
+            { toId = .id
+            , focus = Focus
+            , view = \arrowKeyHandlers item -> ...
+            , leftRight = True
+            , upDown = True
+            }
+            items
+
+Further, the same considerations you would take for `Html.Lazy.lazyN` apply
+to the `item`s passed to this function. That is primitives are checked by value
+and everything else is checked by reference, see <https://guide.elm-lang.org/optimization/lazy>
+
+Crucially, this means that you cannot use records or instances of custom types that do not exist
+on the model (such that the same reference will be passed on each render). Or put into inverse
+terms, you may not pass records or custom types that are instantiated in the view.
+
+Consider the following example using Tooltips. Knowing that we must assign the result of
+`FocusLoop.lazy` to a top-level constant, we might try the following:
+
+    type alias Model =
+        { activeTooltip : Maybe Tooltip
+        , items : List Item
+        }
+
+    type Tooltip
+        = ItemTooltip ItemId
+
+    type alias Item =
+        { id : ItemId
+        }
+
+    view : Model -> Html msg
+    view model =
+        div []
+            [ viewFocusLoop
+                (List.map
+                    (\item ->
+                        { item = item
+                        , tooltipOpen = model.activeTooltip == Just (ItemTooltip item.id)
+                        }
+                    )
+                    model.items
+                )
+            ]
+
+    viewFocusLoop : List { item, tooltipOpen } -> List ( String, Html msg )
+    viewFocusLoop =
+        FocusLoop.lazy
+            { toId = .item.id
+            , focus = Focus
+            , view = \arrowKeyHandlers { item, tooltipOpen } -> ...
+            , leftRight = True
+            , upDown = True
+            }
+
+However this will not work, because in the List.map call we are instantiating
+a new anonymous record, and thus a new reference, on each call to view.
+
+In this case, you will need to use one of the other FocusLoop.lazy functions. To follow
+this thread, see the example for FocusLoop.lazy2.
+
+-}
+lazy :
+    { toId : item -> String
+    , focus : String -> msg
+    , view : List (Key.Event msg) -> item -> Html msg
+    , leftRight : Bool
+    , upDown : Bool
+    , wrappable : Bool
+    }
+    -> List item
+    -> List ( String, Html msg )
+lazy config =
+    lazyHelp Lazy.lazy3
+        apply
+        identity
+        { apply = apply
+        , toId = config.toId
+        , focus = config.focus
+        , view = config.view
+        , leftRight = config.leftRight
+        , upDown = config.upDown
+        , wrappable = config.wrappable
+        }
+
+
+{-| Like FocusLoop.lazy, but with 2 arguments to your view function.
+
+Picking up from the usage example for FocusLoop.lazy, we can use this function to
+use Html.Lazy.lazy2 (actually Html.Lazy.lazy4, but the first two arguments are used
+by FocusLoop.lazy2 itself!) to check on individual arguments.
+
+Because the restriction regarding assigning to a top-level constant still applies,
+our mapping side is the same as before:
+
+    view : Model -> Html msg
+    view model =
+        div []
+            [ viewFocusLoop
+                (List.map
+                    (\item ->
+                        { item = item
+                        , tooltipOpen = model.activeTooltip == Just (ItemTooltip item.id)
+                        }
+                    )
+                    model.items
+                )
+            ]
+
+But for our `viewFocusLoop` function we will use `lazy2` and supply an additional `apply`
+in the configuration to extract our arguments:
+
+    FocusLoop.lazy2
+        { apply = \f { item, tooltipOpen } -> f item tooltipOpen
+        , ...
+        }
+
+You can think of `f` in this function as being the `view` function passed to `Html.Lazy.lazy2`.
+
+i.e.
+
+                        -- vvv This lambda is `f` in the above example. vvv --
+    Html.Lazy.lazy2 <|              \item tooltipOpen -> ...
+
+For a more in-depth example, see UsageExamples/FocusLoop in the component catalog.
+
+-}
+lazy2 :
+    { apply : (a -> b -> Args2 a b) -> item -> Args2 a b
+    , toId : item -> String
+    , focus : String -> msg
+    , view : List (Key.Event msg) -> a -> b -> Html msg
+    , leftRight : Bool
+    , upDown : Bool
+    , wrappable : Bool
+    }
+    -> List item
+    -> List ( String, Html msg )
+lazy2 =
+    lazyHelp Lazy.lazy4 apply2 Args2
+
+
+{-| Like FocusLoop.lazy, but with 3 arguments to your view function.
+
+See lazy and lazy2 usage example for more details.
+
+-}
+lazy3 :
+    { apply : (a -> b -> c -> Args3 a b c) -> item -> Args3 a b c
+    , toId : item -> String
+    , focus : String -> msg
+    , view : List (Key.Event msg) -> a -> b -> c -> Html msg
+    , leftRight : Bool
+    , upDown : Bool
+    , wrappable : Bool
+    }
+    -> List item
+    -> List ( String, Html msg )
+lazy3 =
+    lazyHelp Lazy.lazy5 apply3 Args3
+
+
+{-| Like FocusLoop.lazy, but with 4 arguments to your view function.
+
+See lazy and lazy2 usage example for more details.
+
+-}
+lazy4 :
+    { apply : (a -> b -> c -> d -> Args4 a b c d) -> item -> Args4 a b c d
+    , toId : item -> String
+    , focus : String -> msg
+    , view : List (Key.Event msg) -> a -> b -> c -> d -> Html msg
+    , leftRight : Bool
+    , upDown : Bool
+    , wrappable : Bool
+    }
+    -> List item
+    -> List ( String, Html msg )
+lazy4 =
+    lazyHelp Lazy.lazy6 apply4 Args4
+
+
+{-| Like FocusLoop.lazy, but with 5 arguments to your view function.
+
+See lazy and lazy2 usage example for more details.
+
+-}
+lazy5 :
+    { apply : (a -> b -> c -> d -> e -> Args5 a b c d e) -> item -> Args5 a b c d e
+    , toId : item -> String
+    , focus : String -> msg
+    , view : List (Key.Event msg) -> a -> b -> c -> d -> e -> Html msg
+    , leftRight : Bool
+    , upDown : Bool
+    , wrappable : Bool
+    }
+    -> List item
+    -> List ( String, Html msg )
+lazy5 =
+    lazyHelp Lazy.lazy7 apply5 Args5
+
+
+lazyHelp :
+    ((String -> String -> toView) -> String -> String -> toView)
+    -> (toView -> args -> Html msg)
+    -> toArgs
+    ->
+        { config
+            | view : List (Key.Event msg) -> toView
+            , toId : item -> String
+            , focus : String -> msg
+            , leftRight : Bool
+            , upDown : Bool
+            , apply : toArgs -> item -> args
+            , wrappable : Bool
+        }
+    -> List item
+    -> List ( String, Html msg )
+lazyHelp lazyN applyView toArgs config items =
+    -- This has to be point-free, adding an `items` arg will break lazy.
+    let
+        -- Don't inline this, lazy will not work if passed an anonymous function.
+        view prevId nextId =
+            config.view
+                (case ( prevId, nextId ) of
+                    ( "", "" ) ->
+                        []
+
+                    _ ->
+                        keyEvents config ( Just prevId, Just nextId )
+                )
+    in
+    siblings config.wrappable items
+        |> List.map
+            (\( item, ( maybePrevious, maybeNext ) ) ->
+                let
+                    ( prevId, nextId ) =
+                        Tuple.mapBoth
+                            (Maybe.map config.toId >> Maybe.withDefault "")
+                            (Maybe.map config.toId >> Maybe.withDefault "")
+                            ( maybePrevious, maybeNext )
+
+                    -- We have to use empty strings here instead of maybes
+                    -- so that lazy will check by value instead of by reference.
+                    -- |> Maybe.withDefault ( "", "" )
+                in
+                ( config.toId item
+                , applyView (lazyN view prevId nextId) (config.apply toArgs item)
+                )
+            )
+
+
+type Args2 a1 a2
+    = Args2 a1 a2
+
+
+type Args3 a1 a2 a3
+    = Args3 a1 a2 a3
+
+
+type Args4 a1 a2 a3 a4
+    = Args4 a1 a2 a3 a4
+
+
+type Args5 a1 a2 a3 a4 a5
+    = Args5 a1 a2 a3 a4 a5
+
+
+apply : (a -> b) -> a -> b
+apply f a =
+    f a
+
+
+apply2 : (a -> b -> c) -> Args2 a b -> c
+apply2 f (Args2 a b) =
+    f a b
+
+
+apply3 : (a -> b -> c -> d) -> Args3 a b c -> d
+apply3 f (Args3 a b c) =
+    f a b c
+
+
+apply4 : (a -> b -> c -> d -> e) -> Args4 a b c d -> e
+apply4 f (Args4 a b c d) =
+    f a b c d
+
+
+apply5 : (a -> b -> c -> d -> e -> f) -> Args5 a b c d e -> f
+apply5 f (Args5 a b c d e) =
+    f a b c d e

--- a/src/Nri/Ui/FocusLoop/V2.elm
+++ b/src/Nri/Ui/FocusLoop/V2.elm
@@ -1,0 +1,72 @@
+module Nri.Ui.FocusLoop.V2 exposing (..)
+
+{-| Sometimes, there are sets of interactive elements that we want users to be able to navigate
+through with arrow keys rather than with tabs, and we want the final focus change to wrap.
+This module makes it easier to set up this focus and wrapping behavior.
+
+@docs view, addEvents
+
+-}
+
+import Accessibility.Styled exposing (Html)
+import Accessibility.Styled.Key as Key
+import Nri.Ui.FocusLoop.Internal exposing (keyEvents, siblings)
+
+
+{-| Helper for creating a list of elements with looping arrow-key navigation.
+
+Your `view` function will be called for each item with the corresponding keyboard
+event handlers, as well as the item itself.
+
+e.g.
+
+    FocusLoop.view
+        { id = .id
+        , focus = Focus
+        , leftRight = True
+        , upDown = True
+        , view = viewFocusableItem
+        }
+        [ { id = 1, name = "Foo" } ]
+
+    viewFocusableItem item arrowKeyHandlers =
+        div
+            [ Key.onKeyDownPreventDefault arrowKeyHandlers ]
+            [ text item.name ]
+
+Does your list support adding and removing items? If so, check out `FocusLoop.Lazy` which
+will prevent recalculation of event handlers for every item when the list changes.
+
+-}
+view :
+    { toId : item -> id
+    , focus : id -> msg
+    , view : List (Key.Event msg) -> item -> Html msg
+    , leftRight : Bool
+    , upDown : Bool
+    , wrappable : Bool
+    }
+    -> List item
+    -> List (Html msg)
+view config items =
+    siblings config.wrappable items
+        |> List.map
+            (\( item, ( maybePrevious, maybeNext ) ) ->
+                config.view
+                    (keyEvents config ( Maybe.map config.toId maybePrevious, Maybe.map config.toId maybeNext ))
+                    item
+            )
+
+
+{-| Zip a list of items with its corresponding keyboard events.
+-}
+addEvents :
+    { focus : a -> msg
+    , leftRight : Bool
+    , upDown : Bool
+    , wrappable : Bool
+    }
+    -> List a
+    -> List ( a, List (Key.Event msg) )
+addEvents config items =
+    siblings config.wrappable items |> List.map (Tuple.mapSecond (keyEvents config))


### PR DESCRIPTION
Please use the template that's relevant for your situation and delete the other templates. If this is just a noredink-ui repo doc change, you don't need to follow a template.

# :label: Bump for version `VERSION_NUMBER`

## What changes does this release include?

The easiest and most reliable way to find the changes that this release includes is to go through the changes between the last version number and master: `https://github.com/NoRedInk/noredink-ui/compare/VERSION_NUMBER...master`.

Include links to the relevant PRs in a list in this PR. Be sure to note any risky changes or changes that you will want to alert QA to when upgrading to the new version of noredink-ui.

Please update the PR's name to include a quick note about every linked PR.

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```

```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).

---

# :star2: Adding a new component

## About the component

What is the purpose of the new component? When and where will it be used? How will the reviewer know if this component meets the success criteria?

Please link to any relevant context and stories.

## :framed_picture: What does this change look like?

- If there are user facing changes, you will be asked later to add a designer as a reviewer. Please fill in this section by following [the guidelines for an optimal design review](https://paper.dropbox.com/doc/Guidelines-for-Sharing-User-Facing-Changes-with-Design--BpL8hpJLMugy6033aT5m0JdaAg-bdKGQtYH9qO9I00hUkA6k).
- If there are not user facing changes, include any screenshots or videos that would be helpful to reviewers.

## Component completion checklist

- [ ] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with this component in mind
- [ ] Component has clear documentation
- [ ] Component is in the Component Catalog
  - [ ] Component is categorized reasonably (see [Category](https://github.com/NoRedInk/noredink-ui/blob/master/component-catalog-app/Category.elm) for all the currently available categories). The component can be in multiple categories, if appropriate.
  - [ ] Component has a representative preview for the Component Catalog cards (bonus points for making it delightful!)
  - [ ] Component has a customizable example. Aim for having _every_ possible supported version of the component displayable through the configuration on this page. (Protip: This is handy for testing expected behavior!)
  - [ ] The customizable example produces sample code
  - [ ] The component's example page includes keyboard behavior, if any
  - [ ] The component's example page includes guidance around how to use the component, if necessary
- [ ] Component is tested
  - axe checks and percy snapshots will be automatically added for every component. However, if you want to customize _when_ the checks and snapshots are made, you will need to make changes to [script/puppeteer-tests.js](https://github.com/NoRedInk/noredink-ui/blob/master/script/puppeteer-tests.js).
  - there are 2 ways to add Elm tests:
    - if you want to test the Component Catalog example directly, add ProgramTest-style tests under `component-catalog/tests`
    - if you want to test the component directly, add tests under `tests/Spec`. Historically, this has been the more popular Elm testing strategy for noredink-ui.
- [ ] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [ ] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [ ] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [ ]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [ ]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [ ]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)

---

# :wrench: Modifying a component

## Context

Please link to any relevant context and stories.

## :framed_picture: What does this change look like?

- If there are user facing changes, you will be asked later to add a designer as a reviewer. Please fill in this section by following [the guidelines for an optimal design review](https://paper.dropbox.com/doc/Guidelines-for-Sharing-User-Facing-Changes-with-Design--BpL8hpJLMugy6033aT5m0JdaAg-bdKGQtYH9qO9I00hUkA6k).
- If there are not user facing changes, include any screenshots or videos that would be helpful to reviewers.

## Component completion checklist

- [ ] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [ ] Changes are clearly documented
  - [ ] Component docs include a changelog
  - [ ] Any new exposed functions or properties have docs
- [ ] Changes extend to the Component Catalog
  - [ ] The Component Catalog is updated to use the newest version, if appropriate
  - [ ] The Component Catalog example version number is updated, if appropriate
  - [ ] Any new customizations are available from the Component Catalog
  - [ ] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [ ] Changes to the component are tested/the new version of the component is tested
- [ ] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [ ] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [ ] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [ ] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [ ]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [ ]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [ ]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
