### PR TITLE
Make ClickableText.medium the default

### DIFF
--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -87,18 +87,22 @@ example =
                     [ li []
                         [ ClickableText.link "Display Elements and Scaffolding Container: additional things to know"
                             [ ClickableText.linkExternal "https://paper.dropbox.com/doc/Display-Elements-and-Scaffolding-Container-additional-things-to-know--BwRhBMKyXFFSWz~1mljN29bcAg-6vszpNDLoYIiMyg7Wv66s"
+                            , ClickableText.appearsInline
                             ]
                         , text ", which identifies a number of interesting edge cases and known trade-offs."
                         ]
                     , li []
                         [ ClickableText.link "Tessa's blog post"
                             [ ClickableText.linkExternal "https://blog.noredink.com/post/710448547697426432/word-labels]"
+                            , ClickableText.appearsInline
                             ]
                         , text " explaining the initial constraints and approach."
                         ]
                     , li []
                         [ ClickableText.link "Tessa's demo on early versions of Block and Question Block"
-                            [ ClickableText.linkExternal "https://www.dropbox.com/preview/NRI%20Engineering/Demos/2022-12-22%20-%20Tessa%20-%20QuestionBox%20and%20Block.mp4?role=work" ]
+                            [ ClickableText.linkExternal "https://www.dropbox.com/preview/NRI%20Engineering/Demos/2022-12-22%20-%20Tessa%20-%20QuestionBox%20and%20Block.mp4?role=work"
+                            , ClickableText.appearsInline
+                            ]
                         ]
                     ]
                 ]

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -101,10 +101,8 @@ init =
                         |> ControlExtra.optionalBoolListItem "disabled"
                             ( "ClickableText.disabled True", ClickableText.disabled True )
                     )
-                |> ControlExtra.listItems "CSS & Extra style options"
+                |> ControlExtra.listItems "CSS"
                     (Control.list
-                        |> ControlExtra.optionalBoolListItem "appearsInline"
-                            ( "ClickableText.appearsInline", ClickableText.appearsInline )
                         |> CommonControls.css
                             { moduleName = moduleName
                             , use = ClickableText.css
@@ -128,6 +126,15 @@ init =
                             ( "ClickableText.hideIconForMobile", ClickableText.hideIconForMobile )
                         |> ControlExtra.optionalBoolListItem "hideTextForMobile"
                             ( "ClickableText.hideTextForMobile", ClickableText.hideTextForMobile )
+                    )
+                |> ControlExtra.optionalListItem "Size and display options"
+                    (CommonControls.choice moduleName
+                        [ ( "appearsInline", ClickableText.appearsInline )
+                        , ( "small", ClickableText.small )
+                        , ( "medium", ClickableText.medium )
+                        , ( "large", ClickableText.large )
+                        , ( "modal", ClickableText.modal )
+                        ]
                     )
             )
         |> State

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -81,6 +81,7 @@ init =
             (Control.choice
                 [ ( "button", Control.value Button )
                 , ( "link", Control.value Link )
+                , ( "linkExternal", Control.value LinkExternal )
                 ]
             )
         |> Control.field "label" (Control.string "Clickable Text")
@@ -139,6 +140,7 @@ type alias Settings msg =
 type Type
     = Button
     | Link
+    | LinkExternal
 
 
 {-| -}
@@ -211,6 +213,16 @@ viewExamples ellieLinkConfig (State control) =
                                     ]
                           }
                         ]
+
+                    LinkExternal ->
+                        [ { sectionName = "Link"
+                          , code =
+                                toCode "link"
+                                    [ Code.fromModule moduleName "linkExternal "
+                                        ++ Code.string "https://www.google.com"
+                                    ]
+                          }
+                        ]
         }
     , Heading.h2
         [ Heading.plaintext "Customizable Example"
@@ -234,6 +246,12 @@ viewExamples ellieLinkConfig (State control) =
             Link ->
                 ClickableText.link settings.label
                     (ClickableText.href "/"
+                        :: List.map Tuple.second settings.attributes
+                    )
+
+            LinkExternal ->
+                ClickableText.link settings.label
+                    (ClickableText.linkExternal "https://www.google.com"
                         :: List.map Tuple.second settings.attributes
                     )
         ]
