### PR TITLE
:label: Bump for version `27.12.1`

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "27.12.0",
+    "version": "27.12.1",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
Release for ClickableText.medium adjustments

## What changes does this release include?

### Only include changes to CC:

- https://github.com/NoRedInk/noredink-ui/pull/1622
- https://github.com/NoRedInk/noredink-ui/pull/1626
- https://github.com/NoRedInk/noredink-ui/pull/1628
- https://github.com/NoRedInk/noredink-ui/pull/1629
- https://github.com/NoRedInk/noredink-ui/pull/1630
- https://github.com/NoRedInk/noredink-ui/pull/1632
- https://github.com/NoRedInk/noredink-ui/pull/1631
- https://github.com/NoRedInk/noredink-ui/pull/1633

### User-facing changes that should be QA'd

- https://github.com/NoRedInk/noredink-ui/pull/1635 
    - adjusts the default size of Menu.clickableText to ClickableText.medium
- https://github.com/NoRedInk/noredink-ui/pull/1636 
    - changes the default behavior of ClickableText to `ClickableText.medium`

## How has the API changed?

```
No API changes detected, so this is a PATCH change.
```

