### PR TITLE
Move locked premium button under li

### DIFF
--- a/component-catalog/src/Examples/SideNav.elm
+++ b/component-catalog/src/Examples/SideNav.elm
@@ -18,6 +18,7 @@ import EllieLink
 import Example exposing (Example)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Data.PremiumDisplay as PremiumDisplay
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.SideNav.V5 as SideNav
 import Nri.Ui.Spacing.V1 as Spacing
@@ -200,6 +201,56 @@ view ellieLinkConfig state =
             , SideNav.html [ Text.smallBody [ Text.plaintext "Demo Accounts disabled on staging" ] ]
             , SideNav.entry "Sham Assignment" []
             ]
+        ]
+    , Heading.h2
+        [ Heading.plaintext "Premium Display"
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+        ]
+    , SideNav.view
+        { isCurrentRoute = \route -> route == "/subchildren-unlocked"
+        , routeToString = identity
+        , onSkipNav = SkipToContent
+        }
+        [ SideNav.navLabel "Premium Display"
+        , SideNav.navId "premium-display-sidenav"
+        ]
+        (premiumDisplayEntries "/"
+            ++ [ SideNav.entryWithChildren "As subchildren"
+                    []
+                    (premiumDisplayEntries "/subchildren")
+               , SideNav.compactGroup "In a compact group"
+                    []
+                    (premiumDisplayEntries "/compact")
+               ]
+        )
+    ]
+
+
+premiumDisplayEntries : String -> List (SideNav.Entry String Msg)
+premiumDisplayEntries hrefPrefix =
+    [ SideNav.entry "Free"
+        [ SideNav.premiumDisplay
+            PremiumDisplay.Free
+            (ConsoleLog "Clicked Free SideNav Entry")
+        , SideNav.href (hrefPrefix ++ "-free")
+        ]
+    , SideNav.entry "Unlocked"
+        [ SideNav.premiumDisplay
+            PremiumDisplay.PremiumUnlocked
+            (ConsoleLog "Clicked PremiumUnlocked SideNav Entry")
+        , SideNav.href (hrefPrefix ++ "-unlocked")
+        ]
+    , SideNav.entry "Locked"
+        [ SideNav.premiumDisplay
+            PremiumDisplay.PremiumLocked
+            (ConsoleLog "Clicked PremiumLocked SideNav Entry")
+        , SideNav.href (hrefPrefix ++ "-locked")
+        ]
+    , SideNav.entry "Vouchered"
+        [ SideNav.premiumDisplay
+            PremiumDisplay.PremiumVouchered
+            (ConsoleLog "Clicked PremiumVouchered SideNav Entry")
+        , SideNav.href (hrefPrefix ++ "-vouchered")
         ]
     ]
 

--- a/src/Nri/Ui/SideNav/V5.elm
+++ b/src/Nri/Ui/SideNav/V5.elm
@@ -448,7 +448,7 @@ viewSidebarEntry config extraStyles entry_ =
     case entry_ of
         Entry children entryConfig ->
             if entryConfig.premiumDisplay == PremiumDisplay.PremiumLocked then
-                viewLockedEntry extraStyles entryConfig
+                li [] [ viewLockedEntry extraStyles entryConfig ]
 
             else if anyLinkDescendants (isCurrentRoute config) children then
                 let

--- a/src/Nri/Ui/SideNav/V5.elm
+++ b/src/Nri/Ui/SideNav/V5.elm
@@ -20,6 +20,7 @@ module Nri.Ui.SideNav.V5 exposing
   - uses `ul>li` for the structure
   - adds `aria-current="true"` to the parent of the current page
   - expose missing import
+  - correct locked premium content to match `ul>li` structure
 
 
 ### Changes from V4


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Relates to QUO-325

While working on a PR implementing an underlined blank block in short response, the following test failure popped up:

```
 1) curriculum page Standards has Standards & Tests flow
     Failure/Error: expect(page).to be_axe_clean.excluding("#browse-and-assign-entry__test\\:-act").skipping('landmark-unique')

       Found 1 accessibility violation:

       1) list: <ul> and <ol> must only directly contain <li>, <script> or <template> elements (serious)
           https://dequeuniversity.com/rules/axe/4.7/list?application=axeAPI
           The following 1 node violate this rule:

               Selector: #sidenav > ._d80d60b3
               HTML: <ul class="_d80d60b3">
               Fix all of the following:
               - List element has direct children that are not allowed: button

       Invocation: axe.run({:exclude=>[["#browse-and-assign-entry__test\\:-act"]]}, {:rules=>{"landmark-unique"=>{:enabled=>false}}}, callback);
```

![screenshot_2024-01-22-12-11-05 166](https://github.com/NoRedInk/noredink-ui/assets/32229300/77453ffe-9a39-4e15-977b-da6dd8f78500)

After some research, this is because of the locked premium content being placed directly beneath the `ul`, instead of within an `li`. This PR simply places it within an `li`, fixing the a11y issue.

## :framed_picture: What does this change look like?

<img width="345" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/32229300/95c8ae26-6e5d-47c5-849a-c8e264ff1688">

<img width="474" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/32229300/37d394d1-a416-453a-83da-f6eedc248120">


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x]  Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
