### PR TITLE
Tessa/show underline example

### DIFF
--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -370,7 +370,7 @@ example =
                                 ]
                                 1
                   , description =
-                        """**Labeled blank block**
+                        """**Labeled dashed blank block**
 
 A labelled blank in the sentence.
 
@@ -393,6 +393,36 @@ A labelled blank in the sentence.
                 , { pattern =
                         Code.fromModule moduleName "view "
                             ++ Code.listMultiline
+                                [ Code.fromModule moduleName "label " ++ Code.string "[label text]"
+                                , Code.fromModule moduleName "purple"
+                                , Code.fromModule moduleName "underline"
+                                ]
+                                1
+                  , description =
+                        """**Labeled underline blank block**
+
+A labelled blank in the sentence.
+
+"""
+                            ++ "Please see the \""
+                            ++ blankWidthGuidanceSectionName
+                            ++ "\" table to learn more about using Blanks."
+                  , example =
+                        inParagraph
+                            [ Block.view [ Block.plaintext "If a volcano is extinct, " ]
+                            , Block.view
+                                [ Block.label "pronoun"
+                                , Block.purple
+                                , Block.underline
+                                , Block.labelId pronounId
+                                , Block.labelPosition (Dict.get pronounId offsets)
+                                ]
+                            , Block.view [ Block.plaintext " will never erupt again." ]
+                            ]
+                  }
+                , { pattern =
+                        Code.fromModule moduleName "view "
+                            ++ Code.listMultiline
                                 [ Code.fromModule moduleName "emphasize"
                                 , Code.fromModule moduleName "content "
                                     ++ Code.listMultiline
@@ -404,7 +434,7 @@ A labelled blank in the sentence.
                                         2
                                 ]
                                 1
-                  , description = "**Blanks with emphasis block**\n\nHelp students focus in on a phrase that includes a blank"
+                  , description = "**Dashed Blanks in emphasis block**\n\nHelp students focus in on a phrase that includes a blank"
                   , example =
                         inParagraph
                             [ Block.view [ Block.plaintext "This is an " ]

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -414,8 +414,8 @@ A labelled blank in the sentence.
                                 [ Block.label "pronoun"
                                 , Block.purple
                                 , Block.underline
-                                , Block.labelId pronounId
-                                , Block.labelPosition (Dict.get pronounId offsets)
+                                , Block.labelId pronoun2Id
+                                , Block.labelPosition (Dict.get pronoun2Id offsets)
                                 ]
                             , Block.view [ Block.plaintext " will never erupt again." ]
                             ]
@@ -827,6 +827,11 @@ pronounId =
     "pronoun-label-id"
 
 
+pronoun2Id : String
+pronoun2Id =
+    "pronoun-label-id-2"
+
+
 articleId : String
 articleId =
     "article-label-id"
@@ -868,6 +873,7 @@ blocksWithLabelsIds =
     , adjectiveId
     , editorsNoteId
     , pronounId
+    , pronoun2Id
     , articleId
     , trickyId
     , goalId

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -188,7 +188,16 @@ example =
                     , Block.labelPosition (Dict.get prepositionId offsets)
                     , Block.emphasize
                     ]
-                , Block.view <|
+                , Block.view [ Block.plaintext " " ]
+                , Block.view
+                    [ Block.label "adjective"
+                    , Block.underline
+                    , Block.purple
+                    , Block.labelId adjectiveId
+                    , Block.labelPosition (Dict.get adjectiveId offsets)
+                    , Block.emphasize
+                    ]
+                , Block.view
                     [ Block.content
                         [ Block.bold (List.concat [ Block.phrase " comic ", [ Block.italic (Block.phrase "book") ], Block.phrase " pages. " ])
                         ]
@@ -728,6 +737,11 @@ prepositionId =
     "preposition-label-id"
 
 
+adjectiveId : String
+adjectiveId =
+    "adjective-label-id"
+
+
 editorsNoteId : String
 editorsNoteId =
     "editors-note-label-id"
@@ -776,6 +790,7 @@ blocksWithLabelsIds =
     , subjectId
     , directObjectId
     , prepositionId
+    , adjectiveId
     , editorsNoteId
     , pronounId
     , articleId

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -491,12 +491,24 @@ A labelled blank in the sentence.
                     , sort = Nothing
                     }
                 , Table.custom
