### PR TITLE
Table header color

### DIFF
--- a/src/Nri/Ui/Table/V7.elm
+++ b/src/Nri/Ui/Table/V7.elm
@@ -261,6 +261,7 @@ headerStyles =
     [ padding4 (px 11) (px 12) (px 14) (px 12)
     , textAlign left
     , fontWeight bold
+    , color gray20
     ]
 
 


### PR DESCRIPTION
Set the table header color to gray20 so it's not browser default black

<img width="674" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/13528834/a83b494b-116a-4877-8dbd-f9b3e97b2f8b">