### PR TITLE
Improve reflow for CC on mobile

### DIFF
--- a/component-catalog/src/App.elm
+++ b/component-catalog/src/App.elm
@@ -516,8 +516,9 @@ examplesContainer : List Css.Style -> List (Html msg) -> Html msg
 examplesContainer extraStyles =
     Html.div
         [ css
-            [ Css.displayFlex
-            , Css.flexWrap Css.wrap
+            [ Css.property "display" "grid"
+            , Css.property "grid-template-columns" "repeat(auto-fit, minmax(200px, 1fr))"
+            , Css.justifyContent Css.start
             , Css.property "row-gap" (.value Spacing.verticalSpacerPx)
             , Css.property "column-gap" (.value Spacing.horizontalSpacerPx)
             , Css.batch extraStyles

--- a/component-catalog/src/Example.elm
+++ b/component-catalog/src/Example.elm
@@ -134,9 +134,7 @@ preview_ { swallowEvent, navigate, exampleHref } example =
     Container.view
         [ Container.gray
         , Container.css
-            [ Css.flexBasis (Css.px 200)
-            , Css.flexShrink Css.zero
-            , Css.hover
+            [ Css.hover
                 [ Css.backgroundColor Colors.glacier
                 , Css.cursor Css.pointer
                 ]


### PR DESCRIPTION
Only touches the Component Catalog to try to make the mobile view a bit better.

| | Before | After |
| --- | --- | --- |
| wide viewport component examples| <img width="1725" alt="Screenshot 2024-01-26 at 4 01 02 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/57446d7d-49a5-49f8-941f-1a7c88ac160e"> | <img width="1728" alt="Screenshot 2024-01-26 at 4 00 50 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/436769f9-0404-48a7-8fc4-6abb3ece2d37"> |
| iphone se viewport width component examples |  <img width="1377" alt="Screenshot 2024-01-26 at 4 01 21 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/43ef4627-02fd-44ed-b7f6-b9f56d6ce4a1"> | <img width="1203" alt="Screenshot 2024-01-26 at 4 01 33 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/251f08c1-e60d-43b2-9120-3552f96b5f39"> |
| wide viewport usage examples | <img width="1491" alt="Screenshot 2024-01-26 at 4 05 51 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/8731dfbb-d536-48f4-be6f-cdccd04bc582">  | <img width="1510" alt="Screenshot 2024-01-26 at 4 05 25 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/af95a411-2cb0-4313-bbb1-276f6c12d2b7">  | 
| iphone se viewport width usage examples | <img width="1123" alt="Screenshot 2024-01-26 at 4 05 46 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/e07d9694-e554-4e0a-b094-8f025ed1e6ee">  | <img width="1112" alt="Screenshot 2024-01-26 at 4 05 33 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/cc1f8195-662d-4fd5-9266-4c41d432d5af">  |




