### PR TITLE
A11-3900 Nri.Ui.ClickableText.V4

### DIFF
--- a/component-catalog/src/CommonControls.elm
+++ b/component-catalog/src/CommonControls.elm
@@ -39,7 +39,7 @@ import Examples.Colors
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Http
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Data.PremiumDisplay as PremiumDisplay exposing (PremiumDisplay)
 import Nri.Ui.Svg.V1 exposing (Svg)

--- a/component-catalog/src/CommonControls.elm
+++ b/component-catalog/src/CommonControls.elm
@@ -256,7 +256,6 @@ exampleHtml =
         [ Html.text "darkness of the movie house " ]
     , Html.text "I had only two things on my mind: Paul Newman, and a ride home."
     ]
-    
 
 
 icon :

--- a/component-catalog/src/CommonControls.elm
+++ b/component-catalog/src/CommonControls.elm
@@ -246,8 +246,7 @@ exampleHtml =
     , Html.strong [] [ Html.text "bolded phrase" ]
     , Html.text ". "
     , ClickableText.link quickBrownFox
-        [ ClickableText.small
-        , ClickableText.icon UiIcon.starFilled
+        [ ClickableText.icon UiIcon.starFilled
         , ClickableText.href "http://www.noredink.com"
         , ClickableText.appearsInline
         ]
@@ -257,6 +256,7 @@ exampleHtml =
         [ Html.text "darkness of the movie house " ]
     , Html.text "I had only two things on my mind: Paul Newman, and a ride home."
     ]
+    
 
 
 icon :

--- a/component-catalog/src/EllieLink.elm
+++ b/component-catalog/src/EllieLink.elm
@@ -3,7 +3,7 @@ module EllieLink exposing (Config, SectionExample, view)
 import Dict exposing (Dict)
 import Html.Styled exposing (..)
 import Http
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Url.Builder
 
 

