### PR TITLE
Improve menu examples

### DIFF
--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -19,6 +19,9 @@ import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import EllieLink
 import Example exposing (Example)
+import Examples.Button
+import Examples.ClickableSvg
+import Examples.ClickableText
 import Html.Styled.Attributes exposing (css)
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Button.V10 as Button
@@ -38,6 +41,7 @@ import Nri.Ui.Text.V6 as Text
 import Nri.Ui.TextInput.V8 as TextInput
 import Nri.Ui.Tooltip.V3 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon
+import Routes
 import Set exposing (Set)
 import Svg.Styled as Svg
 import Svg.Styled.Attributes as SvgAttrs
@@ -401,19 +405,39 @@ view ellieLinkConfig state =
         [ Table.string
             { header = "Trigger type"
             , value = .menu
-            , width = Css.pct 30
+            , width = Css.px 0
             , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle, Css.fontWeight Css.bold ]
+            , sort = Nothing
+            }
+        , Table.custom
+            { header = text "Type Signature"
+            , view = \{ typeAnnotation } -> code [] [ text typeAnnotation ]
+            , width = Css.pct 30
+            , cellStyles =
+                always
+                    [ Css.padding2 (Css.px 14) (Css.px 7)
+                    , Css.verticalAlign Css.middle
+                    , Css.fontSize (Css.px 12)
+                    ]
             , sort = Nothing
             }
         , Table.custom
             { header = text "Example"
             , view = .example
-            , width = Css.px 300
+            , width = Css.pct 20
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+            , sort = Nothing
+            }
+        , Table.custom
+            { header = text "Pattern Notes"
+            , view = .patternNotes >> Text.smallBody
+            , width = Css.pct 30
             , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
             , sort = Nothing
             }
         ]
         [ { menu = "Menu.defaultTrigger"
+          , typeAnnotation = "String -> List (Button.Attribute msg) -> Attribute msg"
           , example =
                 Menu.view (FocusAndToggle "defaultTrigger")
                     [ Menu.defaultTrigger "Log in" []
@@ -422,8 +446,19 @@ view ellieLinkConfig state =
                     , Menu.menuId "defaultTrigger"
                     ]
                     []
+          , patternNotes =
+                [ Text.html
+                    [ text "Composes with "
+                    , ClickableText.link "Button"
+                        [ ClickableText.href (Routes.exampleHref Examples.Button.example)
+                        , ClickableText.appearsInline
+                        ]
+                    , text ", so any attribute you use for a Button can also used with this trigger."
+                    ]
+                ]
           }
         , { menu = "Menu.button"
+          , typeAnnotation = "String -> List (Button.Attribute msg) -> Menu.Attribute msg"
           , example =
                 Menu.view (FocusAndToggle "button")
                     [ Menu.button "Log in" []
@@ -432,8 +467,19 @@ view ellieLinkConfig state =
                     , Menu.menuId "button"
                     ]
                     []
+          , patternNotes =
+                [ Text.html
+                    [ text "Composes with "
+                    , ClickableText.link "Button"
+                        [ ClickableText.href (Routes.exampleHref Examples.Button.example)
+                        , ClickableText.appearsInline
+                        ]
+                    , text ", so any attribute you use for a Button can also used with this trigger."
+                    ]
+                ]
           }
         , { menu = "Menu.clickableText"
+          , typeAnnotation = "String -> List (ClickableText.Attribute msg) -> Menu.Attribute msg"
           , example =
                 Menu.view (FocusAndToggle "clickableText")
                     [ Menu.clickableText "Log in" []
@@ -442,8 +488,19 @@ view ellieLinkConfig state =
                     , Menu.menuId "clickableText"
                     ]
                     []
+          , patternNotes =
+                [ Text.html
+                    [ text "Composes with "
+                    , ClickableText.link "ClickableText"
+                        [ ClickableText.href (Routes.exampleHref Examples.ClickableText.example)
+                        , ClickableText.appearsInline
+                        ]
+                    , text ", so any attribute you use for a ClickableText can also used with this trigger."
+                    ]
+                ]
           }
         , { menu = "Menu.clickableSvg with UiIcon.gear"
+          , typeAnnotation = "String -> Svg.Svg -> List (ClickableSvg.Attribute msg) -> Menu.Attribute msg"
           , example =
                 Menu.view (FocusAndToggle "clickableSvg")
                     [ Menu.clickableSvg "Log in" UiIcon.gear []
@@ -452,8 +509,19 @@ view ellieLinkConfig state =
                     , Menu.menuId "clickableSvg"
                     ]
                     []
+          , patternNotes =
+                [ Text.html
+                    [ text "Composes with "
+                    , ClickableText.link "ClickableSvg"
+                        [ ClickableText.href (Routes.exampleHref Examples.ClickableSvg.example)
+                        , ClickableText.appearsInline
+                        ]
+                    , text ", so any attribute you use for a ClickableSvg can also used with this trigger."
+                    ]
+                ]
           }
         , { menu = "Menu.clickableSvgWithoutIndicator with UiIcon.gear"
+          , typeAnnotation = "String -> Svg.Svg -> List (ClickableSvg.Attribute msg) -> Menu.Attribute msg"
           , example =
                 Menu.view (FocusAndToggle "clickableSvgWithoutIndicator")
                     [ Menu.clickableSvgWithoutIndicator "Log in" UiIcon.gear []
@@ -462,6 +530,16 @@ view ellieLinkConfig state =
                     , Menu.menuId "clickableSvgWithoutIndicator"
                     ]
                     []
+          , patternNotes =
+                [ Text.html
+                    [ text "Composes with "
+                    , ClickableText.link "ClickableSvg"
+                        [ ClickableText.href (Routes.exampleHref Examples.ClickableSvg.example)
+                        , ClickableText.appearsInline
+                        ]
+                    , text ", so any attribute you use for a ClickableSvg can also used with this trigger."
+                    ]
+                ]
           }
         ]
     , Heading.h2
