### PR TITLE
[PHX-1379] Bump to 27.8.2 to include markdown support in RadioButtonDotless

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "27.8.1",
+    "version": "27.8.2",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `27.8.2`

## What changes does this release include?

- #1597
- #1603

## How has the API changed?

```
No API changes detected, so this is a PATCH change.
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).