### PR TITLE
Improve radio button example

### DIFF
--- a/component-catalog/src/CommonControls.elm
+++ b/component-catalog/src/CommonControls.elm
@@ -59,10 +59,10 @@ specificColor match =
 premiumDisplay : Control ( String, PremiumDisplay )
 premiumDisplay =
     Control.choice
-        [ ( "Free", Control.value ( "PremiumDisplay.Free", PremiumDisplay.Free ) )
-        , ( "Premium Locked", Control.value ( "PremiumDisplay.PremiumLocked", PremiumDisplay.PremiumLocked ) )
+        [ ( "Premium Locked", Control.value ( "PremiumDisplay.PremiumLocked", PremiumDisplay.PremiumLocked ) )
         , ( "Premium Unlocked", Control.value ( "PremiumDisplay.PremiumUnlocked", PremiumDisplay.PremiumUnlocked ) )
         , ( "Premium Vouchered", Control.value ( "PremiumDisplay.PremiumVouchered", PremiumDisplay.PremiumVouchered ) )
+        , ( "Free", Control.value ( "PremiumDisplay.Free", PremiumDisplay.Free ) )
         ]
 
 

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -531,10 +531,10 @@ controlAttributes =
                                 , RadioButton.containerCss [ Css.width (Css.pct 100) ]
                                 )
                           )
-                        , ( "10px right margin"
+                        , ( "10px left margin"
                           , Control.value
-                                ( "RadioButton.containerCss [ Css.marginRight (Css.px 10) ]"
-                                , RadioButton.containerCss [ Css.marginRight (Css.px 10) ]
+                                ( "RadioButton.containerCss [ Css.marginLeft (Css.px 10) ]"
+                                , RadioButton.containerCss [ Css.marginLeft (Css.px 10) ]
                                 )
                           )
                         ]

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -258,6 +258,56 @@ view ellieLinkConfig state =
           , premiumDisplay = PremiumLocked
           }
         ]
+    , Heading.h2
+        [ Heading.plaintext "Guidance Examples"
+        , Heading.css [ Css.marginTop (Css.px 30) ]
+        ]
+    , Table.view []
+        [ Table.custom
+            { header = text "Attribute"
+            , view = .name >> text
+            , width = Css.pct 10
+            , cellStyles =
+                always
+                    [ Css.padding2 (Css.px 14) (Css.px 7)
+                    , Css.verticalAlign Css.middle
+                    , Css.fontWeight Css.bold
+                    ]
+            , sort = Nothing
+            }
+        , Table.custom
+            { header = text "Example"
+            , view =
+                \{ name, attribute } ->
+                    RadioButton.view
+                        { label = "No default integration"
+                        , name = safeIdWithPrefix "default-integration" name
+                        , value = ()
+                        , selectedValue = Nothing
+                        , valueToString = \_ -> ""
+                        }
+                        [ attribute ]
+            , width = Css.pct 50
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+            , sort = Nothing
+            }
+        ]
+        [ { name = "guidance"
+          , attribute = RadioButton.guidance "Teachers will be able to use any integration."
+          }
+        , { name = "guidanceHtml"
+          , attribute =
+                RadioButton.guidanceHtml
+                    [ text "Teachers will be able to use any "
+                    , ClickableText.link "LMS supported by NoRedInk"
+                        [ ClickableText.linkExternal "https://noredink.zendesk.com/hc/en-us/categories/6424228197403-Integrations"
+                        , ClickableText.small
+                        , ClickableText.appearsInline
+                        ]
+                    , text "."
+                    ]
+          }
+        ]
     , Modal.view
         { title = "Go Premium!"
         , wrapMsg = ModalMsg

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -25,6 +25,7 @@ import Examples.RadioButtonDotless as RadioButtonDotlessExample
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Direction(..), Key(..))
+import Markdown
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
@@ -259,7 +260,7 @@ view ellieLinkConfig state =
           }
         ]
     , Heading.h2
