### PR TITLE
[PHX-1315] Bump to 27.6.0 to include Tooltip stop propagation

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "27.5.0",
+    "version": "27.6.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `27.6.0`

## What changes does this release include?

- #1584

## How has the API changed?

```
---- Nri.Ui.Tooltip.V3 - MINOR ----

    Added:
        stopTooltipMousePropagation : msg -> Nri.Ui.Tooltip.V3.Attribute msg
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).