### PR TITLE
Kraken/menu container stylin

### DIFF
--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -162,6 +162,7 @@ view ellieLinkConfig state =
             , Code.unionType "Msg"
                 [ "ToggleMenu { focus : Maybe String, isOpen : Bool }"
                 , "ToggleTooltip Bool"
+                , "ConsoleLog String"
                 ]
             ]
         , renderExample = Code.unstyledView
@@ -191,16 +192,62 @@ view ellieLinkConfig state =
                                 )
                                 1
                             ++ Code.listMultiline
-                                [ (Code.fromModule moduleName "entry " ++ Code.string "unique-button-id" ++ " <|")
-                                    ++ Code.newlineWithIndent 2
-                                    ++ Code.anonymousFunction "attributes"
-                                        (Code.newlineWithIndent 2
-                                            ++ (Code.fromModule "ClickableText" "button " ++ Code.string "Button")
+                                [ case (Control.currentValue state.settings).entriesKind of
+                                    Single ->
+                                        (Code.fromModule moduleName "entry " ++ Code.string "unique-button-id" ++ " <|")
+                                            ++ Code.newlineWithIndent 2
+                                            ++ Code.anonymousFunction "attributes"
+                                                (Code.newlineWithIndent 3
+                                                    ++ (Code.fromModule "ClickableText" "button " ++ Code.string "Button")
+                                                    ++ Code.listMultiline
+                                                        [ Code.fromModule "ClickableText" "custom" ++ " attributes"
+                                                        ]
+                                                        4
+                                                )
+
+                                    Group ->
+                                        (Code.fromModule moduleName "group " ++ Code.string "customizable-example")
                                             ++ Code.listMultiline
-                                                [ Code.fromModule "ClickableText" "custom" ++ " attributes"
+                                                [ (Code.fromModule moduleName "entry " ++ Code.string "gift-button" ++ " <|")
+                                                    ++ Code.newlineWithIndent 3
+                                                    ++ Code.anonymousFunction "attrs"
+                                                        (Code.newlineWithIndent 4
+                                                            ++ Code.fromModule "ClickableText" "button "
+                                                            ++ Code.string "gift-button"
+                                                            ++ Code.listMultiline
+                                                                [ Code.fromModule "ClickableText" "onClick" ++ " (ConsoleLog " ++ Code.string "Gift" ++ ")"
+                                                                , Code.fromModule "ClickableText" "custom" ++ " attrs"
+                                                                , Code.fromModule "ClickableText" "icon" ++ " UiIcon.gift"
+                                                                ]
+                                                                5
+                                                        )
+                                                , (Code.fromModule moduleName "entry " ++ Code.string "null-button" ++ " <|")
+                                                    ++ Code.newlineWithIndent 3
+                                                    ++ Code.anonymousFunction "attrs"
+                                                        (Code.newlineWithIndent 4
+                                                            ++ Code.fromModule "ClickableText" "button "
+                                                            ++ Code.string "Nope!"
+                                                            ++ Code.listMultiline
+                                                                [ Code.fromModule "ClickableText" "onClick" ++ " (ConsoleLog " ++ Code.string "Nope!" ++ ")"
+                                                                , Code.fromModule "ClickableText" "custom" ++ " attrs"
+                                                                , Code.fromModule "ClickableText" "icon" ++ " UiIcon.null"
+                                                                ]
+                                                                5
+                                                        )
+                                                , (Code.fromModule moduleName "entry " ++ Code.string "no-icon-button" ++ " <|")
+                                                    ++ Code.newlineWithIndent 3
+                                                    ++ Code.anonymousFunction "attrs"
+                                                        (Code.newlineWithIndent 4
+                                                            ++ Code.fromModule "ClickableText" "button "
+                                                            ++ Code.string "Skip"
+                                                            ++ Code.listMultiline
+                                                                [ Code.fromModule "ClickableText" "onClick" ++ " (ConsoleLog " ++ Code.string "Skip" ++ ")"
+                                                                , Code.fromModule "ClickableText" "custom" ++ " attrs"
+                                                                ]
+                                                                5
+                                                        )
                                                 ]
-                                                3
-                                        )
+                                                2
                                 ]
                                 1
                 in
@@ -230,11 +277,37 @@ view ellieLinkConfig state =
                 ++ Menu.isOpen (isOpen "interactiveExample")
                 :: menuAttributes
             )
-            [ Menu.entry "customizable-example" <|
-                \attrs ->
-                    ClickableText.button "Button"
-                        [ ClickableText.onClick (ConsoleLog "Interactive example")
-                        , ClickableText.custom attrs
+            [ case (Control.currentValue state.settings).entriesKind of
+                Single ->
+                    Menu.entry "customizable-example" <|
+                        \attrs ->
+                            ClickableText.button "Button"
+                                [ ClickableText.onClick (ConsoleLog "Interactive example")
+                                , ClickableText.custom attrs
+                                ]
+
+                Group ->
+                    Menu.group "customizable-example"
+                        [ Menu.entry "gift-button" <|
+                            \attrs ->
+                                ClickableText.button "Gift"
+                                    [ ClickableText.onClick (ConsoleLog "Gift")
+                                    , ClickableText.custom attrs
+                                    , ClickableText.icon UiIcon.gift
+                                    ]
+                        , Menu.entry "null-buttonn" <|
+                            \attrs ->
+                                ClickableText.button "Nope!"
+                                    [ ClickableText.onClick (ConsoleLog "Nope!")
+                                    , ClickableText.custom attrs
+                                    , ClickableText.icon UiIcon.null
+                                    ]
+                        , Menu.entry "no-icon-button" <|
+                            \attrs ->
+                                ClickableText.button "Skip"
+                                    [ ClickableText.onClick (ConsoleLog "Skip")
+                                    , ClickableText.custom attrs
+                                    ]
                         ]
             ]
         ]
@@ -810,9 +883,15 @@ type alias State =
     }
 
 
+type EntriesKind
+    = Single
+    | Group
+
+
 type alias Settings =
     { attributes : List ( String, Menu.Attribute Msg )
     , withTooltip : Bool
+    , entriesKind : EntriesKind
     }
 
 
@@ -821,6 +900,12 @@ initSettings =
     Control.record Settings
         |> Control.field "" initSettingAttributes
         |> Control.field "withTooltip" (Control.bool False)
+        |> Control.field "entriesKind"
+            (Control.choice
+                [ ( "Single", Control.value Single )
+                , ( "Group", Control.value Group )
+                ]
+            )
 
 
 initSettingAttributes : Control (List ( String, Menu.Attribute Msg ))
@@ -833,49 +918,49 @@ initSettingAttributes =
                 |> ControlExtra.optionalListItem "containerCss"
                     (Control.choice
                         [ ( "max-width with border"
-                        , Control.value
+                          , Control.value
                                 ( "Menu.containerCss [ maxWidth (px 200), border3 (px 1) solid red ]"
                                 , Menu.containerCss [ Css.maxWidth (Css.px 200), Css.border3 (Css.px 1) Css.solid Colors.red ]
                                 )
-                        )
+                          )
                         , ( "10px right margin"
-                        , Control.value
+                          , Control.value
                                 ( "Menu.containerCss [ marginRight (px 10) ]"
                                 , Menu.containerCss [ Css.marginRight (Css.px 10) ]
                                 )
-                        )
+                          )
                         ]
                     )
                 |> ControlExtra.optionalListItem "groupContainerCss"
                     (Control.choice
                         [ ( "max-width with border"
-                        , Control.value
+                          , Control.value
                                 ( "Menu.groupContainerCss [ maxWidth (px 200), border3 (px 1) solid red ]"
                                 , Menu.groupContainerCss [ Css.maxWidth (Css.px 200), Css.border3 (Css.px 1) Css.solid Colors.red ]
                                 )
-                        )
+                          )
                         , ( "10px right margin"
-                        , Control.value
+                          , Control.value
                                 ( "Menu.groupContainerCss [ marginRight (px 10) ]"
                                 , Menu.groupContainerCss [ Css.marginRight (Css.px 10) ]
                                 )
-                        )
+                          )
                         ]
                     )
                 |> ControlExtra.optionalListItem "entryContainerCss"
                     (Control.choice
                         [ ( "max-width with border"
-                        , Control.value
+                          , Control.value
                                 ( "Menu.entryContainerCss [ maxWidth (px 200), border3 (px 1) solid red ]"
                                 , Menu.entryContainerCss [ Css.maxWidth (Css.px 200), Css.border3 (Css.px 1) Css.solid Colors.red ]
                                 )
-                        )
+                          )
                         , ( "10px right margin"
-                        , Control.value
+                          , Control.value
                                 ( "Menu.entryContainerCss [ marginRight (px 10) ]"
                                 , Menu.entryContainerCss [ Css.marginRight (Css.px 10) ]
                                 )
-                        )
+                          )
                         ]
                     )
             )

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -830,6 +830,54 @@ initSettingAttributes =
             (Control.list
                 |> ControlExtra.optionalListItem "alignment" controlAlignment
                 |> ControlExtra.optionalListItem "menuWidth" controlMenuWidth
+                |> ControlExtra.optionalListItem "containerCss"
+                    (Control.choice
+                        [ ( "max-width with border"
+                        , Control.value
+                                ( "Menu.containerCss [ maxWidth (px 200), border3 (px 1) solid red ]"
+                                , Menu.containerCss [ Css.maxWidth (Css.px 200), Css.border3 (Css.px 1) Css.solid Colors.red ]
+                                )
+                        )
+                        , ( "10px right margin"
+                        , Control.value
+                                ( "Menu.containerCss [ marginRight (px 10) ]"
+                                , Menu.containerCss [ Css.marginRight (Css.px 10) ]
+                                )
+                        )
+                        ]
+                    )
+                |> ControlExtra.optionalListItem "groupContainerCss"
+                    (Control.choice
+                        [ ( "max-width with border"
+                        , Control.value
+                                ( "Menu.groupContainerCss [ maxWidth (px 200), border3 (px 1) solid red ]"
+                                , Menu.groupContainerCss [ Css.maxWidth (Css.px 200), Css.border3 (Css.px 1) Css.solid Colors.red ]
+                                )
+                        )
+                        , ( "10px right margin"
+                        , Control.value
+                                ( "Menu.groupContainerCss [ marginRight (px 10) ]"
+                                , Menu.groupContainerCss [ Css.marginRight (Css.px 10) ]
+                                )
+                        )
+                        ]
+                    )
+                |> ControlExtra.optionalListItem "entryContainerCss"
+                    (Control.choice
+                        [ ( "max-width with border"
+                        , Control.value
+                                ( "Menu.entryContainerCss [ maxWidth (px 200), border3 (px 1) solid red ]"
+                                , Menu.entryContainerCss [ Css.maxWidth (Css.px 200), Css.border3 (Css.px 1) Css.solid Colors.red ]
+                                )
+                        )
+                        , ( "10px right margin"
+                        , Control.value
+                                ( "Menu.entryContainerCss [ marginRight (px 10) ]"
+                                , Menu.entryContainerCss [ Css.marginRight (Css.px 10) ]
+                                )
+                        )
+                        ]
+                    )
             )
         |> ControlExtra.listItems "triggering element"
             (Control.list

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,6 @@
             pkgs.elmPackages.elm
             pkgs.elmPackages.elm-format
             pkgs.elmPackages.elm-test
-            pkgs.elmPackages.elm-language-server
             pkgs.elmPackages.elm-verify-examples
             pkgs.elmPackages.elm-review
             pkgs.elmPackages.elm-json

--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -170,15 +170,14 @@ containerCss styles =
     Attribute <| \config -> { config | containerCss = config.containerCss ++ styles }
 
 
-{-| Adds CSS to the element containing the group.
+{-| Adds CSS to the element containing the group. This will style items created via Menu.group
 -}
 groupContainerCss : List Css.Style -> Attribute msg
 groupContainerCss styles =
     Attribute <| \config -> { config | groupContainerCss = config.groupContainerCss ++ styles }
 
 
-{-| Adds CSS to the element containing the entry.
-I think this is Single in the Entry type.
+{-| Adds CSS to the element containing the entry. This will style items created via Menu.entry
 -}
 entryContainerCss : List Css.Style -> Attribute msg
 entryContainerCss styles =

--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -8,6 +8,7 @@ module Nri.Ui.Menu.V4 exposing
     , navMenuList, disclosure, dialog
     , menuWidth, menuId, menuZIndex
     , alignLeft, alignRight
+    , containerCss
     , Entry, group, entry
     )
 
@@ -51,6 +52,7 @@ A togglable menu view and related buttons.
 @docs navMenuList, disclosure, dialog
 @docs menuWidth, menuId, menuZIndex
 @docs alignLeft, alignRight
+@docs containerCss
 
 
 ## Menu content
@@ -97,6 +99,7 @@ type alias MenuConfig msg =
     , opensOnHover : Bool
     , purpose : Purpose
     , tooltipAttributes : List (Tooltip.Attribute msg)
+    , containerCss : List Style
     }
 
 
@@ -113,6 +116,7 @@ defaultConfig =
     , opensOnHover = False
     , purpose = NavMenu
     , tooltipAttributes = []
+    , containerCss = []
     }
 
 
