### PR TITLE
Add underline option to block

### DIFF
--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -579,6 +579,7 @@ initControl : Control Settings
 initControl =
     ControlExtra.list
         |> ControlExtra.optionalListItemDefaultChecked "content" controlContent
+        |> ControlExtra.optionalListItemDefaultChecked "borderStyle" borderStyleContent
         |> ControlExtra.optionalBoolListItemDefaultChecked "emphasize" ( Code.fromModule moduleName "emphasize", Block.emphasize )
         |> ControlExtra.optionalListItem "label"
             (CommonControls.string ( Code.fromModule moduleName "label", Block.label ) "Fruit")
@@ -648,6 +649,16 @@ controlContent =
         , blankType ( "blank", Block.blank )
         ]
 
+borderStyleContent : Control ( String, Block.Attribute msg )
+borderStyleContent =
+    Control.choice
+        [ ( "Dashed"
+          , Control.value ( "Dashed", Block.dashed )
+          )
+        , ( "Underline"
+          , Control.value ( "Underline", Block.underline )
+          )
+        ]
 
 blankType : ( String, { widthInChars : Int } -> Block.Content msg ) -> ( String, Control ( String, Block.Attribute msg ) )
 blankType ( typeStr, blank ) =

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -649,6 +649,7 @@ controlContent =
         , blankType ( "blank", Block.blank )
         ]
 
+
 borderStyleContent : Control ( String, Block.Attribute msg )
 borderStyleContent =
     Control.choice
@@ -659,6 +660,7 @@ borderStyleContent =
           , Control.value ( "Underline", Block.underline )
           )
         ]
+
 
 blankType : ( String, { widthInChars : Int } -> Block.Content msg ) -> ( String, Control ( String, Block.Attribute msg ) )
 blankType ( typeStr, blank ) =

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -654,10 +654,10 @@ borderStyleContent : Control ( String, Block.Attribute msg )
 borderStyleContent =
     Control.choice
         [ ( "Dashed"
-          , Control.value ( "Dashed", Block.dashed )
+          , Control.value ( "Block.dashed", Block.dashed )
           )
         , ( "Underline"
-          , Control.value ( "Underline", Block.underline )
+          , Control.value ( "Block.underline", Block.underline )
           )
         ]
 

--- a/src/Nri/Ui/Block/V6.elm
+++ b/src/Nri/Ui/Block/V6.elm
@@ -24,7 +24,7 @@ module Nri.Ui.Block.V6 exposing
 
 ## Patch changes
 
-    Add renderReadAloud
+    Add border styles `dashed` and `underline`
 
 @docs view, renderReadAloud, Attribute
 

--- a/src/Nri/Ui/Block/V6.elm
+++ b/src/Nri/Ui/Block/V6.elm
@@ -24,6 +24,7 @@ module Nri.Ui.Block.V6 exposing
 
 ## Patch changes
 
+    Add renderReadAloud
     Add border styles `dashed` and `underline`
 
 @docs view, renderReadAloud, Attribute


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

The goal of this PR is to allow a style for block content that shows an underline when desired.

Related to QUO-325

## :framed_picture: What does this change look like?

When `Block.underline` is passed into the attributes:

<img width="346" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/32229300/798224c5-9bdd-4e42-ae5d-aeb39042ec1c">

When `Block.dashed` is passed in, or no border style attribute is passed in:

<img width="315" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/32229300/7bf6a5b6-6d73-43f7-811f-6c9385e666f1">


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
