### PR TITLE
[PHX-1379] Render markdown in `RadioButtonDotless`

### DIFF
--- a/component-catalog/src/Examples/RadioButtonDotless.elm
+++ b/component-catalog/src/Examples/RadioButtonDotless.elm
@@ -466,7 +466,7 @@ viewExamplesCode selectionSettings selectedValue =
                 ++ Code.recordMultiline
                     [ ( "label", (selectionToString selectionSettings >> Code.string) kind )
                     , ( "name", Code.string "pets" )
-                    , ( "value", selectionToString selectionSettings kind )
+                    , ( "value", Debug.toString kind )
                     , ( "selectedValue"
                       , Code.maybe (Maybe.map (selectionToString selectionSettings) selectedValue)
                       )

--- a/component-catalog/src/Examples/RadioButtonDotless.elm
+++ b/component-catalog/src/Examples/RadioButtonDotless.elm
@@ -103,7 +103,7 @@ controlAttributes =
 initSelectionSettings : Control SelectionSettings
 initSelectionSettings =
     Control.record SelectionSettings
-        |> Control.field "Dogs label" (Control.string "Dogs")
+        |> Control.field "Dogs label" (Control.string "**Dogs**")
         |> Control.field "Dogs" controlAttributes
         |> Control.field "Cats label" (Control.string "Cats")
         |> Control.field "Cats" controlAttributes

--- a/src/Nri/Ui/RadioButtonDotless/V1.elm
+++ b/src/Nri/Ui/RadioButtonDotless/V1.elm
@@ -16,6 +16,7 @@ module Nri.Ui.RadioButtonDotless.V1 exposing
 ### Patch changes:
 
     - Introduce `enabled`/`disabled` attributes and styles
+    - Support markdown for radio button contents (like Button does)
 
 
 # Create a radio button

--- a/src/Nri/Ui/RadioButtonDotless/V1.elm
+++ b/src/Nri/Ui/RadioButtonDotless/V1.elm
@@ -243,6 +243,9 @@ emptyConfig =
 
 
 {-| View the single dotless radio button
+
+`label` supports bold and italic markdown syntax
+
 -}
 view :
     { label : String

--- a/src/Nri/Ui/RadioButtonDotless/V1.elm
+++ b/src/Nri/Ui/RadioButtonDotless/V1.elm
@@ -46,6 +46,7 @@ module Nri.Ui.RadioButtonDotless.V1 exposing
 
 import Accessibility.Styled exposing (..)
 import Accessibility.Styled.Aria as Aria
+import Content
 import Css exposing (..)
 import Html.Styled as Html
 import Html.Styled.Attributes as Attributes exposing (css)
@@ -410,6 +411,6 @@ view { label, name, value, valueToString, selectedValue } attributes =
                         ++ config.labelCss
                     )
                 ]
-                [ text label ]
+                (Content.markdownInline label)
             ]
         ]


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

`RadioButtonDotless` was created to turn Multiple Choice questions into a radio style selection + submit step for the QE.  We missed a feature that the legacy interface support as it used buttons which have markdown support.  This PR adds support for markdown to `RadioButtonDotless` as well. 

- https://linear.app/noredink/issue/PHX-1379/radiobuttondotless-needs-to-handle-markdown

## :framed_picture: What does this change look like?

| Before | After | 
| --- | --- |
| <img width="1436" alt="Screenshot 2024-01-18 at 3 25 42 PM" src="https://github.com/NoRedInk/noredink-ui/assets/12899207/4c741fb3-efcc-4735-a1e9-bb9e575a59e6"> | <img width="1401" alt="Screenshot 2024-01-18 at 3 34 21 PM" src="https://github.com/NoRedInk/noredink-ui/assets/12899207/525d9792-7f5e-4478-9e68-45257368911a"> |


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x]  Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