@@ -152,6 +156,13 @@ Right (this property) is the default behavior.
 alignRight : Attribute msg
 alignRight =
     Attribute <| \config -> { config | alignment = Right }
+
+
+{-| Adds CSS to the element containing the menu.
+-}
+containerCss : List Css.Style -> Attribute msg
+containerCss styles =
+    Attribute <| \config -> { config | containerCss = config.containerCss ++ styles }
 
 
 {-| Whether the menu is open
@@ -460,7 +471,7 @@ viewCustom focusAndToggle config entries =
                                     }
                             }
                )
-            :: styleContainer
+            :: styleContainer config.containerCss
         )
         [ if config.isOpen then
             div
@@ -895,14 +906,14 @@ styleContent contentVisible config =
         ]
 
 
-styleContainer : List (Html.Attribute msg)
-styleContainer =
+styleContainer : List Style -> List (Html.Attribute msg)
+styleContainer styles =
     [ class "Container"
     , AttributesExtra.nriDescription "Nri-Ui-Menu-V4"
-    , css
-        [ position relative
-        , display inlineBlock
-        ]
+    , css <|
+        position relative
+            :: display inlineBlock
+            :: styles
     ]
 
 

--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -8,7 +8,7 @@ module Nri.Ui.Menu.V4 exposing
     , navMenuList, disclosure, dialog
     , menuWidth, menuId, menuZIndex
     , alignLeft, alignRight
