### PR TITLE
A11-3978, A11-3977 make SideNav more semantic and accessible

### DIFF
--- a/src/Nri/Ui/SideNav/V5.elm
+++ b/src/Nri/Ui/SideNav/V5.elm
@@ -15,6 +15,12 @@ module Nri.Ui.SideNav.V5 exposing
 {-|
 
 
+### Patch changes:
+
+  - uses `ul>li` for the structure
+  - adds `aria-current="true"` to the parent of the current page
+
+
 ### Changes from V4
 
   - removes primary and secondary

--- a/src/Nri/Ui/SideNav/V5.elm
+++ b/src/Nri/Ui/SideNav/V5.elm
@@ -407,17 +407,17 @@ viewNav sidenavId config appliedNavAttributes entries showNav =
          ]
             |> List.filterMap identity
         )
-        [ ul
-            [ Attributes.css
-                [ listStyle none
-                , padding zero
-                , margin zero
-                ]
-            ]
-            (viewJust (viewOpenCloseButton sidenavId appliedNavAttributes.navLabel currentEntry) appliedNavAttributes.collapsible
-                :: List.map (viewSidebarEntry config entryStyles) entries
-            )
-        ]
+        (viewJust (viewOpenCloseButton sidenavId appliedNavAttributes.navLabel currentEntry) appliedNavAttributes.collapsible
+            :: [ ul
+                    [ Attributes.css
+                        [ listStyle none
+                        , padding zero
+                        , margin zero
+                        ]
+                    ]
+                    (List.map (viewSidebarEntry config entryStyles) entries)
+               ]
+        )
 
 
 viewSkipLink : msg -> Html msg
@@ -453,31 +453,33 @@ viewSidebarEntry config extraStyles entry_ =
                     id_ =
                         AttributesExtra.safeIdWithPrefix "sidenav-group" entryConfig.title
                 in
-                ul
-                    [ Attributes.css
-                        ([ listStyle none
-                         , padding zero
-                         , margin zero
-                         ]
-                            ++ extraStyles
+                li []
+                    [ ul
+                        [ Attributes.css
+                            ([ listStyle none
+                             , padding zero
+                             , margin zero
+                             ]
+                                ++ extraStyles
+                            )
+                        , Aria.labelledBy id_
+                        ]
+                        (styled span
+                            (sharedEntryStyles
+                                ++ [ backgroundColor Colors.gray92
+                                   , color Colors.navy
+                                   , fontWeight bold
+                                   , cursor default
+                                   , marginBottom (px 10)
+                                   ]
+                            )
+                            [ Attributes.id id_, Aria.currentItem True ]
+                            [ text entryConfig.title ]
+                            :: List.map
+                                (viewSidebarEntry config (marginLeft (px 20) :: extraStyles))
+                                children
                         )
-                    , Aria.labelledBy id_
                     ]
-                    (styled span
-                        (sharedEntryStyles
-                            ++ [ backgroundColor Colors.gray92
-                               , color Colors.navy
-                               , fontWeight bold
-                               , cursor default
-                               , marginBottom (px 10)
-                               ]
-                        )
-                        [ Attributes.id id_, Aria.currentItem True ]
-                        [ text entryConfig.title ]
-                        :: List.map
-                            (viewSidebarEntry config (marginLeft (px 20) :: extraStyles))
-                            children
-                    )
 
             else
                 viewSidebarLeaf config extraStyles entryConfig
@@ -515,7 +517,7 @@ viewSidebarEntry config extraStyles entry_ =
                     , viewRightIcon groupConfig
                     ]
                 , ul
-                    [ Attributes.css [ margin zero, padding zero ]
+                    [ Attributes.css [ margin zero, padding zero, listStyle none ]
                     , Aria.describedBy [ groupTitleId ]
                     ]
                     (List.map
@@ -524,8 +526,8 @@ viewSidebarEntry config extraStyles entry_ =
                                 :: fontWeight (int 400)
                                 :: extraStyles
                             )
-                            >> List.singleton
-                            >> li [ Attributes.css [ listStyle none, margin2 (px 4) zero ] ]
+                         -- >> List.singleton
+                         -- >> span [ Attributes.css [ listStyle none, margin2 (px 4) zero ] ]
                         )
                         children
                     )