@@ -472,14 +550,14 @@ view ellieLinkConfig state =
         [ Table.string
             { header = "Content"
             , value = .name
-            , width = Css.pct 30
+            , width = Css.pct 20
             , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle, Css.fontWeight Css.bold ]
             , sort = Nothing
             }
         , Table.custom
             { header = text "Example"
             , view = \{ name, menuType, entries } -> forcedOpenExample name menuType entries
-            , width = Css.px 300
+            , width = Css.pct 20
             , cellStyles =
                 \{ name } ->
                     let
@@ -514,7 +592,7 @@ view ellieLinkConfig state =
         , Table.custom
             { header = text "Pattern Notes"
             , view = \{ about } -> Text.smallBody [ Text.markdown about ]
-            , width = Css.px 300
+            , width = Css.pct 60
             , cellStyles =
                 always
                     [ Css.padding2 (Css.px 14) (Css.px 7)

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -196,7 +196,7 @@ view ellieLinkConfig state =
                                         (Code.newlineWithIndent 2
                                             ++ (Code.fromModule "ClickableText" "button " ++ Code.string "Button")
                                             ++ Code.listMultiline
-                                                [ Code.fromModule "ClickableText" "small"
+                                                [ Code.fromModule "ClickableText" "medium"
                                                 , Code.fromModule "ClickableText" "custom" ++ " attributes"
                                                 ]
                                                 3
@@ -233,7 +233,7 @@ view ellieLinkConfig state =
             [ Menu.entry "customizable-example" <|
                 \attrs ->
                     ClickableText.button "Button"
-                        [ ClickableText.small
+                        [ ClickableText.medium
                         , ClickableText.onClick (ConsoleLog "Interactive example")
                         , ClickableText.custom attrs
                         ]
@@ -280,7 +280,7 @@ view ellieLinkConfig state =
                         \attrs ->
                             ClickableText.button "Hello"
                                 [ ClickableText.onClick (ConsoleLog "Hello")
-                                , ClickableText.small
+                                , ClickableText.medium
                                 , ClickableText.custom attrs
                                 ]
                     , Menu.group "Menu group"
@@ -288,7 +288,7 @@ view ellieLinkConfig state =
                             \attrs ->
                                 ClickableText.button "Gift"
                                     [ ClickableText.onClick (ConsoleLog "Gift")
-                                    , ClickableText.small
+                                    , ClickableText.medium
                                     , ClickableText.custom attrs
                                     , ClickableText.icon UiIcon.gift
                                     ]
@@ -296,7 +296,7 @@ view ellieLinkConfig state =
                             \attrs ->
                                 ClickableText.button "Nope!"
                                     [ ClickableText.onClick (ConsoleLog "Nope!")
-                                    , ClickableText.small
+                                    , ClickableText.medium
                                     , ClickableText.custom attrs
                                     , ClickableText.icon UiIcon.null
                                     ]
@@ -304,7 +304,7 @@ view ellieLinkConfig state =
                             \attrs ->
                                 ClickableText.button "Skip"
                                     [ ClickableText.onClick (ConsoleLog "Skip")
-                                    , ClickableText.small
+                                    , ClickableText.medium
                                     , ClickableText.custom attrs
                                     ]
                         ]
@@ -312,7 +312,7 @@ view ellieLinkConfig state =
                         \attrs ->
                             ClickableText.button "Performance"
                                 [ ClickableText.onClick (ConsoleLog "Performance")
-                                , ClickableText.small
+                                , ClickableText.medium
                                 , ClickableText.custom attrs
                                 ]
                     ]
@@ -330,21 +330,21 @@ view ellieLinkConfig state =
                     [ Menu.entry "dropdown_list__first" <|
                         \attrs ->
                             ClickableText.button "First"
-                                [ ClickableText.small
+                                [ ClickableText.medium
                                 , ClickableText.onClick (ConsoleLog "First")
                                 , ClickableText.custom attrs
                                 ]
                     , Menu.entry "dropdown_list__second" <|
                         \attrs ->
                             ClickableText.button "Second"
-                                [ ClickableText.small
+                                [ ClickableText.medium
                                 , ClickableText.onClick (ConsoleLog "Second")
                                 , ClickableText.custom attrs
                                 ]
                     , Menu.entry "dropdown_list__third" <|
                         \attrs ->
                             ClickableText.button "Third"
-                                [ ClickableText.small
+                                [ ClickableText.medium
                                 , ClickableText.onClick (ConsoleLog "Third")
                                 , ClickableText.custom attrs
                                 ]
@@ -644,7 +644,7 @@ You will need to pass in the first and last focusable element in the dialog cont
                 [ Menu.entry "list-of-entries-clickable-text-entry" <|
                     \attributes ->
                         ClickableText.button "ClickableText"
-                            [ ClickableText.small
+                            [ ClickableText.medium
                             , ClickableText.custom attributes
                             ]
                 , Menu.entry "list-of-entries-button-entry" <|
@@ -673,7 +673,7 @@ You will need to pass in the first and last focusable element in the dialog cont
                             Menu.entry ("group-clickable-text-entry-" ++ String.fromInt i) <|
                                 \attributes ->
                                     ClickableText.button ("Thing " ++ String.fromInt i)
-                                        [ ClickableText.small
+                                        [ ClickableText.medium
                                         , ClickableText.custom attributes
                                         ]
                         )

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -566,7 +566,14 @@ view ellieLinkConfig state =
           }
         , { name = "Mix of singular entries and grouped entries"
           , entries =
-                [ Menu.group "Display scores as"
+                [ Menu.entry "grades-and-perf" <|
+                    \attributes ->
+                        ClickableText.link "Grades and Performance Help"
+                            [ ClickableText.linkExternal "https://noredink.zendesk.com/hc/en-us/sections/115001041146-Grades-Performance"
+                            , ClickableText.custom attributes
+                            , ClickableText.icon UiIcon.help
+                            ]
+                , Menu.group "Display scores as"
                     [ Menu.entry "percentages" <| viewScoreDisplay "Percentage" Nothing
                     , Menu.entry "points" <| viewScoreDisplay "Points" Nothing
                     ]

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -28,6 +28,7 @@ import Nri.Ui.Colors.Extra as ColorsExtra
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Html.Attributes.V2 exposing (safeIdWithPrefix)
 import Nri.Ui.Menu.V4 as Menu
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V7 as Table
@@ -467,48 +468,91 @@ view ellieLinkConfig state =
     , Table.view []
         [ Table.string
             { header = "Content"
-            , value = .menu
+            , value = .name
             , width = Css.pct 30
             , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle, Css.fontWeight Css.bold ]
             , sort = Nothing
             }
         , Table.custom
             { header = text "Example"
-            , view = .example
+            , view = \{ name, entries } -> forcedOpenExample name entries
             , width = Css.px 300
             , cellStyles =
-                always
+                \{ name } ->
+                    let
+                        buttonId =
+                            forcedOpenExampleButtonId name
+                    in
                     [ Css.padding2 (Css.px 14) (Css.px 7)
                     , Css.verticalAlign Css.middle
-                    , -- when menus are open, we add this overlay to
-                      -- ensure that clicks close the menu.
-                      -- so if the menu is open, nothing else on the page
-                      -- is interactive by mouse.
-                      -- for the purposes of these static examples,
-                      -- this is very unhelpful, so we hide the overlay.
-                      --
-                      -- if changing this code, please ensure the example in the CC is still interactive.
-                      Css.Global.descendants
-                        [ Css.Global.class "Nri-Menu-Overlay"
+                    , Css.Global.descendants
+                        [ -- when menus are open, we add this overlay to
+                          -- ensure that clicks close the menu.
+                          -- so if the menu is open, nothing else on the page
+                          -- is interactive by mouse.
+                          -- for the purposes of these static examples,
+                          -- this is very unhelpful, so we hide the overlay.
+                          --
+                          -- if changing this code, please ensure the example in the CC is still interactive.
+                          Css.Global.class "Nri-Menu-Overlay"
                             [ Css.display Css.none
                             ]
+                        , -- Menus are absolutely positioned, but this is
+                          -- pretty inconvenient for displaying them in a table.
+                          -- This override is so that these Menu will be part of
+                          -- the normal flow of the page, so that their
+                          -- content is always visible.
+                          Css.Global.selector ("#" ++ buttonId ++ " + div")
+                            [ Css.position Css.relative ]
+                        , -- Hide the trigger element
+                          Css.Global.id buttonId
+                            [ Css.display Css.none ]
                         ]
                     ]
             , sort = Nothing
             }
         ]
-        [ { menu = "List of entries"
-          , example =
-                Menu.view (FocusAndToggle "list-of-entries")
-                    [ Menu.clickableSvgWithoutIndicator "List of entries example" UiIcon.starFilled []
-                    , Menu.isOpen True
-                    , Menu.buttonId "list-of-entries"
-                    , Menu.menuId "list-of-entries"
-                    ]
-                    []
+        [ { name = "List of entries"
+          , entries =
+                [ Menu.entry "list-of-entries-clickable-text-entry" <|
+                    \attributes ->
+                        ClickableText.button "ClickableText"
+                            [ ClickableText.small
+                            , ClickableText.custom attributes
+                            ]
+                , Menu.entry "list-of-entries-button-entry" <|
+                    \attributes ->
+                        Button.button "Button"
+                            [ Button.small
+                            , Button.custom attributes
+                            ]
+                , Menu.entry "list-of-entries-clickablesvg-entry" <|
+                    \attributes ->
+                        ClickableSvg.button "ClickableSvg"
+                            UiIcon.arrowPointingRightThick
+                            [ ClickableSvg.small
+                            , ClickableSvg.custom attributes
+                            , ClickableSvg.withBorder
+                            ]
+                ]
           }
         ]
     ]
+
+
+forcedOpenExample : String -> List (Menu.Entry Msg) -> Html Msg
+forcedOpenExample name =
+    Menu.view (FocusAndToggle name)
+        [ Menu.clickableSvgWithoutIndicator (name ++ " example") UiIcon.starFilled []
+        , Menu.isOpen True
+        , Menu.buttonId (forcedOpenExampleButtonId name)
+        , Menu.menuId (safeIdWithPrefix name "menuId")
+        ]
+
+
+forcedOpenExampleButtonId : String -> String
+forcedOpenExampleButtonId name =
+    safeIdWithPrefix name "buttonId"
 
 
 {-| -}

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -574,8 +574,8 @@ view ellieLinkConfig state =
                             , ClickableText.icon UiIcon.help
                             ]
                 , Menu.group "Display scores as"
-                    [ Menu.entry "percentages" <| viewScoreDisplay "Percentage" Nothing
-                    , Menu.entry "points" <| viewScoreDisplay "Points" Nothing
+                    [ Menu.entry "percentages" <| viewScoreDisplay "Percentage" state.scoreDisplay
+                    , Menu.entry "points" <| viewScoreDisplay "Points" state.scoreDisplay
                     ]
                 , Menu.group "Dropped students"
                     [ Menu.entry "dropped-students" <| viewDroppedStudentsSwitch
@@ -601,7 +601,7 @@ forcedOpenExampleButtonId name =
     safeIdWithPrefix name "buttonId"
 
 
-viewScoreDisplay : String -> Maybe String -> List (Attribute msg) -> Html msg
+viewScoreDisplay : String -> Maybe String -> List (Attribute Msg) -> Html Msg
 viewScoreDisplay value selected attributes =
     RadioButton.view
         { label = value
@@ -610,7 +610,11 @@ viewScoreDisplay value selected attributes =
         , selectedValue = selected
         , valueToString = identity
         }
-        [ RadioButton.custom attributes
+        [ -- TODO: when the Menu attributes are attached to the RadioButton
+          -- (as is required for the focus trap to work correctly),
+          -- the RadioButtons become inoperable.
+          -- RadioButton.custom attributes ,
+          RadioButton.onSelect SelectScoreDisplay
         ]
 
 
@@ -632,6 +636,7 @@ init =
     , checkboxChecked = False
     , openTooltips = Set.empty
     , settings = initSettings
+    , scoreDisplay = Nothing
     }
 
 
@@ -641,6 +646,7 @@ type alias State =
     , checkboxChecked : Bool
     , openTooltips : Set String
     , settings : Control Settings
+    , scoreDisplay : Maybe String
     }
 
 
@@ -809,6 +815,7 @@ type Msg
     | ToggleTooltip String Bool
     | FocusAndToggle String { isOpen : Bool, focus : Maybe String }
     | Focused (Result Dom.Error ())
+    | SelectScoreDisplay String
 
 
 {-| -}
@@ -842,6 +849,9 @@ update msg state =
 
         Focused _ ->
             ( state, Cmd.none )
+
+        SelectScoreDisplay name ->
+            ( { state | scoreDisplay = Just name }, Cmd.none )
 
 
 

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -464,7 +464,7 @@ You will need to pass in the first and last focusable element in the dialog cont
             }
         , Table.custom
             { header = text "Pattern Notes"
-            , view = .patternNotes >> Text.smallBody
+            , view = .patternNotes >> List.map (List.singleton >> Text.smallBody) >> div []
             , width = Css.pct 30
             , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
             , sort = Nothing
@@ -531,6 +531,7 @@ You will need to pass in the first and last focusable element in the dialog cont
                         ]
                     , text ", so any attribute you use for a ClickableText can also used with this trigger."
                     ]
+                , Text.markdown " Defaults to using the `ClickableText.medium` size, although this can be overriden."
                 ]
           }
         , { menu = "Menu.clickableSvg with UiIcon.gear"

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -13,6 +13,7 @@ import Category exposing (Category(..))
 import Code
 import CommonControls
 import Css
+import Css.Global
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
@@ -455,6 +456,54 @@ view ellieLinkConfig state =
                     , Menu.isOpen (isOpen "clickableSvgWithoutIndicator")
                     , Menu.buttonId "clickableSvgWithoutIndicator"
                     , Menu.menuId "clickableSvgWithoutIndicator"
+                    ]
+                    []
+          }
+        ]
+    , Heading.h2
+        [ Heading.plaintext "Menu content"
+        , Heading.css [ Css.margin2 Spacing.verticalSpacerPx Css.zero ]
+        ]
+    , Table.view []
+        [ Table.string
+            { header = "Content"
+            , value = .menu
+            , width = Css.pct 30
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle, Css.fontWeight Css.bold ]
+            , sort = Nothing
+            }
+        , Table.custom
+            { header = text "Example"
+            , view = .example
+            , width = Css.px 300
+            , cellStyles =
+                always
+                    [ Css.padding2 (Css.px 14) (Css.px 7)
+                    , Css.verticalAlign Css.middle
+                    , -- when menus are open, we add this overlay to
+                      -- ensure that clicks close the menu.
+                      -- so if the menu is open, nothing else on the page
+                      -- is interactive by mouse.
+                      -- for the purposes of these static examples,
+                      -- this is very unhelpful, so we hide the overlay.
+                      --
+                      -- if changing this code, please ensure the example in the CC is still interactive.
+                      Css.Global.descendants
+                        [ Css.Global.class "Nri-Menu-Overlay"
+                            [ Css.display Css.none
+                            ]
+                        ]
+                    ]
+            , sort = Nothing
+            }
+        ]
+        [ { menu = "List of entries"
+          , example =
+                Menu.view (FocusAndToggle "list-of-entries")
+                    [ Menu.clickableSvgWithoutIndicator "List of entries example" UiIcon.starFilled []
+                    , Menu.isOpen True
+                    , Menu.buttonId "list-of-entries"
+                    , Menu.menuId "list-of-entries"
                     ]
                     []
           }

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -30,7 +30,9 @@ import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Html.Attributes.V2 exposing (safeIdWithPrefix)
 import Nri.Ui.Menu.V4 as Menu
+import Nri.Ui.RadioButton.V4 as RadioButton
 import Nri.Ui.Spacing.V1 as Spacing
+import Nri.Ui.Switch.V3 as Switch
 import Nri.Ui.Table.V7 as Table
 import Nri.Ui.TextInput.V8 as TextInput
 import Nri.Ui.Tooltip.V3 as Tooltip
@@ -536,6 +538,43 @@ view ellieLinkConfig state =
                             ]
                 ]
           }
+        , { name = "Grouped entries"
+          , entries =
+                [ List.range 1 2
+                    |> List.map
+                        (\i ->
+                            Menu.entry ("group-clickable-text-entry-" ++ String.fromInt i) <|
+                                \attributes ->
+                                    ClickableText.button ("Thing " ++ String.fromInt i)
+                                        [ ClickableText.small
+                                        , ClickableText.custom attributes
+                                        ]
+                        )
+                    |> Menu.group "Group of ClickableTexts"
+                , List.range 1 3
+                    |> List.map
+                        (\i ->
+                            Menu.entry ("group-button-entry-" ++ String.fromInt i) <|
+                                \attributes ->
+                                    Button.button ("Thing " ++ String.fromInt i)
+                                        [ Button.small
+                                        , Button.custom attributes
+                                        ]
+                        )
+                    |> Menu.group "Group of Buttons"
+                ]
+          }
+        , { name = "Mix of singular entries and grouped entries"
+          , entries =
+                [ Menu.group "Display scores as"
+                    [ Menu.entry "percentages" <| viewScoreDisplay "Percentage" Nothing
+                    , Menu.entry "points" <| viewScoreDisplay "Points" Nothing
+                    ]
+                , Menu.group "Dropped students"
+                    [ Menu.entry "dropped-students" <| viewDroppedStudentsSwitch
+                    ]
+                ]
+          }
         ]
     ]
 
@@ -553,6 +592,30 @@ forcedOpenExample name =
 forcedOpenExampleButtonId : String -> String
 forcedOpenExampleButtonId name =
     safeIdWithPrefix name "buttonId"
+
+
+viewScoreDisplay : String -> Maybe String -> List (Attribute msg) -> Html msg
+viewScoreDisplay value selected attributes =
+    RadioButton.view
+        { label = value
+        , value = value
+        , name = "score-display"
+        , selectedValue = selected
+        , valueToString = identity
+        }
+        [ RadioButton.custom attributes
+        ]
+
+
+viewDroppedStudentsSwitch : List (Attribute msg) -> Html msg
+viewDroppedStudentsSwitch attributes =
+    Switch.view
+        { label = "Show dropped students"
+        , id = "show-dropped-students"
+        }
+        [ Switch.selected False
+        , Switch.custom attributes
+        ]
 
 
 {-| -}

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -515,7 +515,14 @@ view ellieLinkConfig state =
             { header = text "Pattern Notes"
             , view = \{ about } -> Text.smallBody [ Text.markdown about ]
             , width = Css.px 300
-            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+            , cellStyles =
+                always
+                    [ Css.padding2 (Css.px 14) (Css.px 7)
+                    , Css.verticalAlign Css.top
+                    , Css.Global.descendants
+                        [ Css.Global.pre [ Css.whiteSpace Css.preWrap ]
+                        ]
+                    ]
             , sort = Nothing
             }
         ]
@@ -542,7 +549,7 @@ view ellieLinkConfig state =
                             , ClickableSvg.withBorder
                             ]
                 ]