-    , containerCss
+    , containerCss, groupContainerCss, entryContainerCss
     , Entry, group, entry
     )
 
@@ -19,7 +19,7 @@ module Nri.Ui.Menu.V4 exposing
   - Adjust disabled styles
   - when the Menu is a dialog or disclosure, _don't_ add role menuitem to the entries
   - Use ClickableText.medium as the default size when the trigger is `Menu.clickableText`
-  - Adds containerCss to customize the style of the menu container
+  - Adds containerCss, groupContainerCss, and entryContainerCss to customize the style of the respective containers
 
 Changes from V3:
 
@@ -53,7 +53,7 @@ A togglable menu view and related buttons.
 @docs navMenuList, disclosure, dialog
 @docs menuWidth, menuId, menuZIndex
 @docs alignLeft, alignRight
-@docs containerCss
+@docs containerCss, groupContainerCss, entryContainerCss
 
 
 ## Menu content
@@ -101,6 +101,8 @@ type alias MenuConfig msg =
     , purpose : Purpose
     , tooltipAttributes : List (Tooltip.Attribute msg)
     , containerCss : List Style
+    , groupContainerCss : List Style
+    , entryContainerCss : List Style
     }
 
 
@@ -118,6 +120,8 @@ defaultConfig =
     , purpose = NavMenu
     , tooltipAttributes = []
     , containerCss = []
