### PR TITLE
Correctly display a transparent background for underline blanks

### DIFF
--- a/src/Nri/Ui/Block/V6.elm
+++ b/src/Nri/Ui/Block/V6.elm
@@ -26,6 +26,7 @@ module Nri.Ui.Block.V6 exposing
 
     Add renderReadAloud
     Add border styles `dashed` and `underline`
+    Correctly display a transparent background for underline blanks
 
 @docs view, renderReadAloud, Attribute
 
@@ -737,12 +738,19 @@ viewBlank borderStyle blankHeight (CharacterWidth width) =
                     Css.border3 (Css.px 2) Css.dashed Colors.navy
 
                 Underline ->
-                    Css.borderBottom3 (Css.px 2) Css.solid Colors.navy
+                    Css.borderBottom2 (Css.px 2) Css.solid
             , MediaQuery.highContrastMode
                 [ Css.property "border-color" "CanvasText"
                 , Css.property "background-color" "Canvas"
                 ]
-            , Css.backgroundColor Colors.white
+            , Css.backgroundColor
+                (case borderStyle of
+                    Dashed ->
+                        Colors.white
+
+                    Underline ->
+                        Css.rgba 0 0 0 0
+                )
             , Css.width <| Css.em (min 30 <| max 0.83 (toFloat width * 0.5))
             , Css.display Css.inlineBlock
             , Css.borderRadius

--- a/src/Nri/Ui/Block/V6.elm
+++ b/src/Nri/Ui/Block/V6.elm
@@ -24,9 +24,9 @@ module Nri.Ui.Block.V6 exposing
 
 ## Patch changes
 
-    Add renderReadAloud
-    Add border styles `dashed` and `underline`
-    Correctly display a transparent background for underline blanks
+    - Add renderReadAloud
+    - Add border styles `dashed` and`underline`
+    - Correctly display a transparent background for underline blanks
 
 @docs view, renderReadAloud, Attribute
 


### PR DESCRIPTION
Correctly display a transparent background for underline blanks

# :wrench: Modifying a component

## Context

The background should be transparent, not white, when showing an underlined blank.

## :framed_picture: What does this change look like?

<img width="372" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/32229300/27ee3229-266a-4399-8b00-c266c1fca9f0">

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
