### PR TITLE
Fix indentation for deeply nested menu groups

### DIFF
--- a/component-catalog/src/Examples/SideNav.elm
+++ b/component-catalog/src/Examples/SideNav.elm
@@ -145,7 +145,7 @@ view ellieLinkConfig state =
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
     , SideNav.view
-        { isCurrentRoute = \route -> route == "complex-example__child-2"
+        { isCurrentRoute = \route -> route == "complex-example__grandchild-2"
         , routeToString = identity
         , onSkipNav = SkipToContent
         }
@@ -166,6 +166,15 @@ view ellieLinkConfig state =
                 ]
             , SideNav.entry "Child 2"
                 [ SideNav.href "complex-example__child-2"
+                ]
+            , SideNav.entryWithChildren "Child with Children"
+                []
+                [ SideNav.entry "Grandchild 1"
+                    [ SideNav.href "complex-example__grandchild-1"
+                    ]
+                , SideNav.entry "Grandchild 2"
+                    [ SideNav.href "complex-example__grandchild-2"
+                    ]
                 ]
             ]
         , SideNav.compactGroup "Compact Group"

--- a/component-catalog/src/Examples/SideNav.elm
+++ b/component-catalog/src/Examples/SideNav.elm
@@ -141,6 +141,35 @@ view ellieLinkConfig state =
         (List.map Tuple.second settings.navAttributes)
         (List.map Tuple.second settings.entries)
     , Heading.h2
+        [ Heading.plaintext "Basic example"
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+        ]
+    , SideNav.view
+        { isCurrentRoute = \route -> route == "nested-example__grandchild-2"
+        , routeToString = identity
+        , onSkipNav = SkipToContent
+        }
+        [ SideNav.navLabel "Nested example"
+        , SideNav.navId "nested-example-sidenav"
+        ]
+        [
+            SideNav.entryWithChildren "Entry with Children"
+                [ ]
+                [ SideNav.entry "Child 1"
+                    [ SideNav.href "nested-example__child-1"
+                    ]
+                , SideNav.entryWithChildren "Child 2"
+                    [ ]
+                    [ SideNav.entry "Grandchild 1"
+                        [ SideNav.href "nested-example__grandchild-1"
+                        ]
+                    , SideNav.entry "Grandchild 2"
+                        [ SideNav.href "nested-example__grandchild-2"
+                        ]
+                    ]
+                ]
+        ]
+    , Heading.h2
         [ Heading.plaintext "Complex example"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]

--- a/component-catalog/src/Examples/SideNav.elm
+++ b/component-catalog/src/Examples/SideNav.elm
@@ -145,7 +145,7 @@ view ellieLinkConfig state =
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
     , SideNav.view
-        { isCurrentRoute = \route -> route == "complex-example__grandchild-2"
+        { isCurrentRoute = \route -> route == "complex-example__child-2"
         , routeToString = identity
         , onSkipNav = SkipToContent
         }
@@ -166,15 +166,6 @@ view ellieLinkConfig state =
                 ]
             , SideNav.entry "Child 2"
                 [ SideNav.href "complex-example__child-2"
-                ]
-            , SideNav.entryWithChildren "Child with Children"
-                []
-                [ SideNav.entry "Grandchild 1"
-                    [ SideNav.href "complex-example__grandchild-1"
-                    ]
-                , SideNav.entry "Grandchild 2"
-                    [ SideNav.href "complex-example__grandchild-2"
-                    ]
                 ]
             ]
         , SideNav.compactGroup "Compact Group"

--- a/component-catalog/src/Examples/SideNav.elm
+++ b/component-catalog/src/Examples/SideNav.elm
@@ -152,22 +152,21 @@ view ellieLinkConfig state =
         [ SideNav.navLabel "Nested example"
         , SideNav.navId "nested-example-sidenav"
         ]
-        [
-            SideNav.entryWithChildren "Entry with Children"
-                [ ]
-                [ SideNav.entry "Child 1"
-                    [ SideNav.href "nested-example__child-1"
+        [ SideNav.entryWithChildren "Entry with Children"
+            []
+            [ SideNav.entry "Child 1"
+                [ SideNav.href "nested-example__child-1"
+                ]
+            , SideNav.entryWithChildren "Child 2"
+                []
+                [ SideNav.entry "Grandchild 1"
+                    [ SideNav.href "nested-example__grandchild-1"
                     ]
-                , SideNav.entryWithChildren "Child 2"
-                    [ ]
-                    [ SideNav.entry "Grandchild 1"
-                        [ SideNav.href "nested-example__grandchild-1"
-                        ]
-                    , SideNav.entry "Grandchild 2"
-                        [ SideNav.href "nested-example__grandchild-2"
-                        ]
+                , SideNav.entry "Grandchild 2"
+                    [ SideNav.href "nested-example__grandchild-2"
                     ]
                 ]
+            ]
         ]
     , Heading.h2
         [ Heading.plaintext "Complex example"

--- a/src/Nri/Ui/SideNav/V5.elm
+++ b/src/Nri/Ui/SideNav/V5.elm
@@ -476,7 +476,7 @@ viewSidebarEntry config extraStyles entry_ =
                         [ Attributes.css
                             ([ listStyle none
                              , padding zero
-                             , margin zero
+                             , marginLeft zero |> Css.important
                              ]
                                 ++ extraStyles
                             )

--- a/src/Nri/Ui/SideNav/V5.elm
+++ b/src/Nri/Ui/SideNav/V5.elm
@@ -474,12 +474,9 @@ viewSidebarEntry config extraStyles entry_ =
                         ]
                     , ul
                         [ Attributes.css
-                            ([ listStyle none
-                             , padding zero
-                             , marginLeft zero |> Css.important
-                             ]
-                                ++ extraStyles
-                            )
+                            [ listStyle none
+                            , padding zero
+                            ]
                         , Aria.labelledBy id_
                         ]
                         (List.map


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

This PR fixes the indentation level for deeply nested entries (entryWithChildren->entryWithChildren->entry) in Nri.Ui.SideNav.

## :framed_picture: What does this change look like?

__Before__

![Screenshot 2024-02-28 at 13 57 37](https://github.com/NoRedInk/noredink-ui/assets/5419074/a174ca90-8994-4d6f-93a4-753388e03e67)

__After__

![Screenshot 2024-02-28 at 13 48 13](https://github.com/NoRedInk/noredink-ui/assets/5419074/dcc81bac-45dd-4416-857a-0cf928443fe3)

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [ ] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [ ] Please assign the following reviewers:
  - [ ] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [ ] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [ ] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