--- a/component-catalog/src/Example.elm
+++ b/component-catalog/src/Example.elm
@@ -12,7 +12,7 @@ import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Html.Styled.Lazy as Lazy
 import KeyboardSupport exposing (KeyboardSupport)
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Header.V1 as Header

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -22,7 +22,7 @@ import Html.Styled.Attributes exposing (css)
 import Markdown
 import Nri.Ui.Block.V6 as Block
 import Nri.Ui.Button.V10 as Button
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -336,7 +336,6 @@ example =
                     , ClickableText.link "Assistive Technology Announcement Center (“ATAC”)"
                         [ ClickableText.appearsInline
                         , ClickableText.linkExternal "https://paper.dropbox.com/doc/Assistive-Technology-Announcement-Center-ATAC--B_GuqwWltzU432ueq7p6Z42mAg-bOnmcnzOj631NRls1IBe3"
-                        , ClickableText.small
                         ]
                     ]
                 ]

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -26,7 +26,7 @@ import Html.Styled.Attributes as Attributes exposing (class, css)
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Carousel.V2 as Carousel exposing (Role(..))
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.FocusRing.V1 as FocusRing

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -19,7 +19,7 @@ import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Checkbox.V7 as Checkbox
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
@@ -148,7 +148,7 @@ example =
                             [ text "Be sure to read "
                             , ClickableText.link "the terms and conditions"
                                 [ ClickableText.linkExternal "https://en.wikipedia.org/wiki/Terms_of_service"
-                                , ClickableText.caption
+                                , ClickableText.small
                                 , ClickableText.appearsInline
                                 ]
                             , text " before agreeing to follow them."

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -18,7 +18,7 @@ import EllieLink
 import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Text.V6 as Text
@@ -39,12 +39,7 @@ example =
     , update = update
     , subscriptions = \_ -> Sub.none
     , preview =
-        [ ClickableText.link "Caption"
-            [ ClickableText.icon UiIcon.link
-            , ClickableText.caption
-            , ClickableText.custom [ Key.tabbable False ]
-            ]
-        , ClickableText.link "Small"
+        [ ClickableText.link "Small"
             [ ClickableText.icon UiIcon.link
             , ClickableText.small
             , ClickableText.custom [ Key.tabbable False ]
@@ -186,7 +181,6 @@ viewExamples ellieLinkConfig (State control) =
         [ Heading.plaintext "Inline ClickableText Examples"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
-    , Text.caption (inlineExample "Text.caption" ClickableText.caption)
     , Text.smallBody (inlineExample "Text.smallBody" ClickableText.small)
     , Text.mediumBody (inlineExample "Text.mediumBody" ClickableText.medium)
     ]
@@ -228,8 +222,7 @@ inlineExample textSizeName size =
 
 sizes : List ( ClickableText.Attribute msg, String )
 sizes =
-    [ ( ClickableText.caption, "caption" )
-    , ( ClickableText.small, "small" )
+    [ ( ClickableText.small, "small" )
     , ( ClickableText.medium, "medium" )
     , ( ClickableText.large, "large" )
     ]

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -181,37 +181,33 @@ viewExamples ellieLinkConfig (State control) =
         [ Heading.plaintext "Inline ClickableText Examples"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
-    , Text.smallBody (inlineExample "Text.smallBody" ClickableText.small)
-    , Text.mediumBody (inlineExample "Text.mediumBody" ClickableText.medium)
+    , Text.smallBody (inlineExample "Text.smallBody")
+    , Text.mediumBody (inlineExample "Text.mediumBody")
     ]
         |> div []
 
 
-inlineExample : String -> ClickableText.Attribute Msg -> List (Text.Attribute Msg)
-inlineExample textSizeName size =
+inlineExample : String -> List (Text.Attribute Msg)
+inlineExample textSizeName =
     [ Text.html
         [ text "Sometimes, we'll want our "
         , ClickableText.link "internal links"
             [ ClickableText.appearsInline
-            , size
             , ClickableText.href "/"
             ]
         , text ", "
         , ClickableText.link "external links"
             [ ClickableText.appearsInline
-            , size
             , ClickableText.linkExternal "https://www.google.com/search?q=puppies"
             ]
         , text ", "
         , ClickableText.button "buttons"
             [ ClickableText.appearsInline
-            , size
             , ClickableText.onClick (ShowItWorked moduleName "in-line button")
             ]
         , text " and "
         , ClickableText.button "ClickableTexts with icons"
             [ ClickableText.appearsInline
-            , size
             , ClickableText.onClick (ShowItWorked moduleName "in-line button")
             , ClickableText.icon UiIcon.starFilled
             ]

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -205,11 +205,24 @@ inlineExample textSizeName =
             [ ClickableText.appearsInline
             , ClickableText.onClick (ShowItWorked moduleName "in-line button")
             ]
-        , text " and "
-        , ClickableText.button "ClickableTexts with icons"
+        , text ", "
+        , ClickableText.button "ClickableTexts with left icons"
             [ ClickableText.appearsInline
             , ClickableText.onClick (ShowItWorked moduleName "in-line button")
             , ClickableText.icon UiIcon.starFilled
+            ]
+        , text ", "
+        , ClickableText.button "ClickableTexts with right icons"
+            [ ClickableText.appearsInline
+            , ClickableText.onClick (ShowItWorked moduleName "in-line button")
+            , ClickableText.rightIcon UiIcon.starFilled
+            ]
+        , text ", and "
+        , ClickableText.button "ClickableTexts with left and right icons"
+            [ ClickableText.appearsInline
+            , ClickableText.onClick (ShowItWorked moduleName "in-line button")
+            , ClickableText.icon UiIcon.starFilled
+            , ClickableText.rightIcon UiIcon.starFilled
             ]
         , text (" to show up in-line with " ++ textSizeName ++ " content.")
         ]

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -27,7 +27,7 @@ import Nri.Ui.UiIcon.V1 as UiIcon
 
 version : Int
 version =
-    3
+    4
 
 
 {-| -}

--- a/component-catalog/src/Examples/FocusRing.elm
+++ b/component-catalog/src/Examples/FocusRing.elm
@@ -17,7 +17,7 @@ import Nri.Ui.Accordion.V4 as Accordion exposing (AccordionEntry(..))
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Checkbox.V7 as Checkbox
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Heading.V3 as Heading

--- a/component-catalog/src/Examples/Fonts.elm
+++ b/component-catalog/src/Examples/Fonts.elm
@@ -11,7 +11,7 @@ import Css exposing (Style)
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing

--- a/component-catalog/src/Examples/Header.elm
+++ b/component-catalog/src/Examples/Header.elm
@@ -17,7 +17,7 @@ import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.BreadCrumbs.V2 as BreadCrumbs
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Header.V1 as Header
@@ -65,7 +65,7 @@ example =
                 , mainType = Just "RootHtml.Html msg"
                 , extraCode =
                     [ "import Nri.Ui.BreadCrumbs.V2 as BreadCrumbs"
-                    , "import Nri.Ui.ClickableText.V3 as ClickableText"
+                    , "import Nri.Ui.ClickableText.V4 as ClickableText"
                     ]
                 , renderExample = Code.unstyledView
                 , toExampleCode =

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -22,7 +22,7 @@ import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.Extra as ColorsExtra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
@@ -146,7 +146,7 @@ view ellieLinkConfig state =
         , extraCode =
             [ "import Nri.Ui.Button.V10 as Button"
             , "import Nri.Ui.ClickableSvg.V2 as ClickableSvg"
-            , "import Nri.Ui.ClickableText.V3 as ClickableText"
+            , "import Nri.Ui.ClickableText.V4 as ClickableText"
             , "import Nri.Ui.Tooltip.V3 as Tooltip"
             , Code.newlines
             , Code.unionType "Msg"

--- a/component-catalog/src/Examples/Message.elm
+++ b/component-catalog/src/Examples/Message.elm
@@ -276,31 +276,30 @@ viewContentTable name size =
 contentTypes :
     List
         { contentType : String
-        , content : ClickableText.Attribute msg -> Message.Attribute msg
+        , content : Message.Attribute msg
         }
 contentTypes =
     [ { contentType = "paragraph"
-      , content = \_ -> Message.paragraph "*Hello, there!* Hope you're doing well. Use the following link to go to [a fake destination](google.com)."
+      , content = Message.paragraph "*Hello, there!* Hope you're doing well. Use the following link to go to [a fake destination](google.com)."
       }
     , { contentType = "plaintext"
-      , content = \_ -> Message.plaintext "*Hello, there!* Hope you're doing well. Use the following link to go to [a fake destination](google.com)."
+      , content = Message.plaintext "*Hello, there!* Hope you're doing well. Use the following link to go to [a fake destination](google.com)."
       }
     , { contentType = "markdown"
-      , content = \_ -> Message.markdown "Hello, there! Hope you're doing well. Use the following link to go to [a fake destination](google.com)."
+      , content = Message.markdown "Hello, there! Hope you're doing well. Use the following link to go to [a fake destination](google.com)."
       }
     , { contentType = "html"
       , content =
-            \_ ->
-                Message.html
-                    [ text "Hello, there! Hope you're doing well. Use the following link to go to "
-                    , ClickableText.link "a fake destination"
-                        [ ClickableText.href "google.com"
-                        ]
-                    , text "."
+            Message.html
+                [ text "Hello, there! Hope you're doing well. Use the following link to go to "
+                , ClickableText.link "a fake destination"
+                    [ ClickableText.href "google.com"
                     ]
+                , text "."
+                ]
       }
     , { contentType = "httpError (Bad Body)"
-      , content = \_ -> Message.httpError (Http.BadBody CommonControls.badBodyString)
+      , content = Message.httpError (Http.BadBody CommonControls.badBodyString)
       }
     ]
 

--- a/component-catalog/src/Examples/Message.elm
+++ b/component-catalog/src/Examples/Message.elm
@@ -11,7 +11,7 @@ import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Guidance
 import Http
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Message.V4 as Message
@@ -222,7 +222,7 @@ example =
                 [ Heading.plaintext "Content Type Variations"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
-            , viewContentTable "Message.tiny" Message.tiny ClickableText.caption
+            , viewContentTable "Message.tiny" Message.tiny ClickableText.small
             , viewContentTable "Message.large" Message.large ClickableText.medium
             , viewContentTable "Message.banner" Message.banner ClickableText.large
             ]

--- a/component-catalog/src/Examples/Message.elm
+++ b/component-catalog/src/Examples/Message.elm
@@ -222,15 +222,15 @@ example =
                 [ Heading.plaintext "Content Type Variations"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
-            , viewContentTable "Message.tiny" Message.tiny ClickableText.small
-            , viewContentTable "Message.large" Message.large ClickableText.medium
-            , viewContentTable "Message.banner" Message.banner ClickableText.large
+            , viewContentTable "Message.tiny" Message.tiny
+            , viewContentTable "Message.large" Message.large
+            , viewContentTable "Message.banner" Message.banner
             ]
     }
 
 
-viewContentTable : String -> Message.Attribute Msg -> ClickableText.Attribute Msg -> Html Msg
-viewContentTable name size clickableTextSize =
+viewContentTable : String -> Message.Attribute Msg -> Html Msg
+viewContentTable name size =
     div []
         [ Heading.h3
             [ Heading.plaintext name
@@ -250,7 +250,7 @@ viewContentTable name size clickableTextSize =
                 }
             , Table.custom
                 { header = text "Non-dismissible view"
-                , view = \{ content } -> Message.view [ size, content clickableTextSize ]
+                , view = \{ content } -> Message.view [ size, content ]
                 , width = Css.pct 45
                 , cellStyles = always []
                 , sort = Nothing
@@ -261,7 +261,7 @@ viewContentTable name size clickableTextSize =
                     \{ content } ->
                         Message.view
                             [ size
-                            , content clickableTextSize
+                            , content
                             , Message.onDismiss Ignore
                             ]
                 , width = Css.pct 45
@@ -290,12 +290,11 @@ contentTypes =
       }
     , { contentType = "html"
       , content =
-            \clickableTextSize ->
+            \_ ->
                 Message.html
                     [ text "Hello, there! Hope you're doing well. Use the following link to go to "
                     , ClickableText.link "a fake destination"
                         [ ClickableText.href "google.com"
-                        , clickableTextSize
                         ]
                     , text "."
                     ]

--- a/component-catalog/src/Examples/Modal.elm
+++ b/component-catalog/src/Examples/Modal.elm
@@ -22,7 +22,7 @@ import Html.Styled.Attributes as Attributes exposing (css)
 import KeyboardSupport
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts

--- a/component-catalog/src/Examples/Modal.elm
+++ b/component-catalog/src/Examples/Modal.elm
@@ -358,7 +358,6 @@ fakeATAC =
                 , ClickableText.link "Assistive Technology Announcement Center (“ATAC”)"
                     [ ClickableText.appearsInline
                     , ClickableText.linkExternal "https://paper.dropbox.com/doc/Assistive-Technology-Announcement-Center-ATAC--B_GuqwWltzU432ueq7p6Z42mAg-bOnmcnzOj631NRls1IBe3"
-                    , ClickableText.small
                     ]
                 ]
             ]

--- a/component-catalog/src/Examples/Tooltip.elm
+++ b/component-catalog/src/Examples/Tooltip.elm
@@ -22,7 +22,7 @@ import KeyboardSupport exposing (Key(..))
 import Markdown
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Svg.V1 as Svg

--- a/component-catalog/src/Guidance.elm
+++ b/component-catalog/src/Guidance.elm
@@ -1,7 +1,7 @@
 module Guidance exposing (..)
 
 import Html.Styled exposing (..)
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 
 
 useATACGuide : String -> List (Html msg)

--- a/component-catalog/src/UsageExample.elm
+++ b/component-catalog/src/UsageExample.elm
@@ -9,7 +9,7 @@ import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
 import Html.Styled.Lazy as Lazy
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.MediaQuery.V1 exposing (mobile)

--- a/component-catalog/src/UsageExamples/ClickableCardWithTooltip.elm
+++ b/component-catalog/src/UsageExamples/ClickableCardWithTooltip.elm
@@ -10,7 +10,7 @@ import Category exposing (Category(..))
 import Css
 import Html.Styled exposing (Html)
 import Html.Styled.Events as Events
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.Tooltip.V3 as Tooltip

--- a/elm.json
+++ b/elm.json
@@ -25,6 +25,7 @@
         "Nri.Ui.Checkbox.V7",
         "Nri.Ui.ClickableSvg.V2",
         "Nri.Ui.ClickableText.V3",
+        "Nri.Ui.ClickableText.V4",
         "Nri.Ui.Container.V2",
         "Nri.Ui.Colors.Extra",
         "Nri.Ui.Colors.V1",

--- a/src/Nri/Ui/ClickableText/V4.elm
+++ b/src/Nri/Ui/ClickableText/V4.elm
@@ -154,6 +154,11 @@ type Kind
     | Link
 
 
+type IconPosition
+    = Left
+    | Right
+
+
 {-| -}
 icon : Svg -> Attribute msg
 icon icon_ =
@@ -481,11 +486,6 @@ viewContent config kind =
                 Large ->
                     Css.fontSize (Css.px 18)
 
-        viewIcon styles icon_ =
-            icon_
-                |> Svg.withCss styles
-                |> Svg.toHtml
-
         iconMarginRight =
             case config.size of
                 Inherited ->
@@ -514,6 +514,45 @@ viewContent config kind =
                 Large ->
                     Css.marginLeft (Css.px 4)
 
+        viewIcon position icon_ =
+            icon_
+                |> Svg.withCss
+                    ([ Css.width (Css.em 1)
+                     , Css.height (Css.em 1)
+                     , Css.position Css.relative
+                     , Css.top (Css.em 0.1)
+                     ]
+                        ++ (case position of
+                                Left ->
+                                    iconMarginRight
+                                        :: (case kind of
+                                                Button ->
+                                                    [ -- Position absolute makes the parent ignore the icon's height, preventing misalignment with other inline text
+                                                      Css.position Css.absolute
+                                                    , Css.left Css.zero
+                                                    ]
+
+                                                Link ->
+                                                    []
+                                           )
+                                        ++ config.iconStyles
+
+                                Right ->
+                                    iconMarginLeft
+                                        :: (case kind of
+                                                Button ->
+                                                    [ Css.position Css.absolute
+                                                    , Css.right Css.zero
+                                                    ]
+
+                                                Link ->
+                                                    []
+                                           )
+                                        ++ config.rightIconStyles
+                           )
+                    )
+                |> Svg.toHtml
+
         iconAndTextContainer =
             span
                 [ Attributes.css
@@ -522,6 +561,7 @@ viewContent config kind =
                                 Button ->
                                     [ Css.display Css.inlineFlex
                                     , Css.alignItems Css.center
+                                    , Css.position Css.relative
                                     ]
 
                                 Link ->
@@ -535,49 +575,58 @@ viewContent config kind =
         (case ( config.icon, config.rightIcon ) of
             ( Just leftIcon, Just rightIcon_ ) ->
                 iconAndTextContainer
-                    [ viewIcon
-                        ([ iconMarginRight
-                         , Css.width (Css.em 1)
-                         , Css.height (Css.em 1)
-                         ]
-                            ++ config.iconStyles
-                        )
-                        leftIcon
-                    , span [ ExtraAttributes.nriDescription (dataDescriptor "label") ] [ text config.label ]
-                    , viewIcon
-                        ([ iconMarginLeft
-                         , Css.width (Css.em 1)
-                         , Css.height (Css.em 1)
-                         ]
-                            ++ config.rightIconStyles
-                        )
-                        rightIcon_
+                    [ viewIcon Left leftIcon
+                    , span
+                        [ ExtraAttributes.nriDescription (dataDescriptor "label")
+                        , Attributes.css
+                            (case kind of
+                                Button ->
+                                    [ Css.paddingLeft (Css.em 1.2)
+                                    , Css.paddingRight (Css.em 1.2)
+                                    ]
+
+                                Link ->
+                                    []
+                            )
+                        ]
+                        [ text config.label ]
+                    , viewIcon Right rightIcon_
                     ]
 
             ( Just leftIcon, Nothing ) ->
                 iconAndTextContainer
-                    [ viewIcon
-                        ([ iconMarginRight
-                         , Css.width (Css.em 1)
-                         , Css.height (Css.em 1)
-                         ]
-                            ++ config.iconStyles
-                        )
-                        leftIcon
-                    , span [ ExtraAttributes.nriDescription (dataDescriptor "label") ] [ text config.label ]
+                    [ viewIcon Left leftIcon
+                    , span
+                        [ ExtraAttributes.nriDescription (dataDescriptor "label")
+                        , Attributes.css
+                            (case kind of
+                                Button ->
+                                    [ Css.paddingLeft (Css.em 1.2)
+                                    ]
+
+                                Link ->
+                                    []
+                            )
+                        ]
+                        [ text config.label ]
                     ]
 
             ( Nothing, Just rightIcon_ ) ->
                 iconAndTextContainer
-                    [ span [ ExtraAttributes.nriDescription (dataDescriptor "label") ] [ text config.label ]
-                    , viewIcon
-                        ([ iconMarginLeft
-                         , Css.width (Css.em 1)
-                         , Css.height (Css.em 1)
-                         ]
-                            ++ config.rightIconStyles
-                        )
-                        rightIcon_
+                    [ span
+                        [ ExtraAttributes.nriDescription (dataDescriptor "label")
+                        , Attributes.css
+                            (case kind of
+                                Button ->
+                                    [ Css.paddingRight (Css.em 1.2)
+                                    ]
+
+                                Link ->
+                                    []
+                            )
+                        ]
+                        [ text config.label ]
+                    , viewIcon Right rightIcon_
                     ]
 
             ( Nothing, Nothing ) ->

--- a/src/Nri/Ui/ClickableText/V4.elm
+++ b/src/Nri/Ui/ClickableText/V4.elm
@@ -98,6 +98,7 @@ import Html.Styled.Attributes as Attributes
 import Nri.Ui
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.FocusRing.V1 as FocusRing
+import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
 import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
@@ -527,8 +528,8 @@ clickableTextSharedStyles : Bool -> List Css.Style
 clickableTextSharedStyles isDisabled =
     let
         baseStyles =
-            [ Css.fontFamily Css.inherit
-            , Css.fontWeight Css.inherit
+            [ Fonts.baseFont
+            , Css.fontWeight (Css.int 600)
             ]
     in
     if isDisabled then
@@ -546,6 +547,7 @@ clickableTextSharedStyles isDisabled =
 clickableTextLinkStyles : List Css.Style
 clickableTextLinkStyles =
     [ Css.textDecoration Css.none
+    , Css.display Css.inlineBlock
     ]
 
 

--- a/src/Nri/Ui/ClickableText/V4.elm
+++ b/src/Nri/Ui/ClickableText/V4.elm
@@ -524,30 +524,28 @@ viewContent config kind =
                      ]
                         ++ (case position of
                                 Left ->
-                                    iconMarginRight
-                                        :: (case kind of
-                                                Button ->
-                                                    [ -- Position absolute makes the parent ignore the icon's height, preventing misalignment with other inline text
-                                                      Css.position Css.absolute
-                                                    , Css.left Css.zero
-                                                    ]
+                                    (case kind of
+                                        Button ->
+                                            [ -- Position absolute makes the parent ignore the icon's height, preventing misalignment with other inline text
+                                              Css.position Css.absolute
+                                            , Css.left Css.zero
+                                            ]
 
-                                                Link ->
-                                                    []
-                                           )
+                                        Link ->
+                                            [ iconMarginRight ]
+                                    )
                                         ++ config.iconStyles
 
                                 Right ->
-                                    iconMarginLeft
-                                        :: (case kind of
-                                                Button ->
-                                                    [ Css.position Css.absolute
-                                                    , Css.right Css.zero
-                                                    ]
+                                    (case kind of
+                                        Button ->
+                                            [ Css.position Css.absolute
+                                            , Css.right Css.zero
+                                            ]
 
-                                                Link ->
-                                                    []
-                                           )
+                                        Link ->
+                                            [ iconMarginLeft ]
+                                    )
                                         ++ config.rightIconStyles
                            )
                     )

--- a/src/Nri/Ui/ClickableText/V4.elm
+++ b/src/Nri/Ui/ClickableText/V4.elm
@@ -26,6 +26,8 @@ module Nri.Ui.ClickableText.V4 exposing
   - uses `Css.display Css.inlineFlex` only on buttons
   - removes `"-v2"` from data descriptor
   - uses dataDescriptor for `"clickable-text-label"`
+  - adds `Inherited` size as default
+  - adjusts icon margins for `Inherited` size
 
 
 # About:
@@ -141,7 +143,8 @@ modal =
 
 
 type Size
-    = Small
+    = Inherited
+    | Small
     | Medium
     | Large
 
@@ -383,6 +386,10 @@ appearsInline =
         [ Css.borderBottom3 (Css.px 1) Css.solid Colors.azure
         , Css.Global.withAttribute "aria-disabled=true" [ Css.borderBottom3 (Css.px 1) Css.solid Colors.gray45 ]
         , Css.disabled [ Css.borderBottom3 (Css.px 1) Css.solid Colors.gray45 ]
+        , Css.display Css.inline
+        , Css.fontFamily Css.inherit
+        , Css.fontWeight Css.inherit
+        , Css.fontSize Css.inherit
         ]
 
 
@@ -461,30 +468,56 @@ viewContent :
 viewContent config kind =
     let
         fontSize =
-            sizeToPx config.size
+            case config.size of
+                Inherited ->
+                    Css.fontSize Css.inherit
+
+                Small ->
+                    Css.fontSize (Css.px 13)
+
+                Medium ->
+                    Css.fontSize (Css.px 15)
+
+                Large ->
+                    Css.fontSize (Css.px 18)
 
         viewIcon styles icon_ =
             icon_
-                |> Svg.withWidth fontSize
-                |> Svg.withHeight fontSize
                 |> Svg.withCss styles
                 |> Svg.toHtml
 
-        iconSize =
+        iconMarginRight =
             case config.size of
+                Inherited ->
+                    Css.marginRight (Css.em 0.2)
+
                 Small ->
-                    Css.px 3
+                    Css.marginRight (Css.px 3)
 
                 Medium ->
-                    Css.px 3
+                    Css.marginRight (Css.px 3)
 
                 Large ->
-                    Css.px 4
+                    Css.marginRight (Css.px 4)
+
+        iconMarginLeft =
+            case config.size of
+                Inherited ->
+                    Css.marginLeft (Css.em 0.2)
+
+                Small ->
+                    Css.marginLeft (Css.px 3)
+
+                Medium ->
+                    Css.marginLeft (Css.px 3)
+
+                Large ->
+                    Css.marginLeft (Css.px 4)
 
         iconAndTextContainer =
             span
                 [ Attributes.css
-                    (Css.fontSize fontSize
+                    (fontSize
                         :: (case kind of
                                 Button ->
                                     [ Css.display Css.inlineFlex
@@ -498,25 +531,53 @@ viewContent config kind =
                 ]
                 >> List.singleton
     in
-    span [ Attributes.css [ Css.fontSize fontSize ] ]
+    span [ Attributes.css [ fontSize ] ]
         (case ( config.icon, config.rightIcon ) of
             ( Just leftIcon, Just rightIcon_ ) ->
                 iconAndTextContainer
-                    [ viewIcon (Css.marginRight iconSize :: config.iconStyles) leftIcon
+                    [ viewIcon
+                        ([ iconMarginRight
+                         , Css.width (Css.em 1)
+                         , Css.height (Css.em 1)
+                         ]
+                            ++ config.iconStyles
+                        )
+                        leftIcon
                     , span [ ExtraAttributes.nriDescription (dataDescriptor "label") ] [ text config.label ]
-                    , viewIcon (Css.marginLeft iconSize :: config.rightIconStyles) rightIcon_
+                    , viewIcon
+                        ([ iconMarginLeft
+                         , Css.width (Css.em 1)
+                         , Css.height (Css.em 1)
+                         ]
+                            ++ config.rightIconStyles
+                        )
+                        rightIcon_
                     ]
 
             ( Just leftIcon, Nothing ) ->
                 iconAndTextContainer
-                    [ viewIcon (Css.marginRight iconSize :: config.iconStyles) leftIcon
+                    [ viewIcon
+                        ([ iconMarginRight
+                         , Css.width (Css.em 1)
+                         , Css.height (Css.em 1)
+                         ]
+                            ++ config.iconStyles
+                        )
+                        leftIcon
                     , span [ ExtraAttributes.nriDescription (dataDescriptor "label") ] [ text config.label ]
                     ]
 
             ( Nothing, Just rightIcon_ ) ->
                 iconAndTextContainer
                     [ span [ ExtraAttributes.nriDescription (dataDescriptor "label") ] [ text config.label ]
-                    , viewIcon (Css.marginLeft iconSize :: config.rightIconStyles) rightIcon_
+                    , viewIcon
+                        ([ iconMarginLeft
+                         , Css.width (Css.em 1)
+                         , Css.height (Css.em 1)
+                         ]
+                            ++ config.rightIconStyles
+                        )
+                        rightIcon_
                     ]
 
             ( Nothing, Nothing ) ->
@@ -561,19 +622,6 @@ clickableTextButtonStyles =
     ]
 
 
-sizeToPx : Size -> Css.Px
-sizeToPx size =
-    case size of
-        Small ->
-            Css.px 13
-
-        Medium ->
-            Css.px 15
-
-        Large ->
-            Css.px 18
-
-
 dataDescriptor : String -> String
 dataDescriptor descriptor =
     "clickable-text-" ++ descriptor
@@ -600,7 +648,7 @@ type alias ClickableTextAttributes msg =
 defaults : ClickableTextAttributes msg
 defaults =
     { clickableAttributes = ClickableAttributes.init
-    , size = Medium
+    , size = Inherited
     , label = ""
     , icon = Nothing
     , iconStyles = []

--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -67,7 +67,7 @@ import Json.Decode
 import Nri.Ui.AnimatedIcon.V1 as AnimatedIcon
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra

--- a/src/Nri/Ui/Pagination/V1.elm
+++ b/src/Nri/Ui/Pagination/V1.elm
@@ -14,7 +14,7 @@ import Css
 import Css.Transitions as Transitions
 import Html.Styled.Attributes exposing (css)
 import List.Extra
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.V3 exposing (viewIf)
 

--- a/src/Nri/Ui/SideNav/V4.elm
+++ b/src/Nri/Ui/SideNav/V4.elm
@@ -69,7 +69,7 @@ import Maybe.Extra
 import Nri.Ui
 import Nri.Ui.AnimatedIcon.V1 as AnimatedIcon
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Data.PremiumDisplay as PremiumDisplay exposing (PremiumDisplay)
 import Nri.Ui.FocusRing.V1 as FocusRing

--- a/src/Nri/Ui/SideNav/V5.elm
+++ b/src/Nri/Ui/SideNav/V5.elm
@@ -63,7 +63,7 @@ import Maybe.Extra
 import Nri.Ui
 import Nri.Ui.AnimatedIcon.V1 as AnimatedIcon
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Data.PremiumDisplay as PremiumDisplay exposing (PremiumDisplay)
 import Nri.Ui.FocusRing.V1 as FocusRing

--- a/src/Nri/Ui/Text/V6.elm
+++ b/src/Nri/Ui/Text/V6.elm
@@ -61,7 +61,6 @@ You're in the wrong place! Headings live in Nri.Ui.Heading.V3.
 import Accessibility.Styled as Html exposing (..)
 import Content
 import Css exposing (..)
-import Css.Global exposing (children, typeSelector)
 import Html.Styled.Attributes as Attributes
 import MarkdownStyles
 import Nri.Ui.Colors.V1 exposing (..)

--- a/src/Nri/Ui/Text/V6.elm
+++ b/src/Nri/Ui/Text/V6.elm
@@ -61,6 +61,7 @@ You're in the wrong place! Headings live in Nri.Ui.Heading.V3.
 import Accessibility.Styled as Html exposing (..)
 import Content
 import Css exposing (..)
+import Css.Global exposing (children, typeSelector)
 import Html.Styled.Attributes as Attributes
 import MarkdownStyles
 import Nri.Ui.Colors.V1 exposing (..)
@@ -262,6 +263,13 @@ paragraphStyles config =
     , margin4 (px 0) (px 0) (px config.margin) (px 0)
     , lastChild
         [ margin zero
+        ]
+    , children
+        [ typeSelector "a"
+            [ Css.fontFamily Css.inherit
+            , Css.fontWeight Css.inherit
+            , Css.display Css.inline
+            ]
         ]
     ]
 

--- a/src/Nri/Ui/Text/V6.elm
+++ b/src/Nri/Ui/Text/V6.elm
@@ -264,13 +264,6 @@ paragraphStyles config =
     , lastChild
         [ margin zero
         ]
-    , children
-        [ typeSelector "a"
-            [ Css.fontFamily Css.inherit
-            , Css.fontWeight Css.inherit
-            , Css.display Css.inline
-            ]
-        ]
     ]
 
 

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -66,7 +66,7 @@ import InputLabelInternal
 import Iso8601
 import Keyboard.Event
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.InputStyles.V4 as InputStyles exposing (defaultMarginTop)

--- a/tests/Spec/Nri/Ui/ClickableText.elm
+++ b/tests/Spec/Nri/Ui/ClickableText.elm
@@ -5,7 +5,7 @@ import Accessibility.Role as Role
 import Html.Attributes as Attributes
 import Html.Styled exposing (..)
 import Nri.Test.MouseHelpers.V1 as MouseHelpers
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.UiIcon.V1 as UiIcon
 import ProgramTest exposing (..)
 import Spec.Helpers exposing (expectFailure)
@@ -17,7 +17,7 @@ import Test.Html.Selector as Selector exposing (..)
 
 spec : Test
 spec =
-    describe "Nri.Ui.ClickableText.V3"
+    describe "Nri.Ui.ClickableText.V4"
         [ describe "elements" elementTests
         , describe "attributes" attributeTests
         , describe "icon accessibility" iconAccessibilityTests

--- a/tests/Spec/Nri/Ui/Menu.elm
+++ b/tests/Spec/Nri/Ui/Menu.elm
@@ -4,7 +4,7 @@ import Html.Attributes as Attributes
 import Html.Styled as HtmlStyled
 import Json.Encode as Encode
 import Nri.Test.KeyboardHelpers.V1 as KeyboardHelpers
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Menu.V4 as Menu
 import Nri.Ui.Tooltip.V3 as Tooltip
 import ProgramTest exposing (ProgramTest, ensureViewHas, ensureViewHasNot)

--- a/tests/Spec/Nri/Ui/Tooltip.elm
+++ b/tests/Spec/Nri/Ui/Tooltip.elm
@@ -7,7 +7,7 @@ import Html.Attributes
 import Html.Styled as HtmlStyled
 import Html.Styled.Attributes as Attrs
 import Nri.Test.KeyboardHelpers.V1 as KeyboardHelpers
-import Nri.Ui.ClickableText.V3 as ClickableText
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Tooltip.V3 as Tooltip
 import ProgramTest exposing (ProgramTest, ensureViewHas, ensureViewHasNot)
 import Spec.Helpers exposing (nriDescription)

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -21,6 +21,7 @@
         "Nri.Ui.Checkbox.V7",
         "Nri.Ui.ClickableSvg.V2",
         "Nri.Ui.ClickableText.V3",
+        "Nri.Ui.ClickableText.V4",
         "Nri.Ui.Container.V2",
         "Nri.Ui.Colors.Extra",
         "Nri.Ui.Colors.V1",


### PR DESCRIPTION
# :wrench: Modifying a component

  - removes the `caption` attribute
  - removes `Css.display Css.inlineBlock`
  - inherits font family and weight from parent
  - adjusts font sizes
  - uses `Css.display Css.inlineFlex` only on buttons
  - removes `"-v2"` from data descriptor
  - uses dataDescriptor for `"clickable-text-label"`
  
Fixes:

- https://github.com/NoRedInk/noredink-ui/issues/1431
- https://github.com/NoRedInk/noredink-ui/issues/1364
- https://github.com/NoRedInk/noredink-ui/issues/1496

## Context

Fixes A11-3900

## :framed_picture: What does this change look like?

### Before

![noredink-ui netlify app_(iPhone 14 Pro Max)](https://github.com/NoRedInk/noredink-ui/assets/5647344/c0ceba7b-8b6b-4b29-8592-085ae6edf2c8)

### After

![localhost_8000_(iPhone 14 Pro Max)](https://github.com/NoRedInk/noredink-ui/assets/5647344/90347177-a99e-4466-b87f-0af69b78706b)


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