-          , about = "TODO"
+          , about = "Pass any interactive elements in using `Menu.entry`."
           }
         , { name = "Grouped entries"
           , entries =
@@ -569,7 +576,17 @@ view ellieLinkConfig state =
                         )
                     |> Menu.group "Group of Buttons"
                 ]
-          , about = "TODO"
+          , about =
+                """Use `Menu.group` to create named groups of entries.
+
+
+The structures are recursive and flexible:
+
+    group : String -> List (Entry msg) -> Entry msg
+
+    entry : String -> (List (Html.Attribute msg) -> Html msg) -> Entry msg
+
+"""
           }
         , { name = "Mix of singular entries and grouped entries"
           , entries =
@@ -588,7 +605,14 @@ view ellieLinkConfig state =
                     [ Menu.entry "dropped-students" <| viewDroppedStudentsSwitch state.showDroppedStudents
                     ]
                 ]
-          , about = "TODO"
+          , about =
+                """
+Because `group` and `entry` both result in the same type, individual entries and grouped entries can be displayed together.
+
+Please note that depending on the interactive component you select, our composability may not work correctly yet.
+
+In this realistic example, we can't actually pass the correct attributes to RadioButton or Switch because it will cause the events for those components to be swallowed, rendering them inoperable.
+"""
           }
         ]
     ]

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -34,6 +34,7 @@ import Nri.Ui.RadioButton.V4 as RadioButton
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Switch.V3 as Switch
 import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Text.V6 as Text
 import Nri.Ui.TextInput.V8 as TextInput
 import Nri.Ui.Tooltip.V3 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon
@@ -510,6 +511,13 @@ view ellieLinkConfig state =
                     ]
             , sort = Nothing
             }
+        , Table.custom
+            { header = text "Pattern Notes"
+            , view = \{ about } -> Text.smallBody [ Text.markdown about ]
+            , width = Css.px 300
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+            , sort = Nothing
+            }
         ]
         [ { name = "List of entries"
           , entries =
@@ -534,6 +542,7 @@ view ellieLinkConfig state =
                             , ClickableSvg.withBorder
                             ]
                 ]
+          , about = "TODO"
           }
         , { name = "Grouped entries"
           , entries =
@@ -560,6 +569,7 @@ view ellieLinkConfig state =
                         )
                     |> Menu.group "Group of Buttons"
                 ]
+          , about = "TODO"
           }
         , { name = "Mix of singular entries and grouped entries"
           , entries =
@@ -578,6 +588,7 @@ view ellieLinkConfig state =
                     [ Menu.entry "dropped-students" <| viewDroppedStudentsSwitch state.showDroppedStudents
                     ]
                 ]
+          , about = "TODO"
           }
         ]
     ]

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -247,7 +247,7 @@ view ellieLinkConfig state =
         [ Table.string
             { header = "Menu type"
             , value = .menu
-            , width = Css.pct 30
+            , width = Css.pct 15
             , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle, Css.fontWeight Css.bold ]
             , sort = Nothing
             }