+    , groupContainerCss = []
+    , entryContainerCss = []
     }
 
 
@@ -164,6 +168,21 @@ alignRight =
 containerCss : List Css.Style -> Attribute msg
 containerCss styles =
     Attribute <| \config -> { config | containerCss = config.containerCss ++ styles }
+
+
+{-| Adds CSS to the element containing the group.
+-}
+groupContainerCss : List Css.Style -> Attribute msg
+groupContainerCss styles =
+    Attribute <| \config -> { config | groupContainerCss = config.groupContainerCss ++ styles }
+
+
+{-| Adds CSS to the element containing the entry.
+I think this is Single in the Entry type.
+-}
+entryContainerCss : List Css.Style -> Attribute msg
+entryContainerCss styles =
+    Attribute <| \config -> { config | entryContainerCss = config.entryContainerCss ++ styles }
 
 
 {-| Whether the menu is open
@@ -730,13 +749,15 @@ viewEntry config focusAndToggle { upId, downId, entry_ } =
             entryContainer
                 [ class "MenuEntryContainer"
                 , css
-                    [ padding2 (px 5) zero
-                    , position relative
-                    , firstChild
+                    ([ padding2 (px 5) zero
+                     , position relative
+                     , firstChild
                         [ paddingTop zero ]
-                    , lastChild
+                     , lastChild
                         [ paddingBottom zero ]
-                    ]
+                     ]
+                        ++ config.entryContainerCss
+                    )
                 ]
                 [ view_
                     [ case config.purpose of
@@ -776,7 +797,7 @@ viewEntry config focusAndToggle { upId, downId, entry_ } =
                     Html.text ""
 
                 _ ->
-                    fieldset styleGroupContainer <|
+                    fieldset (styleGroupContainer config.groupContainerCss) <|
                         legend styleGroupTitle
                             [ span (styleGroupTitleText config) [ Html.text title ] ]
                             :: viewEntries config
@@ -833,17 +854,19 @@ styleGroupTitleText config =
     ]
 
 
-styleGroupContainer : List (Html.Attribute msg)
-styleGroupContainer =
+styleGroupContainer : List Style -> List (Html.Attribute msg)
+styleGroupContainer styles =
     [ class "GroupContainer"
     , css
-        [ margin zero
-        , padding zero
-        , paddingBottom (px 15)
-        , border zero
-        , lastChild
+        ([ margin zero
+         , padding zero
+         , paddingBottom (px 15)
+         , border zero
+         , lastChild
             [ paddingBottom zero ]
-        ]
+         ]
+            ++ styles
+        )
     ]
 
 

--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -19,6 +19,7 @@ module Nri.Ui.Menu.V4 exposing
   - Adjust disabled styles
   - when the Menu is a dialog or disclosure, _don't_ add role menuitem to the entries
   - Use ClickableText.medium as the default size when the trigger is `Menu.clickableText`
+  - Adds containerCss to customize the style of the menu container
 
 Changes from V3:
 


### PR DESCRIPTION
# :wrench: Modifying a component

This PR adds functionality to the Menu component to allow customizing css of different containers. You can now style the menu container itself, the container of the single entries, and the container of the group entries. This does not require a major version bump to release.

## Context

https://linear.app/noredink/issue/KRA-1443/add-css-helpers-to-all-nriuimenu-containers

## :framed_picture: What does this change look like?

No user facing changes. This PR simply adds APIs around customizing css at different layers of the menu.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