@@ -598,8 +600,7 @@ viewSidebarLeaf config extraStyles entryConfig =
             isCurrentRoute config entryConfig
     in
     li
-        [ Attributes.css []
-        ]
+        []
         [ Nri.Ui.styled Html.Styled.a
             ("Nri-Ui-SideNav-" ++ linkFunctionName)
             (sharedEntryStyles

--- a/src/Nri/Ui/SideNav/V5.elm
+++ b/src/Nri/Ui/SideNav/V5.elm
@@ -401,9 +401,17 @@ viewNav sidenavId config appliedNavAttributes entries showNav =
          ]
             |> List.filterMap identity
         )
-        (viewJust (viewOpenCloseButton sidenavId appliedNavAttributes.navLabel currentEntry) appliedNavAttributes.collapsible
-            :: List.map (viewSidebarEntry config entryStyles) entries
-        )
+        [ ul
+            [ Attributes.css
+                [ listStyle none
+                , padding zero
+                , margin zero
+                ]
+            ]
+            (viewJust (viewOpenCloseButton sidenavId appliedNavAttributes.navLabel currentEntry) appliedNavAttributes.collapsible
+                :: List.map (viewSidebarEntry config entryStyles) entries
+            )
+        ]
 
 
 viewSkipLink : msg -> Html msg
@@ -435,7 +443,20 @@ viewSidebarEntry config extraStyles entry_ =
                 viewLockedEntry extraStyles entryConfig
 
             else if anyLinkDescendants (isCurrentRoute config) children then
