### PR TITLE
Clean up blank underline block

### DIFF
--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -663,7 +663,7 @@ initControl : Control Settings
 initControl =
     ControlExtra.list
         |> ControlExtra.optionalListItemDefaultChecked "content" controlContent
-        |> ControlExtra.optionalListItemDefaultChecked "blankStyle" blankStyleContent
+        |> ControlExtra.optionalListItem "blankStyle" blankStyleContent
         |> ControlExtra.optionalBoolListItemDefaultChecked "emphasize" ( Code.fromModule moduleName "emphasize", Block.emphasize )
         |> ControlExtra.optionalListItem "label"
             (CommonControls.string ( Code.fromModule moduleName "label", Block.label ) "Fruit")
@@ -737,11 +737,11 @@ controlContent =
 blankStyleContent : Control ( String, Block.Attribute msg )
 blankStyleContent =
     Control.choice
-        [ ( "Dashed"
-          , Control.value ( "Block.dashed", Block.dashed )
-          )
-        , ( "Underline"
+        [ ( "Underline"
           , Control.value ( "Block.underline", Block.underline )
+          )
+        , ( "Dashed"
+          , Control.value ( "Block.dashed", Block.dashed )
           )
         ]
 

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -579,7 +579,7 @@ initControl : Control Settings
 initControl =
     ControlExtra.list
         |> ControlExtra.optionalListItemDefaultChecked "content" controlContent
-        |> ControlExtra.optionalListItemDefaultChecked "borderStyle" borderStyleContent
+        |> ControlExtra.optionalListItemDefaultChecked "blankStyle" blankStyleContent
         |> ControlExtra.optionalBoolListItemDefaultChecked "emphasize" ( Code.fromModule moduleName "emphasize", Block.emphasize )
         |> ControlExtra.optionalListItem "label"
             (CommonControls.string ( Code.fromModule moduleName "label", Block.label ) "Fruit")
@@ -650,8 +650,8 @@ controlContent =
         ]
 
 
-borderStyleContent : Control ( String, Block.Attribute msg )
-borderStyleContent =
+blankStyleContent : Control ( String, Block.Attribute msg )
+blankStyleContent =
     Control.choice
         [ ( "Dashed"
           , Control.value ( "Block.dashed", Block.dashed )

--- a/src/Nri/Ui/Block/V6.elm
+++ b/src/Nri/Ui/Block/V6.elm
@@ -704,7 +704,16 @@ render config =
             , backgroundColor = palette.backgroundColor
             , maybeMarker = maybeMark
             , labelPosition = config.labelPosition
-            , labelCss = config.labelCss
+            , labelCss =
+                config.labelCss
+                    ++ (case ( config.borderStyle, config.content ) of
+                            ( Underline, [ Blank _ ] ) ->
+                                [ Css.top (Css.px 6)
+                                ]
+
+                            _ ->
+                                []
+                       )
             , labelId = config.labelId
             , labelContentId = Maybe.map labelContentId config.labelId
             }
@@ -721,14 +730,19 @@ viewBlank : BorderStyle -> BlankHeight -> CharacterWidth -> Html msg
 viewBlank borderStyle blankHeight (CharacterWidth width) =
     let
         heightStyles =
-            case blankHeight of
-                BlankHeightFull ->
-                    [ Css.paddingTop topBottomSpace
-                    , Css.paddingBottom topBottomSpace
-                    , Css.lineHeight Css.initial
-                    ]
+            case borderStyle of
+                Dashed ->
+                    case blankHeight of
+                        BlankHeightFull ->
+                            [ Css.paddingTop topBottomSpace
+                            , Css.paddingBottom topBottomSpace
+                            , Css.lineHeight Css.initial
+                            ]
 
-                BlankHeightInline ->
+                        BlankHeightInline ->
+                            [ Css.lineHeight (Css.num 1) ]
+
+                Underline ->
                     [ Css.lineHeight (Css.num 1) ]
     in
     span
@@ -738,7 +752,7 @@ viewBlank borderStyle blankHeight (CharacterWidth width) =
                     Css.border3 (Css.px 2) Css.dashed Colors.navy
 
                 Underline ->
-                    Css.borderBottom2 (Css.px 2) Css.solid
+                    Css.borderBottom2 (Css.px 1) Css.solid
             , MediaQuery.highContrastMode
                 [ Css.property "border-color" "CanvasText"
                 , Css.property "background-color" "Canvas"

--- a/src/Nri/Ui/Block/V6.elm
+++ b/src/Nri/Ui/Block/V6.elm
@@ -340,7 +340,7 @@ renderContent config content_ styles =
                         BlankHeightFull
             in
             blockSegmentContainer
-                [ viewBlank config.borderStyle blankHeight length ]
+                [ viewBlank config.blankStyle blankHeight length ]
                 styles
 
         Markdown markdown contents ->
@@ -425,14 +425,14 @@ italic =
 -}
 dashed : Attribute msg
 dashed =
-    Attribute (\config -> { config | borderStyle = Dashed })
+    Attribute (\config -> { config | blankStyle = Dashed })
 
 
 {-| Sets the border style to be underlined
 -}
 underline : Attribute msg
 underline =
-    Attribute (\config -> { config | borderStyle = Underline })
+    Attribute (\config -> { config | blankStyle = Underline })
 
 
 
@@ -524,7 +524,7 @@ toMark :
         | emphasize : Bool
         , label : Maybe String
         , content : List (Content msg)
-        , borderStyle : BorderStyle
+        , blankStyle : BlankStyle
     }
     -> Palette
     -> Maybe Mark
@@ -533,54 +533,27 @@ toMark config { backgroundColor, borderColor } =
         let
             borderWidth =
                 Css.px 1
-
-            borderStyle =
-                case config.borderStyle of
-                    Dashed ->
-                        Css.dashed
-
-                    Underline ->
-                        Css.solid
-
-            borderColor_ =
-                case config.borderStyle of
-                    Dashed ->
-                        borderColor
-
-                    Underline ->
-                        backgroundColor
         in
         Just
             { name = config.label
             , startStyles =
-                [ Css.borderLeft3 borderWidth borderStyle borderColor_
+                [ Css.borderLeft3 borderWidth Css.dashed borderColor
                 , Css.paddingLeft (Css.px 2)
                 ]
             , styles =
                 [ Css.paddingTop topBottomSpace
                 , Css.paddingBottom topBottomSpace
                 , Css.backgroundColor backgroundColor
-                , Css.borderTop3 borderWidth borderStyle borderColor_
-                , Css.borderBottom3 borderWidth borderStyle borderColor_
+                , Css.borderTop3 borderWidth Css.dashed borderColor
+                , Css.borderBottom3 borderWidth Css.dashed borderColor
                 , MediaQuery.highContrastMode
                     [ Css.property "background-color" "Mark"
                     , Css.property "color" "MarkText"
                     , Css.property "forced-color-adjust" "none"
                     ]
-                , Css.batch
-                    (case config.borderStyle of
-                        Dashed ->
-                            []
-
-                        Underline ->
-                            [ Css.textDecoration Css.underline
-                            , Css.property "text-decoration-thickness" "1px"
-                            , Css.property "text-underline-offset" "4.5px"
-                            ]
-                    )
                 ]
             , endStyles =
-                [ Css.borderRight3 borderWidth borderStyle borderColor_
+                [ Css.borderRight3 borderWidth Css.dashed borderColor
                 , Css.paddingRight (Css.px 2)
                 ]
             }
@@ -676,7 +649,7 @@ defaultConfig =
     , theme = Yellow
     , emphasize = False
     , insertWbrAfterSpace = False
-    , borderStyle = Dashed
+    , blankStyle = Dashed
     }
 
 
@@ -690,11 +663,11 @@ type alias Config msg =
     , theme : Theme
     , emphasize : Bool
     , insertWbrAfterSpace : Bool
-    , borderStyle : BorderStyle
+    , blankStyle : BlankStyle
     }
 
 
-type BorderStyle
+type BlankStyle
     = Dashed
     | Underline
 
@@ -728,11 +701,11 @@ type BlankHeight
     | BlankHeightInline
 
 
-viewBlank : BorderStyle -> BlankHeight -> CharacterWidth -> Html msg
-viewBlank borderStyle blankHeight (CharacterWidth width) =
+viewBlank : BlankStyle -> BlankHeight -> CharacterWidth -> Html msg
+viewBlank blankStyle blankHeight (CharacterWidth width) =
     let
         heightStyles =
-            case borderStyle of
+            case blankStyle of
                 Dashed ->
                     case blankHeight of
                         BlankHeightFull ->
@@ -745,22 +718,22 @@ viewBlank borderStyle blankHeight (CharacterWidth width) =
                             [ Css.lineHeight (Css.num 1) ]
 
                 Underline ->
-                    [ Css.lineHeight (Css.num 1) ]
+                    [ Css.lineHeight (Css.num 0.75) ]
     in
     span
         [ css
-            [ case borderStyle of
+            [ case blankStyle of
                 Dashed ->
                     Css.border3 (Css.px 2) Css.dashed Colors.navy
 
                 Underline ->
-                    Css.borderBottom2 (Css.px 1) Css.solid
+                    Css.borderBottom2 (Css.rem 0.1) Css.solid
             , MediaQuery.highContrastMode
                 [ Css.property "border-color" "CanvasText"
                 , Css.property "background-color" "Canvas"
                 ]
             , Css.backgroundColor
-                (case borderStyle of
+                (case blankStyle of
                     Dashed ->
                         Colors.white
 
@@ -771,7 +744,7 @@ viewBlank borderStyle blankHeight (CharacterWidth width) =
             , Css.display Css.inlineBlock
             , Css.borderRadius
                 (Css.px
-                    (case borderStyle of
+                    (case blankStyle of
                         Dashed ->
                             4
 

--- a/src/Nri/Ui/Block/V6.elm
+++ b/src/Nri/Ui/Block/V6.elm
@@ -542,7 +542,7 @@ toMark config { backgroundColor, borderColor } =
                     Underline ->
                         Css.solid
 
-            notBottomBorderColor =
+            borderColor_ =
                 case config.borderStyle of
                     Dashed ->
                         borderColor
@@ -553,23 +553,34 @@ toMark config { backgroundColor, borderColor } =
         Just
             { name = config.label
             , startStyles =
-                [ Css.borderLeft3 borderWidth borderStyle notBottomBorderColor
+                [ Css.borderLeft3 borderWidth borderStyle borderColor_
                 , Css.paddingLeft (Css.px 2)
                 ]
             , styles =
                 [ Css.paddingTop topBottomSpace
                 , Css.paddingBottom topBottomSpace
                 , Css.backgroundColor backgroundColor
-                , Css.borderTop3 borderWidth borderStyle notBottomBorderColor
-                , Css.borderBottom3 borderWidth borderStyle borderColor
+                , Css.borderTop3 borderWidth borderStyle borderColor_
+                , Css.borderBottom3 borderWidth borderStyle borderColor_
                 , MediaQuery.highContrastMode
                     [ Css.property "background-color" "Mark"
                     , Css.property "color" "MarkText"
                     , Css.property "forced-color-adjust" "none"
                     ]
+                , Css.batch
+                    (case config.borderStyle of
+                        Dashed ->
+                            []
+
+                        Underline ->
+                            [ Css.textDecoration Css.underline
+                            , Css.property "text-decoration-thickness" "1px"
+                            , Css.property "text-underline-offset" "4.5px"
+                            ]
+                    )
                 ]
             , endStyles =
-                [ Css.borderRight3 borderWidth borderStyle notBottomBorderColor
+                [ Css.borderRight3 borderWidth borderStyle borderColor_
                 , Css.paddingRight (Css.px 2)
                 ]
             }

--- a/src/Nri/Ui/Block/V6.elm
+++ b/src/Nri/Ui/Block/V6.elm
@@ -715,16 +715,7 @@ render config =
             , backgroundColor = palette.backgroundColor
             , maybeMarker = maybeMark
             , labelPosition = config.labelPosition
-            , labelCss =
-                config.labelCss
-                    ++ (case ( config.borderStyle, config.content ) of
-                            ( Underline, [ Blank _ ] ) ->
-                                [ Css.top (Css.px 6)
-                                ]
-
-                            _ ->
-                                []
-                       )
+            , labelCss = config.labelCss
             , labelId = config.labelId
             , labelContentId = Maybe.map labelContentId config.labelId
             }

--- a/src/Nri/Ui/Block/V6.elm
+++ b/src/Nri/Ui/Block/V6.elm
@@ -730,7 +730,14 @@ viewBlank blankStyle blankHeight (CharacterWidth width) =
                     Css.borderBottom2 (Css.rem 0.1) Css.solid
             , MediaQuery.highContrastMode
                 [ Css.property "border-color" "CanvasText"
-                , Css.property "background-color" "Canvas"
+                , Css.batch
+                    (case blankStyle of
+                        Dashed ->
+                            [ Css.property "background-color" "Canvas" ]
+
+                        Underline ->
+                            []
+                    )
                 ]
             , Css.backgroundColor
                 (case blankStyle of


### PR DESCRIPTION
Change some minor styles based on feedback from Stacey.

# :wrench: Modifying a component

## Context

https://github.com/NoRedInk/NoRedInk/pull/46846#issuecomment-1883598283

## :framed_picture: What does this change look like?

![image](https://github.com/NoRedInk/noredink-ui/assets/32229300/a6e62b8d-a0c3-4e4d-acaa-0605b0007e5e)


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers (applicable Sep 2023–Dec 2023):
  - [x] [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) - Someone from this group will review your PR in full.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for ACCESSIBILITY ONLY.
  - [x]  Someone from your team who can review requirements from your team's perspective. (This could be the same person from the [a11y-volunteer-reviewers](https://github.com/orgs/NoRedInk/teams/volunteer-a11y-reviewers) group if you'd like.)
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
