### PR TITLE
Adds noMargin option for checkboxes

### DIFF
--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -306,6 +306,7 @@ initAttributes =
                   )
                 ]
             )
+        |> ControlExtra.optionalBoolListItem "noMargin" ( "noMargin True", Checkbox.noMargin True )
 
 
 viewExampleWithCode : State -> Settings -> ( String, Html Msg )

--- a/component-catalog/src/Examples/PremiumCheckbox.elm
+++ b/component-catalog/src/Examples/PremiumCheckbox.elm
@@ -221,6 +221,7 @@ controlAttributes =
             { moduleName = moduleName
             , use = PremiumCheckbox.setCheckboxDisabledLabelCss
             }
+        |> ControlExtra.optionalBoolListItem "noMargin" ( "noMargin True", PremiumCheckbox.noMargin True )
 
 
 viewExampleWithCode : State -> Settings -> ( String, Html Msg )

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -6,8 +6,8 @@ module Nri.Ui.Checkbox.V7 exposing
     , selectedFromBool
     , containerCss, labelCss, custom, nriDescription, id, testId
     , disabled, enabled, guidance, guidanceHtml
-    , viewIcon
     , noMargin
+    , viewIcon
     )
 
 {-|
@@ -55,6 +55,7 @@ module Nri.Ui.Checkbox.V7 exposing
 @docs selectedFromBool
 @docs containerCss, labelCss, custom, nriDescription, id, testId
 @docs disabled, enabled, guidance, guidanceHtml
+@docs noMargin
 
 
 ### Internal

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -7,6 +7,7 @@ module Nri.Ui.Checkbox.V7 exposing
     , containerCss, labelCss, custom, nriDescription, id, testId
     , disabled, enabled, guidance, guidanceHtml
     , viewIcon
+    , noMargin
     )
 
 {-|
@@ -23,6 +24,7 @@ module Nri.Ui.Checkbox.V7 exposing
   - set cursor to not-allowed when disabled
   - update color styling
   - update unselected enabled label color
+  - adds noMargin
 
 
 ## Changes from V6:
@@ -180,6 +182,13 @@ testId id_ =
     custom [ Extra.testId id_ ]
 
 
+{-| Remove default spacing from the top and bottom of the checkbox.
+-}
+noMargin : Bool -> Attribute value
+noMargin removeMargin =
+    Attribute <| \config -> { config | removeMargin = removeMargin }
+
+
 {-| Customizations for the Checkbox.
 -}
 type Attribute msg
@@ -197,6 +206,7 @@ type alias Config msg =
     , custom : List (Html.Attribute msg)
     , containerCss : List Css.Style
     , labelCss : List Css.Style
+    , removeMargin : Bool
     }
 
 
@@ -223,6 +233,7 @@ emptyConfig =
     , custom = []
     , containerCss = []
     , labelCss = []
+    , removeMargin = False
     }
 
 
@@ -286,6 +297,7 @@ view { label, selected } attributes =
                     )
     in
     checkboxContainer config_
