### PR TITLE
Honor icon/rightIcon on entries with children

### DIFF
--- a/component-catalog/src/Examples/SideNav.elm
+++ b/component-catalog/src/Examples/SideNav.elm
@@ -23,6 +23,7 @@ import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.SideNav.V5 as SideNav
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Text.V6 as Text
+import Nri.Ui.UiIcon.V1 as UiIcon
 
 
 version : Int
@@ -145,9 +146,9 @@ view ellieLinkConfig state =
                 , Text.css [ Css.paddingBottom (Css.px 10) ]
                 ]
             ]
-        , SideNav.entry "Entry" []
+        , SideNav.entry "Entry" [ SideNav.icon UiIcon.person ]
         , SideNav.entryWithChildren "Entry with Children"
-            []
+            [ SideNav.icon UiIcon.bulb ]
             [ SideNav.entry "Child 1"
                 [ SideNav.href "complex-example__child-1"
                 ]

--- a/src/Nri/Ui/SideNav/V5.elm
+++ b/src/Nri/Ui/SideNav/V5.elm
@@ -21,6 +21,7 @@ module Nri.Ui.SideNav.V5 exposing
   - adds `aria-current="true"` to the parent of the current page
   - expose missing import
   - correct locked premium content to match `ul>li` structure
+  - honor icon/rightIcon for entries with children
 
 
 ### Changes from V4
@@ -467,7 +468,10 @@ viewSidebarEntry config extraStyles entry_ =
                                ]
                         )
                         [ Attributes.id id_, Aria.currentItem True ]
-                        [ text entryConfig.title ]
+                        [ viewLeftIcon entryConfig
+                        , text entryConfig.title
+                        , viewRightIcon entryConfig
+                        ]
                     , ul
                         [ Attributes.css
                             ([ listStyle none


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

As part of KRA-1345 we are going to use SideNav.icon for the emoji. We noticed that the icons are not rendered for entries with children. This PR fixes that.

## :framed_picture: What does this change look like?

Before this PR (with both entries using SideNav.icon)
<img width="519" alt="Screenshot 2024-01-30 at 17 58 48" src="https://github.com/NoRedInk/noredink-ui/assets/459923/f8fd31ff-916b-40c9-bf7d-da24c211efb9">



After this PR 

<img width="527" alt="Screenshot 2024-01-30 at 17 58 30" src="https://github.com/NoRedInk/noredink-ui/assets/459923/dd1cf809-d023-4cec-bd99-650991bee7e9">


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [ ] Please assign the following reviewers:
  - [ ]  Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [ ]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
