### PR TITLE
quo 427 noredink ui add support for skipping animation in ballon

### DIFF
--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -686,6 +686,8 @@ initControl =
                     )
                 |> ControlExtra.optionalListItem "label"
                     (CommonControls.string ( Code.fromModule moduleName "label", Block.label ) "Fruit")
+                |> ControlExtra.optionalBoolListItem "skipLabelAnimation"
+                    ( Code.fromModule moduleName "skipLabelAnimation", Block.skipLabelAnimation )
                 |> ControlExtra.optionalListItem "labelPosition"
                     (Control.map
                         (\( code, v ) ->

--- a/elm.json
+++ b/elm.json
@@ -57,6 +57,7 @@
         "Nri.Ui.Mark.V3",
         "Nri.Ui.Mark.V4",
         "Nri.Ui.Mark.V5",
+        "Nri.Ui.Mark.V6",
         "Nri.Ui.MasteryIcon.V1",
         "Nri.Ui.MediaQuery.V1",
         "Nri.Ui.Menu.V4",

--- a/src/Nri/Ui/Block/V6.elm
+++ b/src/Nri/Ui/Block/V6.elm
@@ -700,7 +700,7 @@ render config =
             , labelCss = config.labelCss
             , labelId = config.labelId
             , labelContentId = Maybe.map labelContentId config.labelId
-            , skipTagAnimation = False
+            , skipTagAnimation = config.skipLabelAnimation
             }
             config.content
         )

--- a/src/Nri/Ui/Block/V6.elm
+++ b/src/Nri/Ui/Block/V6.elm
@@ -11,7 +11,7 @@ module Nri.Ui.Block.V6 exposing
     , labelCss
     , yellow, cyan, magenta, green, blue, purple, brown
     , insertLineBreakOpportunities
-    , dashed, underline
+    , dashed, underline, skipLabelAnimation
     )
 
 {-| Changes from V5:
@@ -27,6 +27,7 @@ module Nri.Ui.Block.V6 exposing
     - Add renderReadAloud
     - Add border styles `dashed` and`underline`
     - Correctly display a transparent background for underline blanks
+    - Add `skipLabelAnimation`, so balloon animation can be skipped
 
 @docs view, renderReadAloud, Attribute
 
@@ -59,7 +60,7 @@ You will need these helpers if you want to prevent label overlaps. (Which is to 
 
 @docs yellow, cyan, magenta, green, blue, purple, brown
 @docs insertLineBreakOpportunities
-@docs dashed, underline
+@docs dashed, underline, skipLabelAnimation
 
 -}
 
@@ -629,6 +630,12 @@ labelId id_ =
     Attribute (\config -> { config | labelId = Just id_ })
 
 
+{-| -}
+skipLabelAnimation : Attribute msg
+skipLabelAnimation =
+    Attribute (\config -> { config | skipLabelAnimation = True })
+
+
 
 -- Internals
 
@@ -650,6 +657,7 @@ defaultConfig =
     , emphasize = False
     , insertWbrAfterSpace = False
     , blankStyle = Dashed
+    , skipLabelAnimation = False
     }
 
 
@@ -664,6 +672,7 @@ type alias Config msg =
     , emphasize : Bool
     , insertWbrAfterSpace : Bool
     , blankStyle : BlankStyle
+    , skipLabelAnimation : Bool
     }
 
 

--- a/src/Nri/Ui/Block/V6.elm
+++ b/src/Nri/Ui/Block/V6.elm
@@ -72,7 +72,7 @@ import Html.Styled.Attributes as Attributes exposing (css)
 import List.Extra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra exposing (nriDescription)
-import Nri.Ui.Mark.V5 as Mark exposing (Mark)
+import Nri.Ui.Mark.V6 as Mark exposing (Mark)
 import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Position exposing (xOffsetPx)
 
@@ -700,6 +700,7 @@ render config =
             , labelCss = config.labelCss
             , labelId = config.labelId
             , labelContentId = Maybe.map labelContentId config.labelId
+            , skipTagAnimation = False
             }
             config.content
         )