@@ -395,7 +413,7 @@ sizeExamples settings =
             }
         , Table.custom
             { header = text "External link"
-            , view = \{ size } -> sizeExamplesFor ClickableText.link [ size, ClickableText.linkExternal "google.com" ]
+            , view = \{ size } -> sizeExamplesFor ClickableText.link [ size, ClickableText.linkExternal "https://www.google.com" ]
             , width = Css.px 10
             , cellStyles =
                 always

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -10,7 +10,7 @@ import Accessibility.Styled.Key as Key
 import Category exposing (Category(..))
 import Code
 import CommonControls
-import Css exposing (middle, verticalAlign)
+import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
@@ -19,7 +19,6 @@ import Example exposing (Example)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.ClickableText.V4 as ClickableText
-import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V7 as Table
@@ -184,10 +183,27 @@ viewExamples ellieLinkConfig (State control) =
                 ]
         }
     , Heading.h2
-        [ Heading.plaintext "Customizable Examples"
+        [ Heading.plaintext "Customizable Example"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
-    , buttons settings
+    , div
+        [ css
+            [ Css.displayFlex
+            , Css.justifyContent Css.center
+            , Css.alignItems Css.center
+            , Css.minHeight (Css.px 150)
+            ]
+        ]
+        [ ClickableText.button settings.label
+            (ClickableText.onClick (ShowItWorked moduleName "customizable example")
+                :: List.map Tuple.second settings.attributes
+            )
+        ]
+    , Heading.h2
+        [ Heading.plaintext "Set Sizes Examples"
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+        ]
+    , sizeExamples settings
     , Heading.h2
         [ Heading.plaintext "Inline ClickableText Examples"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
@@ -246,6 +262,8 @@ viewExamples ellieLinkConfig (State control) =
         , ( Text.ugSmallBody, "ugSmallBody" )
         , ( Text.ugMediumBody, "ugMediumBody" )
         ]
+        |> List.singleton
+        |> div [ css [ Css.overflow Css.auto ] ]
     ]
         |> div []
 
@@ -301,46 +319,72 @@ sizes =
     ]
 
 
