### PR TITLE
Speed up highlighter by special casing `selectShortest` for non-overlapping case

### DIFF
--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -20,6 +20,11 @@ module Nri.Ui.Highlighter.V5 exposing
 Highlighter provides a view/model/update to display a view to highlight text and show marks.
 
 
+# Patch changes:
+
+  - Optimized `selectShortest` for the normal case of 0 or 1 highlight.
+
+
 # Types
 
 @docs Model, Msg, PointerMsg

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -832,7 +832,6 @@ selectShortest getHighlightable state =
             )
 
 
-
 highlightLengths : { model | highlightables : List (Highlightable marker), sorter : Sorter marker } -> List { marker : marker, length : Int }
 highlightLengths model =
     model.highlightables


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Juan, Juliano, and I have been spending a lot of time chasing highlighter performance recently in large documents. One function that consumes a lot of cycles is `selectShortest`, which is built to select the highlight that is the shortest when there are multiple potentially overlapping highlights.  

The thing is, overlapping highlights are not that common at all.  In fact they are rare.  For most cases, there is either 0 or 1 highlight that a user is hovering over.  In that case its obvious what the "shortest highlight" is and we can skip the expensive work of building `highlightLengths`.

This is a 73% speedup for a large guided draft with a handful of highlights.  The more highlights on the page the greater the difference would be. 

PHX-1464

## :framed_picture: What does this change look like?

No visual changes, performance improvements only. 

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