--- a/src/Nri/Ui/Highlighter/V4.elm
+++ b/src/Nri/Ui/Highlighter/V4.elm
@@ -63,7 +63,7 @@ import Markdown.Inline
 import Nri.Ui.Highlightable.V3 as Highlightable exposing (Highlightable)
 import Nri.Ui.HighlighterTool.V1 as Tool
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
-import Nri.Ui.Mark.V5 as Mark exposing (Mark)
+import Nri.Ui.Mark.V6 as Mark exposing (Mark)
 import Set exposing (Set)
 import Sort exposing (Sorter)
 import Sort.Dict as Dict

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -64,7 +64,7 @@ import Markdown.Inline
 import Nri.Ui.Highlightable.V3 as Highlightable exposing (Highlightable)
 import Nri.Ui.HighlighterTool.V1 as Tool
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
-import Nri.Ui.Mark.V5 as Mark exposing (Mark)
+import Nri.Ui.Mark.V6 as Mark exposing (Mark)
 import Set exposing (Set)
 import Sort exposing (Sorter)
 import Sort.Dict as Dict

--- a/src/Nri/Ui/Mark/V6.elm
+++ b/src/Nri/Ui/Mark/V6.elm
@@ -6,6 +6,7 @@ module Nri.Ui.Mark.V6 exposing
 
 {-|
 
+
 ### Changes from V5
 
     -  Add `skipTagAnimation` for skipping balloon animations
@@ -286,7 +287,8 @@ viewMarkedByBalloon config markedWith segments =
         (case segments of
             first :: remainder ->
                 first
-                    :: viewJust (viewBalloon config) markedWith.name                    :: viewJust (\_ -> viewBalloonSpacer config) markedWith.name
+                    :: viewJust (viewBalloon config) markedWith.name
+                    :: viewJust (\_ -> viewBalloonSpacer config) markedWith.name
                     :: remainder
 
             [] ->
@@ -312,7 +314,7 @@ viewMarked tagStyle markedWith segments =
                     )
                 ]
             ]
