### PR TITLE
Release new styling options for block

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "27.6.0",
+    "version": "27.7.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
Releasing the new options for styling a block.

# :label: Bump for version `27.7.0`

## What changes does this release include?

#1582 

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```
This is a MINOR change.

---- Nri.Ui.Block.V6 - MINOR ----

    Added:
        dashed : Nri.Ui.Block.V6.Attribute msg
        underline : Nri.Ui.Block.V6.Attribute msg
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).
