### PR TITLE
Add `.modal`s to examples

### DIFF
--- a/component-catalog/src/Examples/Button.elm
+++ b/component-catalog/src/Examples/Button.elm
@@ -179,13 +179,7 @@ controlAttributes =
         |> ControlExtra.listItems "Size & Width"
             (Control.list
                 |> ControlExtra.optionalListItem "size"
-                    (CommonControls.choice moduleName
-                        [ ( "small", Button.small )
-                        , ( "medium", Button.medium )
-                        , ( "large", Button.large )
-                        , ( "modal", Button.modal )
-                        ]
-                    )
+                    (CommonControls.choice moduleName sizes)
                 |> ControlExtra.optionalListItem "width"
                     (CommonControls.choice moduleName
                         [ ( "exactWidth 120", Button.exactWidth 120 )
@@ -393,15 +387,18 @@ viewCustomizableExample model =
         (List.map Tuple.second model.attributes)
 
 
+sizes : List ( String, Button.Attribute msg )
+sizes =
+    [ ( "small", Button.small )
+    , ( "medium", Button.medium )
+    , ( "large", Button.large )
+    , ( "modal", Button.modal )
+    ]
+
+
 buttonsTable : Html msg
 buttonsTable =
     let
-        sizes =
-            [ ( Button.small, "small" )
-            , ( Button.medium, "medium" )
-            , ( Button.large, "large" )
-            ]
-
         styles =
             [ ( Button.primary, "primary" )
             , ( Button.secondary, "secondary" )
@@ -439,7 +436,7 @@ buttonsTable =
                 )
             ]
 
-        exampleCell cellStyle ( view, viewName ) ( style, styleName ) ( setSize, sizeName ) =
+        exampleCell cellStyle ( view, viewName ) ( style, styleName ) ( sizeName, setSize ) =
             inCell cellStyle <| view (sizeName ++ " " ++ styleName ++ " " ++ viewName) [ setSize, style ]
 
         inCell style content =
@@ -455,7 +452,7 @@ buttonsTable =
     List.concat
         [ [ sizes
                 |> List.map
-                    (\( _, sizeName ) ->
+                    (\( sizeName, _ ) ->
                         th [ css [ Css.padding2 (Css.px 25) Css.zero ] ]
                             [ code [] [ text (Code.fromModule moduleName sizeName) ]
                             ]

--- a/component-catalog/src/Examples/Button.elm
+++ b/component-catalog/src/Examples/Button.elm
@@ -461,7 +461,9 @@ buttonsTable =
           ]
         , List.concatMap exampleRow styles
         ]
-        |> table [ css [ Css.borderCollapse Css.collapse ] ]
+        |> table [ css [ Css.borderCollapse Css.collapse, Css.width (Css.pct 100) ] ]
+        |> List.singleton
+        |> div [ css [ Css.overflow Css.auto ] ]
 
 
 toggleButtons : Set Int -> Html Msg

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -243,6 +243,7 @@ sizes =
     [ ( ClickableText.small, "small" )
     , ( ClickableText.medium, "medium" )
     , ( ClickableText.large, "large" )
+    , ( ClickableText.modal, "modal" )
     ]
 
 

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -19,6 +19,7 @@ import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.ClickableText.V4 as ClickableText
+import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Text.V6 as Text
@@ -271,6 +272,8 @@ buttons settings =
                     |> exampleCell
             )
         ]
+        |> List.singleton
+        |> div [ css [ Css.overflow Css.auto ] ]
 
 
 row : String -> List (Html msg) -> Html msg
@@ -280,4 +283,11 @@ row label tds =
 
 exampleCell : Html msg -> Html msg
 exampleCell view =
-    td [ css [ verticalAlign middle, Css.width (Css.px 200) ] ] [ view ]
+    td
+        [ css
+            [ verticalAlign middle
+            , Css.width (Css.px 200)
+            , Css.borderTop3 (Css.px 1) Css.solid Colors.gray85
+            ]
+        ]
+        [ view ]


### PR DESCRIPTION
Component Catalog changes only.

| | Before | After |
| --- | --- | --- |
| adds `Button.modal` to the button examples table | <img width="1213" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/a7bf0ebe-6655-4fe8-baa5-b6d48e9a1e1a"> | <img width="1380" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/4a832e64-a169-4dc6-a630-e87549701c62"> |
| adds `ClickableText.modal` to the clickabletext examples table | <img width="812" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/8068a4c0-fa82-4f95-8952-93ea30ad052b"> | <img width="890" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/21c22b1a-9793-4325-a1f8-ad7b8d3e8780"> |




