### PR TITLE
Style code output

### DIFF
--- a/component-catalog/src/Debug/Control.elm
+++ b/component-catalog/src/Debug/Control.elm
@@ -32,6 +32,7 @@ import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Checkbox.V7 as Checkbox
 import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 exposing (safeIdWithPrefix)
 import Nri.Ui.Select.V9 as Select
 import Nri.Ui.TextArea.V5 as TextArea
@@ -457,6 +458,7 @@ view_ msg (Control c) currentLabel =
                         [ css
                             [ fontSize (rem 1)
                             , color Colors.navy
+                            , Fonts.baseFont
                             ]
                         ]
                         [ Html.text currentLabel ]

--- a/component-catalog/src/Debug/Control/View.elm
+++ b/component-catalog/src/Debug/Control/View.elm
@@ -52,9 +52,11 @@ view config =
         [ Container.html
             [ section
                 [ css
-                    [ withMedia [ notMobile ]
-                        [ flexBasis (pct 55)
-                        , marginRight Spacing.horizontalSpacerPx
+                    [ padding4 (px 20) zero (px 20) (px 20)
+                    , border3 (px 2) solid Colors.red
+                    , withMedia [ notMobile ]
+                        [ flexBasis (pct 50)
+                        , marginRight (px 30)
                         ]
                     ]
                 ]
@@ -63,7 +65,10 @@ view config =
                 ]
             , section
                 [ css
-                    [ withMedia [ mobile ] [ marginTop Spacing.verticalSpacerPx ]
+                    [ padding (px 20)
+                    , flexGrow (num 1)
+                    , border3 (px 2) solid Colors.purple
+                    , withMedia [ mobile ] [ marginTop Spacing.verticalSpacerPx ]
                     ]
                 ]
                 (Heading.h2 [ Heading.plaintext "Code Sample" ]
@@ -73,9 +78,9 @@ view config =
         , Container.css
             [ marginTop Spacing.verticalSpacerPx
             , displayFlex
-            , flexWrap wrap
             , withMedia [ mobile ] [ flexDirection column ]
             ]
+        , Container.paddingPx 0
         ]
 
 

--- a/component-catalog/src/Debug/Control/View.elm
+++ b/component-catalog/src/Debug/Control/View.elm
@@ -15,10 +15,11 @@ import Example
 import ExampleSection
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
-import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Html.V3 exposing (viewIf)
-import Nri.Ui.MediaQuery.V1 exposing (mobile)
+import Nri.Ui.MediaQuery.V1 exposing (mobile, notMobile)
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Text.V6 as Text
 
@@ -47,27 +48,34 @@ view config =
         exampleCodes =
             config.toExampleCode value
     in
-    div
-        [ css
-            [ displayFlex
-            , alignItems stretch
-            , Css.flexWrap Css.wrap
-            , Css.property "gap" "10px"
-            , withMedia [ mobile ] [ flexDirection column, alignItems stretch ]
-            , Spacing.pageTopWhitespace
-            ]
-        ]
-        [ viewSection "Settings"
-            [ div
+    Container.view
+        [ Container.html
+            [ section
                 [ css
-                    [ Css.Global.descendants
-                        [ Css.Global.everything [ Fonts.baseFont ]
+                    [ withMedia [ notMobile ]
+                        [ flexBasis (pct 55)
+                        , marginRight Spacing.horizontalSpacerPx
                         ]
                     ]
                 ]
-                [ Control.view config.update config.settings ]
+                [ Heading.h2 [ Heading.plaintext "Settings" ]
+                , Control.view config.update config.settings
+                ]
+            , section
+                [ css
+                    [ withMedia [ mobile ] [ marginTop Spacing.verticalSpacerPx ]
+                    ]
+                ]
+                (Heading.h2 [ Heading.plaintext "Code Sample" ]
+                    :: List.map (viewExampleCode ellieLink config) exampleCodes
+                )
             ]
-        , viewExampleCode ellieLink config exampleCodes
+        , Container.css
+            [ marginTop Spacing.verticalSpacerPx
+            , displayFlex
+            , flexWrap wrap
+            , withMedia [ mobile ] [ flexDirection column ]
+            ]
         ]
 
 
@@ -81,46 +89,32 @@ viewExampleCode :
             , extraCode : List String
             , renderExample : String -> String
         }
-    -> List { sectionName : String, code : String }
+    -> { sectionName : String, code : String }
     -> Html msg
-viewExampleCode ellieLink component values =
-    viewSection "Code Sample" <|
-        Text.smallBodyGray
-            [ Text.plaintext "😎 Configure the \"Settings\" on this page to update the code sample, then paste it into your editor!"
+viewExampleCode ellieLink component example =
+    details
+        []
+        [ summary []
+            [ Heading.h3
+                [ Heading.css [ display inline ]
+                , Heading.plaintext example.sectionName
+                ]
             ]
-            :: List.concatMap
-                (\example ->
-                    [ details
-                        []
-                        [ summary []
-                            [ Heading.h3
-                                [ Heading.css [ Css.display Css.inline ]
-                                , Heading.plaintext example.sectionName
-                                ]
-                            ]
-                        , ellieLink
-                            { fullModuleName = Example.fullName component
-                            , name = component.name
-                            , sectionName = example.sectionName
-                            , mainType = component.mainType
-                            , extraCode = component.extraCode
-                            , renderExample = component.renderExample
-                            , code = example.code
-                            }
-                        , code
-                            [ css
-                                [ display block
-                                , whiteSpace preWrap
-                                , Css.marginTop (px 8)
-                                ]
-                            ]
-                            [ text example.code ]
-                        ]
-                    ]
-                )
-                values
-
-
-viewSection : String -> List (Html msg) -> Html msg
-viewSection name =
-    ExampleSection.sectionWithCss name [ flex (int 1) ] (div [])
+        , ellieLink
+            { fullModuleName = Example.fullName component
+            , name = component.name
+            , sectionName = example.sectionName
+            , mainType = component.mainType
+            , extraCode = component.extraCode
+            , renderExample = component.renderExample
+            , code = example.code
+            }
+        , code
+            [ css
+                [ display block
+                , whiteSpace preWrap
+                , marginTop (px 8)
+                ]
+            ]
+            [ text example.code ]
+        ]

--- a/component-catalog/src/Debug/Control/View.elm
+++ b/component-catalog/src/Debug/Control/View.elm
@@ -128,7 +128,7 @@ codeSampleHeading =
 viewCodeDetails : Html msg -> { sectionName : String, code : String } -> Html msg
 viewCodeDetails ellieLink example =
     details
-        []
+        [ css [ marginTop (px 10) ] ]
         [ summary [ css [ color Colors.yellow ] ]
             [ Heading.h3
                 [ Heading.css [ display inline, color Colors.yellow ]

--- a/component-catalog/src/Debug/Control/View.elm
+++ b/component-catalog/src/Debug/Control/View.elm
@@ -67,9 +67,7 @@ view config =
                 ]
                 [ Control.view config.update config.settings ]
             ]
-        , viewIf
-            (\_ -> viewExampleCode ellieLink config exampleCodes)
-            (not (List.isEmpty exampleCodes))
+        , viewExampleCode ellieLink config exampleCodes
         ]
 
 

--- a/component-catalog/src/Debug/Control/View.elm
+++ b/component-catalog/src/Debug/Control/View.elm
@@ -128,7 +128,14 @@ codeSampleHeading =
 viewCodeDetails : Html msg -> { sectionName : String, code : String } -> Html msg
 viewCodeDetails ellieLink example =
     details
-        [ css [ marginTop (px 10) ] ]
+        [ css
+            [ paddingTop (px 5)
+            , paddingBottom (px 5)
+            , borderBottom3 (px 1) solid Colors.gray45
+            , firstOfType [ marginTop (px 10) ]
+            , lastChild [ borderWidth zero, paddingBottom zero ]
+            ]
+        ]
         [ summary [ css [ color Colors.yellow ] ]
             [ Heading.h3
                 [ Heading.css [ display inline, color Colors.yellow ]

--- a/component-catalog/src/Debug/Control/View.elm
+++ b/component-catalog/src/Debug/Control/View.elm
@@ -7,21 +7,17 @@ module Debug.Control.View exposing (view)
 -}
 
 import Css exposing (..)
-import Css.Global
 import Css.Media exposing (withMedia)
 import Debug.Control as Control exposing (Control)
 import EllieLink
 import Example
-import ExampleSection
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Heading.V3 as Heading
-import Nri.Ui.Html.V3 exposing (viewIf)
 import Nri.Ui.MediaQuery.V1 exposing (mobile, notMobile)
 import Nri.Ui.Spacing.V1 as Spacing
-import Nri.Ui.Text.V6 as Text
 
 
 {-| -}

--- a/component-catalog/src/Debug/Control/View.elm
+++ b/component-catalog/src/Debug/Control/View.elm
@@ -71,6 +71,8 @@ view config =
                     ]
                 , withMedia [ notMobile ]
                     [ flexBasis (pct 50)
+                    , flexGrow zero
+                    , flexShrink zero
                     , paddingRight (px 30)
                     , borderTopRightRadius zero
                     , borderBottomRightRadius zero

--- a/component-catalog/src/Debug/Control/View.elm
+++ b/component-catalog/src/Debug/Control/View.elm
@@ -48,39 +48,53 @@ view config =
         exampleCodes =
             config.toExampleCode value
     in
-    Container.view
-        [ Container.html
-            [ section
-                [ css
-                    [ padding4 (px 20) zero (px 20) (px 20)
-                    , border3 (px 2) solid Colors.red
-                    , withMedia [ notMobile ]
-                        [ flexBasis (pct 50)
-                        , marginRight (px 30)
-                        ]
-                    ]
-                ]
-                [ Heading.h2 [ Heading.plaintext "Settings" ]
-                , Control.view config.update config.settings
-                ]
-            , section
-                [ css
-                    [ padding (px 20)
-                    , flexGrow (num 1)
-                    , border3 (px 2) solid Colors.purple
-                    , withMedia [ mobile ] [ marginTop Spacing.verticalSpacerPx ]
-                    ]
-                ]
-                (Heading.h2 [ Heading.plaintext "Code Sample" ]
-                    :: List.map (viewExampleCode ellieLink config) exampleCodes
-                )
-            ]
-        , Container.css
+    div
+        [ css
             [ marginTop Spacing.verticalSpacerPx
             , displayFlex
             , withMedia [ mobile ] [ flexDirection column ]
             ]
-        , Container.paddingPx 0
+        ]
+        [ Container.view
+            [ Container.html
+                [ Heading.h2 [ Heading.plaintext "Settings" ]
+                , Control.view config.update config.settings
+                ]
+            , Container.css
+                [ withMedia [ mobile ]
+                    [ borderBottomLeftRadius zero
+                    , borderBottomRightRadius zero
+                    ]
+                , withMedia [ notMobile ]
+                    [ flexBasis (pct 50)
+                    , paddingRight (px 30)
+                    , borderTopRightRadius zero
+                    , borderBottomRightRadius zero
+                    ]
+                ]
+            ]
+        , Container.view
+            [ Container.html
+                (Heading.h2
+                    [ Heading.plaintext "Code Sample"
+                    , Heading.css [ color Colors.white ]
+                    ]
+                    :: List.map (viewExampleCode ellieLink config) exampleCodes
+                )
+            , Container.css
+                [ padding (px 20)
+                , flexGrow (num 1)
+                , backgroundColor Colors.gray20
+                , withMedia [ mobile ]
+                    [ borderTopLeftRadius zero
+                    , borderTopRightRadius zero
+                    ]
+                , withMedia [ notMobile ]
+                    [ borderTopLeftRadius zero
+                    , borderBottomLeftRadius zero
+                    ]
+                ]
+            ]
         ]
 
 
@@ -99,9 +113,9 @@ viewExampleCode :
 viewExampleCode ellieLink component example =
     details
         []
-        [ summary []
+        [ summary [ css [ color Colors.yellow ] ]
             [ Heading.h3
-                [ Heading.css [ display inline ]
+                [ Heading.css [ display inline, color Colors.yellow ]
                 , Heading.plaintext example.sectionName
                 ]
             ]
@@ -119,6 +133,7 @@ viewExampleCode ellieLink component example =
                 [ display block
                 , whiteSpace preWrap
                 , marginTop (px 8)
+                , color Colors.yellow
                 ]
             ]
             [ text example.code ]

--- a/component-catalog/src/Debug/Control/View.elm
+++ b/component-catalog/src/Debug/Control/View.elm
@@ -83,20 +83,26 @@ view config =
             ]
         , Container.view
             [ Container.html
-                (Heading.h2
-                    [ Heading.plaintext "Code Sample"
-                    , Heading.css [ color Colors.white ]
-                    ]
-                    :: (case exampleCodes of
-                            singular :: [] ->
-                                [ ellieLink singular
-                                , viewCode singular.code
+                (case exampleCodes of
+                    singular :: [] ->
+                        [ div
+                            [ css
+                                [ displayFlex
+                                , flexWrap wrap
+                                , property "gap" "5px"
+                                , justifyContent spaceBetween
                                 ]
+                            ]
+                            [ codeSampleHeading
+                            , ellieLink singular
+                            ]
+                        , viewCode singular.code
+                        ]
 
-                            _ ->
-                                List.map (\example -> viewCodeDetails (ellieLink example) example)
-                                    exampleCodes
-                       )
+                    _ ->
+                        codeSampleHeading
+                            :: List.map (\example -> viewCodeDetails (ellieLink example) example)
+                                exampleCodes
                 )
             , Container.css
                 [ padding (px 20)
@@ -115,6 +121,14 @@ view config =
         ]
 
 
+codeSampleHeading : Html msg
+codeSampleHeading =
+    Heading.h2
+        [ Heading.plaintext "Code Sample"
+        , Heading.css [ color Colors.white ]
+        ]
+
+
 viewCodeDetails : Html msg -> { sectionName : String, code : String } -> Html msg
 viewCodeDetails ellieLink example =
     details
@@ -125,8 +139,16 @@ viewCodeDetails ellieLink example =
                 , Heading.plaintext example.sectionName
                 ]
             ]
-        , ellieLink
-        , viewCode example.code
+        , div
+            [ css
+                [ displayFlex
+                , flexWrap wrap
+                , property "gap" "5px"
+                , alignItems flexStart
+                , justifyContent spaceBetween
+                ]
+            ]
+            [ viewCode example.code, ellieLink ]
         ]
 
 

--- a/component-catalog/src/Debug/Control/View.elm
+++ b/component-catalog/src/Debug/Control/View.elm
@@ -42,8 +42,16 @@ view config =
         value =
             Control.currentValue config.settings
 
-        ellieLink =
+        ellieLink example =
             EllieLink.view config.ellieLinkConfig
+                { fullModuleName = Example.fullName config
+                , name = config.name
+                , sectionName = example.sectionName
+                , mainType = config.mainType
+                , extraCode = config.extraCode
+                , renderExample = config.renderExample
+                , code = example.code
+                }
 
         exampleCodes =
             config.toExampleCode value
@@ -79,7 +87,16 @@ view config =
                     [ Heading.plaintext "Code Sample"
                     , Heading.css [ color Colors.white ]
                     ]
-                    :: List.map (viewExampleCode ellieLink config) exampleCodes
+                    :: (case exampleCodes of
+                            singular :: [] ->
+                                [ ellieLink singular
+                                , viewCode singular.code
+                                ]
+
+                            _ ->
+                                List.map (\example -> viewCodeDetails (ellieLink example) example)
+                                    exampleCodes
+                       )
                 )
             , Container.css
                 [ padding (px 20)
@@ -98,19 +115,8 @@ view config =
         ]
 
 
-viewExampleCode :
-    (EllieLink.SectionExample -> Html msg)
-    ->
-        { component
-            | name : String
-            , version : Int
-            , mainType : Maybe String
-            , extraCode : List String
-            , renderExample : String -> String
-        }
-    -> { sectionName : String, code : String }
-    -> Html msg
-viewExampleCode ellieLink component example =
+viewCodeDetails : Html msg -> { sectionName : String, code : String } -> Html msg
+viewCodeDetails ellieLink example =
     details
         []
         [ summary [ css [ color Colors.yellow ] ]
@@ -120,21 +126,18 @@ viewExampleCode ellieLink component example =
                 ]
             ]
         , ellieLink
-            { fullModuleName = Example.fullName component
-            , name = component.name
-            , sectionName = example.sectionName
-            , mainType = component.mainType
-            , extraCode = component.extraCode
-            , renderExample = component.renderExample
-            , code = example.code
-            }
-        , code
-            [ css
-                [ display block
-                , whiteSpace preWrap
-                , marginTop (px 8)
-                , color Colors.yellow
-                ]
-            ]
-            [ text example.code ]
+        , viewCode example.code
         ]
+
+
+viewCode : String -> Html msg
+viewCode code_ =
+    code
+        [ css
+            [ display block
+            , whiteSpace preWrap
+            , marginTop (px 8)
+            , color Colors.yellow
+            ]
+        ]
+        [ text code_ ]

--- a/component-catalog/src/EllieLink.elm
+++ b/component-catalog/src/EllieLink.elm
@@ -1,5 +1,6 @@
 module EllieLink exposing (Config, SectionExample, view)
 
+import Accessibility.Styled.Aria as Aria
 import Dict exposing (Dict)
 import Html.Styled exposing (..)
 import Http
@@ -25,10 +26,15 @@ type alias SectionExample =
 
 view : Config -> SectionExample -> Html msg
 view config example =
-    Button.link ("View " ++ example.sectionName ++ " example on Ellie")
+    let
+        linkName =
+            "Open in Ellie"
+    in
+    Button.link linkName
         [ Button.linkExternal (generateEllieLink config example)
         , Button.tertiary
         , Button.small
+        , Button.custom [ Aria.label (example.sectionName ++ " " ++ linkName) ]
         ]
 
 

--- a/component-catalog/src/EllieLink.elm
+++ b/component-catalog/src/EllieLink.elm
@@ -3,7 +3,7 @@ module EllieLink exposing (Config, SectionExample, view)
 import Dict exposing (Dict)
 import Html.Styled exposing (..)
 import Http
-import Nri.Ui.ClickableText.V4 as ClickableText
+import Nri.Ui.Button.V10 as Button
 import Url.Builder
 
 
@@ -25,9 +25,10 @@ type alias SectionExample =
 
 view : Config -> SectionExample -> Html msg
 view config example =
-    ClickableText.link ("View " ++ example.sectionName ++ " example on Ellie")
-        [ ClickableText.linkExternal (generateEllieLink config example)
-        , ClickableText.small
+    Button.link ("View " ++ example.sectionName ++ " example on Ellie")
+        [ Button.linkExternal (generateEllieLink config example)
+        , Button.tertiary
+        , Button.small
         ]
 
 

--- a/component-catalog/src/Example.elm
+++ b/component-catalog/src/Example.elm
@@ -190,7 +190,7 @@ view_ ellieLinkConfig example state =
 
 viewAbout : List (Html Never) -> Html msg
 viewAbout about =
-    Html.div [] about
+    Html.div [ Attributes.css [ Css.margin2 (Css.px 10) Css.zero ] ] about
         |> Html.map never
 
 

--- a/component-catalog/src/Example.elm
+++ b/component-catalog/src/Example.elm
@@ -3,6 +3,7 @@ module Example exposing (Example, extraLinks, fromRouteName, fullName, preview, 
 import Accessibility.Styled.Aria as Aria
 import Category exposing (Category)
 import Css
+import Css.Global
 import Css.Media exposing (withMedia)
 import EllieLink
 import EventExtras
@@ -190,7 +191,16 @@ view_ ellieLinkConfig example state =
 
 viewAbout : List (Html Never) -> Html msg
 viewAbout about =
-    Html.div [ Attributes.css [ Css.margin2 (Css.px 10) Css.zero ] ] about
+    Html.div
+        [ Attributes.css
+            [ Css.margin2 (Css.px 10) Css.zero
+            , Css.Global.descendants
+                [ Css.Global.code
+                    [ Css.fontSize (Css.px 13.5) ]
+                ]
+            ]
+        ]
+        about
         |> Html.map never
 
 

--- a/component-catalog/src/Examples/Accordion.elm
+++ b/component-catalog/src/Examples/Accordion.elm
@@ -71,15 +71,19 @@ example =
             ]
         ]
     , about =
-        [ ul [ css [ paddingLeft (px 16), margin zero ] ]
-            [ li [] [ text "The Accordion component is designed to be used when you have either a list or a tree of expandables. It may also be used when there's only one expandable. " ]
-            , li []
-                [ text "Devs should watch the entirety of "
-                , ClickableText.link "Tessa's Accordion demo"
-                    [ ClickableText.linkExternal "https://noredink.zoom.us/rec/play/kLjOvS0PX5y-YYas6VmtUf5eEb1ViqNKKB-01gCELXG5tMjINEdop6dXrmfCyfC1A3Xj9kTUK8eIDe0.LO5NQR0X3udwz13x?canPlayFromShare=true&from=share_recording_detail&startTime=1681398154000&componentName=rec-play&originRequestUrl=https%3A%2F%2Fnoredink.zoom.us%2Frec%2Fshare%2F6R2Tk0FkzAYJ-44Q4Qs2Dx2RPR1GCXOCcaQsEai6vbtkO8oo9Ke8-_goIVwPDn9I.VVXdtb2PlpuTEqGs%3FstartTime%3D1681398154000"
-                    , ClickableText.appearsInline
+        [ Text.smallBody
+            [ Text.html
+                [ ul [ css [ paddingLeft (px 16), margin zero ] ]
+                    [ li [] [ text "The Accordion component is designed to be used when you have either a list or a tree of expandables. It may also be used when there's only one expandable. " ]
+                    , li []
+                        [ text "Devs should watch the entirety of "
+                        , ClickableText.link "Tessa's Accordion demo"
+                            [ ClickableText.linkExternal "https://noredink.zoom.us/rec/play/kLjOvS0PX5y-YYas6VmtUf5eEb1ViqNKKB-01gCELXG5tMjINEdop6dXrmfCyfC1A3Xj9kTUK8eIDe0.LO5NQR0X3udwz13x?canPlayFromShare=true&from=share_recording_detail&startTime=1681398154000&componentName=rec-play&originRequestUrl=https%3A%2F%2Fnoredink.zoom.us%2Frec%2Fshare%2F6R2Tk0FkzAYJ-44Q4Qs2Dx2RPR1GCXOCcaQsEai6vbtkO8oo9Ke8-_goIVwPDn9I.VVXdtb2PlpuTEqGs%3FstartTime%3D1681398154000"
+                            , ClickableText.appearsInline
+                            ]
+                        , text " before using. Discussion of how to attach styles correctly begins at 5:10."
+                        ]
                     ]
-                , text " before using. Discussion of how to attach styles correctly begins at 5:10."
                 ]
             ]
         ]

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -80,7 +80,7 @@ example =
             |> p [ css [ Fonts.baseFont, Css.fontSize (Css.px 12), Css.margin Css.zero ] ]
         ]
     , about =
-        [ Text.mediumBody
+        [ Text.smallBody
             [ Text.html
                 [ text "You might also know the Block element as a “Display Element”. Learn more in "
                 , ClickableText.link "Display Elements and Scaffolding Container: additional things to know"

--- a/component-catalog/src/Examples/BreadCrumbs.elm
+++ b/component-catalog/src/Examples/BreadCrumbs.elm
@@ -74,10 +74,10 @@ example =
             ]
         ]
     , about =
-        [ Text.mediumBody [ Text.markdown "`BreadCrumbs` orient users and provide convenient links to go \"up\" to parent pages." ]
-        , Text.mediumBody [ Text.markdown "Typically, you'll use `Header.view` (rather than `BreadCrumbs.view`) to render primary/`h1`-level `BreadCrumbs`. You may use `BreadCrumbs.viewSecondary` to render `h2`-level `BreadCrumbs`." ]
-        , Text.mediumBody [ Text.markdown "You should use `BreadCrumbs.headerId` to move focus to the current `h1` or `h2` and `BreadCrumbs.toPageTitle` to dynamically change the title when the page context changes." ]
-        , Text.mediumBody
+        [ Text.smallBody [ Text.markdown "`BreadCrumbs` orient users and provide convenient links to go \"up\" to parent pages." ]
+        , Text.smallBody [ Text.markdown "Typically, you'll use `Header.view` (rather than `BreadCrumbs.view`) to render primary/`h1`-level `BreadCrumbs`. You may use `BreadCrumbs.viewSecondary` to render `h2`-level `BreadCrumbs`." ]
+        , Text.smallBody [ Text.markdown "You should use `BreadCrumbs.headerId` to move focus to the current `h1` or `h2` and `BreadCrumbs.toPageTitle` to dynamically change the title when the page context changes." ]
+        , Text.smallBody
             [ Text.html
                 [ text "This and more is explained in depth in Tessa's "
                 , ClickableText.link "BreadCrumbs component demo"

--- a/component-catalog/src/Examples/FocusRing.elm
+++ b/component-catalog/src/Examples/FocusRing.elm
@@ -47,7 +47,7 @@ example =
         , example_ FocusRing.tightStyles
         ]
     , about =
-        [ Text.mediumBody
+        [ Text.smallBody
             [ Text.html
                 [ text "Custom high-contrast focus ring styles. Learn more about this component in "
                 , ClickableText.link "Custom Focus Rings on the NoRedInk blog"

--- a/component-catalog/src/Examples/Fonts.elm
+++ b/component-catalog/src/Examples/Fonts.elm
@@ -46,7 +46,7 @@ example =
         ]
             |> List.map viewPreview
     , about =
-        [ Text.mediumBody
+        [ Text.smallBody
             [ Text.html
                 [ Html.text "Learn more about kid-friendly and accessible fonts starting at 24:40 in "
                 , ClickableText.link "Kids Websites: Where Fun and Accessibility Come to Play"

--- a/component-catalog/src/Examples/RadioButtonDotless.elm
+++ b/component-catalog/src/Examples/RadioButtonDotless.elm
@@ -162,7 +162,7 @@ example =
     , subscriptions = \_ -> Sub.none
     , preview = preview
     , about =
-        [ Text.mediumBodyGray [ Text.markdown "This component behaves like a `RadioButton`, but has the look and feel of a normal `Button`.  It is a good choice to use for \"multiple choice\" style questions as it separates the act of choosing an answer and submitting the answer - preventing frustrating mistakes." ]
+        [ Text.smallBody [ Text.markdown "This component behaves like a `RadioButton`, but has the look and feel of a normal `Button`.  It is a good choice to use for \"multiple choice\" style questions as it separates the act of choosing an answer and submitting the answer - preventing frustrating mistakes." ]
         ]
     , view = view
     , categories = [ Inputs ]


### PR DESCRIPTION
Component Catalog example code reskinning! 🎉 

| | Before | After |
| --- | --- | --- |
| w/1 example, mobile | <img width="836" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/3447a99d-c74b-423e-b0af-af0d99730a9b"> | <img width="836" alt="Screenshot 2024-02-02 at 1 32 43 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/3c415ef4-58fd-4863-8379-60c40894af43"> |
| w/1 example, desktop | <img width="1362" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/4acd4fc6-0bc3-447d-ab4e-f687f086dc9e"> | <img width="1375" alt="Screenshot 2024-02-02 at 1 32 35 PM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/447c63a4-0f03-4741-837c-f144037cabcb"> |
| w/2 examples, mobile | <img width="838" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/8b5b6672-ea1d-4552-9201-0fac92d97576"> | <img width="833" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/f66fc654-1761-4a86-b4cd-b002241c8721"> |
| w/2 examples, desktop | <img width="1364" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/5ca89a83-e43c-44ff-bcc2-51075c954ea6"> | <img width="1360" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/5ec4da51-049b-42dd-a1a4-027bb9764224"> |


Based (roughly) off of https://cloud.antetype.com/exports/link/0499b00d-fe06-465c-a8e7-9e9f8f8e9efe/?starting=0&screen=id519257437l