### PR TITLE
Add Menu.captionedGroup, text+menu css helpers, example

### DIFF
--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -658,7 +658,7 @@ You will need to pass in the first and last focusable element in the dialog cont
             }
         , Table.custom
             { header = text "Example"
-            , view = \{ name, menuType, entries } -> forcedOpenExample name menuType entries
+            , view = \{ name, attributes, entries } -> forcedOpenExample name attributes entries
             , width = Css.pct 20
             , cellStyles =
                 \{ name } ->
@@ -707,7 +707,7 @@ You will need to pass in the first and last focusable element in the dialog cont
             }
         ]
         [ { name = "List of entries"
-          , menuType = Menu.navMenuList
+          , attributes = [ Menu.navMenuList ]
           , entries =
                 [ Menu.entry "list-of-entries-clickable-text-entry" <|
                     \attributes ->
@@ -733,7 +733,7 @@ You will need to pass in the first and last focusable element in the dialog cont
           , about = "Pass any interactive elements in using `Menu.entry`."
           }
         , { name = "Grouped entries"
-          , menuType = Menu.navMenuList
+          , attributes = [ Menu.navMenuList ]
           , entries =
                 [ List.range 1 2
                     |> List.map
@@ -771,7 +771,7 @@ The structures are recursive and flexible:
 """
           }
         , { name = "Mix of singular entries and grouped entries"
-          , menuType = Menu.disclosure { lastId = droppedStudentsId }
+          , attributes = [ Menu.disclosure { lastId = droppedStudentsId } ]
           , entries =
                 [ Menu.entry "grades-and-perf" <|
                     \attributes ->
@@ -797,24 +797,102 @@ Please note that depending on the interactive component you select, our composab
 In this realistic example, we can't actually pass the correct attributes to RadioButton or Switch because it will cause the events for those components to be swallowed, rendering them inoperable.
 """
           }
+        , { name = "Custom CSS"
+          , attributes =
+                [ Menu.disclosure { lastId = "which-should-i-choose" }
+                , Menu.menuWidth 350
+                , Menu.menuCss
+                    [ Css.padding (Css.px 20)
+                    ]
+                , Menu.groupContainerCss
+                    [ Css.displayFlex
+                    , Css.property "gap" "10px"
+                    ]
+                , Menu.groupTitleCss
+                    [ Css.fontSize (Css.px 16)
+                    , Css.fontWeight (Css.int 700)
+                    , Css.color Colors.gray20
+                    ]
+                , Menu.groupCaptionCss
+                    [ Css.fontSize (Css.px 13)
+                    ]
+                ]
+          , entries =
+                [ Menu.captionedGroup "Quick Write"
+                    "Students write independently, without lessons or tips."
+                    [ Menu.entry "preview-quick-write" <|
+                        \attributes ->
+                            ClickableSvg.link "Preview"
+                                UiIcon.preview
+                                [ ClickableSvg.linkExternal "about:blank"
+                                , ClickableSvg.secondary
+                                , ClickableSvg.withBorder
+                                , ClickableSvg.custom attributes
+                                ]
+                    , Menu.entry "assign-quick-write" <|
+                        \attributes ->
+                            ClickableSvg.link "Assign"
+                                UiIcon.arrowPointingRightThick
+                                [ ClickableSvg.linkExternal "about:blank"
+                                , ClickableSvg.primary
+                                , ClickableSvg.withBorder
+                                , ClickableSvg.custom attributes
+                                ]
+                    ]
+                , Menu.captionedGroup "Guided Draft"
+                    "Students draft with the support of tutorials, models, and targeted tips."
+                    [ Menu.entry "preview-guided-draft" <|
+                        \attributes ->
+                            ClickableSvg.link "Preview"
+                                UiIcon.preview
+                                [ ClickableSvg.linkExternal "about:blank"
+                                , ClickableSvg.secondary
+                                , ClickableSvg.withBorder
+                                , ClickableSvg.custom attributes
+                                ]
+                    , Menu.entry "assign-guided-draft" <|
+                        \attributes ->
+                            ClickableSvg.link "Assign"
+                                UiIcon.arrowPointingRightThick
+                                [ ClickableSvg.linkExternal "about:blank"
+                                , ClickableSvg.primary
+                                , ClickableSvg.withBorder
+                                , ClickableSvg.custom attributes
+                                ]
+                    ]
+                , Menu.entry "which-should-i-choose" <|
+                    \attributes ->
+                        ClickableText.link "Which should I choose?"
+                            [ ClickableText.linkExternal "about:blank"
+                            , ClickableText.icon UiIcon.help
+                            , ClickableText.custom attributes
+                            ]
+                ]
+          , about = """
+Each container can be styled with CSS to achieve the desired layout.
+
+In this example, we use `Menu.menuCss` to reduce the menu padding, `Menu.groupContainerCss` to layout horizontally, and `Menu.groupTitleCss` and `Menu.groupCaptionCss` to style typography.
+"""
+          }
         ]
     ]
 
 
-forcedOpenExample : String -> Menu.Attribute Msg -> List (Menu.Entry Msg) -> Html Msg
-forcedOpenExample name type_ =
+forcedOpenExample : String -> List (Menu.Attribute Msg) -> List (Menu.Entry Msg) -> Html Msg
+forcedOpenExample name attributes =
     Menu.view (FocusAndToggle name)
-        [ Menu.clickableSvgWithoutIndicator (name ++ " example")
+        ([ Menu.clickableSvgWithoutIndicator (name ++ " example")
             UiIcon.arrowDown
             [ ClickableSvg.exactSize 15
             , ClickableSvg.css [ Css.marginLeft (Css.px 17) ]
             ]
-        , Menu.isOpen True
-        , Menu.buttonId (forcedOpenExampleButtonId name)
-        , Menu.menuId (safeIdWithPrefix name "menuId")
-        , Menu.alignLeft
-        , type_
-        ]
+         , Menu.isOpen True
+         , Menu.buttonId (forcedOpenExampleButtonId name)
+         , Menu.menuId (safeIdWithPrefix name "menuId")
+         , Menu.alignLeft
+         ]
+            ++ attributes
+        )
 
 
 forcedOpenExampleButtonId : String -> String

--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -850,8 +850,7 @@ viewEntry config focusAndToggle { upId, downId, entry_ } =
                                     Text.caption
                                         [ Text.plaintext c
                                         , Text.id captionId
-                                        , Text.css
-                                            [ paddingTop (px 2) ]
+                                        , Text.css <| styleGroupCaption config
                                         ]
                                 )
                                 caption
