### PR TITLE
Add narrow (500px) helpers to Spacing

### DIFF
--- a/component-catalog/src/Examples/Spacing.elm
+++ b/component-catalog/src/Examples/Spacing.elm
@@ -250,13 +250,6 @@ view ellieLinkConfig state =
             , sort = Nothing
             }
         , Table.string
-            { header = "Content alignment"
-            , value = .alignment
-            , width = Css.pct 10
-            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
-            , sort = Nothing
-            }
-        , Table.string
             { header = "Content max-width"
             , value = .maxWidth
             , width = Css.pct 10
@@ -270,13 +263,54 @@ view ellieLinkConfig state =
             , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
             , sort = Nothing
             }
+        , Table.string
+            { header = "Relevant breakpoint"
+            , value = .breakpoint
+            , width = Css.pct 10
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+            , sort = Nothing
+            }
         ]
-        [ { name = "centeredContentWithSidePadding", alignment = "Centered", maxWidth = "1000px", sidePadding = "when viewport <= 970px" }
-        , { name = "centeredContent", alignment = "Centered", maxWidth = "1000px", sidePadding = "0px" }
-        , { name = "centeredQuizEngineContentWithSidePadding", alignment = "Centered", maxWidth = "750px", sidePadding = "when viewport <= 720px" }
-        , { name = "centeredQuizEngineContent", alignment = "Centered", maxWidth = "750px", sidePadding = "0px" }
-        , { name = "centeredContentWithSidePaddingAndCustomWidth", alignment = "Centered", maxWidth = "(customizable)", sidePadding = "when viewport <= (custom breakpoint value - 30)" }
-        , { name = "centeredContentWithCustomWidth", alignment = "Centered", maxWidth = "(customizable)", sidePadding = "0px" }
+        [ { name = "centeredContentWithSidePadding"
+          , maxWidth = "1000px"
+          , sidePadding = "when viewport <= 970px"
+          , breakpoint = "MediaQuery.mobileBreakpoint"
+          }
+        , { name = "centeredContent"
+          , maxWidth = "1000px"
+          , sidePadding = "0px"
+          , breakpoint = "MediaQuery.mobileBreakpoint"
+          }
+        , { name = "centeredQuizEngineContentWithSidePadding"
+          , maxWidth = "750px"
+          , sidePadding = "when viewport <= 720px"
+          , breakpoint = "MediaQuery.quizEngineMobileBreakpoint"
+          }
+        , { name = "centeredQuizEngineContent"
+          , maxWidth = "750px"
+          , sidePadding = "0px"
+          , breakpoint = "MediaQuery.quizEngineMobileBreakpoint"
+          }
+        , { name = "centeredNarrowContentWithSidePadding"
+          , maxWidth = "500px"
+          , sidePadding = "when viewport <= 470px"
+          , breakpoint = "MediaQuery.narrowMobileBreakpoint"
+          }
+        , { name = "centeredNarrowContent"
+          , maxWidth = "500px"
+          , sidePadding = "0px"
+          , breakpoint = "MediaQuery.narrowMobileBreakpoint"
+          }
+        , { name = "centeredContentWithSidePaddingAndCustomWidth"
+          , maxWidth = "(customizable)"
+          , sidePadding = "when viewport <= (custom breakpoint value - 30)"
+          , breakpoint = "(customizable)"
+          }
+        , { name = "centeredContentWithCustomWidth"
+          , maxWidth = "(customizable)"
+          , sidePadding = "0px"
+          , breakpoint = "(customizable)"
+          }
         ]
     , Heading.h2 [ Heading.plaintext "Constants", Heading.css [ Css.marginTop Spacing.verticalSpacerPx ] ]
     , Table.view []

--- a/component-catalog/src/Examples/Spacing.elm
+++ b/component-catalog/src/Examples/Spacing.elm
@@ -397,6 +397,10 @@ controlSettings =
                     |> asChoice
                  , ( "quizEngineCenteredContent", Spacing.quizEngineCenteredContent )
                     |> asChoice
+                 , ( "centeredNarrowContentWithSidePadding", Spacing.centeredNarrowContentWithSidePadding )
+                    |> asChoice
+                 , ( "narrowCenteredContent", Spacing.narrowCenteredContent )
+                    |> asChoice
                  , ( "centeredContentWithSidePaddingAndCustomWidth"
                    , Control.map
                         (\value ->

--- a/src/Nri/Ui/Spacing/V1.elm
+++ b/src/Nri/Ui/Spacing/V1.elm
@@ -1,6 +1,7 @@
 module Nri.Ui.Spacing.V1 exposing
     ( centeredContentWithSidePadding, centeredContent
     , centeredQuizEngineContentWithSidePadding, quizEngineCenteredContent
+    , centeredNarrowContentWithSidePadding, narrowCenteredContent
     , centeredContentWithSidePaddingAndCustomWidth, centeredContentWithCustomWidth
     , pageTopWhitespace, pageTopWhitespacePx
     , pageSideWhitespace, pageSideWhitespacePx
@@ -8,13 +9,16 @@ module Nri.Ui.Spacing.V1 exposing
     , verticalSpacerPx, horizontalSpacerPx
     )
 
-{-|
+{-| Patch changes:
+
+  - added centeredNarrowContentWithSidePadding, narrowCenteredContent
 
 
 ## Center a container on the page:
 
 @docs centeredContentWithSidePadding, centeredContent
 @docs centeredQuizEngineContentWithSidePadding, quizEngineCenteredContent
+@docs centeredNarrowContentWithSidePadding, narrowCenteredContent
 @docs centeredContentWithSidePaddingAndCustomWidth, centeredContentWithCustomWidth
 
 
@@ -116,6 +120,30 @@ This style does not add side padding on mobile, which means that this can be use
 quizEngineCenteredContent : Style
 quizEngineCenteredContent =
     centeredContentWithCustomWidth MediaQuery.quizEngineBreakpoint
+
+
+{-| Use this style on pages with a narrow (500px) breakpoint.
+
+This is identical to `content`, except that it uses the narrow breakpoint instead of the mobile breakpoint.
+
+If you have a container that should snap flush to the edges on mobile, this isn't the right style to use.
+
+-}
+centeredNarrowContentWithSidePadding : Style
+centeredNarrowContentWithSidePadding =
+    centeredContentWithSidePaddingAndCustomWidth MediaQuery.narrowMobileBreakpoint
+
+
+{-| Use this style on pages with a narrow (500px) breakpoint.
+
+This is identical to `centeredContent`, except that it uses the narrow breakpoint instead of the mobile breakpoint.
+
+This style does not add side padding on mobile, which means that this can be used for containers that should snap flush to the edges of the mobile viewport.
+
+-}
+narrowCenteredContent : Style
+narrowCenteredContent =
+    centeredContentWithCustomWidth MediaQuery.narrowMobileBreakpoint
 
 
 {-| Convenience for adding the appriopriate amount of whitespace on the sides of a full-width container on the page or on the page with side padding.


### PR DESCRIPTION
Fixes https://github.com/NoRedInk/noredink-ui/issues/1556

## :framed_picture: What does this change look like?

<img width="1376" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/a5c7a585-1fbb-45a1-971e-e4446175f52c">

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x]  Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
