### PR TITLE
Add Block resources

### DIFF
--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -96,6 +96,10 @@ example =
                             ]
                         , text " explaining the initial constraints and approach."
                         ]
+                    , li []
+                        [ ClickableText.link "Tessa's demo on early versions of Block and Question Block"
+                            [ ClickableText.linkExternal "https://www.dropbox.com/preview/NRI%20Engineering/Demos/2022-12-22%20-%20Tessa%20-%20QuestionBox%20and%20Block.mp4?role=work" ]
+                        ]
                     ]
                 ]
             ]

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -82,9 +82,20 @@ example =
     , about =
         [ Text.mediumBody
             [ Text.html
-                [ text "You might also know the Block element as a “Display Element”. Learn more in "
-                , ClickableText.link "Display Elements and Scaffolding Container: additional things to know"
-                    [ ClickableText.linkExternal "https://paper.dropbox.com/doc/Display-Elements-and-Scaffolding-Container-additional-things-to-know--BwRhBMKyXFFSWz~1mljN29bcAg-6vszpNDLoYIiMyg7Wv66s"
+                [ text "You might also know the Block element as a “Display Element”. Learn more about this component in: "
+                , ul []
+                    [ li []
+                        [ ClickableText.link "Display Elements and Scaffolding Container: additional things to know"
+                            [ ClickableText.linkExternal "https://paper.dropbox.com/doc/Display-Elements-and-Scaffolding-Container-additional-things-to-know--BwRhBMKyXFFSWz~1mljN29bcAg-6vszpNDLoYIiMyg7Wv66s"
+                            ]
+                        , text ", which identifies a number of interesting edge cases and known trade-offs."
+                        ]
+                    , li []
+                        [ ClickableText.link "Tessa's blog post"
+                            [ ClickableText.linkExternal "https://blog.noredink.com/post/710448547697426432/word-labels]"
+                            ]
+                        , text " explaining the initial constraints and approach."
+                        ]
                     ]
                 ]
             ]


### PR DESCRIPTION
Component Catalog changes only -- expands Block resources.

<img width="1461" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/183f8cee-2c20-4235-a434-dccd9f61e331">

@micahhahn I've got a list of a11ybat team demos, but I didn't keep track of demos you've done. Are there other resources you want to add to the Block example?