### PR TITLE
Bat/breadcrumbs additional info

### DIFF
--- a/component-catalog/src/Example.elm
+++ b/component-catalog/src/Example.elm
@@ -191,7 +191,7 @@ view_ ellieLinkConfig example =
 
 viewAbout : List (Html Never) -> Html msg
 viewAbout about =
-    Text.mediumBody [ Text.html about ]
+    Html.div [] about
         |> Html.map never
 
 

--- a/component-catalog/src/Example.elm
+++ b/component-catalog/src/Example.elm
@@ -17,7 +17,6 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Header.V1 as Header
 import Nri.Ui.MediaQuery.V1 exposing (mobile)
-import Nri.Ui.Text.V6 as Text
 
 
 type alias Example state msg =

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -80,9 +80,13 @@ example =
             |> p [ css [ Fonts.baseFont, Css.fontSize (Css.px 12), Css.margin Css.zero ] ]
         ]
     , about =
-        [ text "You might also know the Block element as a “Display Element”. Learn more in "
-        , ClickableText.link "Display Elements and Scaffolding Container: additional things to know"
-            [ ClickableText.linkExternal "https://paper.dropbox.com/doc/Display-Elements-and-Scaffolding-Container-additional-things-to-know--BwRhBMKyXFFSWz~1mljN29bcAg-6vszpNDLoYIiMyg7Wv66s"
+        [ Text.mediumBody
+            [ Text.html
+                [ text "You might also know the Block element as a “Display Element”. Learn more in "
+                , ClickableText.link "Display Elements and Scaffolding Container: additional things to know"
+                    [ ClickableText.linkExternal "https://paper.dropbox.com/doc/Display-Elements-and-Scaffolding-Container-additional-things-to-know--BwRhBMKyXFFSWz~1mljN29bcAg-6vszpNDLoYIiMyg7Wv66s"
+                    ]
+                ]
             ]
         ]
     , view =

--- a/component-catalog/src/Examples/BreadCrumbs.elm
+++ b/component-catalog/src/Examples/BreadCrumbs.elm
@@ -26,6 +26,7 @@ import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 
 
@@ -73,16 +74,19 @@ example =
             ]
         ]
     , about =
