### PR TITLE
Add `rightIcon` to `RadioButton`

### DIFF
--- a/component-catalog/src/CommonControls.elm
+++ b/component-catalog/src/CommonControls.elm
@@ -329,6 +329,7 @@ rightIcon moduleName f =
               , "(Svg.withLabel \"Opens in new tab\" UiIcon.openInNewTab)"
               , UiIcon.openInNewTab
               )
+            , ( "gradingAssistant", "UiIcon.gradingAssistant", UiIcon.gradingAssistant )
             ]
             |> Control.choice
         )

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -398,6 +398,7 @@ controlAttributes =
             , errorMessage = Just RadioButton.errorMessage
             , message = "The statement must be true."
             }
+        |> CommonControls.icon "RadioButton" RadioButton.rightIcon
 
 
 labelVisibility : Control ( String, RadioButton.Attribute Selection Msg )

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -398,7 +398,7 @@ controlAttributes =
             , errorMessage = Just RadioButton.errorMessage
             , message = "The statement must be true."
             }
-        |> CommonControls.icon "RadioButton" RadioButton.rightIcon
+        |> CommonControls.rightIcon "RadioButton" RadioButton.rightIcon
 
 
 labelVisibility : Control ( String, RadioButton.Attribute Selection Msg )

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -72,7 +72,6 @@ import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.Pennant.V3 as Pennant
 import Nri.Ui.Svg.V1 exposing (Svg)
-import Nri.Ui.UiIcon.V1 as UiIcon
 import Svg.Styled as Svg
 import Svg.Styled.Attributes as SvgAttributes
 

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -7,6 +7,7 @@ module Nri.Ui.RadioButton.V4 exposing
     , hiddenLabel, visibleLabel
     , containerCss, labelCss, custom, nriDescription, id, testId
     , disabled, enabled, errorIf, errorMessage, guidance, guidanceHtml
+    , rightIcon
     )
 
 {-|
@@ -50,6 +51,7 @@ module Nri.Ui.RadioButton.V4 exposing
 @docs hiddenLabel, visibleLabel
 @docs containerCss, labelCss, custom, nriDescription, id, testId
 @docs disabled, enabled, errorIf, errorMessage, guidance, guidanceHtml
+@docs rightIcon
 
 -}
 
@@ -69,6 +71,7 @@ import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
 import Nri.Ui.Pennant.V3 as Pennant
 import Nri.Ui.Svg.V1 exposing (Svg)
+import Nri.Ui.UiIcon.V1 as UiIcon
 import Svg.Styled as Svg
 import Svg.Styled.Attributes as SvgAttributes
 
@@ -114,6 +117,13 @@ guidance =
 guidanceHtml : List (Html msg) -> Attribute value msg
 guidanceHtml =
     Attribute << InputErrorAndGuidanceInternal.setGuidanceHtml
+
+
+{-| Adds an icon to the right of the label
+-}
+rightIcon : Svg -> Attribute value msg
+rightIcon icon =
+    Attribute <| \config -> { config | rightIcon = Just icon }
 
 
 {-| Fire a message parameterized by the value type when selecting a radio option
@@ -236,6 +246,7 @@ type alias Config value msg =
     , onSelect : Maybe (value -> msg)
     , onLockedMsg : Maybe msg
     , disclosedContent : List (Html msg)
+    , rightIcon : Maybe Svg
     }
 
 
@@ -254,6 +265,7 @@ emptyConfig =
     , onSelect = Nothing
     , onLockedMsg = Nothing
     , disclosedContent = []
+    , rightIcon = Nothing
     }
 
 
@@ -437,7 +449,19 @@ view { label, name, value, valueToString, selectedValue } attributes =
                         premiumPennant
 
                       else