-buttons : Settings Msg -> Html Msg
-buttons settings =
-    let
-        sizeRow label render =
-            row label (List.map render sizes)
-    in
-    table []
-        [ tr [] (td [] [] :: List.map (\( size, sizeLabel ) -> th [] [ text sizeLabel ]) sizes)
-        , sizeRow ".link"
-            (\( size, sizeLabel ) ->
-                ClickableText.link settings.label
-                    (size :: List.map Tuple.second settings.attributes)
-                    |> exampleCell
-            )
-        , sizeRow ".button"
-            (\( size, sizeLabel ) ->
-                ClickableText.button settings.label
-                    (size
-                        :: ClickableText.onClick (ShowItWorked moduleName sizeLabel)
-                        :: List.map Tuple.second settings.attributes
-                    )
-                    |> exampleCell
-            )
+sizeExamples : Settings Msg -> Html Msg
+sizeExamples settings =
+    Table.view []
+        [ Table.custom
+            { header = text "Size"
+            , view =
+                \{ sizeName } ->
+                    code [ css [ Css.fontSize (Css.px 12) ] ]
+                        [ text (Code.fromModule "ClickableText" sizeName)
+                        ]
+            , width = Css.px 10
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+            , sort = Nothing
+            }
+        , Table.custom
+            { header = text "Button"
+            , view = \{ size } -> sizeExamplesFor ClickableText.button [ size ]
+            , width = Css.px 10
+            , cellStyles =
+                always
+                    [ Css.padding2 (Css.px 14) (Css.px 7)
+                    , Css.verticalAlign Css.top
+                    ]
+            , sort = Nothing
+            }
+        , Table.custom
+            { header = text "Link"
+            , view = \{ size } -> sizeExamplesFor ClickableText.link [ size ]
+            , width = Css.px 10
+            , cellStyles =
+                always
+                    [ Css.padding2 (Css.px 14) (Css.px 7)
+                    , Css.verticalAlign Css.top
+                    ]
+            , sort = Nothing
+            }
+        , Table.custom
+            { header = text "External link"
+            , view = \{ size } -> sizeExamplesFor ClickableText.link [ size, ClickableText.linkExternal "google.com" ]
+            , width = Css.px 10
+            , cellStyles =
+                always
+                    [ Css.padding2 (Css.px 14) (Css.px 7)
+                    , Css.verticalAlign Css.top
+                    ]
+            , sort = Nothing
+            }
         ]
+        (List.map (\( size, sizeName ) -> { size = size, sizeName = sizeName }) sizes)
         |> List.singleton
         |> div [ css [ Css.overflow Css.auto ] ]
 
 
-row : String -> List (Html msg) -> Html msg
-row label tds =
-    tr [] (th [] [ td [] [ text label ] ] :: tds)
-
-
-exampleCell : Html msg -> Html msg
-exampleCell view =
-    td
-        [ css
-            [ verticalAlign middle
-            , Css.width (Css.px 200)
-            , Css.borderTop3 (Css.px 1) Css.solid Colors.gray85
+sizeExamplesFor : (String -> List (ClickableText.Attribute msg) -> Html msg) -> List (ClickableText.Attribute msg) -> Html msg
+sizeExamplesFor render attrs =
+    ul [ css [ Css.margin Css.zero ] ]
+        [ li [] [ render "No icons" attrs ]
+        , li [] [ render "Left icon" (attrs ++ [ ClickableText.icon UiIcon.arrowLeft ]) ]
+        , li [] [ render "Right icon" (attrs ++ [ ClickableText.rightIcon UiIcon.arrowRight ]) ]
+        , li []
+            [ render "Disabled w/icons"
+                (attrs
+                    ++ [ ClickableText.icon UiIcon.arrowLeft
+                       , ClickableText.rightIcon UiIcon.arrowRight
+                       , ClickableText.disabled True
+                       ]
+                )
             ]
         ]
-        [ view ]

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -22,6 +22,7 @@ import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
+import Nri.Ui.Table.V7 as Table
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 
@@ -191,13 +192,59 @@ viewExamples ellieLinkConfig (State control) =
         [ Heading.plaintext "Inline ClickableText Examples"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
-    , Text.caption (inlineExample "Text.caption")
-    , Text.smallBody (inlineExample "Text.smallBody")
-    , Text.smallBodyGray (inlineExample "Text.smallBodyGray")
-    , Text.mediumBody (inlineExample "Text.mediumBody")
-    , Text.mediumBodyGray (inlineExample "Text.mediumBodyGray")
-    , Text.ugSmallBody (inlineExample "Text.ugSmallBody")
-    , Text.ugMediumBody (inlineExample "Text.ugMediumBody")
+    , Table.view []
+        [ Table.custom
+            { header = text "Displayed"
+            , view = \( view, name ) -> view (inlineExample name)
+            , width = Css.pct 70
+            , cellStyles = always [ Css.padding2 (Css.px 14) (Css.px 7), Css.verticalAlign Css.middle ]
+            , sort = Nothing
+            }
+        , Table.custom
+            { header = text "Pattern"
+            , view =
+                \( _, textName ) ->
+                    code []
+                        [ text
+                            (Code.fromModule "Text"
+                                textName
+                                ++ Code.listMultiline
+                                    [ Code.fromModule "Text" "html"
+                                        ++ Code.listMultiline
+                                            [ "…"
+                                            , Code.fromModule moduleName
+                                                "link "
+                                                ++ Code.string "internal links"
+                                                ++ Code.listMultiline
+                                                    [ Code.fromModule moduleName "appearsInline"
+                                                    , Code.fromModule moduleName "href " ++ Code.string "/"
+                                                    ]
+                                                    3
+                                            , "…"
+                                            ]
+                                            2
+                                    ]
+                                    1
+                            )
+                        ]
+            , width = Css.px 10
+            , cellStyles =
+                always
+                    [ Css.padding2 (Css.px 14) (Css.px 7)
+                    , Css.verticalAlign Css.top
+                    , Css.whiteSpace Css.preWrap
+                    ]
+            , sort = Nothing
+            }
+        ]
+        [ ( Text.caption, "caption" )
+        , ( Text.smallBody, "smallBody" )
+        , ( Text.smallBodyGray, "smallBodyGray" )
+        , ( Text.mediumBody, "mediumBody" )
+        , ( Text.mediumBodyGray, "mediumBodyGray" )
+        , ( Text.ugSmallBody, "ugSmallBody" )
+        , ( Text.ugMediumBody, "ugMediumBody" )
+        ]
     ]
         |> div []
 

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -91,8 +91,6 @@ init =
                     (Control.list
                         |> CommonControls.iconNotCheckedByDefault moduleName ClickableText.icon
                         |> CommonControls.rightIcon moduleName ClickableText.rightIcon
-                        |> ControlExtra.optionalBoolListItem "hideIconForMobile"
-                            ( "ClickableText.hideIconForMobile", ClickableText.hideIconForMobile )
                     )
                 |> ControlExtra.listItems "State & Type"
                     (Control.list
@@ -107,8 +105,6 @@ init =
                     (Control.list
                         |> ControlExtra.optionalBoolListItem "appearsInline"
                             ( "ClickableText.appearsInline", ClickableText.appearsInline )
-                        |> ControlExtra.optionalBoolListItem "hideTextForMobile"
-                            ( "ClickableText.hideTextForMobile", ClickableText.hideTextForMobile )
                         |> CommonControls.css
                             { moduleName = moduleName
                             , use = ClickableText.css
@@ -125,6 +121,13 @@ init =
                             { moduleName = moduleName
                             , use = ClickableText.notMobileCss
                             }
+                    )
+                |> ControlExtra.listItems "Compact mobile options"
+                    (Control.list
+                        |> ControlExtra.optionalBoolListItem "hideIconForMobile"
+                            ( "ClickableText.hideIconForMobile", ClickableText.hideIconForMobile )
+                        |> ControlExtra.optionalBoolListItem "hideTextForMobile"
+                            ( "ClickableText.hideTextForMobile", ClickableText.hideTextForMobile )
                     )
             )
         |> State

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -191,8 +191,13 @@ viewExamples ellieLinkConfig (State control) =
         [ Heading.plaintext "Inline ClickableText Examples"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
+    , Text.caption (inlineExample "Text.caption")
     , Text.smallBody (inlineExample "Text.smallBody")
+    , Text.smallBodyGray (inlineExample "Text.smallBodyGray")
     , Text.mediumBody (inlineExample "Text.mediumBody")
+    , Text.mediumBodyGray (inlineExample "Text.mediumBodyGray")
+    , Text.ugSmallBody (inlineExample "Text.ugSmallBody")
+    , Text.ugMediumBody (inlineExample "Text.ugMediumBody")
     ]
         |> div []
 

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -88,7 +88,7 @@ init =
             (Control.list
                 |> ControlExtra.listItems "Icons"
                     (Control.list
-                        |> CommonControls.icon moduleName ClickableText.icon
+                        |> CommonControls.iconNotCheckedByDefault moduleName ClickableText.icon
                         |> CommonControls.rightIcon moduleName ClickableText.rightIcon
                         |> ControlExtra.optionalBoolListItem "hideIconForMobile"
                             ( "ClickableText.hideIconForMobile", ClickableText.hideIconForMobile )

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -192,6 +192,7 @@ viewExamples ellieLinkConfig (State control) =
         [ Heading.plaintext "Inline ClickableText Examples"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
+    , Text.caption [ Text.markdown "Be sure to add the `appearsInline` property if the `ClickableText` appears inline. Otherwise, your styles will not match up nicely. You should not add an explicit size." ]
     , Table.view []
         [ Table.custom
             { header = text "Displayed"
@@ -204,7 +205,7 @@ viewExamples ellieLinkConfig (State control) =
             { header = text "Pattern"
             , view =
                 \( _, textName ) ->
-                    code []
+                    code [ css [ Css.fontSize (Css.px 12) ] ]
                         [ text
                             (Code.fromModule "Text"
                                 textName

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -196,8 +196,7 @@ view ellieLinkConfig state =
                                         (Code.newlineWithIndent 2
                                             ++ (Code.fromModule "ClickableText" "button " ++ Code.string "Button")
                                             ++ Code.listMultiline
-                                                [ Code.fromModule "ClickableText" "medium"
-                                                , Code.fromModule "ClickableText" "custom" ++ " attributes"
+                                                [ Code.fromModule "ClickableText" "custom" ++ " attributes"
                                                 ]
                                                 3
                                         )
@@ -233,8 +232,7 @@ view ellieLinkConfig state =
             [ Menu.entry "customizable-example" <|
                 \attrs ->
                     ClickableText.button "Button"
-                        [ ClickableText.medium
-                        , ClickableText.onClick (ConsoleLog "Interactive example")
+                        [ ClickableText.onClick (ConsoleLog "Interactive example")
                         , ClickableText.custom attrs
                         ]
             ]
@@ -280,7 +278,6 @@ view ellieLinkConfig state =
                         \attrs ->
                             ClickableText.button "Hello"
                                 [ ClickableText.onClick (ConsoleLog "Hello")
-                                , ClickableText.medium
                                 , ClickableText.custom attrs
                                 ]
                     , Menu.group "Menu group"
@@ -288,7 +285,6 @@ view ellieLinkConfig state =
                             \attrs ->
                                 ClickableText.button "Gift"
                                     [ ClickableText.onClick (ConsoleLog "Gift")
-                                    , ClickableText.medium
                                     , ClickableText.custom attrs
                                     , ClickableText.icon UiIcon.gift
                                     ]
@@ -296,7 +292,6 @@ view ellieLinkConfig state =
                             \attrs ->
                                 ClickableText.button "Nope!"
                                     [ ClickableText.onClick (ConsoleLog "Nope!")
-                                    , ClickableText.medium
                                     , ClickableText.custom attrs
                                     , ClickableText.icon UiIcon.null
                                     ]
@@ -304,7 +299,6 @@ view ellieLinkConfig state =
                             \attrs ->
                                 ClickableText.button "Skip"
                                     [ ClickableText.onClick (ConsoleLog "Skip")
-                                    , ClickableText.medium
                                     , ClickableText.custom attrs
                                     ]
                         ]
@@ -312,7 +306,6 @@ view ellieLinkConfig state =
                         \attrs ->
                             ClickableText.button "Performance"
                                 [ ClickableText.onClick (ConsoleLog "Performance")
-                                , ClickableText.medium
                                 , ClickableText.custom attrs
                                 ]
                     ]

--- a/component-catalog/src/Examples/Message.elm
+++ b/component-catalog/src/Examples/Message.elm
@@ -289,20 +289,21 @@ contentTypes :
         }
 contentTypes =
     [ { contentType = "paragraph"
-      , content = Message.paragraph "*Hello, there!* Hope you're doing well. Use the following link to go to [a fake destination](google.com)."
+      , content = Message.paragraph "*Hello, there!* Hope you're doing well. Use the following link to go to [a fake destination](https://www.google.com)."
       }
     , { contentType = "plaintext"
-      , content = Message.plaintext "*Hello, there!* Hope you're doing well. Use the following link to go to [a fake destination](google.com)."
+      , content = Message.plaintext "*Hello, there!* Hope you're doing well. Use the following link to go to [a fake destination](https://www.google.com)."
       }
     , { contentType = "markdown"
-      , content = Message.markdown "Hello, there! Hope you're doing well. Use the following link to go to [a fake destination](google.com)."
+      , content = Message.markdown "Hello, there! Hope you're doing well. Use the following link to go to [a fake destination](https://www.google.com)."
       }
     , { contentType = "html"
       , content =
             Message.html
                 [ text "Hello, there! Hope you're doing well. Use the following link to go to "
                 , ClickableText.link "a fake destination"
-                    [ ClickableText.href "google.com"
+                    [ ClickableText.href "https://www.google.com"
+                    , ClickableText.appearsInline
                     ]
                 , text "."
                 ]

--- a/src/Nri/Ui/ClickableText/V4.elm
+++ b/src/Nri/Ui/ClickableText/V4.elm
@@ -14,7 +14,9 @@ module Nri.Ui.ClickableText.V4 exposing
     , css, notMobileCss, mobileCss, quizEngineMobileCss, rightIconCss
     )
 
-{-|
+{-| Patch changes
+
+  - switchs `Medium` size to the default
 
 
 # Changes from V3
@@ -117,7 +119,8 @@ small =
     set (\attributes -> { attributes | size = Small })
 
 
-{-| -}
+{-| `Medium` is the default size.
+-}
 medium : Attribute msg
 medium =
     set (\attributes -> { attributes | size = Medium })
@@ -695,7 +698,7 @@ type alias ClickableTextAttributes msg =
 defaults : ClickableTextAttributes msg
 defaults =
     { clickableAttributes = ClickableAttributes.init
-    , size = Inherited
+    , size = Medium
     , label = ""
     , icon = Nothing
     , iconStyles = []

--- a/src/Nri/Ui/ClickableText/V4.elm
+++ b/src/Nri/Ui/ClickableText/V4.elm
@@ -390,15 +390,22 @@ disabled value =
 -}
 appearsInline : Attribute msg
 appearsInline =
-    css
-        [ Css.borderBottom3 (Css.px 1) Css.solid Colors.azure
-        , Css.Global.withAttribute "aria-disabled=true" [ Css.borderBottom3 (Css.px 1) Css.solid Colors.gray45 ]
-        , Css.disabled [ Css.borderBottom3 (Css.px 1) Css.solid Colors.gray45 ]
-        , Css.display Css.inline
-        , Css.fontFamily Css.inherit
-        , Css.fontWeight Css.inherit
-        , Css.fontSize Css.inherit
-        ]
+    set
+        (\config ->
+            { config
+                | customStyles =
+                    List.append config.customStyles
+                        [ Css.borderBottom3 (Css.px 1) Css.solid Colors.azure
+                        , Css.Global.withAttribute "aria-disabled=true" [ Css.borderBottom3 (Css.px 1) Css.solid Colors.gray45 ]
+                        , Css.disabled [ Css.borderBottom3 (Css.px 1) Css.solid Colors.gray45 ]
+                        , Css.display Css.inline
+                        , Css.fontFamily Css.inherit
+                        , Css.fontWeight Css.inherit
+                        , Css.fontSize Css.inherit
+                        ]
+                , size = Inherited
+            }
+        )
 
 
 {-| Specifies custom styles for the rightIcon


### PR DESCRIPTION
## Context

We've decided to make `ClickableText.medium` the default size/behavior. [(Private) Slack convo](https://noredink.slack.com/archives/C02NMHB1K55/p1707516194922589) on the topic.

This will eliminate the previous default state that we didn't expect to be used much, where the font styles would be inherited, but the clickable would not have "inline" styles applied otherwise.

As part of this PR, I also:
- updated the Menu example to remove `ClickableText.medium` lines (the default behavior will compose nicely now)
- improved the ClickableText example page to make all the states more clear (hopefully -- that's the goal!)

## :framed_picture: What does this change look like?

### Before

![noredink-ui netlify app_ (5)](https://github.com/NoRedInk/noredink-ui/assets/8811312/3c4fc536-37e0-4883-964e-1728241f47e2)

### After

![localhost_8000_ (15)](https://github.com/NoRedInk/noredink-ui/assets/8811312/51f21a9f-e122-44ff-8de0-25523ea82e5e)

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x]  Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x]  [team-accessibilibats-a11ybats](https://github.com/orgs/NoRedInk/teams/team-accessibilibats-a11ybats) - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x]  If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