-        [ text "BreadCrumbs orient users to their location and provide convenient links to go 'up' to parent pages."
-        , text "Typically, you'll use Header.view rather than BreadCrumbs.view to render primary/h1-level BreadCrumbs."
-        , text "You may use BreadCrumbs.viewSecondary to render h2-level BreadCrumbs."
-        , text "You should use BreadCrumbs.headerId to move focus to the current h1 or h2 and BreadCrumbs.toPageTitle to dynamically change the title when the page context changes."
-        , text "This and more is all explained in more depth in Tessa's "
-        , ClickableText.link "BreadCrumbs component demo"
-            [ ClickableText.linkExternal "https://noredink.zoom.us/rec/play/x1x2Vz0fpj-qz0qf5gi5cpTy9Is1sIWGfwCoZ1_iOELkmkBtGUpdKyD6TydBM9vvFgJdD0jP3DUmZp4K.BU8uDgAVoRddWSd2?canPlayFromShare=true&from=share_recording_detail&startTime=1682608412000&componentName=rec-play&originRequestUrl=https%3A%2F%2Fnoredink.zoom.us%2Frec%2Fshare%2FtmIuIbuqWmFU20191vHs15QJv1ikMYQrcSKLXOMOOXlDQTHOg2-23ehZbZyG9f8L.c05C6jZecqKyPjub%3FstartTime%3D1682608412000"
-            , ClickableText.appearsInline
+        [ Text.mediumBody [ Text.markdown "`BreadCrumbs` orient users and provide convenient links to go \"up\" to parent pages." ]
+        , Text.mediumBody [ Text.markdown "Typically, you'll use `Header.view` (rather than `BreadCrumbs.view`) to render primary/`h1`-level `BreadCrumbs`. You may use `BreadCrumbs.viewSecondary` to render `h2`-level `BreadCrumbs`." ]
+        , Text.mediumBody [ Text.markdown "You should use `BreadCrumbs.headerId` to move focus to the current `h1` or `h2` and `BreadCrumbs.toPageTitle` to dynamically change the title when the page context changes." ]
+        , Text.mediumBody
+            [ Text.html
+                [ text "This and more is explained in depth in Tessa's "
+                , ClickableText.link "BreadCrumbs component demo"
+                    [ ClickableText.linkExternal "https://noredink.zoom.us/rec/play/x1x2Vz0fpj-qz0qf5gi5cpTy9Is1sIWGfwCoZ1_iOELkmkBtGUpdKyD6TydBM9vvFgJdD0jP3DUmZp4K.BU8uDgAVoRddWSd2?canPlayFromShare=true&from=share_recording_detail&startTime=1682608412000&componentName=rec-play&originRequestUrl=https%3A%2F%2Fnoredink.zoom.us%2Frec%2Fshare%2FtmIuIbuqWmFU20191vHs15QJv1ikMYQrcSKLXOMOOXlDQTHOg2-23ehZbZyG9f8L.c05C6jZecqKyPjub%3FstartTime%3D1682608412000"
+                    , ClickableText.appearsInline
+                    ]
+                , text "."
+                ]
             ]
-        , text "."
         ]
     , view =
         \ellieLinkConfig state ->

--- a/component-catalog/src/Examples/BreadCrumbs.elm
+++ b/component-catalog/src/Examples/BreadCrumbs.elm
@@ -18,6 +18,7 @@ import Example exposing (Example)
 import Html.Styled.Attributes exposing (css, href)
 import Nri.Ui.AssignmentIcon.V2 as AssignmentIcon
 import Nri.Ui.BreadCrumbs.V2 as BreadCrumbs exposing (BreadCrumbAttribute, BreadCrumbs)
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
@@ -71,7 +72,18 @@ example =
             , previewText "Sub-Category "
             ]
         ]
-    , about = []
+    , about =
+        [ text "BreadCrumbs orient users to their location and provide convenient links to go 'up' to parent pages."
+        , text "Typically, you'll use Header.view rather than BreadCrumbs.view to render primary/h1-level BreadCrumbs."
+        , text "You may use BreadCrumbs.viewSecondary to render h2-level BreadCrumbs."
+        , text "You should use BreadCrumbs.headerId to move focus to the current h1 or h2 and BreadCrumbs.toPageTitle to dynamically change the title when the page context changes."
+        , text "This and more is all explained in more depth in Tessa's "
+        , ClickableText.link "BreadCrumbs component demo"
+            [ ClickableText.linkExternal "https://noredink.zoom.us/rec/play/x1x2Vz0fpj-qz0qf5gi5cpTy9Is1sIWGfwCoZ1_iOELkmkBtGUpdKyD6TydBM9vvFgJdD0jP3DUmZp4K.BU8uDgAVoRddWSd2?canPlayFromShare=true&from=share_recording_detail&startTime=1682608412000&componentName=rec-play&originRequestUrl=https%3A%2F%2Fnoredink.zoom.us%2Frec%2Fshare%2FtmIuIbuqWmFU20191vHs15QJv1ikMYQrcSKLXOMOOXlDQTHOg2-23ehZbZyG9f8L.c05C6jZecqKyPjub%3FstartTime%3D1682608412000"
+            , ClickableText.appearsInline
+            ]
+        , text "."
+        ]
     , view =
         \ellieLinkConfig state ->
             let

--- a/component-catalog/src/Examples/Button.elm
+++ b/component-catalog/src/Examples/Button.elm
@@ -20,6 +20,7 @@ import Examples.RadioButtonDotless as RadioButtonDotlessExample
 import Html.Styled exposing (..)
 import Html.Styled.Attributes as Attributes exposing (css)
 import Nri.Ui.Button.V10 as Button
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Message.V4 as Message
@@ -76,12 +77,14 @@ example =
             ]
         ]
     , about =