@@ -256,6 +256,13 @@ view ellieLinkConfig state =
             , view = .example
             , width = Css.px 300
             , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+            , sort = Nothing
+            }
+        , Table.custom
+            { header = text "Description"
+            , view = \{ description } -> Text.smallBody [ Text.markdown description ]
+            , width = Css.pct 60
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.top ]
             , sort = Nothing
             }
         ]
@@ -309,6 +316,7 @@ view ellieLinkConfig state =
                                 , ClickableText.custom attrs
                                 ]
                     ]
+          , description = "Makes the menu follow the [Navigation Menu pattern](https://www.w3.org/WAI/ARIA/apg/example-index/menu-button/menu-button-links.html), but without the ul/li structure."
           }
         , { menu = "Menu.navMenuList"
           , example =
@@ -341,6 +349,9 @@ view ellieLinkConfig state =
                                 , ClickableText.custom attrs
                                 ]
                     ]
+          , description = """
+Same as navMenu, except that a ul/li structure will be added as a fall-through.
+    """
           }
         , { menu = "Menu.disclosure"
           , example =
@@ -368,6 +379,17 @@ view ellieLinkConfig state =
                                     ]
                                 ]
                     ]
+          , description =
+                """
+ Makes the menu behave as a disclosure.
+
+For more information, please read [Disclosure (Show/Hide) pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/).
+
+You will need to pass in the last focusable element in the disclosed content in order for:
+
+  - any focusable elements in the disclosed content to be keyboard accessible
+  - the disclosure to close appropriately when the user tabs past all of the disclosed content
+"""
           }
         , { menu = "Menu.dialog"
           , example =
@@ -395,6 +417,18 @@ view ellieLinkConfig state =
                                     ]
                                 ]
                     ]
