### PR TITLE
[PHX-1317] Ensure a consistent experience for Nri.Block for Screen Readers

### DIFF
--- a/component-catalog/src/Examples/UiIcon.elm
+++ b/component-catalog/src/Examples/UiIcon.elm
@@ -197,7 +197,7 @@ all =
         , ( "star", UiIcon.star, [] )
         , ( "starFilled", UiIcon.starFilled, [] )
         , ( "starOutline", UiIcon.starOutline, [] )
-        , ( "no", UiIcon.no, [])
+        , ( "no", UiIcon.no, [] )
         ]
       )
     , ( "Badges & Celebration"

--- a/src/Nri/Ui/Mark/V5.elm
+++ b/src/Nri/Ui/Mark/V5.elm
@@ -10,6 +10,7 @@ module Nri.Ui.Mark.V5 exposing
 ### Patch changes:
 
     - Fix line-height for spacer element reducing the amount of vertical space consumed by the balloons
+    - Fix SR experience for <mark> tags
 
 
 ### Changes from V4
@@ -23,6 +24,7 @@ module Nri.Ui.Mark.V5 exposing
 -}
 
 import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Role as Role
 import Accessibility.Styled.Style exposing (invisibleStyle)
 import Content
 import Css exposing (Color, Style)
@@ -279,9 +281,9 @@ viewMarkedByBalloon :
     -> Html msg
 viewMarkedByBalloon config markedWith segments =
     Html.mark
-        [ markedWith.name
-            |> Maybe.map (\name -> Aria.roleDescription (stripMarkdownSyntax name ++ " highlight"))
-            |> Maybe.withDefault AttributesExtra.none
+        [ -- Drop the `mark` role as various screen readers interpret it differently.
+          -- Instead we offer additional invisible and accessible content to denote the highlight.
+          Role.presentation
         , css [ Css.backgroundColor Css.transparent, Css.position Css.relative ]
         ]
         -- the balloon should never end up on a line by itself, so we put it in the DOM
@@ -301,9 +303,9 @@ viewMarkedByBalloon config markedWith segments =
 viewMarked : TagStyle -> Mark -> List (Html msg) -> Html msg
 viewMarked tagStyle markedWith segments =
     Html.mark
-        [ markedWith.name
-            |> Maybe.map (\name -> Aria.roleDescription (stripMarkdownSyntax name ++ " highlight"))
-            |> Maybe.withDefault AttributesExtra.none
+        [ -- Drop the `mark` role as various screen readers interpret it differently.
+          -- Instead we offer additional invisible and accessible content to denote the highlight.
+          Role.presentation
         , css
             [ Css.backgroundColor Css.transparent
             , Css.Global.children

--- a/tests/Spec/Nri/Ui/Block.elm
+++ b/tests/Spec/Nri/Ui/Block.elm
@@ -128,9 +128,6 @@ labelMarkdownSpec =
                     -- should not include markdown (e.g., no asterisks)
                     , hasBefore "start This is markdown" "Hello"
                     , hasAfter "end This is markdown" "there"
-
-                    -- The roledescription should also not include markdown special characters
-                    , Query.has [ Selector.attribute (Aria.roleDescription "This is markdown highlight") ]
                     ]
     ]
 


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Screen readers differ on how the read `<mark>` tags.   In some cases this lead to the browser saying "highlight" more than once - and in some cases even saying it after **every single word** in a display element block!  See Charbel's detailed analysis in the Slack link below.  

This PR standardizes the experience of Nri.Block for SR users by adding the `presentation` role to the `<mark>` element.  We also remove the `aria-roledescription` attributes for the case of labels.  This is ok as we add the the label text to the `::before` and `::after` contents.

[Slack Thread](https://noredink.slack.com/archives/C02NVG4M45U/p1702070670902059)

[PHX-1317 Ensure consistent experience for Nri.Block for Screen Readers](https://linear.app/noredink/issue/PHX-1317/fix-a11y-in-nriuiblock)

## :framed_picture: What does this change look like?

- If there are user facing changes, you will be asked later to add a designer as a reviewer. Please fill in this section by following [the guidelines for an optimal design review](https://paper.dropbox.com/doc/Guidelines-for-Sharing-User-Facing-Changes-with-Design--BpL8hpJLMugy6033aT5m0JdaAg-bdKGQtYH9qO9I00hUkA6k).
- If there are not user facing changes, include any screenshots or videos that would be helpful to reviewers.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