-       ]
+        ]
         (case markedWith.name of
             Just name ->
                 viewStartHighlightTag tagStyle markedWith name :: segments
@@ -619,4 +621,3 @@ stripMarkdownSyntax markdown =
 
         _ ->
             markdown
-

--- a/src/Nri/Ui/Mark/V6.elm
+++ b/src/Nri/Ui/Mark/V6.elm
@@ -1,0 +1,622 @@
+module Nri.Ui.Mark.V6 exposing
+    ( Mark
+    , view, viewWithInlineTags, viewWithBalloonTags
+    , viewWithOverlaps
+    )
+
+{-|
+
+### Changes from V5
+
+    -  Add `skipTagAnimation` for skipping balloon animations
+
+@docs Mark
+@docs view, viewWithInlineTags, viewWithBalloonTags
+@docs viewWithOverlaps
+
+-}
+
+import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Role as Role
+import Accessibility.Styled.Style exposing (invisibleStyle)
+import Content
+import Css exposing (Color, Style)
+import Css.Global
+import Css.Media
+import Html.Styled as Html exposing (Html, span)
+import Html.Styled.Attributes exposing (class, css)
+import Markdown.Block
+import Markdown.Inline
+import Nri.Ui.Balloon.V2 as Balloon
+import Nri.Ui.Colors.Extra
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Html.Attributes.V2 as AttributesExtra
+import Nri.Ui.Html.V3 exposing (viewJust)
+import Nri.Ui.MediaQuery.V1 as MediaQuery
+import Sort exposing (Sorter)
+import Sort.Set as Set exposing (Set)
+import String.Extra
+
+
+{-| -}
+type alias Mark =
+    { name : Maybe String
+    , startStyles : List Css.Style
+    , styles : List Css.Style
+    , endStyles : List Css.Style
+    }
+
+
+{-| When elements are marked, wrap them in a single `mark` html node.
+-}
+view :
+    (content -> List Style -> Html msg)
+    -> List ( content, Maybe Mark )
+    -> List (Html msg)
+view =
+    view_ HiddenTags
+
+
+{-| When elements are marked, add ::before and ::after elements indicating the start and end of the highlight.
+
+(We can't use a `mark` HTML element here because of the tree structure of HTML)
+
+-}
+viewWithOverlaps :
+    (content -> List Style -> Html msg)
+    -> List ( content, List Mark )
+    -> List (Html msg)
+viewWithOverlaps viewSegment segments =
+    segments
+        |> List.foldr
+            (\( content, marks ) ( lastMarks, acc ) ->
+                ( Set.fromList maybeStringSorter (List.map .name marks)
+                , { content = content
+                  , marks = marks
+                  , after = ignoreRepeats lastMarks marks
+                  }
+                    :: acc
+                )
+            )
+            ( Set.empty maybeStringSorter, [] )
+        |> Tuple.second
+        |> List.foldl
+            (\{ content, marks, after } ( lastMarks, acc ) ->
+                let
+                    segment startingStyles =
+                        viewSegment content
+                            [ tagBeforeContent before
+                            , tagAfterContent after
+                            , Css.batch startingStyles
+                            , Css.batch (List.concatMap .styles marks)
+                            , Css.batch (List.concatMap .endStyles after)
+                            ]
+
+                    startStyles =
+                        List.concatMap (\markedWith -> markedWith.styles ++ markedWith.startStyles) before
+
+                    before =
+                        ignoreRepeats lastMarks marks
+                in
+                ( Set.fromList maybeStringSorter (List.map .name marks)
+                , acc
+                    ++ (case List.filterMap .name before of
+                            [] ->
+                                [ segment startStyles ]
+
+                            names ->
+                                [ span [ css startStyles ]
+                                    [ viewInlineTag
+                                        [ Css.display Css.none
+                                        , MediaQuery.highContrastMode
+                                            [ Css.property "forced-color-adjust" "none"
+                                            , Css.display Css.inline |> Css.important
+                                            , Css.property "color" "initial" |> Css.important
+                                            ]
+                                        ]
+                                        (String.Extra.toSentenceOxford names)
+                                    ]
+                                , segment []
+                                ]
+                       )
+                )
+            )
+            ( Set.empty maybeStringSorter, [] )
+        |> Tuple.second
+
+
+ignoreRepeats : Set (Maybe String) -> List Mark -> List Mark
+ignoreRepeats lastMarks list =
+    List.filter (\x -> not (Set.memberOf lastMarks x.name)) list
+
+
+maybeStringSorter : Sorter (Maybe String)
+maybeStringSorter =
+    Sort.by (Maybe.withDefault "") Sort.alphabetical
+
+
+{-| When elements are marked, wrap them in a single `mark` html node.
+
+Show the label for the mark, if present, in-line with the emphasized content.
+
+-}
+viewWithInlineTags :
+    (content -> List Style -> Html msg)
+    -> List ( content, Maybe Mark )
+    -> List (Html msg)
+viewWithInlineTags =
+    view_ InlineTags
+
+
+type alias LabelPosition =
+    { totalHeight : Float
+    , arrowHeight : Float
+    , zIndex : Int
+    , xOffset : Float
+    }
+
+
+{-| When elements are marked, wrap them in a single `mark` html node.
+
+Show the label for the mark, if present, in a balloon centered above the emphasized content.
+
+-}
+viewWithBalloonTags :
+    { renderSegment : c -> List Style -> Html msg
+    , backgroundColor : Color
+    , maybeMarker : Maybe Mark
+    , labelPosition : Maybe LabelPosition
+    , labelCss : List Css.Style
+    , labelId : Maybe String
+    , labelContentId : Maybe String
+    , skipTagAnimation : Bool
+    }
+    -> List c
+    -> List (Html msg)
+viewWithBalloonTags ({ renderSegment, maybeMarker } as config) contents =
+    case maybeMarker of
+        Just markedWith ->
+            let
+                lastIndex =
+                    List.length contents - 1
+            in
+            [ viewMarkedByBalloon config
+                markedWith
+                (List.indexedMap
+                    (\index content -> renderSegment content (markedWithBalloonStyles markedWith lastIndex index))
+                    contents
+                )
+            ]
+
+        Nothing ->
+            List.map (\content -> renderSegment content []) contents
+
+
+markedWithBalloonStyles : Mark -> Int -> Int -> List Css.Style
+markedWithBalloonStyles marked lastIndex index =
+    List.concat
+        [ if index == 0 then
+            -- if we're on the first highlighted element, we add
+            -- a `before` content saying what kind of highlight we're starting
+            tagBeforeContent [ marked ] :: marked.startStyles
+
+          else
+            []
+        , marked.styles
+        , if index == lastIndex then
+            Css.after
+                [ cssContent
+                    ("end "
+                        ++ (Maybe.map (\name -> stripMarkdownSyntax name) marked.name
+                                |> Maybe.withDefault "highlight"
+                           )
+                    )
+                , invisibleStyle
+                ]
+                :: marked.endStyles
+
+          else
+            []
+        , -- display:inline-block is necessary for the balloon-spacer to actually
+          -- take up vertical space.
+          [ Css.display Css.inlineBlock
+          , Css.lineHeight (Css.num 1.2)
+          , Css.margin2 (Css.px 2) Css.zero
+          ]
+        ]
+
+
+type TagStyle
+    = HiddenTags
+    | InlineTags
+
+
+{-| When elements are marked, wrap them in a single `mark` html node.
+
+Show the label for the mark, if present, in-line with the emphasized content when `showTagsInline` is True.
+
+-}
+view_ :
+    TagStyle
+    -> (content -> List Style -> Html msg)
+    -> List ( content, Maybe Mark )
+    -> List (Html msg)
+view_ tagStyle viewSegment highlightables =
+    case highlightables of
+        [] ->
+            []
+
+        ( _, marked ) :: _ ->
+            let
+                segments =
+                    List.indexedMap
+                        (\index ( content, mark ) -> viewSegment content (markStyles tagStyle index mark))
+                        highlightables
+            in
+            case marked of
+                Just markedWith ->
+                    [ viewMarked tagStyle markedWith segments ]
+
+                Nothing ->
+                    segments
+
+
+viewMarkedByBalloon :
+    { config
+        | backgroundColor : Color
+        , labelPosition : Maybe LabelPosition
+        , labelCss : List Css.Style
+        , labelId : Maybe String
+        , labelContentId : Maybe String
+        , skipTagAnimation : Bool
+    }
+    -> Mark
+    -> List (Html msg)
+    -> Html msg
+viewMarkedByBalloon config markedWith segments =
+    Html.mark
+        [ -- Drop the `mark` role as various screen readers interpret it differently.
+          -- Instead we offer additional invisible and accessible content to denote the highlight.
+          Role.presentation
+        , css [ Css.backgroundColor Css.transparent, Css.position Css.relative ]
+        ]
+        -- the balloon should never end up on a line by itself, so we put it in the DOM
+        -- after the first segment.
+        (case segments of
+            first :: remainder ->
+                first
+                    :: viewJust (viewBalloon config) markedWith.name                    :: viewJust (\_ -> viewBalloonSpacer config) markedWith.name
+                    :: remainder
+
+            [] ->
+                []
+        )
+
+
+viewMarked : TagStyle -> Mark -> List (Html msg) -> Html msg
+viewMarked tagStyle markedWith segments =
+    Html.mark
+        [ -- Drop the `mark` role as various screen readers interpret it differently.
+          -- Instead we offer additional invisible and accessible content to denote the highlight.
+          Role.presentation
+        , css
+            [ Css.backgroundColor Css.transparent
+            , Css.Global.children
+                [ Css.Global.selector ":last-child"
+                    (Css.after
+                        [ Css.property "content" ("\" end " ++ (Maybe.map (\name -> stripMarkdownSyntax name) markedWith.name |> Maybe.withDefault "highlight") ++ " \"")
+                        , invisibleStyle
+                        ]
+                        :: markedWith.endStyles
+                    )
+                ]
+            ]
+       ]
+        (case markedWith.name of
+            Just name ->
+                viewStartHighlightTag tagStyle markedWith name :: segments
+
+            Nothing ->
+                segments
+        )
+
+
+viewStartHighlightTag : TagStyle -> Mark -> String -> Html msg
+viewStartHighlightTag tagStyle marked name =
+    span
+        [ css
+            (marked.styles
+                ++ (-- start styles are attached to the first segment, unless there's
+                    -- an inline tag to show, in which case we'll attach the styles to the start tag.
+                    case tagStyle of
+                        HiddenTags ->
+                            if marked.name == Nothing then
+                                []
+
+                            else
+                                [ MediaQuery.highContrastMode marked.startStyles ]
+
+                        InlineTags ->
+                            if marked.name == Nothing then
+                                []
+
+                            else
+                                marked.startStyles
+                   )
+            )
+        , class "highlighter-inline-tag highlighter-inline-tag-highlighted"
+        ]
+        [ viewTag tagStyle name ]
+
+
+markStyles : TagStyle -> Int -> Maybe Mark -> List Css.Style
+markStyles tagStyle index marked =
+    case ( index == 0, marked ) of
+        ( True, Just markedWith ) ->
+            -- if we're on the first highlighted element, we add
+            -- a `before` content saying what kind of highlight we're starting
+            tagBeforeContent [ markedWith ]
+                :: markedWith.styles
+                ++ -- if we're on the first element, and the mark has a name,
+                   -- there's an inline tag that we might need to show.
+                   -- if we're not showing a visual tag, we can attach the start styles to the first segment
+                   (case tagStyle of
+                        HiddenTags ->
+                            if markedWith.name == Nothing then
+                                markedWith.startStyles
+
+                            else
+                                [ MediaQuery.notHighContrastMode
+                                    (markedWith.startStyles
+                                        ++ [ -- override for the left border that's typically
+                                             -- added in Nri.Ui.HighlighterTool
+                                             MediaQuery.highContrastMode
+                                                [ Css.important (Css.borderLeftWidth Css.zero)
+                                                ]
+                                           ]
+                                    )
+                                ]
+
+                        InlineTags ->
+                            if markedWith.name == Nothing then
+                                markedWith.startStyles
+
+                            else
+                                []
+                   )
+
+        _ ->
+            Maybe.map .styles marked
+                |> Maybe.withDefault []
+
+
+tagBeforeContent : List Mark -> Css.Style
+tagBeforeContent marks =
+    if List.isEmpty marks then
+        Css.batch []
+
+    else
+        Css.before
+            [ cssContent (highlightDescription "start" marks)
+            , invisibleStyle
+            ]
+
+
+tagAfterContent : List Mark -> Css.Style
+tagAfterContent marks =
+    if List.isEmpty marks then
+        Css.batch []
+
+    else
+        Css.after
+            [ cssContent (highlightDescription "end" marks)
+            , invisibleStyle
+            ]
+
+
+highlightDescription : String -> List Mark -> String
+highlightDescription prefix marks =
+    let
+        names =
+            String.Extra.toSentenceOxford (List.filterMap (.name >> Maybe.map stripMarkdownSyntax) marks)
+    in
+    if names == "" then
+        prefix ++ " highlight"
+
+    else if List.length marks == 1 then
+        prefix ++ " " ++ names ++ " highlight"
+
+    else
+        prefix ++ " " ++ names ++ " highlights"
+
+
+cssContent : String -> Css.Style
+cssContent content =
+    Css.property "content" ("\" " ++ content ++ " \"")
+
+
+viewTag : TagStyle -> String -> Html msg
+viewTag tagStyle =
+    case tagStyle of
+        InlineTags ->
+            viewInlineTag
+                [ MediaQuery.highContrastMode
+                    [ Css.property "forced-color-adjust" "none"
+                    , Css.property "color" "initial" |> Css.important
+                    ]
+                ]
+
+        HiddenTags ->
+            viewInlineTag
+                [ Css.display Css.none
+                , MediaQuery.highContrastMode
+                    [ Css.property "forced-color-adjust" "none"
+                    , Css.display Css.inline |> Css.important
+                    , Css.property "color" "initial" |> Css.important
+                    ]
+                ]
+
+
+viewInlineTag : List Css.Style -> String -> Html msg
+viewInlineTag customizations name =
+    span
+        [ css
+            [ Fonts.baseFont
+            , Css.backgroundColor Colors.white
+            , Css.color Colors.navy
+            , Css.padding2 (Css.px 2) (Css.px 4)
+            , Css.borderRadius (Css.px 3)
+            , Css.margin2 Css.zero (Css.px 5)
+            , Css.boxShadow5 Css.zero (Css.px 1) (Css.px 1) Css.zero Colors.gray75
+            , Css.batch customizations
+            ]
+        , -- we use the :before element to convey details about the start of the
+          -- highlighter to screenreaders, so the visual label is redundant
+          Aria.hidden True
+        ]
+        (Content.markdownInline name)
+
+
+viewBalloon :
+    { config
+        | backgroundColor : Color
+        , labelPosition : Maybe LabelPosition
+        , labelCss : List Css.Style
+        , labelId : Maybe String
+        , labelContentId : Maybe String
+    }
+    -> String
+    -> Html msg
+viewBalloon config label =
+    Balloon.view
+        [ Balloon.onTop
+        , Balloon.containerCss
+            [ Css.position Css.absolute
+            , Css.top (Css.px -6)
+            , -- using position, 50% is wrt the parent container
+              -- using transform & translate, 50% is wrt to the element itself
+              -- combining these two properties, we can center the tag against the parent container
+              -- for any arbitrary width element
+              Css.left (Css.pct 50)
+            , Css.property "transform" "translateX(-50%) translateY(-100%)"
+            , case Maybe.map .zIndex config.labelPosition of
+                Just zIndex ->
+                    Css.zIndex (Css.int zIndex)
+
+                Nothing ->
+                    Css.batch []
+            , Css.batch config.labelCss
+            ]
+        , Balloon.css
+            [ Css.padding3 Css.zero (Css.px 6) (Css.px 1)
+            , Css.property "box-shadow" "none"
+            , Css.property "width" "max-content"
+            , -- this min-width prevents the arrow from gapping at the corners where the balloon is rounded
+              -- if the border radius of the balloon changes, this value might need to change as well
+              Css.minWidth (Css.px 30)
+            , Css.maxWidth (Css.px 150)
+            , Css.textAlign Css.center
+            , Css.whiteSpace Css.normal
+            , Css.property "word-break" "break-word"
+            , Css.batch <|
+                case config.labelPosition of
+                    Just { xOffset } ->
+                        if xOffset /= 0 then
+                            [ Css.property "transform" ("translateX(" ++ String.fromFloat xOffset ++ "px)") ]
+
+                        else
+                            []
+
+                    Nothing ->
+                        []
+            ]
+        , Balloon.custom
+            [ -- we use the :before element to convey details about the start of the
+              -- highlighter to screenreaders, so the visual label is redundant
+              Aria.hidden True
+            ]
+        , Balloon.customTheme
+            { backgroundColor = config.backgroundColor
+            , color = Nri.Ui.Colors.Extra.highContrastColor config.backgroundColor
+            }
+        , Balloon.highContrastModeTheme
+            { backgroundColor = "Mark"
+            , color = "MarkText"
+            }
+        , case config.labelContentId of
+            Just id_ ->
+                Balloon.contentId id_
+
+            Nothing ->
+                Balloon.css []
+        , Balloon.markdown label
+        , case config.labelId of
+            Just id_ ->
+                Balloon.id id_
+
+            Nothing ->
+                Balloon.css []
+        , case config.labelPosition of
+            Just { arrowHeight } ->
+                Balloon.arrowHeight arrowHeight
+
+            Nothing ->
+                Balloon.css []
+        ]
+
+
+viewBalloonSpacer : { config | labelPosition : Maybe { b | totalHeight : Float }, skipTagAnimation : Bool } -> Html msg
+viewBalloonSpacer config =
+    span
+        [ css
+            [ Css.display Css.inlineBlock
+            , if config.skipTagAnimation then
+                Css.batch []
+
+              else
+                Css.Media.withMediaQuery
+                    [ "(prefers-reduced-motion: no-preference)" ]
+                    [ Css.property "transition" "padding 0.8s ease" ]
+            , config.labelPosition
+                |> Maybe.map
+                    (\{ totalHeight } ->
+                        Css.paddingTop (Css.px totalHeight)
+                    )
+                |> Maybe.withDefault (Css.batch [])
+            ]
+        , AttributesExtra.nriDescription "balloon-spacer"
+        ]
+        [ -- this element should never be displayed to anyone.
+          -- It's only present to take up vertical space in order to align the label.
+          span
+            [ css
+                [ Css.visibility Css.hidden
+                , Css.overflowX Css.hidden
+                , Css.width (Css.px 0)
+                , Css.display Css.inlineBlock
+                , Css.Media.withMediaQuery
+                    [ "(prefers-reduced-motion: no-preference)" ]
+                    [ Css.property "transition" "line-height 0.8s ease"
+                    , case config.labelPosition of
+                        Nothing ->
+                            Css.lineHeight (Css.num 0)
+
+                        Just _ ->
+                            Css.lineHeight Css.initial
+                    ]
+                ]
+            ]
+            [ Html.text "()" ]
+        ]
+
+
+stripMarkdownSyntax : String -> String
+stripMarkdownSyntax markdown =
+    case Markdown.Block.parse Nothing markdown of
+        [ Markdown.Block.Paragraph _ inlines ] ->
+            Markdown.Inline.extractText inlines
+
+        _ ->
+            markdown
+

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -53,6 +53,7 @@
         "Nri.Ui.Mark.V3",
         "Nri.Ui.Mark.V4",
         "Nri.Ui.Mark.V5",
+        "Nri.Ui.Mark.V6",
         "Nri.Ui.MasteryIcon.V1",
         "Nri.Ui.MediaQuery.V1",
         "Nri.Ui.Menu.V4",


### PR DESCRIPTION
# :wrench: Modifying a component

## Context
Adding option to skip balloon animation in both Mark, and Block components.
## :framed_picture: What does this change look like?
No visual changes, just avoiding animations programatically.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - [Issue](https://linear.app/noredink/issue/QUO-427/noredink-ui-add-support-for-skipping-animation-in-ballon-labels-for)
- [x] Please assign the following reviewers:
  - [x]  Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