-                        text ""
+                        case config.rightIcon of
+                            Just icon ->
+                                icon
+                                    |> Nri.Ui.Svg.V1.withWidth (px 20)
+                                    |> Nri.Ui.Svg.V1.withHeight (px 20)
+                                    |> Nri.Ui.Svg.V1.withCss
+                                        [ marginLeft (px 4)
+                                        , verticalAlign middle
+                                        ]
+                                    |> Nri.Ui.Svg.V1.toHtml
+
+                            Nothing ->
+                                text ""
                     ]
                 ]
              ]

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -23,6 +23,7 @@ module Nri.Ui.RadioButton.V4 exposing
     and removes onClick event handler. These changes prevent the element from
     being selected but keep it in the tab order and ensure that tooltips can
     still be displayed when the element is focused.
+  - add `rightIcon` property
 
 
 ### Changes from V3:

--- a/src/Nri/Ui/RadioButton/V4.elm
+++ b/src/Nri/Ui/RadioButton/V4.elm
@@ -70,6 +70,7 @@ import Nri.Ui.Data.PremiumDisplay as PremiumDisplay exposing (PremiumDisplay)
 import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
+import Nri.Ui.Html.V3 exposing (viewIf, viewJust)
 import Nri.Ui.Pennant.V3 as Pennant
 import Nri.Ui.Svg.V1 exposing (Svg)
 import Svg.Styled as Svg
@@ -445,23 +446,8 @@ view { label, name, value, valueToString, selectedValue } attributes =
                             [ css config.labelCss ]
                         )
                         [ Html.text label ]
-                    , if isPremium then
-                        premiumPennant
-
-                      else
-                        case config.rightIcon of
-                            Just icon ->
-                                icon
-                                    |> Nri.Ui.Svg.V1.withWidth (px 20)
-                                    |> Nri.Ui.Svg.V1.withHeight (px 20)
-                                    |> Nri.Ui.Svg.V1.withCss
-                                        [ marginLeft (px 4)
-                                        , verticalAlign middle
-                                        ]
-                                    |> Nri.Ui.Svg.V1.toHtml
-
-                            Nothing ->
-                                text ""
+                    , viewJust viewIcon config.rightIcon
+                    , viewIf (\_ -> premiumPennant) isPremium
                     ]
                 ]
              ]
@@ -473,6 +459,18 @@ view { label, name, value, valueToString, selectedValue } attributes =
                         []
                    )
             )
+
+
+viewIcon : Svg -> Html msg
+viewIcon icon =
+    icon
+        |> Nri.Ui.Svg.V1.withWidth (px 20)
+        |> Nri.Ui.Svg.V1.withHeight (px 20)
+        |> Nri.Ui.Svg.V1.withCss
+            [ marginLeft (px 4)
+            , verticalAlign middle
+            ]
+        |> Nri.Ui.Svg.V1.toHtml
 
 
 viewLockedButton : { idValue : String, label : String } -> Config value msg -> Html msg
@@ -540,6 +538,7 @@ viewLockedButton { idValue, label } config =
                             config.labelCss
                     ]
                     [ Html.text label ]
+                , viewJust viewIcon config.rightIcon
                 , premiumPennant
                 ]
             ]


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

https://noredink.slack.com/archives/C0VVDLEES/p1706727431228269

## :framed_picture: What does this change look like?

![image](https://github.com/NoRedInk/noredink-ui/assets/12688694/f4995d65-9a2d-40e2-8c53-8eec795349ad)

## Component completion checklist

- [X] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [X] Changes are clearly documented
  - [X] Component docs include a changelog
  - [X] Any new exposed functions or properties have docs
- [X] Changes extend to the Component Catalog
  - [X] The Component Catalog is updated to use the newest version, if appropriate
  - [X] The Component Catalog example version number is updated, if appropriate
  - [X] Any new customizations are available from the Component Catalog
  - [X] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [X] Changes to the component are tested/the new version of the component is tested
- [X] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [X] Please assign the following reviewers:
  - [X]  Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [X]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [X]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
