### PR TITLE
Remove the distinct border from the disabled textarea and textinput

### DIFF
--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -15,6 +15,7 @@ module Nri.Ui.Menu.V4 exposing
 
   - improve interoperability with Tooltip (Note that tooltip keyboard events are not fully supported!)
   - Use Nri.Ui.WhenFocusLeaves.V2
+  - Adjust disabled styles
 
 Changes from V3:
 

--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -911,10 +911,18 @@ viewDefaultTrigger title menuConfig buttonAttributes attributes =
 
            else
             Button.css []
+         , if menuConfig.isDisabled then
+            Button.css
+                [ Css.borderColor Colors.gray85 |> Css.important
+                , Css.backgroundColor Colors.gray85 |> Css.important
+                ]
+
+           else
+            Button.css []
          , Button.rightIcon
             (AnimatedIcon.arrowDownUp menuConfig.isOpen
                 |> (if menuConfig.isDisabled then
-                        identity
+                        Svg.withColor Colors.gray45
 
                     else
                         Svg.withColor Colors.azure

--- a/src/Nri/Ui/Select/V9.elm
+++ b/src/Nri/Ui/Select/V9.elm
@@ -14,8 +14,11 @@ module Nri.Ui.Select.V9 exposing
 
 {-| Build a select input with a label, optional guidance, and error messaging.
 
+Patch changes:
 
-# Changes from V8
+  - Adjust disabled styles
+
+Changes from V8
 
     - The option `value` attribute is no longer prefixed with `nri-select-`;
       This is not a breaking change to the API, but affects automated tests

--- a/src/Nri/Ui/Select/V9.elm
+++ b/src/Nri/Ui/Select/V9.elm
@@ -469,6 +469,9 @@ viewSelect config_ config =
                 (if isInError then
                     Colors.purple
 
+                 else if config.disabled then
+                    Colors.gray85
+
                  else
                     Colors.gray75
                 )
@@ -604,7 +607,7 @@ selectArrowsCss config =
     let
         color =
             (if config.disabled then
-                Colors.gray20
+                Colors.gray45
 
              else
                 Colors.azure

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -373,6 +373,7 @@ view_ label config =
             , Css.batch
                 (if config.disabled then
                     [ Css.boxShadow Css.none |> Css.important
+                    , Css.borderColor Colors.gray85 |> Css.important
                     , Css.backgroundColor Colors.gray85
                     ]
 

--- a/src/Nri/Ui/TextArea/V5.elm
+++ b/src/Nri/Ui/TextArea/V5.elm
@@ -21,6 +21,7 @@ module Nri.Ui.TextArea.V5 exposing
 ### Patch changes
 
   - no longer defaults the placeholder value to the label text
+  - Adjust disabled styles
 
 
 ### Changes from V4

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -928,6 +928,7 @@ view label attributes =
                         , Css.batch
                             (if config.disabled then
                                 [ Css.backgroundColor Colors.gray85
+                                , Css.borderColor Colors.gray85 |> Css.important
                                 , Css.property "box-shadow" "none" |> Css.important
                                 ]
 

--- a/src/Nri/Ui/TextInput/V7.elm
+++ b/src/Nri/Ui/TextInput/V7.elm
@@ -17,6 +17,7 @@ module Nri.Ui.TextInput.V7 exposing
 # Patch changes
 
   - no longer defaults the placeholder value to the label text
+  - Adjust disabled styles
 
 
 # Changes from V6


### PR DESCRIPTION
Fixes https://github.com/NoRedInk/noredink-ui/issues/1555

## :framed_picture: What does this change look like?

| | Before | After |
| --- | --- | --- |
| TextInput | <img width="624" alt="Screenshot 2024-01-17 at 11 52 58 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/1cdab3f4-fc37-4d79-880e-0e489ab82854"> | <img width="630" alt="Screenshot 2024-01-17 at 11 52 47 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/0b74b155-cfa2-42ac-a0e8-80a86b21aad5"> |
| TextArea | <img width="838" alt="Screenshot 2024-01-17 at 11 50 33 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/7c03ee11-b1e0-46a7-b41e-faa7f612e043"> | <img width="828" alt="Screenshot 2024-01-17 at 11 50 18 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/5b7fc75a-16fb-4f76-8944-03ebd8a5ae0c"> |
| Select | <img width="835" alt="Screenshot 2024-01-17 at 11 56 10 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/b716aa3e-5941-4b59-b3cc-d257321ef996"> | <img width="828" alt="Screenshot 2024-01-17 at 11 55 54 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/9f7859e1-6880-48c8-a5b5-a4afb6383c99"> |
| Menu | <img width="130" alt="Screenshot 2024-01-17 at 11 57 34 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/4723da53-d199-4d3f-9150-a5ccd4366195"> | <img width="137" alt="Screenshot 2024-01-17 at 12 09 52 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/65880c88-f066-4c98-9c49-2808c95add07"> |


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x]  Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
