### PR TITLE
Version bump to 28.1.0 (TextArea.onFocus, plus component-catalog updates)

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "28.0.0",
+    "version": "28.1.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `28.1.0`

## What changes does this release include?

- #1651 
- #1648 
- #1641 
- #1640 

## How has the API changed?

```
This is a MINOR change.

---- Nri.Ui.TextArea.V5 - MINOR ----

    Added:
        onFocus : msg -> Nri.Ui.TextArea.V5.Attribute msg

```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).
