### PR TITLE
27.9.0 release - Fixes for SideNav, new ClickableText V4, narrow helpers for Spacing

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "27.8.2",
+    "version": "27.9.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `27.9.0`

## What changes does this release include?

The easiest and most reliable way to find the changes that this release includes is to go through the changes between the last version number and master: `https://github.com/NoRedInk/noredink-ui/compare/VERSION_NUMBER...master`.

- #1605 - Correct the premium lock button to be an `li` beneath the parent `ul`
- #1589 - Added ClickableText V4
- #1602 - Add examples for premium checkboxes
- #1601 - Correctly expose `CollapsibleConfig` from SideNav
- #1598 - Add helpers for narrow Spacing options.


## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```
---- ADDED MODULES - MINOR ----

    Nri.Ui.ClickableText.V4


---- Nri.Ui.SideNav.V5 - MINOR ----

    Added:
        type alias CollapsibleConfig msg =
            { isOpen : Basics.Bool
            , toggle : Basics.Bool -> msg
            , isTooltipOpen : Basics.Bool
            , toggleTooltip : Basics.Bool -> msg
            }


---- Nri.Ui.Spacing.V1 - MINOR ----

    Added:
        centeredNarrowContentWithSidePadding : Css.Style
        narrowCenteredContent : Css.Style
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).
