### PR TITLE
Fix sidenav styles

### DIFF
--- a/src/Nri/Ui/SideNav/V5.elm
+++ b/src/Nri/Ui/SideNav/V5.elm
@@ -456,7 +456,7 @@ viewSidebarEntry config extraStyles entry_ =
                     id_ =
                         AttributesExtra.safeIdWithPrefix "sidenav-group" entryConfig.title
                 in
-                li []
+                li [ Attributes.css extraStyles ]
                     [ styled span
                         (sharedEntryStyles
                             ++ [ backgroundColor Colors.gray92


### PR DESCRIPTION
[Ben noticed](https://noredink.slack.com/archives/C9MEFL3KL/p1706300757729469?thread_ts=1706298959.789299&cid=C9MEFL3KL) that the Sidenav wasn't rendering correctly on Component pages when a Category is selected. This fixes.

### Before

<img width="470" alt="Screenshot 2024-01-26 at 2 10 21 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/a104495d-a0bd-4e23-a126-7d9529f1426c">

### After

<img width="460" alt="Screenshot 2024-01-26 at 2 09 59 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/598b954a-883d-4739-bbe6-2008770a0c26">
