### PR TITLE
Add confirmation before overwriting example

### DIFF
--- a/script/add-example.sh
+++ b/script/add-example.sh
@@ -10,6 +10,29 @@ read -p "What is the name of the new component? " example_name
 
 echo ""
 
+path=component-catalog/src/Examples/"${example_name}.elm"
+
+if test -f "${path}"; then
+    echo "${path} exists."
+    echo ""
+    read -p "Do you want to overwrite the existing ${example_name} example? (y/n) " overwrite
+
+    while true; do
+    case $overwrite in
+        [yY] )
+            echo ""
+            echo "Okay, we'll proceed and plan to overwrite ${path}."
+            echo ""
+            break;;
+        [nN] )
+            echo ""
+            echo "Okay, not overwriting the example. Exiting, bye 👋"
+            exit;;
+        * ) echo "Please enter Y, y, N, or n to proceed.";;
+    esac
+    done
+fi
+
 while true; do
 read -p "Is this component a collection of icons? (y/n) " yn
 case $yn in
@@ -44,7 +67,7 @@ done
 echo ""
 echo "Creating \`Examples.${example_name}\` for you in the component-catalog folder."
 
-path=component-catalog/src/Examples/"${example_name}.elm"
+
 printf "${template}" >| "${path}"
 
 echo ""
@@ -52,6 +75,7 @@ echo "Created ${path}."
 
 echo ""
 echo "Regenerating \`Examples.elm\` so it inclues \`Examples.${example_name}\`."
+echo ""
 
 . ./script/regenerate-examples.sh
 

--- a/script/templates/icon-collection-example.elm
+++ b/script/templates/icon-collection-example.elm
@@ -29,7 +29,7 @@ example =
     , version = 1
     , label = "FIRST_ICON_MEANING"
     , name = "firstIconName"
-    , icon = COLLECTION_NAME.starFilled
+    , icon = COLLECTION_NAME.firstIconName
     , renderSvgCode = Code.fromModule "COLLECTION_NAME"
     , preview =
         -- TODO: add more icons to the preview


### PR DESCRIPTION
Component Catalog improvement only, for devs using `script/add-example.sh`.

### Overwriting an existing example:
```
➜  noRedInk-ui (tessa/improve-add-example) script/add-example.sh                                                      ✭
Let's add a new component example to the Component Catalog!

What is the name of the new component? UiIcon

component-catalog/src/Examples/UiIcon.elm exists.

Do you want to overwrite the existing UiIcon example? (y/n) y

Okay, we'll proceed and plan to overwrite component-catalog/src/Examples/UiIcon.elm.

Is this component a collection of icons? (y/n) ^C

```

### Not overwriting an existing example
```
➜  noRedInk-ui (tessa/improve-add-example) script/add-example.sh                                                      ✭
Let's add a new component example to the Component Catalog!

What is the name of the new component? UiIcon

component-catalog/src/Examples/UiIcon.elm exists.

Do you want to overwrite the existing UiIcon example? (y/n) n

Okay, not overwriting the example. Exiting, bye 👋

```

### Adding a brand-new example
```
➜  noRedInk-ui (tessa/improve-add-example) script/add-example.sh                                                      ✭
Let's add a new component example to the Component Catalog!

What is the name of the new component? NewThing

Is this component a collection of icons? (y/n) n

Great, we'll set up a typical blank example page in `Examples.NewThing`.

Creating `Examples.NewThing` for you in the component-catalog folder.

Created component-catalog/src/Examples/NewThing.elm.

Regenerating `Examples.elm` so it inclues `Examples.NewThing`.

Cataloging the `component-catalog/src/Examples/` folder...
Replacing `component-catalog/src/Examples.elm`...
Done! `Examples` should now be up to date.

🚨 There are TODOs for you to complete in component-catalog/src/Examples/NewThing.elm. 🚨
```