### PR TITLE
Modal guidance

### DIFF
--- a/component-catalog/src/Examples/Modal.elm
+++ b/component-catalog/src/Examples/Modal.elm
@@ -186,7 +186,7 @@ example =
     , about =
         Guidance.useATACGuide moduleName
             ++ [ Text.smallBody
-                    [ Text.markdown "Generally, you'll want to pair the `Modal.warning` theme with the `Button.danger` theme and the `Modal.info` theme with the `Button.primary` theme."
+                    [ Text.markdown "Pair the `Modal.warning` theme with the `Button.danger` theme and the `Modal.info` theme with the `Button.primary` theme."
                     ]
                , Text.smallBody
                     [ Text.markdown "Use `Button.modal` and/or `ClickableText.modal` within the `Modal` footer." ]

--- a/component-catalog/src/Examples/Modal.elm
+++ b/component-catalog/src/Examples/Modal.elm
@@ -186,7 +186,7 @@ example =
     , about =
         Guidance.useATACGuide moduleName
             ++ [ Text.smallBody
-                    [ Text.plaintext "Generally, you'll want to pair the Modal.warning theme with the Button.danger theme and the Modal.info theme with the Button.primary theme."
+                    [ Text.markdown "Generally, you'll want to pair the `Modal.warning` theme with the `Button.danger` theme and the `Modal.info` theme with the `Button.primary` theme."
                     ]
                ]
     , view =

--- a/component-catalog/src/Examples/Modal.elm
+++ b/component-catalog/src/Examples/Modal.elm
@@ -77,8 +77,7 @@ initViewSettings =
         |> Control.field "Content"
             (Control.stringTextarea <|
                 String.join "\n\n"
-                    [ "Generally, you'll want to pair the Modal.warning theme with the Button.danger theme and the Modal.info theme with the Button.primary theme."
-                    , "Muffin liquorice powder liquorice jujubes biscuit cookie candy canes lemon drops. Liquorice powder carrot cake dragée icing tootsie roll apple pie lemon drops lemon drops. Jujubes danish bear claw cotton candy. Dragée apple pie tiramisu. Sugar plum dessert pastry marzipan chocolate cake dragée sesame snaps. Marshmallow gingerbread lemon drops. Brownie chocolate fruitcake pastry. Powder jelly beans jujubes. Croissant macaroon dessert cookie candy canes jelly jujubes. Muffin liquorice ice cream wafer donut danish soufflé dragée chocolate bar. Candy croissant candy wafer toffee lemon drops croissant danish sugar plum. Cookie cake candy canes. Pastry powder muffin soufflé tootsie roll sweet cookie tiramisu."
+                    [ "Muffin liquorice powder liquorice jujubes biscuit cookie candy canes lemon drops. Liquorice powder carrot cake dragée icing tootsie roll apple pie lemon drops lemon drops. Jujubes danish bear claw cotton candy. Dragée apple pie tiramisu. Sugar plum dessert pastry marzipan chocolate cake dragée sesame snaps. Marshmallow gingerbread lemon drops. Brownie chocolate fruitcake pastry. Powder jelly beans jujubes. Croissant macaroon dessert cookie candy canes jelly jujubes. Muffin liquorice ice cream wafer donut danish soufflé dragée chocolate bar. Candy croissant candy wafer toffee lemon drops croissant danish sugar plum. Cookie cake candy canes. Pastry powder muffin soufflé tootsie roll sweet cookie tiramisu."
                     , "Candy cake danish gingerbread. Caramels toffee cupcake toffee sweet. Gummi bears candy cheesecake sweet. Pie gingerbread sugar plum halvah muffin icing marzipan wafer icing. Candy fruitcake gummies icing marzipan. Halvah jelly beans candy candy canes biscuit bonbon sesame snaps. Biscuit carrot cake croissant cake chocolate lollipop candy biscuit croissant. Topping jujubes apple pie croissant chocolate cake. Liquorice cookie dragée gummies cotton candy fruitcake lemon drops candy canes. Apple pie lemon drops gummies cake chocolate bar cake jelly-o tiramisu. Chocolate bar icing pudding marshmallow cake soufflé soufflé muffin. Powder lemon drops biscuit sugar plum cupcake carrot cake powder cake dragée. Bear claw gummi bears liquorice sweet roll."
                     ]
             )
@@ -184,7 +183,12 @@ example =
                 ]
             ]
         ]
-    , about = Guidance.useATACGuide moduleName
+    , about =
+        Guidance.useATACGuide moduleName
+            ++ [ Text.smallBody
+                    [ Text.plaintext "Generally, you'll want to pair the Modal.warning theme with the Button.danger theme and the Modal.info theme with the Button.primary theme."
+                    ]
+               ]
     , view =
         \ellieLinkConfig state ->
             let

--- a/component-catalog/src/Examples/Modal.elm
+++ b/component-catalog/src/Examples/Modal.elm
@@ -186,9 +186,6 @@ example =
     , about =
         Guidance.useATACGuide moduleName
             ++ [ Text.smallBody
-                    [ Text.markdown "Pair the `Modal.warning` theme with the `Button.danger` theme and the `Modal.info` theme with the `Button.primary` theme."
-                    ]
-               , Text.smallBody
                     [ Text.markdown "Use `Button.modal` and/or `ClickableText.modal` within the `Modal` footer." ]
                ]
     , view =

--- a/component-catalog/src/Examples/Modal.elm
+++ b/component-catalog/src/Examples/Modal.elm
@@ -188,6 +188,8 @@ example =
             ++ [ Text.smallBody
                     [ Text.markdown "Generally, you'll want to pair the `Modal.warning` theme with the `Button.danger` theme and the `Modal.info` theme with the `Button.primary` theme."
                     ]
+               , Text.smallBody
+                    [ Text.markdown "Use `Button.modal` and/or `ClickableText.modal` within the `Modal` footer." ]
                ]
     , view =
         \ellieLinkConfig state ->

--- a/component-catalog/src/Guidance.elm
+++ b/component-catalog/src/Guidance.elm
@@ -10,7 +10,7 @@ import Routes
 
 useATACGuide : String -> List (Html msg)
 useATACGuide moduleName =
-    [ Text.mediumBody
+    [ Text.smallBody
         [ Text.html
             [ text ("To ensure your use of " ++ moduleName ++ " is accessible to assistive technology, please review the ")
             , ClickableText.link "Assistive technology notification design & development guide"


### PR DESCRIPTION
Component Catalog change only.

Fixes https://linear.app/noredink/issue/A11-4104/move-modal-guidance-from-text-field-to-about-section

Clarifies https://noredink.slack.com/archives/C02NMHB1K55/p1707433597293789?thread_ts=1707432784.790109&cid=C02NMHB1K55

<img width="682" alt="image" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/15e70d29-52c4-42a3-bb35-fbbc2040fb0d">
