### PR TITLE
Make Highlighter views lazy

### DIFF
--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -859,19 +859,22 @@ highlightLengths model =
 
 {-| -}
 view : Model marker -> Html (Msg marker)
-view model =
-    view_
-        { showTagsInline = False
-        , maybeTool = Just model.marker
-        , mouseOverIndex = model.mouseOverIndex
-        , mouseDownIndex = model.mouseDownIndex
-        , hintingIndices = model.hintingIndices
-        , overlaps = False
-        , viewSegment = viewHighlightable { renderMarkdown = False, overlaps = False } model
-        , id = model.id
-        , highlightables = model.highlightables
-        , sorter = Just model.sorter
-        }
+view =
+    lazy
+        (\model ->
+            view_
+                { showTagsInline = False
+                , maybeTool = Just model.marker
+                , mouseOverIndex = model.mouseOverIndex
+                , mouseDownIndex = model.mouseDownIndex
+                , hintingIndices = model.hintingIndices
+                , overlaps = False
+                , viewSegment = viewHighlightable { renderMarkdown = False, overlaps = False } model
+                , id = model.id
+                , highlightables = model.highlightables
+                , sorter = Just model.sorter
+                }
+        )
 
 
 {-| -}
@@ -902,48 +905,54 @@ WARNING: markdown is rendered highlightable by highlightable, so be sure to prov
 
 -}
 viewMarkdown : Model marker -> Html (Msg marker)
-viewMarkdown model =
-    view_
-        { showTagsInline = False
-        , maybeTool = Just model.marker
-        , mouseOverIndex = model.mouseOverIndex
-        , mouseDownIndex = model.mouseDownIndex
-        , hintingIndices = model.hintingIndices
-        , overlaps = False
-        , viewSegment = viewHighlightable { renderMarkdown = True, overlaps = False } model
-        , id = model.id
-        , highlightables = model.highlightables
-        , sorter = Just model.sorter
-        }
+viewMarkdown =
+    lazy
+        (\model ->
+            view_
+                { showTagsInline = False
+                , maybeTool = Just model.marker
+                , mouseOverIndex = model.mouseOverIndex
+                , mouseDownIndex = model.mouseDownIndex
+                , hintingIndices = model.hintingIndices
+                , overlaps = False
+                , viewSegment = viewHighlightable { renderMarkdown = True, overlaps = False } model
+                , id = model.id
+                , highlightables = model.highlightables
+                , sorter = Just model.sorter
+                }
+        )
 
 
 {-| -}
 static : { config | id : String, highlightables : List (Highlightable marker) } -> Html msg