+          , description =
+                """
+ Makes the menu behave as a dialog.
+
+For more information, please read [Dialog pattern](https://w3c.github.io/aria-practices/examples/dialog-modal/dialog.html/).
+
+You will need to pass in the first and last focusable element in the dialog content in order for:
+
+  - any focusable elements in the dialog content to be keyboard accessible
+  - the tab to wrap around appropriately when the user tabs past all of the dialog content
+
+"""
           }
         ]
     , Heading.h2

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -478,7 +478,7 @@ view ellieLinkConfig state =
             }
         , Table.custom
             { header = text "Example"
-            , view = \{ name, entries } -> forcedOpenExample name entries
+            , view = \{ name, menuType, entries } -> forcedOpenExample name menuType entries
             , width = Css.px 300
             , cellStyles =
                 \{ name } ->
@@ -527,6 +527,7 @@ view ellieLinkConfig state =
             }
         ]
         [ { name = "List of entries"
+          , menuType = Menu.navMenuList
           , entries =
                 [ Menu.entry "list-of-entries-clickable-text-entry" <|
                     \attributes ->
@@ -552,6 +553,7 @@ view ellieLinkConfig state =
           , about = "Pass any interactive elements in using `Menu.entry`."
           }
         , { name = "Grouped entries"
+          , menuType = Menu.navMenuList
           , entries =
                 [ List.range 1 2
                     |> List.map
@@ -589,6 +591,7 @@ The structures are recursive and flexible:
 """
           }
         , { name = "Mix of singular entries and grouped entries"
+          , menuType = Menu.disclosure { lastId = droppedStudentsId }
           , entries =
                 [ Menu.entry "grades-and-perf" <|
                     \attributes ->
@@ -618,8 +621,8 @@ In this realistic example, we can't actually pass the correct attributes to Radi
     ]
 
 
-forcedOpenExample : String -> List (Menu.Entry Msg) -> Html Msg
-forcedOpenExample name =
+forcedOpenExample : String -> Menu.Attribute Msg -> List (Menu.Entry Msg) -> Html Msg
+forcedOpenExample name type_ =
     Menu.view (FocusAndToggle name)
         [ Menu.clickableSvgWithoutIndicator (name ++ " example")
             UiIcon.arrowDown
@@ -630,6 +633,7 @@ forcedOpenExample name =
         , Menu.buttonId (forcedOpenExampleButtonId name)
         , Menu.menuId (safeIdWithPrefix name "menuId")
         , Menu.alignLeft
+        , type_
         ]
 
 
@@ -659,7 +663,7 @@ viewDroppedStudentsSwitch : Bool -> List (Attribute Msg) -> Html Msg
 viewDroppedStudentsSwitch showDroppedStudents attributes =
     Switch.view
         { label = "Show dropped students"
-        , id = "show-dropped-students"
+        , id = droppedStudentsId
         }
         [ Switch.onSwitch ShowDroppedStudents
         , Switch.selected showDroppedStudents
@@ -669,6 +673,11 @@ viewDroppedStudentsSwitch showDroppedStudents attributes =
         -- the Switch become inoperable.
         --, Switch.custom attributes
         ]
+
+
+droppedStudentsId : String
+droppedStudentsId =
+    "show-dropped-students"
 
 
 {-| -}

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -575,7 +575,7 @@ view ellieLinkConfig state =
                     , Menu.entry "points" <| viewScoreDisplay "Points" state.scoreDisplay
                     ]
                 , Menu.group "Dropped students"
-                    [ Menu.entry "dropped-students" <| viewDroppedStudentsSwitch
+                    [ Menu.entry "dropped-students" <| viewDroppedStudentsSwitch state.showDroppedStudents
                     ]
                 ]
           }
@@ -612,7 +612,7 @@ viewScoreDisplay value selected attributes =
         , selectedValue = selected
         , valueToString = identity
         }
-        [ -- TODO: when the Menu attributes are attached to the RadioButton
+        [ -- To Fix: when the Menu attributes are attached to the RadioButton
           -- (as is required for the focus trap to work correctly),
           -- the RadioButtons become inoperable.
           -- RadioButton.custom attributes ,
@@ -620,14 +620,19 @@ viewScoreDisplay value selected attributes =
         ]
 
 
-viewDroppedStudentsSwitch : List (Attribute msg) -> Html msg
-viewDroppedStudentsSwitch attributes =
+viewDroppedStudentsSwitch : Bool -> List (Attribute Msg) -> Html Msg
+viewDroppedStudentsSwitch showDroppedStudents attributes =
     Switch.view
         { label = "Show dropped students"
         , id = "show-dropped-students"
         }
-        [ Switch.selected False
-        , Switch.custom attributes
+        [ Switch.onSwitch ShowDroppedStudents
+        , Switch.selected showDroppedStudents
+
+        -- To Fix: when the Menu attributes are attached to the Switch
+        -- (as is required for the focus trap to work correctly),
+        -- the Switch become inoperable.
+        --, Switch.custom attributes
         ]
 
 
@@ -639,6 +644,7 @@ init =
     , openTooltips = Set.empty
     , settings = initSettings
     , scoreDisplay = Nothing
+    , showDroppedStudents = False
     }
 
 
@@ -649,6 +655,7 @@ type alias State =
     , openTooltips : Set String
     , settings : Control Settings
     , scoreDisplay : Maybe String
+    , showDroppedStudents : Bool
     }
 
 
@@ -818,6 +825,7 @@ type Msg
     | FocusAndToggle String { isOpen : Bool, focus : Maybe String }
     | Focused (Result Dom.Error ())
     | SelectScoreDisplay String
+    | ShowDroppedStudents Bool
 
 
 {-| -}
@@ -854,6 +862,9 @@ update msg state =
 
         SelectScoreDisplay name ->
             ( { state | scoreDisplay = Just name }, Cmd.none )
+
+        ShowDroppedStudents showDroppedStudents ->
+            ( { state | showDroppedStudents = showDroppedStudents }, Cmd.none )
 
 
 

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -506,9 +506,6 @@ view ellieLinkConfig state =
                           -- content is always visible.
                           Css.Global.selector ("#" ++ buttonId ++ " + div")
                             [ Css.position Css.relative ]
-                        , -- Hide the trigger element
-                          Css.Global.id buttonId
-                            [ Css.display Css.none ]
                         ]
                     ]
             , sort = Nothing
@@ -589,10 +586,15 @@ view ellieLinkConfig state =
 forcedOpenExample : String -> List (Menu.Entry Msg) -> Html Msg
 forcedOpenExample name =
     Menu.view (FocusAndToggle name)
-        [ Menu.clickableSvgWithoutIndicator (name ++ " example") UiIcon.starFilled []
+        [ Menu.clickableSvgWithoutIndicator (name ++ " example")
+            UiIcon.arrowDown
+            [ ClickableSvg.exactSize 15
+            , ClickableSvg.css [ Css.marginLeft (Css.px 17) ]
+            ]
         , Menu.isOpen True
         , Menu.buttonId (forcedOpenExampleButtonId name)
         , Menu.menuId (safeIdWithPrefix name "menuId")
+        , Menu.alignLeft
         ]
 
 

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -487,7 +487,7 @@ You will need to pass in the first and last focusable element in the dialog cont
                         [ ClickableText.href (Routes.exampleHref Examples.Button.example)
                         , ClickableText.appearsInline
                         ]
-                    , text ", so any attribute you use for a Button can also used with this trigger."
+                    , text ", so any attribute you use for a Button can also be used with this trigger."
                     ]
                 ]
           }
@@ -508,7 +508,7 @@ You will need to pass in the first and last focusable element in the dialog cont
                         [ ClickableText.href (Routes.exampleHref Examples.Button.example)
                         , ClickableText.appearsInline
                         ]
-                    , text ", so any attribute you use for a Button can also used with this trigger."
+                    , text ", so any attribute you use for a Button can also be used with this trigger."
                     ]
                 ]
           }
@@ -529,7 +529,7 @@ You will need to pass in the first and last focusable element in the dialog cont
                         [ ClickableText.href (Routes.exampleHref Examples.ClickableText.example)
                         , ClickableText.appearsInline
                         ]
-                    , text ", so any attribute you use for a ClickableText can also used with this trigger."
+                    , text ", so any attribute you use for a ClickableText can also be used with this trigger."
                     ]
                 , Text.markdown " Defaults to using the `ClickableText.medium` size, although this can be overriden."
                 ]
@@ -551,7 +551,7 @@ You will need to pass in the first and last focusable element in the dialog cont
                         [ ClickableText.href (Routes.exampleHref Examples.ClickableSvg.example)
                         , ClickableText.appearsInline
                         ]
-                    , text ", so any attribute you use for a ClickableSvg can also used with this trigger."
+                    , text ", so any attribute you use for a ClickableSvg can also be used with this trigger."
                     ]
                 ]
           }
@@ -572,7 +572,7 @@ You will need to pass in the first and last focusable element in the dialog cont
                         [ ClickableText.href (Routes.exampleHref Examples.ClickableSvg.example)
                         , ClickableText.appearsInline
                         ]
-                    , text ", so any attribute you use for a ClickableSvg can also used with this trigger."
+                    , text ", so any attribute you use for a ClickableSvg can also be used with this trigger."
                     ]
                 ]
           }

--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -17,6 +17,7 @@ module Nri.Ui.Menu.V4 exposing
   - Use Nri.Ui.WhenFocusLeaves.V2
   - Adjust disabled styles
   - when the Menu is a dialog or disclosure, _don't_ add role menuitem to the entries
+  - Use ClickableText.medium as the default size when the trigger is `Menu.clickableText`
 
 Changes from V3:
 
@@ -968,6 +969,7 @@ viewClickableText : String -> MenuConfig msg -> List (ClickableText.Attribute ms
 viewClickableText title menuConfig clickableTextAttributes attributes =
     ClickableText.button title
         ([ ClickableText.custom attributes
+         , ClickableText.medium
          , ClickableText.disabled menuConfig.isDisabled
          , ClickableText.rightIcon (AnimatedIcon.arrowDownUp menuConfig.isOpen)
          , ClickableText.rightIconCss

--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -468,6 +468,9 @@ viewCustom focusAndToggle config entries =
                         , focus = Nothing
                         }
                     )
+                    -- if changing or removing this class (`.Nri-Menu-Overlay`),
+                    -- please be sure that the Menu example in the Component Catalog
+                    -- continues to work correctly
                     :: class "Nri-Menu-Overlay"
                     :: styleOverlay config
                 )

--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -16,6 +16,7 @@ module Nri.Ui.Menu.V4 exposing
   - improve interoperability with Tooltip (Note that tooltip keyboard events are not fully supported!)
   - Use Nri.Ui.WhenFocusLeaves.V2
   - Adjust disabled styles
+  - when the Menu is a dialog or disclosure, _don't_ add role menuitem to the entries
 
 Changes from V3:
 
@@ -725,7 +726,18 @@ viewEntry config focusAndToggle { upId, downId, entry_ } =
                     ]
                 ]
                 [ view_
-                    [ Role.menuItem
+                    [ case config.purpose of
+                        NavMenu ->
+                            Role.menuItem
+
+                        NavMenuList ->
+                            Role.menuItem
+
+                        Disclosure _ ->
+                            AttributesExtra.none
+
+                        Dialog _ ->
+                            AttributesExtra.none
                     , Attributes.id id
                     , Key.tabbable False
                     , Key.onKeyDownPreventDefault


### PR DESCRIPTION
Primarily, this improves the example page in the Component Catalog for Menu so that there's actionable information.

However, this also made a small change to fix an axe failure: when the menu type is not navMenu or navMenuList, we no longer add the "menuitem" role to entries as it's not appropriate in these cases.

This PR also adjusts the default size of `Menu.clickableText` to `ClickableText.medium`, [per a11ybat channel slack conversation with Ben](https://noredink.slack.com/archives/C02NMHB1K55/p1707511046054389).

## :framed_picture: What does this change look like?

### Before

![noredink-ui netlify app_ (4)](https://github.com/NoRedInk/noredink-ui/assets/8811312/7a42eb31-25bb-4f12-bc93-8406e3a66608)

### After


![localhost_8000_ (14)](https://github.com/NoRedInk/noredink-ui/assets/8811312/6b14e72f-fcf8-4873-b0f7-4e42f7673a39)



## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x]  Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
