### PR TITLE
Bump version to 28.3.1 - Highlighter performance improvements

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "28.3.0",
+    "version": "28.3.1",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `28.3.1`

## What changes does this release include?

This is a patch release including two PRs that should dramatically improve the performance of our highlighter component (especially in the Inline Comments use case), and a refactor of Highlighter internals:
  - https://github.com/NoRedInk/noredink-ui/pull/1661
  - https://github.com/NoRedInk/noredink-ui/pull/1662
  - https://github.com/NoRedInk/noredink-ui/pull/1663

## How has the API changed?

No API changes!


## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).