-                    { header = text "Example"
+                    { header = text "Dashed Example"
                     , view =
                         \{ textExample, blankExample } ->
                             div []
                                 [ div [] [ Block.view (Block.emphasize :: textExample) ]
                                 , div [] [ Block.view blankExample ]
+                                ]
+                    , width = Css.px 300
+                    , cellStyles = always [ Css.padding2 (Css.px 4) (Css.px 7), Css.verticalAlign Css.top ]
+                    , sort = Nothing
+                    }
+                , Table.custom
+                    { header = text "Underline Example"
+                    , view =
+                        \{ textExample, blankExample } ->
+                            div []
+                                [ div [] [ Block.view (Block.emphasize :: Block.underline :: textExample) ]
+                                , div [] [ Block.view (Block.underline :: blankExample) ]
                                 ]
                     , width = Css.px 300
                     , cellStyles = always [ Css.padding2 (Css.px 4) (Css.px 7), Css.verticalAlign Css.top ]

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -455,6 +455,39 @@ A labelled blank in the sentence.
                         Code.fromModule moduleName "view "
                             ++ Code.listMultiline
                                 [ Code.fromModule moduleName "emphasize"
+                                , Code.fromModule moduleName "underline"
+                                , Code.fromModule moduleName "content "
+                                    ++ Code.listMultiline
+                                        [ "…"
+                                        , Code.fromModule moduleName "blank "
+                                            ++ Code.record [ ( "widthInChars", "8" ) ]
+                                        , "…"
+                                        ]
+                                        2
+                                ]
+                                1
+                  , description = "**Underline Blanks in emphasis block**\n\nHelp students focus in on a phrase that includes a blank"
+                  , example =
+                        inParagraph
+                            [ Block.view [ Block.plaintext "This is an " ]
+                            , Block.view
+                                [ Block.emphasize
+                                , Block.underline
+                                , (List.concat >> Block.content)
+                                    [ Block.phrase "emphasized subsegement "
+                                    , [ Block.blank { widthInChars = 8 } ]
+                                    , Block.phrase " emphasized"
+                                    ]
+                                ]
+                            , Block.view
+                                [ Block.plaintext " in a seed."
+                                ]
+                            ]
+                  }
+                , { pattern =
+                        Code.fromModule moduleName "view "
+                            ++ Code.listMultiline
+                                [ Code.fromModule moduleName "emphasize"
                                 , Code.fromModule moduleName "content "
                                     ++ Code.listMultiline
                                         [ "…"


### PR DESCRIPTION
I noticed that https://github.com/NoRedInk/noredink-ui/pull/1582 didn't update the static examples for Block use, so I thought I'd add expand the examples (good to have Percy looking out, after all!)

I think adding these additional cases also makes it apparent that the API now does some presumably undesirable things:

### 1. Double underlines for blank within emphasis

<img width="676" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/2914081e-0d5a-4095-98e7-4d2313eee2f6">

Note that the "emphasis" is no longer dashed. The emphasis uses an underline style _and_ the blank uses an underline style.

### 2. Double underline for blanks with emphasis

<img width="307" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/05d82edc-b198-4f9a-8059-441c9d66b040">

There's a similar problem here -- the blank has 2 underlines underneath it.

### 3. Should non-blanks ever be underlined?

<img width="290" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/fbde6f3e-1377-4d53-91e0-2a27e9e06c81">

Is it intended that the API can support underlining non-blanks?

## :framed_picture: What does this change look like?


| | Before | After |
| --- | --- | --- |
| Main complex static example | <img width="1318" alt="Screenshot 2024-01-12 at 3 34 32 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/1317e4f0-3d24-4c8c-9aa2-f86d172a8334"> |  <img width="1354" alt="Screenshot 2024-01-12 at 3 34 16 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/c87a45e0-e1e1-416e-a87c-bfc663505552"> |
| Simple blank example | <img width="1367" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/ddf38ef8-c7a1-4d29-b549-d5bf61e136c9"> |  <img width="1370" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/c86f45f4-7af4-4256-a459-3ff010b0d563"> |
| Within emphasis blank example | <img width="1352" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/d63f0a06-8d11-424c-a299-11cff33aed28"> | <img width="1351" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/84d574c8-ceab-4c43-a2cd-9fbf4494675f"> |
| Blank width guidance | <img width="1363" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/735842de-4ecf-4f7b-914b-4780e6c5c209"> | <img width="1360" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/eb50ac5a-8c55-4e0b-b852-74344c4f4827"> |