-        [ let
-            url =
-                Routes.exampleHref RadioButtonDotlessExample.example
-          in
-          Message.view
-            [ Message.markdown <| "Looking for a group of buttons where only one button is selectable at a time? Check out [RadioButtonDotless](" ++ url ++ ")"
+        [ Message.view
+            [ Message.html
+                [ text "Looking for a group of buttons where only one button is selectable at a time? Check out "
+                , ClickableText.link "RadioButtonDotless"
+                    [ ClickableText.href (Routes.exampleHref RadioButtonDotlessExample.example)
+                    , ClickableText.appearsInline
+                    ]
+                ]
             ]
         ]
     , view = \ellieLinkConfig state -> [ viewButtonExamples ellieLinkConfig state ]

--- a/component-catalog/src/Examples/FocusRing.elm
+++ b/component-catalog/src/Examples/FocusRing.elm
@@ -27,6 +27,7 @@ import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Switch.V3 as Switch
 import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Task
 
@@ -46,12 +47,16 @@ example =
         , example_ FocusRing.tightStyles
         ]
     , about =
-        [ text "Custom high-contrast focus ring styles. Learn more about this component in "
-        , ClickableText.link "Custom Focus Rings on the NoRedInk blog"
-            [ ClickableText.linkExternal "https://blog.noredink.com/post/703458632758689792/custom-focus-rings"
-            , ClickableText.appearsInline
+        [ Text.mediumBody
+            [ Text.html
+                [ text "Custom high-contrast focus ring styles. Learn more about this component in "
+                , ClickableText.link "Custom Focus Rings on the NoRedInk blog"
+                    [ ClickableText.linkExternal "https://blog.noredink.com/post/703458632758689792/custom-focus-rings"
+                    , ClickableText.appearsInline
+                    ]
+                , text "."
+                ]
             ]
-        , text "."
         ]
     , view =
         \_ state ->

--- a/component-catalog/src/Examples/Fonts.elm
+++ b/component-catalog/src/Examples/Fonts.elm
@@ -16,6 +16,7 @@ import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Text.V6 as Text
 
 
 {-| -}
@@ -45,17 +46,21 @@ example =
         ]
             |> List.map viewPreview
     , about =
-        [ Html.text "Learn more about kid-friendly and accessible fonts starting at 24:40 in "
-        , ClickableText.link "Kids Websites: Where Fun and Accessibility Come to Play"
-            [ ClickableText.linkExternal "https://www.deque.com/axe-con/sessions/kids-websites-where-fun-and-accessibility-come-to-play/"
-            , ClickableText.appearsInline
+        [ Text.mediumBody
+            [ Text.html
+                [ Html.text "Learn more about kid-friendly and accessible fonts starting at 24:40 in "
+                , ClickableText.link "Kids Websites: Where Fun and Accessibility Come to Play"
+                    [ ClickableText.linkExternal "https://www.deque.com/axe-con/sessions/kids-websites-where-fun-and-accessibility-come-to-play/"
+                    , ClickableText.appearsInline
+                    ]
+                , Html.text " and in "
+                , ClickableText.link "Accessible fonts and readability: the basics"
+                    [ ClickableText.linkExternal "https://business.scope.org.uk/article/font-accessibility-and-readability-the-basics#:~:text=This%20can%20affect%20reading%20speed,does%20this%20is%20Gill%20Sans."
+                    , ClickableText.appearsInline
+                    ]
+                , Html.text "."
+                ]
             ]
-        , Html.text " and in "
-        , ClickableText.link "Accessible fonts and readability: the basics"
-            [ ClickableText.linkExternal "https://business.scope.org.uk/article/font-accessibility-and-readability-the-basics#:~:text=This%20can%20affect%20reading%20speed,does%20this%20is%20Gill%20Sans."
-            , ClickableText.appearsInline
-            ]
-        , Html.text "."
         ]
     , view =
         \ellieLinkConfig _ ->

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -26,6 +26,7 @@ import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V10 as Button
+import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Data.PremiumDisplay as PremiumDisplay
 import Nri.Ui.Heading.V3 as Heading
@@ -63,12 +64,14 @@ example =
     , subscriptions = subscriptions
     , preview = preview
     , about =
-        [ let
-            url =
-                Routes.exampleHref RadioButtonDotlessExample.example
-          in
-          Message.view
-            [ Message.markdown <| "Looking for radio button that's styled more like a button?<br />Check out [RadioButtonDotless](" ++ url ++ ")"
+        [ Message.view
+            [ Message.html
+                [ text "Looking for a group of buttons where only one button is selectable at a time? Check out "
+                , ClickableText.link "RadioButtonDotless"
+                    [ ClickableText.href (Routes.exampleHref RadioButtonDotlessExample.example)
+                    , ClickableText.appearsInline
+                    ]
+                ]
             ]
         ]
     , view = view

--- a/component-catalog/src/Guidance.elm
+++ b/component-catalog/src/Guidance.elm
@@ -2,13 +2,18 @@ module Guidance exposing (..)
 
 import Html.Styled exposing (..)
 import Nri.Ui.ClickableText.V4 as ClickableText
+import Nri.Ui.Text.V6 as Text
 
 
 useATACGuide : String -> List (Html msg)
 useATACGuide moduleName =
-    [ text ("To ensure your use of " ++ moduleName ++ " is accessible to assistive technology, please review the ")
-    , ClickableText.link "Assistive technology notification design & development guide"
-        [ ClickableText.linkExternal "https://noredinkaccessibility.screenstepslive.com/a/1651037-assistive-technology-notification-design-development-guide"
+    [ Text.mediumBody
+        [ Text.html
+            [ text ("To ensure your use of " ++ moduleName ++ " is accessible to assistive technology, please review the ")
+            , ClickableText.link "Assistive technology notification design & development guide"
+                [ ClickableText.linkExternal "https://noredinkaccessibility.screenstepslive.com/a/1651037-assistive-technology-notification-design-development-guide"
+                ]
+            , text (" to see if your use case fits any listed in the guide. If it does, please follow the guide to learn how to properly implement " ++ moduleName ++ ".")
+            ]
         ]
-    , text (" to see if your use case fits any listed in the guide. If it does, please follow the guide to learn how to properly implement " ++ moduleName ++ ".")
     ]

--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -2,6 +2,7 @@ Nri.Ui.Accordion.V3,upgrade to V4
 Nri.Ui.Block.V4,upgrade to V6
 Nri.Ui.Block.V5,upgrade to V6
 Nri.Ui.Carousel.V1,upgrade to V2
+Nri.Ui.ClickableText.V3,upgrade to V4
 Nri.Ui.WhenFocusLeaves.V1,upgrade to V2
 Nri.Ui.Highlighter.V4,upgrade to V5
 Nri.Ui.Mark.V2,upgrade to V5

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -88,6 +88,9 @@ hint = 'upgrade to V7'
 hint = 'upgrade to V2'
 usages = ['component-catalog-app/Examples/Tooltip.elm']
 
+[forbidden."Nri.Ui.ClickableText.V3"]
+hint = 'upgrade to V4'
+
 [forbidden."Nri.Ui.Container.V1"]
 hint = 'upgrade to V2'
 


### PR DESCRIPTION
Component Catalog-only change.

Adds an About section to BreadCrumbs:
<img width="1450" alt="Screenshot 2024-01-31 at 10 57 12 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/bad08142-2de5-484a-9e4c-daec656c42da">

This also changes the "About" default to not wrap the content automatically with Text.mediumBody and Text.html, as this was limiting in terms of the type of content that could be passed through. 