-                div [ Attributes.css extraStyles ]
+                let
+                    id_ =
+                        AttributesExtra.safeIdWithPrefix "sidenav-group" entryConfig.title
+                in
+                ul
+                    [ Attributes.css
+                        ([ listStyle none
+                         , padding zero
+                         , margin zero
+                         ]
+                            ++ extraStyles
+                        )
+                    , Aria.labelledBy id_
+                    ]
                     (styled span
                         (sharedEntryStyles
                             ++ [ backgroundColor Colors.gray92
@@ -445,7 +466,7 @@ viewSidebarEntry config extraStyles entry_ =
                                , marginBottom (px 10)
                                ]
                         )
-                        []
+                        [ Attributes.id id_, Aria.currentItem True ]
                         [ text entryConfig.title ]
                         :: List.map
                             (viewSidebarEntry config (marginLeft (px 20) :: extraStyles))
@@ -570,30 +591,34 @@ viewSidebarLeaf config extraStyles entryConfig =
         isCurrent =
             isCurrentRoute config entryConfig
     in
-    Nri.Ui.styled Html.Styled.a
-        ("Nri-Ui-SideNav-" ++ linkFunctionName)
-        (sharedEntryStyles
-            ++ extraStyles
-            ++ (if isCurrent then
-                    [ backgroundColor Colors.glacier
-                    , color Colors.navy
-                    , fontWeight bold
-                    , visited [ color Colors.navy ]
-                    ]
+    li
+        [ Attributes.css []
+        ]
+        [ Nri.Ui.styled Html.Styled.a
+            ("Nri-Ui-SideNav-" ++ linkFunctionName)
+            (sharedEntryStyles
+                ++ extraStyles
+                ++ (if isCurrent then
+                        [ backgroundColor Colors.glacier
+                        , color Colors.navy
+                        , fontWeight bold
+                        , visited [ color Colors.navy ]
+                        ]
 
-                else
-                    []
-               )
-            ++ entryConfig.customStyles
-        )
-        (Attributes.class FocusRing.customClass
-            :: AttributesExtra.includeIf isCurrent Aria.currentPage
-            :: attributes
-            ++ entryConfig.customAttributes
-        )
-        [ viewLeftIcon entryConfig
-        , text entryConfig.title
-        , viewRightIcon entryConfig
+                    else
+                        []
+                   )
+                ++ entryConfig.customStyles
+            )
+            (Attributes.class FocusRing.customClass
+                :: AttributesExtra.includeIf isCurrent Aria.currentPage
+                :: attributes
+                ++ entryConfig.customAttributes
+            )
+            [ viewLeftIcon entryConfig
+            , text entryConfig.title
+            , viewRightIcon entryConfig
+            ]
         ]
 
 

--- a/src/Nri/Ui/SideNav/V5.elm
+++ b/src/Nri/Ui/SideNav/V5.elm
@@ -454,7 +454,18 @@ viewSidebarEntry config extraStyles entry_ =
                         AttributesExtra.safeIdWithPrefix "sidenav-group" entryConfig.title
                 in
                 li []
-                    [ ul
+                    [ styled span
+                        (sharedEntryStyles
+                            ++ [ backgroundColor Colors.gray92
+                               , color Colors.navy
+                               , fontWeight bold
+                               , cursor default
+                               , marginBottom (px 10)
+                               ]
+                        )
+                        [ Attributes.id id_, Aria.currentItem True ]
+                        [ text entryConfig.title ]
+                    , ul
                         [ Attributes.css
                             ([ listStyle none
                              , padding zero
@@ -464,20 +475,9 @@ viewSidebarEntry config extraStyles entry_ =
                             )
                         , Aria.labelledBy id_
                         ]
-                        (styled span
-                            (sharedEntryStyles
-                                ++ [ backgroundColor Colors.gray92
-                                   , color Colors.navy
-                                   , fontWeight bold
-                                   , cursor default
-                                   , marginBottom (px 10)
-                                   ]
-                            )
-                            [ Attributes.id id_, Aria.currentItem True ]
-                            [ text entryConfig.title ]
-                            :: List.map
-                                (viewSidebarEntry config (marginLeft (px 20) :: extraStyles))
-                                children
+                        (List.map
+                            (viewSidebarEntry config (marginLeft (px 20) :: extraStyles))
+                            children
                         )
                     ]
 
@@ -485,7 +485,7 @@ viewSidebarEntry config extraStyles entry_ =
                 viewSidebarLeaf config extraStyles entryConfig
 
         Html html_ ->
-            div [ Attributes.css extraStyles ] html_
+            li [ Attributes.css extraStyles ] html_
 
         CompactGroup children groupConfig ->
             let

--- a/src/Nri/Ui/SideNav/V5.elm
+++ b/src/Nri/Ui/SideNav/V5.elm
@@ -494,7 +494,7 @@ viewSidebarEntry config extraStyles entry_ =
                         "sidenav-compact-group"
                         groupConfig.title
             in
-            styled div
+            styled li
                 (margin2 (px 8) zero
                     :: extraStyles
                     ++ groupConfig.customStyles

--- a/src/Nri/Ui/SideNav/V5.elm
+++ b/src/Nri/Ui/SideNav/V5.elm
@@ -61,6 +61,7 @@ import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Style as Style
 import ClickableAttributes exposing (ClickableAttributes)
 import Css exposing (..)
+import Css.Global
 import Css.Media
 import Html.Styled
 import Html.Styled.Attributes as Attributes
@@ -517,7 +518,12 @@ viewSidebarEntry config extraStyles entry_ =
                     , viewRightIcon groupConfig
                     ]
                 , ul
-                    [ Attributes.css [ margin zero, padding zero, listStyle none ]
+                    [ Attributes.css
+                        [ margin zero
+                        , padding zero
+                        , listStyle none
+                        , Css.Global.children [ Css.Global.typeSelector "li" [ margin2 (px 4) zero ] ]
+                        ]
                     , Aria.describedBy [ groupTitleId ]
                     ]
                     (List.map
@@ -526,8 +532,6 @@ viewSidebarEntry config extraStyles entry_ =
                                 :: fontWeight (int 400)
                                 :: extraStyles
                             )
-                         -- >> List.singleton
-                         -- >> span [ Attributes.css [ listStyle none, margin2 (px 4) zero ] ]
                         )
                         children
                     )


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Use `ul>li` for the structure and add `aria-current="true"` to the parent item of the current page

- A11-3978
- A11-3977

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
