### PR TITLE
Add Novels AssignmentIcons

### DIFF
--- a/component-catalog/src/Examples/AssignmentIcon.elm
+++ b/component-catalog/src/Examples/AssignmentIcon.elm
@@ -75,6 +75,7 @@ all =
         , ( "peerReview", AssignmentIcon.peerReview, [] )
         , ( "selfReview", AssignmentIcon.selfReview, [] )
         , ( "dailyWriting", AssignmentIcon.dailyWriting, [] )
+        , ( "novels", AssignmentIcon.novels, [] )
         ]
       )
     , ( "Writing II"
@@ -84,6 +85,7 @@ all =
         , ( "selfReviewCircled", AssignmentIcon.selfReviewCircled, [] )
         , ( "gradingAssistantCircled", AssignmentIcon.gradingAssistantCircled, [] )
         , ( "dailyWritingCircled", AssignmentIcon.dailyWritingCircled, [] )
+        , ( "novelsCircled", AssignmentIcon.novelsCircled, [] )
         ]
       )
     , ( "Stages"

--- a/src/Nri/Ui/AssignmentIcon/V2.elm
+++ b/src/Nri/Ui/AssignmentIcon/V2.elm
@@ -2,8 +2,8 @@ module Nri.Ui.AssignmentIcon.V2 exposing
     ( diagnostic, planningDiagnosticCircled, unitDiagnosticCircled
     , practice, practiceCircled
     , quiz, quizCircled, passageQuizCircled
-    , quickWrite, guidedDraft, peerReview, selfReview, dailyWriting
-    , quickWriteCircled, guidedDraftCircled, peerReviewCircled, selfReviewCircled, dailyWritingCircled, gradingAssistantCircled
+    , quickWrite, guidedDraft, peerReview, selfReview, dailyWriting, novels
+    , quickWriteCircled, guidedDraftCircled, peerReviewCircled, selfReviewCircled, dailyWritingCircled, novelsCircled, gradingAssistantCircled
     , submitting, rating, revising
     , startPrimary, startSecondary
     , assessment, standards, writing, modules
@@ -26,8 +26,8 @@ module Nri.Ui.AssignmentIcon.V2 exposing
 
 # Writing
 
-@docs quickWrite, guidedDraft, peerReview, selfReview, dailyWriting
-@docs quickWriteCircled, guidedDraftCircled, peerReviewCircled, selfReviewCircled, dailyWritingCircled, gradingAssistantCircled
+@docs quickWrite, guidedDraft, peerReview, selfReview, dailyWriting, novels
+@docs quickWriteCircled, guidedDraftCircled, peerReviewCircled, selfReviewCircled, dailyWritingCircled, novelsCircled, gradingAssistantCircled
 
 
 # Stages
@@ -240,6 +240,18 @@ dailyWriting =
                     []
                 ]
             ]
+        ]
+
+
+{-| -}
+novels : Nri.Ui.Svg.V1.Svg
+novels =
+    Nri.Ui.Svg.V1.init "0 0 41 39"
+        [ Svg.path
+            [ Attributes.fill "currentcolor"
+            , Attributes.d "M3.21249 33.6C3.59687 34.1719 4.37029 34.325 4.94373 33.9438C7.13125 32.4813 9.70293 31.7 12.3345 31.7C14.9658 31.7 17.5377 32.4812 19.7253 33.9438C19.93 34.0813 20.1722 34.1563 20.4191 34.1563H20.5691C20.8191 34.1594 21.066 34.0875 21.2753 33.95C23.4613 32.4828 26.0333 31.7 28.6661 31.7C31.2989 31.7 33.8709 32.4828 36.0569 33.95C36.2632 34.0844 36.5038 34.1563 36.7507 34.1563C37.1194 34.1609 37.4695 34.0031 37.7101 33.725C37.9522 33.4469 38.0585 33.0766 38.0007 32.7125V32.5188V9.37518C38.0007 8.95954 37.7944 8.5705 37.4507 8.33766C34.9554 6.66578 32.0367 5.74078 29.0351 5.6689C26.0335 5.59702 23.0727 6.38138 20.5007 7.93138C17.9272 6.3923 14.9695 5.61574 11.9711 5.69386C8.9742 5.77042 6.06027 6.69854 3.56947 8.36886C3.21791 8.59698 3.00383 8.98762 3.00071 9.40638V32.5V32.7C2.95384 33.0156 3.0304 33.3375 3.21321 33.6L3.21249 33.6ZM35.5001 10.0752V30.7376C31.1517 28.647 26.0845 28.6626 21.7501 30.7814V10.075C23.8267 8.82807 26.2033 8.16871 28.6253 8.16871C31.0473 8.16871 33.4237 8.82807 35.5005 10.075L35.5001 10.0752ZM12.3753 8.2002C14.7956 8.1877 17.1721 8.83612 19.2505 10.0752V30.8C14.9161 28.6812 9.84889 28.6656 5.50049 30.7562V10.0938C7.57549 8.84385 9.95369 8.18449 12.3757 8.18761L12.3753 8.2002Z"
+            ]
+            []
         ]
 
 