-static config =
-    view_
-        { showTagsInline = False
-        , maybeTool = Nothing
-        , mouseOverIndex = Nothing
-        , mouseDownIndex = Nothing
-        , hintingIndices = Nothing
-        , overlaps = False
-        , viewSegment =
-            viewHighlightableSegment
-                { interactiveHighlighterId = Nothing
-                , focusIndex = Nothing
-                , eventListeners = []
+static =
+    lazy
+        (\config ->
+            view_
+                { showTagsInline = False
                 , maybeTool = Nothing
                 , mouseOverIndex = Nothing
                 , mouseDownIndex = Nothing
                 , hintingIndices = Nothing
-                , renderMarkdown = False
-                , sorter = Nothing
                 , overlaps = False
+                , viewSegment =
+                    viewHighlightableSegment
+                        { interactiveHighlighterId = Nothing
+                        , focusIndex = Nothing
+                        , eventListeners = []
+                        , maybeTool = Nothing
+                        , mouseOverIndex = Nothing
+                        , mouseDownIndex = Nothing
+                        , hintingIndices = Nothing
+                        , renderMarkdown = False
+                        , sorter = Nothing
+                        , overlaps = False
+                        }
+                , id = config.id
+                , highlightables = config.highlightables
+                , sorter = Nothing
                 }
-        , id = config.id
-        , highlightables = config.highlightables
-        , sorter = Nothing
-        }
+        )
 
 
 {-| Same as `static`, but will render strings like "_blah_" inside of emphasis tags.
@@ -954,64 +963,70 @@ WARNING: markdown is rendered highlightable by highlightable, so be sure to prov
 
 -}
 staticMarkdown : { config | id : String, highlightables : List (Highlightable marker) } -> Html msg
-staticMarkdown config =
-    view_
-        { showTagsInline = False
-        , maybeTool = Nothing
-        , mouseOverIndex = Nothing
-        , mouseDownIndex = Nothing
-        , hintingIndices = Nothing
-        , overlaps = False
-        , viewSegment =
-            viewHighlightableSegment
-                { interactiveHighlighterId = Nothing
-                , focusIndex = Nothing
-                , eventListeners = []
+staticMarkdown =
+    lazy
+        (\config ->
+            view_
+                { showTagsInline = False
                 , maybeTool = Nothing
                 , mouseOverIndex = Nothing
                 , mouseDownIndex = Nothing
                 , hintingIndices = Nothing
-                , renderMarkdown = True
-                , sorter = Nothing
                 , overlaps = False
+                , viewSegment =
+                    viewHighlightableSegment
+                        { interactiveHighlighterId = Nothing
+                        , focusIndex = Nothing
+                        , eventListeners = []
+                        , maybeTool = Nothing
+                        , mouseOverIndex = Nothing
+                        , mouseDownIndex = Nothing
+                        , hintingIndices = Nothing
+                        , renderMarkdown = True
+                        , sorter = Nothing
+                        , overlaps = False
+                        }
+                , id = config.id
+                , highlightables = config.highlightables
+                , sorter = Nothing
                 }
-        , id = config.id
-        , highlightables = config.highlightables
-        , sorter = Nothing
-        }
+        )
 
 
 {-| -}
 staticWithTags : { config | id : String, highlightables : List (Highlightable marker) } -> Html msg
-staticWithTags config =
-    let
-        viewStaticHighlightableWithTags : Highlightable marker -> List Css.Style -> Html msg
-        viewStaticHighlightableWithTags =
-            viewHighlightableSegment
-                { interactiveHighlighterId = Nothing
-                , focusIndex = Nothing
-                , eventListeners = []
+staticWithTags =
+    lazy
+        (\config ->
+            let
+                viewStaticHighlightableWithTags : Highlightable marker -> List Css.Style -> Html msg
+                viewStaticHighlightableWithTags =
+                    viewHighlightableSegment
+                        { interactiveHighlighterId = Nothing
+                        , focusIndex = Nothing
+                        , eventListeners = []
+                        , maybeTool = Nothing
+                        , mouseOverIndex = Nothing
+                        , mouseDownIndex = Nothing
+                        , hintingIndices = Nothing
+                        , renderMarkdown = False
+                        , sorter = Nothing
+                        , overlaps = False
+                        }
+            in
+            view_
+                { showTagsInline = True
                 , maybeTool = Nothing
                 , mouseOverIndex = Nothing
                 , mouseDownIndex = Nothing
                 , hintingIndices = Nothing
-                , renderMarkdown = False
-                , sorter = Nothing
                 , overlaps = False
+                , viewSegment = viewStaticHighlightableWithTags
+                , id = config.id
+                , highlightables = config.highlightables
+                , sorter = Nothing
                 }
-    in
-    view_
-        { showTagsInline = True
-        , maybeTool = Nothing
-        , mouseOverIndex = Nothing
-        , mouseDownIndex = Nothing
-        , hintingIndices = Nothing
-        , overlaps = False
-        , viewSegment = viewStaticHighlightableWithTags
-        , id = config.id
-        , highlightables = config.highlightables
-        , sorter = Nothing
-        }
+        )
 
 
 {-| Same as `staticWithTags`, but will render strings like "_blah_" inside of emphasis tags.
@@ -1022,35 +1037,38 @@ WARNING: markdown is rendered highlightable by highlightable, so be sure to prov
 
 -}
 staticMarkdownWithTags : { config | id : String, highlightables : List (Highlightable marker) } -> Html msg
-staticMarkdownWithTags config =
-    let
-        viewStaticHighlightableWithTags : Highlightable marker -> List Css.Style -> Html msg
-        viewStaticHighlightableWithTags =
-            viewHighlightableSegment
-                { interactiveHighlighterId = Nothing
-                , focusIndex = Nothing
-                , eventListeners = []
+staticMarkdownWithTags =
+    lazy
+        (\config ->
+            let
+                viewStaticHighlightableWithTags : Highlightable marker -> List Css.Style -> Html msg
+                viewStaticHighlightableWithTags =
+                    viewHighlightableSegment
+                        { interactiveHighlighterId = Nothing
+                        , focusIndex = Nothing
+                        , eventListeners = []
+                        , maybeTool = Nothing
+                        , mouseOverIndex = Nothing
+                        , mouseDownIndex = Nothing
+                        , hintingIndices = Nothing
+                        , renderMarkdown = True
+                        , sorter = Nothing
+                        , overlaps = False
+                        }
+            in
+            view_
+                { showTagsInline = True
                 , maybeTool = Nothing
                 , mouseOverIndex = Nothing
                 , mouseDownIndex = Nothing
                 , hintingIndices = Nothing
-                , renderMarkdown = True
-                , sorter = Nothing
                 , overlaps = False
+                , viewSegment = viewStaticHighlightableWithTags
+                , id = config.id
+                , highlightables = config.highlightables
+                , sorter = Nothing
                 }
-    in
-    view_
-        { showTagsInline = True
-        , maybeTool = Nothing
-        , mouseOverIndex = Nothing
-        , mouseDownIndex = Nothing
-        , hintingIndices = Nothing
-        , overlaps = False
-        , viewSegment = viewStaticHighlightableWithTags
-        , id = config.id
-        , highlightables = config.highlightables
-        , sorter = Nothing
-        }
+        )
 
 
 {-| Groups highlightables with the same state together.

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -57,6 +57,7 @@ import Css
 import Html.Styled as Html exposing (Attribute, Html, p, span)
 import Html.Styled.Attributes exposing (attribute, class, css)
 import Html.Styled.Events as Events
+import Html.Styled.Lazy exposing (lazy)
 import Json.Decode
 import List.Extra
 import Markdown.Block
@@ -875,19 +876,22 @@ view model =
 
 {-| -}
 viewWithOverlappingHighlights : Model marker -> Html (Msg marker)
-viewWithOverlappingHighlights model =
-    view_
-        { showTagsInline = False
-        , maybeTool = Just model.marker
-        , mouseOverIndex = model.mouseOverIndex
-        , mouseDownIndex = model.mouseDownIndex
-        , hintingIndices = model.hintingIndices
-        , overlaps = True
-        , viewSegment = viewHighlightable { renderMarkdown = False, overlaps = True } model
-        , id = model.id
-        , highlightables = model.highlightables
-        , sorter = Just model.sorter
-        }
+viewWithOverlappingHighlights =
+    lazy
+        (\model ->
+            view_
+                { showTagsInline = False
+                , maybeTool = Just model.marker
+                , mouseOverIndex = model.mouseOverIndex
+                , mouseDownIndex = model.mouseDownIndex
+                , hintingIndices = model.hintingIndices
+                , overlaps = True
+                , viewSegment = viewHighlightable { renderMarkdown = False, overlaps = True } model
+                , id = model.id
+                , highlightables = model.highlightables
+                , sorter = Just model.sorter
+                }
+        )
 
 
 {-| Same as `view`, but will render strings like "_blah_" inside of emphasis tags.

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -20,6 +20,11 @@ module Nri.Ui.Highlighter.V5 exposing
 Highlighter provides a view/model/update to display a view to highlight text and show marks.
 
 
+# Patch changes:
+
+  - Made all highlighter views lazy
+
+
 # Types
 
 @docs Model, Msg, PointerMsg


### PR DESCRIPTION
## Context

Makes `Highlighter.V5` use `Html.Styled.lazy` by default for all its views.

This is motivated by performance issues on the Guided Drafts inline comments highlighter.

Among other things, we noticed we were rendering the highlighter unnecessarily a lot. Making the page generally sluggish even on interactions that didn't touch the highlighter at all. In that page the gain also happens to make the highlighter itself way faster, because we have multiple highlighters in the page (so operating a highlighter now updates just the one you need, not all of them).

We first thought about adding `lazy` just to that use case, but figured there might be value in applying it generally. 

**_Why we would want to make this the default:_**
  - Highlighter views are pretty heavy
  - It's hard to note when things start getting slow, and then dedicate time to changing it
    - For example: the GD highlighter has been super slow for years and we just managed to focus our efforts on making it better now!
  - In practice, there shouldn't be any downsides in doing this (see note below)

**_Why we would NOT want to make this the default:_**
  - The only potential downside we (well, Micah!) could think of is that `lazy` forces elm-css to build its stylesheets and add a `<style>` tag next to the lazy node. This means that if you have N lazy highlighters you will end up with N `<style>` tags, probably with lots of duplicated classes. This is known to be slow in Chrome for large Ns (>100s), but I think it's very unlikely that we'll use the highlighter this way. If we ever do, we can always change the API to allow disabling the default lazy behavior.

**Results**

This change made the GD highlighter WAAAAY more responsive, as you can see in the videos below.

Here are profiler results for hovering out of a word, for example. Note how we went from 82ms to 5ms to render the new state:
<img width="1099" alt="Screenshot 2024-03-29 at 08 44 03" src="https://github.com/NoRedInk/noredink-ui/assets/753421/37601bf2-39d9-4cc5-b337-02c8bbe656bc">
<img width="475" alt="Screenshot 2024-03-29 at 08 44 33" src="https://github.com/NoRedInk/noredink-ui/assets/753421/b054a487-0f94-4256-9b16-ed39f49a77d4">



## :framed_picture: What does this change look like?

These videos were taken on my fast dev laptop with 4x CPU throttling, compiling elm without `--debug`.

### Before `lazy`

https://github.com/NoRedInk/noredink-ui/assets/753421/6440413d-495c-48e8-9c18-f4406ba65275



### After `lazy`

https://github.com/NoRedInk/noredink-ui/assets/753421/f71d1037-0c3a-4eeb-bd91-5fac75c43209



## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