+        config
         [ if config.isDisabled then
             div
                 [ css [ cursor notAllowed ]
@@ -355,15 +367,28 @@ selectedToMaybe selected =
             Nothing
 
 
-checkboxContainer : { a | identifier : String, containerCss : List Style } -> List (Html msg) -> Html msg
-checkboxContainer model =
+checkboxContainer :
+    { a
+        | identifier : String
+        , containerCss : List Style
+    }
+    -> { b | removeMargin : Bool }
+    -> List (Html msg)
+    -> Html msg
+checkboxContainer model { removeMargin } =
     Html.span
         [ css
             [ displayFlex
             , alignItems center
             , marginLeft (px -4)
-            , paddingTop (px 5)
-            , paddingBottom (px 5)
+            , batch <|
+                if removeMargin then
+                    []
+
+                else
+                    [ paddingTop (px 5)
+                    , paddingBottom (px 5)
+                    ]
             , height inherit
             , pseudoClass "focus-within"
                 [ Css.Global.descendants

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -534,8 +534,7 @@ viewIcon styles icon =
         [ css
             [ borderRadius (px 3)
             , height (Css.px checkboxIconHeight)
-            , boxSizing contentBox
-            , marginRight (px 7)
+            , marginRight (px 9)
             ]
         , Attributes.class "checkbox-icon-container"
         ]

--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -299,9 +299,7 @@ view { label, selected } attributes =
     checkboxContainer config_
         config
         [ if config.isDisabled then
-            div
-                [ css [ cursor notAllowed ]
-                ]
+            div [ css [ cursor notAllowed ] ]
                 [ viewIcon [] disabledIcon ]
 
           else
@@ -380,14 +378,13 @@ checkboxContainer model { removeMargin } =
         [ css
             [ displayFlex
             , alignItems center
-            , marginLeft (px -4)
             , batch <|
                 if removeMargin then
                     []
 
                 else
-                    [ paddingTop (px 5)
-                    , paddingBottom (px 5)
+                    [ paddingTop (px 9)
+                    , paddingBottom (px 9)
                     ]
             , height inherit
             , pseudoClass "focus-within"
@@ -448,19 +445,10 @@ viewCheckboxLabel :
     -> Html.Html msg
 viewCheckboxLabel config styles =
     let
-        marginTopAdjustment =
-            case config.guidance of
-                Just _ ->
-                    marginTop (Css.px -highContrastBorderWidth)
-
-                Nothing ->
-                    Css.batch []
-
         attributes =
             List.concat
                 [ [ css
                         (paddingLeft (Css.px checkboxIconWidth)
-                            :: marginTopAdjustment
                             :: marginLeft (Css.px -checkboxIconWidth)
                             :: (if config.hideLabel then
                                     minHeight (Css.px checkboxIconHeight)
@@ -544,11 +532,9 @@ viewIcon : List Style -> Svg -> Html msg
 viewIcon styles icon =
     Html.div
         [ css
-            [ border3 (px highContrastBorderWidth) solid transparent
-            , borderRadius (px 3)
+            [ borderRadius (px 3)
             , height (Css.px checkboxIconHeight)
             , boxSizing contentBox
-            , margin (px 2)
             , marginRight (px 7)
             ]
         , Attributes.class "checkbox-icon-container"
@@ -566,8 +552,3 @@ viewIcon styles icon =
             [ Nri.Ui.Svg.V1.toHtml (Nri.Ui.Svg.V1.withCss styles icon)
             ]
         ]
-
-
-highContrastBorderWidth : Float
-highContrastBorderWidth =
-    2

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -272,7 +272,7 @@ viewLockedButton { idValue, label, containerCss, onLockedMsg } =
             , position relative
             , backgroundColor Css.transparent
             , border Css.zero
-            , padding zero
+            , padding2 (px 9) zero
             , cursor pointer
             , Css.batch containerCss
             , textAlign left
@@ -290,9 +290,6 @@ viewLockedButton { idValue, label, containerCss, onLockedMsg } =
             [ css
                 [ outline Css.none
                 , Fonts.baseFont
-                , margin zero
-                , marginLeft (px -4)
-                , padding zero
                 , fontSize (px 15)
                 , display inlineBlock
                 , Css.property "transition" "all 0.4s ease"
@@ -308,14 +305,11 @@ viewLockedButton { idValue, label, containerCss, onLockedMsg } =
                     , position relative
                     , Fonts.baseFont
                     , fontSize (px 15)
-                    , Css.outline3 (Css.px 2) Css.solid Css.transparent
                     ]
                 ]
                 [ Checkbox.viewIcon [] CheckboxIcons.uncheckedDisabled
                 , Html.span
-                    [ css
-                        [ color Colors.gray45
-                        ]
+                    [ css [ color Colors.gray45 ]
                     ]
                     [ Html.text label ]
                 ]
@@ -328,7 +322,9 @@ viewPremiumFlag icon =
     icon
         |> Svg.withLabel "Premium"
         |> Svg.withWidth (Css.px iconWidth)
-        |> Svg.withHeight (Css.px 30)
+        |> Svg.withHeight
+            -- The checkbox is 27px by 27px, which we should match
+            (Css.px 27)
         |> Svg.withCss [ Css.marginRight (Css.px iconRightMargin), Css.flexShrink Css.zero ]
         |> Svg.toHtml
 

--- a/src/Nri/Ui/PremiumCheckbox/V8.elm
+++ b/src/Nri/Ui/PremiumCheckbox/V8.elm
@@ -8,6 +8,7 @@ module Nri.Ui.PremiumCheckbox.V8 exposing
     , setCheckboxContainerCss
     , setCheckboxEnabledLabelCss
     , setCheckboxDisabledLabelCss
+    , noMargin
     )
 
 {-|
@@ -17,6 +18,8 @@ module Nri.Ui.PremiumCheckbox.V8 exposing
 
   - Added vouchered state for premium vouchers with gift pennant
   - Replaced lock icon with disabled checkbox for locked state
+  - Adjust height of locked Premium button to match other checkbox states
+  - Support no-margin option
 
 
 ## Changes from V7:
@@ -48,6 +51,7 @@ module Nri.Ui.PremiumCheckbox.V8 exposing
 @docs setCheckboxContainerCss
 @docs setCheckboxEnabledLabelCss
 @docs setCheckboxDisabledLabelCss
+@docs noMargin
 
 -}
 
@@ -132,6 +136,13 @@ setCheckboxDisabledLabelCss checkboxDisabledLabelCss =
     Attribute <| \config -> { config | checkboxDisabledLabelCss = checkboxDisabledLabelCss }
 
 
+{-| Remove default spacing from the top and bottom of the checkbox.
+-}
+noMargin : Bool -> Attribute value
+noMargin removeMargin =
+    Attribute <| \config -> { config | removeMargin = removeMargin }
+
+
 {-| -}
 selected : Bool -> Attribute msg
 selected isSelected =
@@ -167,6 +178,7 @@ type alias Config msg =
     , checkboxContainerCss : List Css.Style
     , checkboxEnabledLabelCss : List Css.Style
     , checkboxDisabledLabelCss : List Css.Style
+    , removeMargin : Bool
     }
 
 
@@ -184,6 +196,7 @@ emptyConfig =
     , checkboxContainerCss = []
     , checkboxEnabledLabelCss = []
     , checkboxDisabledLabelCss = []
+    , removeMargin = False
     }
 
 
@@ -229,6 +242,7 @@ view { label, onChange } attributes =
             , label = label
             , containerCss = config.containerCss
             , onLockedMsg = config.onLockedMsg
+            , removeMargin = config.removeMargin
             }
 
     else
@@ -259,12 +273,21 @@ view { label, onChange } attributes =
 
                   else
                     Checkbox.labelCss config.checkboxEnabledLabelCss
+                , Checkbox.noMargin config.removeMargin
                 ]
             ]
 
 
-viewLockedButton : { a | idValue : String, label : String, containerCss : List Style, onLockedMsg : Maybe msg } -> Html msg
-viewLockedButton { idValue, label, containerCss, onLockedMsg } =
+viewLockedButton :
+    { a
+        | idValue : String
+        , label : String
+        , containerCss : List Style
+        , onLockedMsg : Maybe msg
+        , removeMargin : Bool
+    }
+    -> Html msg
+viewLockedButton { idValue, label, containerCss, onLockedMsg, removeMargin } =
     Html.button
         [ css
             [ height inherit
@@ -272,7 +295,11 @@ viewLockedButton { idValue, label, containerCss, onLockedMsg } =
             , position relative
             , backgroundColor Css.transparent
             , border Css.zero
-            , padding2 (px 9) zero
+            , if removeMargin then
+                padding zero
+
+              else
+                padding2 (px 9) zero
             , cursor pointer
             , Css.batch containerCss
             , textAlign left


### PR DESCRIPTION
Fixes https://github.com/NoRedInk/noredink-ui/issues/1455

## :framed_picture: What does this change look like?


### No-margin checkbox:
<img width="348" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/5e371d35-b9b9-4d2c-a531-85c99d36de89">

### No-margin premium checkboxes:

<img width="243" alt="Screenshot 2024-01-22 at 1 58 37 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/34f4f5c1-757e-4543-b805-a6653b5c0374">

<img width="247" alt="Screenshot 2024-01-22 at 1 58 31 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/e6554ed0-f168-4cef-8629-3ffe4288a7d4">

<img width="241" alt="Screenshot 2024-01-22 at 1 58 20 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/84453714-b356-4965-a82f-88b6d2aac9c2">



<details>
<summary> Previous description, PR has changed since this was relevant
</summary>


### With default margins

<img width="360" alt="Screenshot 2024-01-17 at 4 05 28 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/3a3d6bc9-34ec-49c9-b715-5e627d0152fb">

### No default margins

<img width="349" alt="Screenshot 2024-01-17 at 4 05 40 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/f349d652-365d-4950-866b-5310874276da">

Please note that the _icon_ still has some margins on it:
<img width="338" alt="Screenshot 2024-01-17 at 4 05 54 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/16377db8-2aec-492d-bcf1-e7f00ffd360d">

</details>

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x]  Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