@@ -642,3 +654,19 @@ dailyWritingCircled =
             ]
     in
     encircle 70 toIcon
+
+
+novelsCircled : Nri.Ui.Svg.V1.Svg
+novelsCircled =
+    let
+        toIcon circle =
+            [ circle
+            , Svg.path
+                [ Attributes.fill "#FFF"
+                , Attributes.transform "translate(10 9)"
+                , Attributes.d "M3.21249 33.6C3.59687 34.1719 4.37029 34.325 4.94373 33.9438C7.13125 32.4813 9.70293 31.7 12.3345 31.7C14.9658 31.7 17.5377 32.4812 19.7253 33.9438C19.93 34.0813 20.1722 34.1563 20.4191 34.1563H20.5691C20.8191 34.1594 21.066 34.0875 21.2753 33.95C23.4613 32.4828 26.0333 31.7 28.6661 31.7C31.2989 31.7 33.8709 32.4828 36.0569 33.95C36.2632 34.0844 36.5038 34.1563 36.7507 34.1563C37.1194 34.1609 37.4695 34.0031 37.7101 33.725C37.9522 33.4469 38.0585 33.0766 38.0007 32.7125V32.5188V9.37518C38.0007 8.95954 37.7944 8.5705 37.4507 8.33766C34.9554 6.66578 32.0367 5.74078 29.0351 5.6689C26.0335 5.59702 23.0727 6.38138 20.5007 7.93138C17.9272 6.3923 14.9695 5.61574 11.9711 5.69386C8.9742 5.77042 6.06027 6.69854 3.56947 8.36886C3.21791 8.59698 3.00383 8.98762 3.00071 9.40638V32.5V32.7C2.95384 33.0156 3.0304 33.3375 3.21321 33.6L3.21249 33.6ZM35.5001 10.0752V30.7376C31.1517 28.647 26.0845 28.6626 21.7501 30.7814V10.075C23.8267 8.82807 26.2033 8.16871 28.6253 8.16871C31.0473 8.16871 33.4237 8.82807 35.5005 10.075L35.5001 10.0752ZM12.3753 8.2002C14.7956 8.1877 17.1721 8.83612 19.2505 10.0752V30.8C14.9161 28.6812 9.84889 28.6656 5.50049 30.7562V10.0938C7.57549 8.84385 9.95369 8.18449 12.3757 8.18761L12.3753 8.2002Z"
+                ]
+                []
+            ]
+    in
+    encircle 60 toIcon

--- a/src/Nri/Ui/AssignmentIcon/V2.elm
+++ b/src/Nri/Ui/AssignmentIcon/V2.elm
@@ -656,6 +656,7 @@ dailyWritingCircled =
     encircle 70 toIcon
 
 
+{-| -}
 novelsCircled : Nri.Ui.Svg.V1.Svg
 novelsCircled =
     let


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Adds `AssignmentIcons.V2.novels` and `AssignmentIcons.V2.novelsCircled`

## :framed_picture: What does this change look like?
![Screenshot 2024-01-12 at 13 33 56](https://github.com/NoRedInk/noredink-ui/assets/5419074/27085b64-7b70-4e08-8dad-1f543e367113)
![Screenshot 2024-01-12 at 13 33 44](https://github.com/NoRedInk/noredink-ui/assets/5419074/f2f2868e-e689-4b6f-b791-4faaab977bf8)

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [ ] Changes are clearly documented
  - [ ] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [ ] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [ ]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