-        [ Heading.plaintext "Guidance Examples"
+        [ Heading.plaintext "Extra Content Examples"
         , Heading.css [ Css.marginTop (Css.px 30) ]
         ]
     , Table.view []
@@ -277,35 +278,82 @@ view ellieLinkConfig state =
             }
         , Table.custom
             { header = text "Example"
-            , view =
-                \{ name, attribute } ->
-                    RadioButton.view
-                        { label = "No default integration"
-                        , name = safeIdWithPrefix "default-integration" name
-                        , value = ()
-                        , selectedValue = Nothing
-                        , valueToString = \_ -> ""
-                        }
-                        [ attribute ]
+            , view = .view
             , width = Css.pct 50
             , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
             , sort = Nothing
             }
+        , Table.custom
+            { header = text "Notes"
+            , view = .description >> Markdown.toHtml Nothing >> List.map fromUnstyled >> span []
+            , width = Css.px 150
+            , cellStyles = always [ Css.padding2 Css.zero (Css.px 7), Css.verticalAlign Css.top ]
+            , sort = Nothing
+            }
         ]
         [ { name = "guidance"
-          , attribute = RadioButton.guidance "Teachers will be able to use any integration."
+          , view =
+                RadioButton.view
+                    { label = "No default integration"
+                    , name = safeIdWithPrefix "default-integration" "guidance"
+                    , value = ()
+                    , selectedValue = Nothing
+                    , valueToString = \_ -> ""
+                    }
+                    [ RadioButton.guidance "Teachers will be able to use any integration." ]
+          , description = ""
           }
         , { name = "guidanceHtml"
-          , attribute =
-                RadioButton.guidanceHtml
-                    [ text "Teachers will be able to use any "
-                    , ClickableText.link "LMS supported by NoRedInk"
-                        [ ClickableText.linkExternal "https://noredink.zendesk.com/hc/en-us/categories/6424228197403-Integrations"
-                        , ClickableText.small
-                        , ClickableText.appearsInline
+          , view =
+                RadioButton.view
+                    { label = "No default integration"
+                    , name = safeIdWithPrefix "default-integration" "guidanceHtml"
+                    , value = ()
+                    , selectedValue = Nothing
+                    , valueToString = \_ -> ""
+                    }
+                    [ RadioButton.guidanceHtml
+                        [ text "Teachers will be able to use any "
+                        , ClickableText.link "LMS supported by NoRedInk"
+                            [ ClickableText.linkExternal "https://noredink.zendesk.com/hc/en-us/categories/6424228197403-Integrations"
+                            , ClickableText.small
+                            , ClickableText.appearsInline
+                            ]
+                        , text "."
                         ]
-                    , text "."
                     ]
+          , description = ""
+          }
+        , { name = "errorMessage"
+          , view =
+                RadioButton.view
+                    { label = "No default integration"
+                    , name = safeIdWithPrefix "default-integration" "errorMessage"
+                    , value = ()
+                    , selectedValue = Nothing
+                    , valueToString = \_ -> ""
+                    }
+                    [ RadioButton.errorMessage (Just "Uh oh! I'm not sure why you can't make this selection.")
+                    ]
+          , description = "\"errorMessage\" is never used in the monorepo. I can't imagine a case when it would be used, since errors seem likely to apply to the group of radio buttons, and not to an individual radio button option. Presented here for completeness."
+          }
+        , { name = "disclosure"
+          , view =
+                RadioButton.view
+                    { label = "Only students who have mastered NoRedInk’s practice topics"
+                    , name = "who-can-rate"
+                    , value = ()
+                    , selectedValue = Just ()
+                    , valueToString = \_ -> ""
+                    }
+                    [ RadioButton.disclosure
+                        [ Text.caption
+                            [ Text.plaintext
+                                "Requiring students to achieve mastery on criteria before rating will help prepare them to give feedback, but it will also add significant time to the assignment."
+                            ]
+                        ]
+                    ]
+          , description = "\"disclosure\" content only appears when the given RadioButton is selected."
           }
         ]
     , Modal.view

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -473,64 +473,72 @@ initSelectionSettings =
 controlAttributes : Control (List ( String, RadioButton.Attribute Selection Msg ))
 controlAttributes =
     Control.list
-        |> ControlExtra.optionalListItem "label visibility" labelVisibility
-        |> ControlExtra.optionalListItem "status" disabledOrEnabled
-        |> ControlExtra.optionalListItem "onLockedClick" onLockedClick
-        |> ControlExtra.optionalListItem "premium"
-            -- TODO: allow the teacher premium level to vary as well:
-            (Control.map
-                (\( premiumDisplay, pDisplay ) ->
-                    ( "RadioButton.premium " ++ premiumDisplay, RadioButton.premium pDisplay )
-                )
-                premiumDisplay
+        |> ControlExtra.listItems "Content & Status"
+            (Control.list
+                |> ControlExtra.optionalListItem "status" disabledOrEnabled
+                |> ControlExtra.optionalListItem "disclosure" controlDisclosure
+                |> CommonControls.guidanceAndErrorMessage
+                    { moduleName = moduleName
+                    , guidance = RadioButton.guidance
+                    , guidanceHtml = RadioButton.guidanceHtml
+                    , errorMessage = Just RadioButton.errorMessage
+                    , message = "The statement must be true."
+                    }
+                |> CommonControls.rightIcon "RadioButton" RadioButton.rightIcon
             )
-        |> ControlExtra.optionalListItem "containerCss"
-            (Control.choice
-                [ ( "max-width with border"
-                  , Control.value
-                        ( "RadioButton.containerCss [ Css.maxWidth (Css.px 200), Css.border3 (Css.px 1) Css.solid Colors.red ]"
-                        , RadioButton.containerCss [ Css.maxWidth (Css.px 200), Css.border3 (Css.px 1) Css.solid Colors.red ]
+        |> ControlExtra.listItems "Upsell options"
+            (Control.list
+                |> ControlExtra.optionalListItem "onLockedClick" onLockedClick
+                |> ControlExtra.optionalListItem "premium"
+                    (Control.map
+                        (\( premiumDisplay, pDisplay ) ->
+                            ( "RadioButton.premium " ++ premiumDisplay, RadioButton.premium pDisplay )
                         )
-                  )
-                , ( "100% width"
-                  , Control.value
-                        ( "RadioButton.containerCss [ Css.width (Css.pct 100) ]"
-                        , RadioButton.containerCss [ Css.width (Css.pct 100) ]
-                        )
-                  )
-                , ( "10px right margin"
-                  , Control.value
-                        ( "RadioButton.containerCss [ Css.marginRight (Css.px 10) ]"
-                        , RadioButton.containerCss [ Css.marginRight (Css.px 10) ]
-                        )
-                  )
-                ]
+                        premiumDisplay
+                    )
             )
-        |> ControlExtra.optionalListItem "labelCss"
-            (Control.choice
-                [ ( "backgroundColor highlightMagenta"
-                  , Control.value
-                        ( "RadioButton.labelCss [ Css.backgroundColor Colors.highlightMagenta ]"
-                        , RadioButton.labelCss [ Css.backgroundColor Colors.highlightMagenta ]
-                        )
-                  )
-                , ( "1px ochreDark border"
-                  , Control.value
-                        ( "RadioButton.labelCss [ Css.border3 (Css.px 1) Css.solid Colors.ochreDark ]"
-                        , RadioButton.labelCss [ Css.border3 (Css.px 1) Css.solid Colors.ochreDark ]
-                        )
-                  )
-                ]
+        |> ControlExtra.listItems "Style Extras"
+            (Control.list
+                |> ControlExtra.optionalListItem "containerCss"
+                    (Control.choice
+                        [ ( "max-width with border"
+                          , Control.value
+                                ( "RadioButton.containerCss [ Css.maxWidth (Css.px 200), Css.border3 (Css.px 1) Css.solid Colors.red ]"
+                                , RadioButton.containerCss [ Css.maxWidth (Css.px 200), Css.border3 (Css.px 1) Css.solid Colors.red ]
+                                )
+                          )
+                        , ( "100% width"
+                          , Control.value
+                                ( "RadioButton.containerCss [ Css.width (Css.pct 100) ]"
+                                , RadioButton.containerCss [ Css.width (Css.pct 100) ]
+                                )
+                          )
+                        , ( "10px right margin"
+                          , Control.value
+                                ( "RadioButton.containerCss [ Css.marginRight (Css.px 10) ]"
+                                , RadioButton.containerCss [ Css.marginRight (Css.px 10) ]
+                                )
+                          )
+                        ]
+                    )
+                |> ControlExtra.optionalListItem "labelCss"
+                    (Control.choice
+                        [ ( "backgroundColor highlightMagenta"
+                          , Control.value
+                                ( "RadioButton.labelCss [ Css.backgroundColor Colors.highlightMagenta ]"
+                                , RadioButton.labelCss [ Css.backgroundColor Colors.highlightMagenta ]
+                                )
+                          )
+                        , ( "1px ochreDark border"
+                          , Control.value
+                                ( "RadioButton.labelCss [ Css.border3 (Css.px 1) Css.solid Colors.ochreDark ]"
+                                , RadioButton.labelCss [ Css.border3 (Css.px 1) Css.solid Colors.ochreDark ]
+                                )
+                          )
+                        ]
+                    )
+                |> ControlExtra.optionalListItem "label visibility" labelVisibility
             )
-        |> ControlExtra.optionalListItem "disclosure" controlDisclosure
-        |> CommonControls.guidanceAndErrorMessage
-            { moduleName = moduleName
-            , guidance = RadioButton.guidance
-            , guidanceHtml = RadioButton.guidanceHtml
-            , errorMessage = Just RadioButton.errorMessage
-            , message = "The statement must be true."
-            }
-        |> CommonControls.rightIcon "RadioButton" RadioButton.rightIcon
 
 
 labelVisibility : Control ( String, RadioButton.Attribute Selection Msg )

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -28,8 +28,9 @@ import KeyboardSupport exposing (Direction(..), Key(..))
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.Data.PremiumDisplay as PremiumDisplay
+import Nri.Ui.Data.PremiumDisplay as PremiumDisplay exposing (..)
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Html.Attributes.V2 exposing (safeIdWithPrefix)
 import Nri.Ui.Message.V4 as Message
 import Nri.Ui.Modal.V12 as Modal
 import Nri.Ui.RadioButton.V4 as RadioButton
@@ -173,29 +174,36 @@ view ellieLinkConfig state =
         ]
     , viewExamples selectionSettings state.selectedValue
     , Heading.h2
-        [ Heading.plaintext "State Examples"
+        [ Heading.plaintext "State & Premium Display Examples"
         , Heading.css [ Css.marginTop (Css.px 30) ]
         ]
     , Table.view []
         [ Table.string
             { header = "State"
             , value = .name
-            , width = Css.pct 30
+            , width = Css.px 10
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle, Css.fontWeight Css.bold ]
+            , sort = Nothing
+            }
+        , Table.string
+            { header = "Premium Display"
+            , value = .premiumDisplay >> Debug.toString
+            , width = Css.px 10
             , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle, Css.fontWeight Css.bold ]
             , sort = Nothing
             }
         , Table.custom
             { header = text "Enabled"
             , view =
-                \{ name, selectedValue } ->
+                \{ name, selectedValue, premiumDisplay } ->
                     RadioButton.view
                         { label = "Include pandas"
-                        , name = name ++ "-" ++ "enabled"
+                        , name = safeIdWithPrefix ("enabled-" ++ Debug.toString premiumDisplay) name
                         , value = ()
                         , selectedValue = selectedValue
                         , valueToString = \_ -> ""
                         }
-                        []
+                        [ RadioButton.premium premiumDisplay ]
             , width = Css.px 150
             , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
             , sort = Nothing
@@ -203,15 +211,15 @@ view ellieLinkConfig state =
         , Table.custom
             { header = text "Disabled"
             , view =
-                \{ name, selectedValue } ->
+                \{ name, selectedValue, premiumDisplay } ->
                     RadioButton.view
                         { label = "Include pandas"
-                        , name = name ++ "-" ++ "disabled"
+                        , name = safeIdWithPrefix ("disabled-" ++ Debug.toString premiumDisplay) name
                         , value = ()
                         , selectedValue = selectedValue
                         , valueToString = \_ -> ""
                         }
-                        [ RadioButton.disabled ]
+                        [ RadioButton.disabled, RadioButton.premium premiumDisplay ]
             , width = Css.px 150
             , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
             , sort = Nothing
@@ -219,9 +227,11 @@ view ellieLinkConfig state =
         ]
         [ { name = "Deselected"
           , selectedValue = Nothing
+          , premiumDisplay = Free
           }
         , { name = "Selected"
           , selectedValue = Just ()
+          , premiumDisplay = Free
           }
         ]
     , Modal.view

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -36,9 +36,11 @@ import Nri.Ui.Message.V4 as Message
 import Nri.Ui.Modal.V12 as Modal
 import Nri.Ui.RadioButton.V4 as RadioButton
 import Nri.Ui.Spacing.V1 as Spacing
+import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Table.V7 as Table
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.Tooltip.V3 as Tooltip
+import Nri.Ui.UiIcon.V1 as UiIcon
 import Routes
 import Task
 
@@ -354,6 +356,20 @@ view ellieLinkConfig state =
                         ]
                     ]
           , description = "\"disclosure\" content only appears when the given RadioButton is selected."
+          }
+        , { name = "rightIcon"
+          , view =
+                RadioButton.view
+                    { label = "Automatically assign a grade"
+                    , name = "grading-assistant"
+                    , value = ()
+                    , selectedValue = Nothing
+                    , valueToString = \_ -> ""
+                    }
+                    [ RadioButton.rightIcon
+                        (Svg.withLabel "Grade with Grading Assistant" UiIcon.gradingAssistant)
+                    ]
+          , description = ""
           }
         ]
     , Modal.view

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -233,6 +233,30 @@ view ellieLinkConfig state =
           , selectedValue = Just ()
           , premiumDisplay = Free
           }
+        , { name = "Deselected"
+          , selectedValue = Nothing
+          , premiumDisplay = PremiumUnlocked
+          }
+        , { name = "Selected"
+          , selectedValue = Just ()
+          , premiumDisplay = PremiumUnlocked
+          }
+        , { name = "Deselected"
+          , selectedValue = Nothing
+          , premiumDisplay = PremiumVouchered
+          }
+        , { name = "Selected"
+          , selectedValue = Just ()
+          , premiumDisplay = PremiumVouchered
+          }
+        , { name = "Deselected"
+          , selectedValue = Nothing
+          , premiumDisplay = PremiumLocked
+          }
+        , { name = "Selected"
+          , selectedValue = Just ()
+          , premiumDisplay = PremiumLocked
+          }
         ]
     , Modal.view
         { title = "Go Premium!"

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -34,6 +34,7 @@ import Nri.Ui.Message.V4 as Message
 import Nri.Ui.Modal.V12 as Modal
 import Nri.Ui.RadioButton.V4 as RadioButton
 import Nri.Ui.Spacing.V1 as Spacing
+import Nri.Ui.Table.V7 as Table
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.Tooltip.V3 as Tooltip
 import Routes
@@ -171,6 +172,58 @@ view ellieLinkConfig state =
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
     , viewExamples selectionSettings state.selectedValue
+    , Heading.h2
+        [ Heading.plaintext "State Examples"
+        , Heading.css [ Css.marginTop (Css.px 30) ]
+        ]
+    , Table.view []
+        [ Table.string
+            { header = "State"
+            , value = .name
+            , width = Css.pct 30
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle, Css.fontWeight Css.bold ]
+            , sort = Nothing
+            }
+        , Table.custom
+            { header = text "Enabled"
+            , view =
+                \{ name, selectedValue } ->
+                    RadioButton.view
+                        { label = "Include pandas"
+                        , name = name ++ "-" ++ "enabled"
+                        , value = ()
+                        , selectedValue = selectedValue
+                        , valueToString = \_ -> ""
+                        }
+                        []
+            , width = Css.px 150
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+            , sort = Nothing
+            }
+        , Table.custom
+            { header = text "Disabled"
+            , view =
+                \{ name, selectedValue } ->
+                    RadioButton.view
+                        { label = "Include pandas"
+                        , name = name ++ "-" ++ "disabled"
+                        , value = ()
+                        , selectedValue = selectedValue
+                        , valueToString = \_ -> ""
+                        }
+                        [ RadioButton.disabled ]
+            , width = Css.px 150
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+            , sort = Nothing
+            }
+        ]
+        [ { name = "Deselected"
+          , selectedValue = Nothing
+          }
+        , { name = "Selected"
+          , selectedValue = Just ()
+          }
+        ]
     , Modal.view
         { title = "Go Premium!"
         , wrapMsg = ModalMsg

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -197,7 +197,7 @@ view ellieLinkConfig state =
             , view =
                 \{ name, selectedValue, premiumDisplay } ->
                     RadioButton.view
-                        { label = "Include pandas"
+                        { label = "Send back for revisions"
                         , name = safeIdWithPrefix ("enabled-" ++ Debug.toString premiumDisplay) name
                         , value = ()
                         , selectedValue = selectedValue
@@ -213,7 +213,7 @@ view ellieLinkConfig state =
             , view =
                 \{ name, selectedValue, premiumDisplay } ->
                     RadioButton.view
-                        { label = "Include pandas"
+                        { label = "Send back for revisions"
                         , name = safeIdWithPrefix ("disabled-" ++ Debug.toString premiumDisplay) name
                         , value = ()
                         , selectedValue = selectedValue

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -156,7 +156,7 @@ view ellieLinkConfig state =
                 ++ Code.caseExpression "animals"
                     [ ( "Dogs", Code.string "Dogs" )
                     , ( "Cats", Code.string "Cats" )
-                    , ( "Rabbits", Code.string selectionSettings.rabbitsLabel )
+                    , ( "Rabbits", Code.string selectionSettings.label )
                     ]
                     1
             ]
@@ -372,22 +372,40 @@ view ellieLinkConfig state =
 
 viewExamplesCode : SelectionSettings -> Maybe Selection -> String
 viewExamplesCode selectionSettings selectedValue =
-    let
-        toExampleCode ( kind, settings ) =
-            Code.fromModule "RadioButton" "view"
+    "div []"
+        ++ Code.listMultiline
+            [ Code.fromModule "RadioButton" "view"
                 ++ Code.recordMultiline
-                    [ ( "label", (selectionToString selectionSettings >> Code.string) kind )
+                    [ ( "label", Code.string "Dogs" )
                     , ( "name", Code.string "pets" )
-                    , ( "value", selectionToString selectionSettings kind )
-                    , ( "selectedValue"
-                      , Code.maybe (Maybe.map (selectionToString selectionSettings) selectedValue)
-                      )
+                    , ( "value", "Dogs" )
+                    , ( "selectedValue", Debug.toString selectedValue )
                     , ( "valueToString", "toString" )
                     ]
                     2
-                ++ Code.listMultiline (List.map Tuple.first settings) 2
-    in
-    "div []" ++ Code.listMultiline (List.map toExampleCode (examples selectionSettings)) 1
+                ++ Code.list []
+            , Code.fromModule "RadioButton" "view"
+                ++ Code.recordMultiline
+                    [ ( "label", Code.string "Cats" )
+                    , ( "name", Code.string "pets" )
+                    , ( "value", "Cats" )
+                    , ( "selectedValue", Debug.toString selectedValue )
+                    , ( "valueToString", "toString" )
+                    ]
+                    2
+                ++ Code.list []
+            , Code.fromModule "RadioButton" "view"
+                ++ Code.recordMultiline
+                    [ ( "label", Code.string selectionSettings.label )
+                    , ( "name", Code.string "pets" )
+                    , ( "value", "Rabbits" )
+                    , ( "selectedValue", Debug.toString selectedValue )
+                    , ( "valueToString", "toString" )
+                    ]
+                    2
+                ++ Code.listMultiline (List.map Tuple.first selectionSettings.attributes) 2
+            ]
+            1
 
 
 viewExamples : SelectionSettings -> Maybe Selection -> Html Msg
@@ -413,7 +431,7 @@ examples :
 examples selectionSettings =
     [ ( Dogs, [] )
     , ( Cats, [] )
-    , ( Rabbits, selectionSettings.rabbits )
+    , ( Rabbits, selectionSettings.attributes )
     ]
 
 
@@ -424,7 +442,7 @@ type Selection
 
 
 selectionToString : SelectionSettings -> Selection -> String
-selectionToString { rabbitsLabel } selection =
+selectionToString { label } selection =
     case selection of
         Dogs ->
             "Dogs"
@@ -433,7 +451,7 @@ selectionToString { rabbitsLabel } selection =
             "Cats"
 
         Rabbits ->
-            rabbitsLabel
+            label
 
 
 {-| -}
@@ -458,8 +476,8 @@ init =
 
 
 type alias SelectionSettings =
-    { rabbitsLabel : String
-    , rabbits : List ( String, RadioButton.Attribute Selection Msg )
+    { label : String
+    , attributes : List ( String, RadioButton.Attribute Selection Msg )
     }
 
 

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -485,7 +485,13 @@ viewExamples selectionSettings selectedValue =
                 }
                 (RadioButton.onSelect Select :: List.map Tuple.second settings)
     in
-    div [ css [ Css.flexBasis (Css.px 300) ] ]
+    div
+        [ css
+            [ Css.displayFlex
+            , Css.flexDirection Css.column
+            , Css.property "gap" "10px"
+            ]
+        ]
         (List.map viewExample_ (examples selectionSettings))
 
 
@@ -589,10 +595,10 @@ controlAttributes =
                                 , RadioButton.containerCss [ Css.maxWidth (Css.px 200), Css.border3 (Css.px 1) Css.solid Colors.red ]
                                 )
                           )
-                        , ( "100% width"
+                        , ( "backgroundColor aquaLight"
                           , Control.value
-                                ( "RadioButton.containerCss [ Css.width (Css.pct 100) ]"
-                                , RadioButton.containerCss [ Css.width (Css.pct 100) ]
+                                ( "RadioButton.containerCss [ Css.backgroundColor Colors.aquaLight ]"
+                                , RadioButton.containerCss [ Css.backgroundColor Colors.aquaLight ]
                                 )
                           )
                         , ( "10px left margin"

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -393,7 +393,7 @@ view ellieLinkConfig state =
         [ Heading.plaintext "Tooltip Example"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
-    , div []
+    , Tuple.second container
         [ RadioButton.view
             { label = "Dogs"
             , name = "pets-2"
@@ -436,7 +436,7 @@ view ellieLinkConfig state =
 
 viewExamplesCode : SelectionSettings -> Maybe Selection -> String
 viewExamplesCode selectionSettings selectedValue =
-    "div []"
+    Tuple.first container
         ++ Code.listMultiline
             [ Code.fromModule "RadioButton" "view"
                 ++ Code.recordMultiline
@@ -485,14 +485,33 @@ viewExamples selectionSettings selectedValue =
                 }
                 (RadioButton.onSelect Select :: List.map Tuple.second settings)
     in
-    div
+    Tuple.second container
+        (List.map viewExample_ (examples selectionSettings))
+
+
+container : ( String, List (Html msg) -> Html msg )
+container =
+    ( "div"
+        ++ Code.listMultiline
+            [ "css"
+                ++ Code.listMultiline
+                    [ "Css.displayFlex"
+                    , "Css.flexDirection Css.column"
+                    , "Css.property \"gap\" \"10px\""
+                    , "Css.alignItems Css.flexStart"
+                    ]
+                    2
+            ]
+            1
+    , div
         [ css
             [ Css.displayFlex
             , Css.flexDirection Css.column
             , Css.property "gap" "10px"
+            , Css.alignItems Css.flexStart
             ]
         ]
-        (List.map viewExample_ (examples selectionSettings))
+    )
 
 
 examples :

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -154,8 +154,8 @@ view ellieLinkConfig state =
             , "toString : Animals -> String"
             , "toString animals ="
                 ++ Code.caseExpression "animals"
-                    [ ( "Dogs", Code.string selectionSettings.dogsLabel )
-                    , ( "Cats", Code.string selectionSettings.catsLabel )
+                    [ ( "Dogs", Code.string "Dogs" )
+                    , ( "Cats", Code.string "Cats" )
                     , ( "Rabbits", Code.string selectionSettings.rabbitsLabel )
                     ]
                     1
@@ -411,8 +411,8 @@ examples :
     SelectionSettings
     -> List ( Selection, List ( String, RadioButton.Attribute Selection Msg ) )
 examples selectionSettings =
-    [ ( Dogs, selectionSettings.dogs )
-    , ( Cats, selectionSettings.cats )
+    [ ( Dogs, [] )
+    , ( Cats, [] )
     , ( Rabbits, selectionSettings.rabbits )
     ]
 
@@ -424,13 +424,13 @@ type Selection
 
 
 selectionToString : SelectionSettings -> Selection -> String
-selectionToString { dogsLabel, catsLabel, rabbitsLabel } selection =
+selectionToString { rabbitsLabel } selection =
     case selection of
         Dogs ->
-            dogsLabel
+            "Dogs"
 
         Cats ->
-            catsLabel
+            "Cats"
 
         Rabbits ->
             rabbitsLabel
@@ -458,11 +458,7 @@ init =
 
 
 type alias SelectionSettings =
-    { dogsLabel : String
-    , dogs : List ( String, RadioButton.Attribute Selection Msg )
-    , catsLabel : String
-    , cats : List ( String, RadioButton.Attribute Selection Msg )
-    , rabbitsLabel : String
+    { rabbitsLabel : String
     , rabbits : List ( String, RadioButton.Attribute Selection Msg )
     }
 
@@ -470,18 +466,14 @@ type alias SelectionSettings =
 initSelectionSettings : Control SelectionSettings
 initSelectionSettings =
     Control.record SelectionSettings
-        |> Control.field "Dogs label" (Control.string "Dogs")
-        |> Control.field "Dogs" controlAttributes
-        |> Control.field "Cats label" (Control.string "Cats")
-        |> Control.field "Cats" controlAttributes
-        |> Control.field "Rabbits label" (Control.string "Rabbits")
-        |> Control.field "Rabbits" controlAttributes
+        |> Control.field "3rd radio label" (Control.string "Rabbits (customizable)")
+        |> Control.field "" controlAttributes
 
 
 controlAttributes : Control (List ( String, RadioButton.Attribute Selection Msg ))
 controlAttributes =
     Control.list
-        |> ControlExtra.optionalListItem "visibility" labelVisibility
+        |> ControlExtra.optionalListItem "label visibility" labelVisibility
         |> ControlExtra.optionalListItem "status" disabledOrEnabled
         |> ControlExtra.optionalListItem "onLockedClick" onLockedClick
         |> ControlExtra.optionalListItem "premium"


### PR DESCRIPTION
Component Catalog improvement only.

Make the RadioButton example more usable by:
- making the customizable example _less_ customizable
- organizing the settings
- adding static examples showcasing states/combinations

### Before

![noredink-ui netlify app_ (1)](https://github.com/NoRedInk/noredink-ui/assets/8811312/25cb6a98-264e-4833-978f-6edae034b30b)


### After

![localhost_8000_ (10)](https://github.com/NoRedInk/noredink-ui/assets/8811312/1eb0b034-30e4-407e-bbc0-127c1a3585ce)
