### PR TITLE
Add Carousel demo link

### DIFF
--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -240,7 +240,18 @@ example =
                 ]
             ]
         ]
-    , about = []
+    , about =
+        [ Text.smallBody
+            [ Text.html
+                [ text "Watch "
+                , ClickableText.link "Tessa's Carousel demo"
+                    [ ClickableText.linkExternal "https://www.dropbox.com/scl/fi/ilb105gyk6adcpt72f5vf/Carousel-demo.mov?rlkey=if2o9dqgfq1ucjkp9tput1rez&dl=0"
+                    , ClickableText.appearsInline
+                    ]
+                , text " for a brief intro on the Carousel component and its usage."
+                ]
+            ]
+        ]
     , view =
         \ellieLinkConfig model ->
             let


### PR DESCRIPTION
Component Catalog change only.

Adds demo link for Carousel.

Fixes A11-4117

<img width="690" alt="Screenshot 2024-02-16 at 11 55 11 AM" src="https://github.com/NoRedInk/noredink-ui/assets/8811312/f7209555-2563-4c2c-b8d4-41bdc1019bba">