@@ -909,6 +908,11 @@ styleGroupTitleText config =
         ]
             ++ config.groupTitleCss
     ]
+
+
+styleGroupCaption : MenuConfig msg -> List Style
+styleGroupCaption config =
+    paddingTop (px 2) :: config.groupCaptionCss
 
 
 styleGroupContainer : List Style -> List (Html.Attribute msg)

--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -72,6 +72,7 @@ import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes as Attributes exposing (class, classList, css)
 import Html.Styled.Events as Events
 import Json.Decode
+import Maybe.Extra as Maybe
 import Nri.Ui.AnimatedIcon.V1 as AnimatedIcon
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
@@ -842,7 +843,9 @@ viewEntry config focusAndToggle { upId, downId, entry_ } =
                         div [ css [ flexGrow (int 1) ] ]
                             [ legend styleGroupTitle
                                 [ span
-                                    (Aria.describedBy [ captionId ] :: styleGroupTitleText config)
+                                    (styleGroupTitleText config
+                                        |> Maybe.cons (Maybe.map (always (Aria.describedBy [ captionId ])) caption)
+                                    )
                                     [ Html.text title ]
                                 ]
                             , viewJust


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

[Slack thread](https://noredink.slack.com/archives/C0VVDLEES/p1707420654830799?thread_ts=1707322899.357929&cid=C0VVDLEES)

- Adds a `captionedGroup` entry initialized to create a menu entry group with a text caption (in addition to the legend).
- Adds `menuCss`, `groupTitleCss`, and `groupCaptionCss` styling helper attributes

---

I did a few different attempts at trying to use the existing `group` initializer with an additional builder function or attribute (but one that _only_ accepted groups, not normal entries–phantom types, etc.) but couldn't get anything to work with the recursion. womp womp.

## :framed_picture: What does this change look like?

Example in component-catalog

![Screenshot 2024-03-18 at 11 34 24](https://github.com/NoRedInk/noredink-ui/assets/5419074/fa87c787-7298-48bc-bd73-954dc292a3bc)

- If there are user facing changes, you will be asked later to add a designer as a reviewer. Please fill in this section by following [the guidelines for an optimal design review](https://paper.dropbox.com/doc/Guidelines-for-Sharing-User-Facing-Changes-with-Design--BpL8hpJLMugy6033aT5m0JdaAg-bdKGQtYH9qO9I00hUkA6k).
- If there are not user facing changes, include any screenshots or videos that would be helpful to reviewers.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [ ] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [ ] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [ ] Please assign the following reviewers:
  - [ ] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [ ] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [ ] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
