### PR TITLE
:wrench: Ensure there's room for the modal close X

### DIFF
--- a/src/Nri/Ui/Modal/V12.elm
+++ b/src/Nri/Ui/Modal/V12.elm
@@ -12,10 +12,11 @@ module Nri.Ui.Modal.V12 exposing
     , isOpen
     )
 
-{-|
+{-| Patch changes:
 
+  - adjust the padding of the heading when the close X is present for viewports less than 1000px wide
 
-# Changes fro V11:
+Changes from V11:
 
   - remove use of FocusTrap type alias
   - return ids to focus on instead of cmds (in order to make modals more testable via the effect pattern with program-test)

--- a/src/Nri/Ui/Modal/V12.elm
+++ b/src/Nri/Ui/Modal/V12.elm
@@ -467,13 +467,13 @@ titleStyles config =
             (Css.px 40)
             titleSidePadding
             (Css.px 20)
+        , Css.Media.withMedia [ mobile ]
+            [ Css.padding3 (Css.px 20) titleSidePadding Css.zero
+            ]
         , Css.margin Css.zero
         , Css.fontSize (Css.px 20)
         , Css.textAlign Css.center
         , Css.color config.titleColor
-        , Css.Media.withMedia [ mobile ]
-            [ Css.padding3 (Css.px 20) (Css.px 20) Css.zero
-            ]
         ]
 
     else


### PR DESCRIPTION
## Context

Fixes A11-4004
Fixes A11-4012

The modal's close x currently sometimes partially obscures the modal's title on mobile.

This PR adjusts the modal title's padding on mobile when the x is present so that there's no overlap between the x and the title.

## :framed_picture: What does this change look like?


| Before | After |
|  --- | --- |
| <img width="543" alt="Screenshot 2024-01-17 at 9 35 12 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/e1bcdb9f-d9b4-46c9-b0cd-b3438b19cab8">  | <img width="536" alt="Screenshot 2024-01-17 at 9 34 52 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/084c5cc5-44e3-416c-bdb5-5df722beec59"> |

---

Here is the padding highlighted:
<img width="548" alt="Screenshot 2024-01-17 at 9 35 21 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/f740386b-0964-44c8-ae08-bfe514d2a679">


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x]  Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
