### PR TITLE
[PHX-1513] Add fold functions to Highlighter on noredink-ui

### DIFF
--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -511,6 +511,7 @@ foldHighlightsSource =
     , [ "Finally", " ", "one", " ", "more" ]
     ]
 
+
 viewFoldHighlights : Highlighter.Model String -> Html (Highlighter.Msg String)
 viewFoldHighlights model =
     List.Extra.mapAccuml

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -511,17 +511,11 @@ foldHighlightsSource =
     , [ "Finally", " ", "one", " ", "more" ]
     ]
 
-
-swap : ( a, b ) -> ( b, a )
-swap ( a, b ) =
-    ( b, a )
-
-
 viewFoldHighlights : Highlighter.Model String -> Html (Highlighter.Msg String)
 viewFoldHighlights model =
     List.Extra.mapAccuml
         (\state sourceRow ->
-            List.Extra.mapAccuml (\innerState _ -> Highlighter.viewFoldHighlighter innerState [] |> swap) state sourceRow
+            List.Extra.mapAccuml (\innerState _ -> Highlighter.viewFoldHighlighter [] innerState) state sourceRow
                 |> Tuple.mapSecond (List.concat >> li [])
         )
         (Highlighter.initFoldState model)

--- a/elm.json
+++ b/elm.json
@@ -100,6 +100,7 @@
         "elm/regex": "1.0.0 <= v < 2.0.0",
         "elm/svg": "1.0.1 <= v < 2.0.0",
         "elm/time": "1.0.0 <= v < 2.0.0",
+        "elm-community/dict-extra": "2.4.0 <= v < 3.0.0",
         "elm-community/list-extra": "8.6.0 <= v < 9.0.0",
         "elm-community/maybe-extra": "5.3.0 <= v < 6.0.0",
         "elm-community/random-extra": "3.2.0 <= v < 4.0.0",

--- a/elm.json
+++ b/elm.json
@@ -100,7 +100,6 @@
         "elm/regex": "1.0.0 <= v < 2.0.0",
         "elm/svg": "1.0.1 <= v < 2.0.0",
         "elm/time": "1.0.0 <= v < 2.0.0",
-        "elm-community/dict-extra": "2.4.0 <= v < 3.0.0",
         "elm-community/list-extra": "8.6.0 <= v < 9.0.0",
         "elm-community/maybe-extra": "5.3.0 <= v < 6.0.0",
         "elm-community/random-extra": "3.2.0 <= v < 4.0.0",

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -1140,6 +1140,8 @@ findOverlapsSupport model =
         }
 
 
+{-| A type that contains information needed to render individual `Highlightable`s one at a time
+-}
 type FoldState marker
     = FoldState
         { model : Model marker
@@ -1148,6 +1150,8 @@ type FoldState marker
         }
 
 
+{-| Computes all the mark styles necessary to perform a fold over the `Highlightable` elements
+-}
 initFoldState : Model marker -> FoldState marker
 initFoldState model =
     let
@@ -1189,6 +1193,11 @@ initFoldState model =
         }
 
 
+{-| Render a single `Highlightable` while also returning an updated state.
+
+A list of extraStyles is also accepted if, for example, you want to apply bold / italic / underline formatting to the generated span.
+
+-}
 viewFoldHighlighter : FoldState marker -> List Css.Style -> ( List (Html (Msg marker)), FoldState marker )
 viewFoldHighlighter (FoldState ({ model, overlapsSupport } as foldState)) extraStyles =
     viewFoldHelper
@@ -1202,6 +1211,11 @@ viewFoldHighlighter (FoldState ({ model, overlapsSupport } as foldState)) extraS
         extraStyles
 
 
+{-| Render a single `Highlightable` that is NOT interactive while also returning an updated state.
+
+A list of extraStyles is also accepted if, for example, you want to apply bold / italic / underline formatting to the generated span.
+
+-}
 viewFoldStatic : FoldState marker -> List Css.Style -> ( List (Html msg), FoldState marker )
 viewFoldStatic =
     viewFoldHelper

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -915,30 +915,8 @@ viewWithOverlappingHighlights =
     lazy
         (\model ->
             let
-                hoveredMarkers =
-                    model.highlightables
-                        |> List.Extra.find (\h -> Just h.index == model.mouseOverIndex)
-                        |> Maybe.map (.marked >> List.map .kind)
-                        |> Maybe.withDefault []
-
                 overlaps =
-                    OverlapsSupported
-                        { hoveredMarkerWithShortestHighlight =
-                            case hoveredMarkers of
-                                [] ->
-                                    Nothing
-
-                                marker :: [] ->
-                                    Just marker
-
-                                first :: second :: rest ->
-                                    Just
-                                        (markerWithShortestHighlight
-                                            model.sorter
-                                            model.highlightables
-                                            ( first, second, rest )
-                                        )
-                        }
+                    findOverlapsSupport model
             in
             view_
                 { showTagsInline = False
@@ -1122,6 +1100,33 @@ staticMarkdownWithTags =
                 }
         )
 
+
+findOverlapsSupport : Model marker -> OverlapsSupport marker
+findOverlapsSupport model =
+    let
+        hoveredMarkers =
+            model.highlightables
+                |> List.Extra.find (\h -> Just h.index == model.mouseOverIndex)
+                |> Maybe.map (.marked >> List.map .kind)
+                |> Maybe.withDefault []
+    in
+    OverlapsSupported
+        { hoveredMarkerWithShortestHighlight =
+            case hoveredMarkers of
+                [] ->
+                    Nothing
+
+                marker :: [] ->
+                    Just marker
+
+                first :: second :: rest ->
+                    Just
+                        (markerWithShortestHighlight
+                            model.sorter
+                            model.highlightables
+                            ( first, second, rest )
+                        )
+        }
 
 {-| Groups highlightables with the same state together.
 -}

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -1181,7 +1181,7 @@ initFoldState model =
             , endStyles = marker.endGroupClass
             }
 
-        markStyles =
+        precomputedSegments =
             model.highlightables
                 |> List.map (\highlightable -> ( highlightable, List.map (toMark highlightable) highlightable.marked ))
                 |> Mark.overlappingStyles
@@ -1189,7 +1189,7 @@ initFoldState model =
     FoldState
         { model = model
         , overlapsSupport = overlapsSupport
-        , state = markStyles
+        , state = precomputedSegments
         }
 
 

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -1198,8 +1198,8 @@ initFoldState model =
 A list of extraStyles is also accepted if, for example, you want to apply bold / italic / underline formatting to the generated span.
 
 -}
-viewFoldHighlighter : FoldState marker -> List Css.Style -> ( List (Html (Msg marker)), FoldState marker )
-viewFoldHighlighter (FoldState ({ model, overlapsSupport } as foldState)) extraStyles =
+viewFoldHighlighter : List Css.Style -> FoldState marker -> ( FoldState marker, List (Html (Msg marker)) )
+viewFoldHighlighter extraStyles (FoldState ({ model, overlapsSupport } as foldState)) =
     viewFoldHelper
         (viewHighlightable
             { renderMarkdown = False
@@ -1207,8 +1207,8 @@ viewFoldHighlighter (FoldState ({ model, overlapsSupport } as foldState)) extraS
             }
             model
         )
-        (FoldState foldState)
         extraStyles
+        (FoldState foldState)
 
 
 {-| Render a single `Highlightable` that is NOT interactive while also returning an updated state.
@@ -1216,7 +1216,7 @@ viewFoldHighlighter (FoldState ({ model, overlapsSupport } as foldState)) extraS
 A list of extraStyles is also accepted if, for example, you want to apply bold / italic / underline formatting to the generated span.
 
 -}
-viewFoldStatic : FoldState marker -> List Css.Style -> ( List (Html msg), FoldState marker )
+viewFoldStatic : List Css.Style -> FoldState marker -> ( FoldState marker, List (Html msg) )
 viewFoldStatic =
     viewFoldHelper
         (viewHighlightableSegment
@@ -1234,13 +1234,13 @@ viewFoldStatic =
         )
 
 
-viewFoldHelper : (Highlightable marker -> List Css.Style -> Html msg) -> FoldState marker -> List Css.Style -> ( List (Html msg), FoldState marker )
-viewFoldHelper viewSegment (FoldState ({ state } as foldState)) extraStyles =
+viewFoldHelper : (Highlightable marker -> List Css.Style -> Html msg) -> List Css.Style -> FoldState marker -> ( FoldState marker, List (Html msg) )
+viewFoldHelper viewSegment extraStyles (FoldState ({ state } as foldState)) =
     case state of
         [] ->
             -- If we are in this position then the caller has called the step function too many times.
             -- We return empty output and the same fold state.
-            ( [], FoldState foldState )
+            ( FoldState foldState, [] )
 
         ( highlightable, maybeLabelElement, markStyles ) :: todoState ->
             let
@@ -1251,13 +1251,13 @@ viewFoldHelper viewSegment (FoldState ({ state } as foldState)) extraStyles =
             in
             case maybeLabelElement of
                 Nothing ->
-                    ( [ segmentHtml ]
-                    , FoldState { foldState | state = todoState }
+                    ( FoldState { foldState | state = todoState }
+                    , [ segmentHtml ]
                     )
 
                 Just labelElement ->
-                    ( [ Html.map never labelElement, segmentHtml ]
-                    , FoldState { foldState | state = todoState }
+                    ( FoldState { foldState | state = todoState }
+                    , [ Html.map never labelElement, segmentHtml ]
                     )
 
 

--- a/src/Nri/Ui/Mark/V6.elm
+++ b/src/Nri/Ui/Mark/V6.elm
@@ -107,7 +107,7 @@ overlappingStyles segments =
                     patchRevStyles
 
                 ( ( prevContent, prevLabel, prevStyles ) :: otherPrevStyles, _ ) ->
-                    ( prevContent, prevLabel, prevStyles ++ (tagAfterContent endedMarks :: List.concatMap .endStyles endedMarks) ) :: otherPrevStyles
+                    ( prevContent, prevLabel, prevStyles ++ (tagAfterContent endedMarks ++ List.concatMap .endStyles endedMarks) ) :: otherPrevStyles
 
         { priorMarks, revStyles } =
             List.foldl
@@ -125,12 +125,7 @@ overlappingStyles segments =
                                 |> Set.toList
 
                         startStyles =
-                            case startedMarks of
-                                [] ->
-                                    []
-
-                                _ ->
-                                    tagBeforeContent startedMarks :: List.concatMap .startStyles startedMarks
+                            tagBeforeContent startedMarks ++ List.concatMap .startStyles startedMarks
 
                         currentStyles =
                             List.concatMap .styles marks
@@ -233,7 +228,7 @@ markedWithBalloonStyles marked lastIndex index =
         [ if index == 0 then
             -- if we're on the first highlighted element, we add
             -- a `before` content saying what kind of highlight we're starting
-            tagBeforeContent [ marked ] :: marked.startStyles
+            tagBeforeContent [ marked ] ++ marked.startStyles
 
           else
             []
@@ -392,7 +387,7 @@ markStyles tagStyle index marked =
             -- if we're on the first highlighted element, we add
             -- a `before` content saying what kind of highlight we're starting
             tagBeforeContent [ markedWith ]
-                :: markedWith.styles
+                ++ markedWith.styles
                 ++ -- if we're on the first element, and the mark has a name,
                    -- there's an inline tag that we might need to show.
                    -- if we're not showing a visual tag, we can attach the start styles to the first segment
@@ -426,28 +421,30 @@ markStyles tagStyle index marked =
                 |> Maybe.withDefault []
 
 
-tagBeforeContent : List Mark -> Css.Style
+tagBeforeContent : List Mark -> List Css.Style
 tagBeforeContent marks =
     if List.isEmpty marks then
-        Css.batch []
+        []
 
     else
-        Css.before
+        [ Css.before
             [ cssContent (highlightDescription "start" marks)
             , invisibleStyle
             ]
+        ]
 
 
-tagAfterContent : List Mark -> Css.Style
+tagAfterContent : List Mark -> List Css.Style
 tagAfterContent marks =
     if List.isEmpty marks then
-        Css.batch []
+        []
 
     else
-        Css.after
+        [ Css.after
             [ cssContent (highlightDescription "end" marks)
             , invisibleStyle
             ]
+        ]
 
 
 highlightDescription : String -> List Mark -> String

--- a/src/Nri/Ui/Mark/V6.elm
+++ b/src/Nri/Ui/Mark/V6.elm
@@ -11,6 +11,11 @@ module Nri.Ui.Mark.V6 exposing
 
     -  Add `skipTagAnimation` for skipping balloon animations
 
+
+### Patch changes
+
+    - Factor `overlappingStyles` out of `viewWithOverlaps` to allow consumers finer grained control of rendering mark elements.
+
 @docs Mark
 @docs view, viewWithInlineTags, viewWithBalloonTags
 @docs viewWithOverlaps, overlappingStyles
@@ -81,6 +86,13 @@ viewWithOverlaps viewSegment segments =
             )
 
 
+{-| Compute the styles required to mark the segments.
+
+You can use this if you require more control over the structure of how marked elements are laid out than `viewWithOverlaps` provides.
+
+The `Maybe (Html msg)` result is a label element that should be rendered before the current segment.
+
+-}
 overlappingStyles : List ( content, List Mark ) -> List ( content, Maybe (Html msg), List Style )
 overlappingStyles segments =
     let

--- a/src/Nri/Ui/Mark/V6.elm
+++ b/src/Nri/Ui/Mark/V6.elm
@@ -111,10 +111,10 @@ overlappingStyles segments =
 
         { priorMarks, revStyles } =
             List.foldl
-                (\( content, marks ) state ->
+                (\( segmentContent, segmentMarks ) state ->
                     let
                         currentMarks =
-                            Set.fromList markSorter marks
+                            Set.fromList markSorter segmentMarks
 
                         startedMarks =
                             Set.dropIf (Set.memberOf state.priorMarks) currentMarks
@@ -128,7 +128,7 @@ overlappingStyles segments =
                             tagBeforeContent startedMarks ++ List.concatMap .startStyles startedMarks
 
                         currentStyles =
-                            List.concatMap .styles marks
+                            List.concatMap .styles segmentMarks
 
                         ( maybeStartLabels, styles ) =
                             case List.filterMap .name startedMarks of
@@ -151,7 +151,7 @@ overlappingStyles segments =
                                     , currentStyles
                                     )
                     in
-                    { priorMarks = currentMarks, revStyles = ( content, maybeStartLabels, styles ) :: updateEndRevStyles state.revStyles endedMarks }
+                    { priorMarks = currentMarks, revStyles = ( segmentContent, maybeStartLabels, styles ) :: updateEndRevStyles state.revStyles endedMarks }
                 )
                 { priorMarks = Set.empty markSorter, revStyles = [] }
                 segments

--- a/src/Nri/Ui/Mark/V6.elm
+++ b/src/Nri/Ui/Mark/V6.elm
@@ -24,8 +24,6 @@ import Content
 import Css exposing (Color, Style)
 import Css.Global
 import Css.Media
-import Dict
-import Dict.Extra
 import Html.Styled as Html exposing (Html, span)
 import Html.Styled.Attributes exposing (class, css)
 import Markdown.Block
@@ -38,7 +36,7 @@ import Nri.Ui.Html.Attributes.V2 as AttributesExtra
 import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Sort exposing (Sorter)
-import Sort.Set as Set exposing (Set)
+import Sort.Set as Set
 import String.Extra
 
 

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -4,6 +4,7 @@ import Accessibility.Aria as Aria
 import Accessibility.Key as Key
 import Expect exposing (Expectation)
 import Html.Styled exposing (Html, toUnstyled)
+import Html.Styled.Attributes
 import List.Extra
 import Nri.Test.KeyboardHelpers.V1 as KeyboardHelpers
 import Nri.Test.MouseHelpers.V1 as MouseHelpers
@@ -426,6 +427,8 @@ markdownHighlightNameTests =
     , testIt "staticWithTags" Highlighter.staticWithTags
     , testIt "staticMarkdownWithTags" Highlighter.staticMarkdownWithTags
     , testIt "viewWithOverlappingHighlights" Highlighter.viewWithOverlappingHighlights
+    , testIt "viewFoldHighlight" renderWithFoldHighlight
+    , testIt "viewFoldStatic" renderWithFoldStatic
     ]
 
 
@@ -726,6 +729,40 @@ joinAdjacentInteractiveHighlightsTests =
     ]
 
 
+renderWithFoldHighlight : Highlighter.Model marker -> Html (Highlighter.Msg marker)
+renderWithFoldHighlight model =
+    List.Extra.mapAccuml
+        (\state _ ->
+            let
+                ( output, newState ) =
+                    Highlighter.viewFoldHighlighter state []
+            in
+            ( newState, output )
+        )
+        (Highlighter.initFoldState model)
+        model.highlightables
+        |> Tuple.second
+        |> List.concat
+        |> Html.Styled.p [ Html.Styled.Attributes.id "test-id", Html.Styled.Attributes.class "highlighter-container" ]
+
+
+renderWithFoldStatic : Highlighter.Model marker -> Html (Highlighter.Msg marker)
+renderWithFoldStatic model =
+    List.Extra.mapAccuml
+        (\state _ ->
+            let
+                ( output, newState ) =
+                    Highlighter.viewFoldStatic state []
+            in
+            ( newState, output )
+        )
+        (Highlighter.initFoldState model)
+        model.highlightables
+        |> Tuple.second
+        |> List.concat
+        |> Html.Styled.p [ Html.Styled.Attributes.id "test-id", Html.Styled.Attributes.class "highlighter-container" ]
+
+
 overlappingHighlightTests : List Test
 overlappingHighlightTests =
     let
@@ -825,4 +862,6 @@ overlappingHighlightTests =
             ]
     in
     [ describe "viewWithOverlappingHighlights" (staticAssertions Highlighter.viewWithOverlappingHighlights)
+    , describe "viewFoldHighlight" (staticAssertions renderWithFoldHighlight)
+    , describe "viewFoldStatic" (staticAssertions renderWithFoldStatic)
     ]

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -732,13 +732,7 @@ joinAdjacentInteractiveHighlightsTests =
 renderWithFoldHighlight : Highlighter.Model marker -> Html (Highlighter.Msg marker)
 renderWithFoldHighlight model =
     List.Extra.mapAccuml
-        (\state _ ->
-            let
-                ( output, newState ) =
-                    Highlighter.viewFoldHighlighter state []
-            in
-            ( newState, output )
-        )
+        (\state _ -> Highlighter.viewFoldHighlighter [] state)
         (Highlighter.initFoldState model)
         model.highlightables
         |> Tuple.second
@@ -749,13 +743,7 @@ renderWithFoldHighlight model =
 renderWithFoldStatic : Highlighter.Model marker -> Html (Highlighter.Msg marker)
 renderWithFoldStatic model =
     List.Extra.mapAccuml
-        (\state _ ->
-            let
-                ( output, newState ) =
-                    Highlighter.viewFoldStatic state []
-            in
-            ( newState, output )
-        )
+        (\state _ -> Highlighter.viewFoldStatic [] state)
         (Highlighter.initFoldState model)
         model.highlightables
         |> Tuple.second

--- a/tests/Spec/Nri/Ui/Mark.elm
+++ b/tests/Spec/Nri/Ui/Mark.elm
@@ -107,8 +107,12 @@ tagAfterContent marks =
         ]
 
 
-{-| Mark.overlappingStyles gives us a (Maybe (Html msg)) for the label outputs,
-but we can't test equality on HTML elements very well so we need to drop it.
+{-| Mark.overlappingStyles gives us an optional `Maybe (Html msg)` element for the start of
+marks that have names. We can't test equality on HTML elements reliably so we drop it.
+
+Note that start styles are applied **directly on** this element if it exists, so we see start
+styles drop out of the tested output - which can be a bit confusing.
+
 -}
 testOverlappingStyles : List ( content, List Mark.Mark ) -> List ( content, List Css.Style )
 testOverlappingStyles inputs =

--- a/tests/Spec/Nri/Ui/Mark.elm
+++ b/tests/Spec/Nri/Ui/Mark.elm
@@ -1,0 +1,25 @@
+module Spec.Nri.Ui.Mark exposing (..)
+
+import Expect
+import Nri.Ui.Mark.V6 as Mark
+import Test exposing (..)
+
+
+tests : Test
+tests =
+    describe "Nri.Ui.Mark"
+        [ describe "overlappingStyles"
+            [ test "with no marks" <|
+                \_ ->
+                    [ ( 1, [] )
+                    , ( 2, [] )
+                    , ( 3, [] )
+                    ]
+                        |> Mark.overlappingStyles
+                        |> Expect.equalLists
+                            [ ( 1, Nothing, [] )
+                            , ( 2, Nothing, [] )
+                            , ( 3, Nothing, [] )
+                            ]
+            ]
+        ]

--- a/tests/Spec/Nri/Ui/Mark.elm
+++ b/tests/Spec/Nri/Ui/Mark.elm
@@ -1,9 +1,87 @@
 module Spec.Nri.Ui.Mark exposing (..)
 
+import Accessibility.Styled.Aria as Aria
+import Content
 import Css
 import Expect
+import Html.Styled as Html exposing (Html, span)
+import Html.Styled.Attributes exposing (class, css)
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Mark.V6 as Mark
+import Nri.Ui.MediaQuery.V1 as MediaQuery
+import String.Extra
 import Test exposing (..)
+
+
+startStyles : List Css.Style
+startStyles =
+    [ Css.color (Css.hex "000000") ]
+
+
+markStyles : List Css.Style
+markStyles =
+    [ Css.fontWeight Css.bold ]
+
+
+endStyles : List Css.Style
+endStyles =
+    [ Css.position Css.absolute ]
+
+
+start2Styles : List Css.Style
+start2Styles =
+    [ Css.color (Css.hex "222222") ]
+
+
+mark2Styles : List Css.Style
+mark2Styles =
+    [ Css.fontWeight Css.bolder ]
+
+
+end2Styles : List Css.Style
+end2Styles =
+    [ Css.position Css.fixed ]
+
+
+{-| Cloned from Mark.V6 for testing
+-}
+viewLabels : List String -> List Css.Style -> Html msg
+viewLabels names startStyles_ =
+    span [ css startStyles_ ]
+        [ span
+            [ css
+                [ Fonts.baseFont
+                , Css.backgroundColor Colors.white
+                , Css.color Colors.navy
+                , Css.padding2 (Css.px 2) (Css.px 4)
+                , Css.borderRadius (Css.px 3)
+                , Css.margin2 Css.zero (Css.px 5)
+                , Css.boxShadow5 Css.zero (Css.px 1) (Css.px 1) Css.zero Colors.gray75
+                , Css.batch
+                    [ Css.display Css.none
+                    , MediaQuery.highContrastMode
+                        [ Css.property "forced-color-adjust" "none"
+                        , Css.display Css.inline |> Css.important
+                        , Css.property "color" "initial" |> Css.important
+                        ]
+                    ]
+                ]
+            , -- we use the :before element to convey details about the start of the
+              -- highlighter to screenreaders, so the visual label is redundant
+              Aria.hidden True
+            ]
+            (Content.markdownInline (String.Extra.toSentenceOxford names))
+        ]
+
+
+{-| Mark.overlappingStyles gives us a (Maybe (Html msg)) for the label outputs,
+but we can't test equality on HTML elements very well so we need to drop it.
+-}
+testOverlappingStyles : List ( content, List Mark.Mark ) -> List ( content, List Css.Style )
+testOverlappingStyles inputs =
+    Mark.overlappingStyles inputs
+        |> List.map (\( content, _, styles_ ) -> ( content, styles_ ))
 
 
 tests : Test
@@ -16,57 +94,38 @@ tests =
                     , ( 2, [] )
                     , ( 3, [] )
                     ]
-                        |> Mark.overlappingStyles
+                        |> testOverlappingStyles
                         |> Expect.equalLists
-                            [ ( 1, Nothing, [] )
-                            , ( 2, Nothing, [] )
-                            , ( 3, Nothing, [] )
+                            [ ( 1, [] )
+                            , ( 2, [] )
+                            , ( 3, [] )
                             ]
             , test "mark on single segment" <|
                 \_ ->
-                    let
-                        startStyles =
-                            [ Css.color (Css.hex "000000") ]
-
-                        styles =
-                            [ Css.fontWeight Css.bold ]
-
-                        endStyles =
-                            [ Css.position Css.absolute ]
-                    in
                     [ ( 1, [] )
                     , ( 2
                       , [ { name = Nothing
                           , startStyles = startStyles
-                          , styles = styles
+                          , styles = markStyles
                           , endStyles = endStyles
                           }
                         ]
                       )
                     , ( 3, [] )
                     ]
-                        |> Mark.overlappingStyles
+                        |> testOverlappingStyles
                         |> Expect.equalLists
-                            [ ( 1, Nothing, [] )
-                            , ( 2, Nothing, startStyles ++ styles ++ endStyles )
-                            , ( 3, Nothing, [] )
+                            [ ( 1, [] )
+                            , ( 2, startStyles ++ markStyles ++ endStyles )
+                            , ( 3, [] )
                             ]
             , test "mark spanning multiple segments" <|
                 \_ ->
                     let
-                        startStyles =
-                            [ Css.color (Css.hex "000000") ]
-
-                        styles =
-                            [ Css.fontWeight Css.bold ]
-
-                        endStyles =
-                            [ Css.position Css.absolute ]
-
                         mark =
                             { name = Nothing
                             , startStyles = startStyles
-                            , styles = styles
+                            , styles = markStyles
                             , endStyles = endStyles
                             }
                     in
@@ -75,12 +134,170 @@ tests =
                     , ( 3, [ mark ] )
                     , ( 4, [] )
                     ]
-                        |> Mark.overlappingStyles
+                        |> testOverlappingStyles
                         |> Expect.equalLists
-                            [ ( 1, Nothing, [] )
-                            , ( 2, Nothing, startStyles ++ styles )
-                            , ( 3, Nothing, styles ++ endStyles )
-                            , ( 4, Nothing, [] )
+                            [ ( 1, [] )
+                            , ( 2, startStyles ++ markStyles )
+                            , ( 3, markStyles ++ endStyles )
+                            , ( 4, [] )
+                            ]
+            , test "named mark one segment" <|
+                \_ ->
+                    let
+                        mark =
+                            { name = Just "mark"
+                            , startStyles = startStyles
+                            , styles = markStyles
+                            , endStyles = endStyles
+                            }
+                    in
+                    [ ( 1, [] )
+                    , ( 2, [ mark ] )
+                    , ( 3, [] )
+                    ]
+                        |> testOverlappingStyles
+                        |> Expect.equalLists
+                            [ ( 1, [] )
+                            , ( 2, markStyles ++ endStyles )
+                            , ( 3, [] )
+                            ]
+            , test "named mark two segments" <|
+                \_ ->
+                    let
+                        mark =
+                            { name = Just "mark"
+                            , startStyles = startStyles
+                            , styles = markStyles
+                            , endStyles = endStyles
+                            }
+                    in
+                    [ ( 1, [] )
+                    , ( 2, [ mark ] )
+                    , ( 3, [ mark ] )
+                    , ( 4, [] )
+                    ]
+                        |> testOverlappingStyles
+                        |> Expect.equalLists
+                            [ ( 1, [] )
+                            , ( 2, markStyles )
+                            , ( 3, markStyles ++ endStyles )
+                            , ( 4, [] )
+                            ]
+            , test "two marks" <|
+                \_ ->
+                    let
+                        mark1 =
+                            { name = Just "mark1"
+                            , startStyles = startStyles
+                            , styles = markStyles
+                            , endStyles = endStyles
+                            }
+
+                        mark2 =
+                            { name = Just "mark2"
+                            , startStyles = start2Styles
+                            , styles = mark2Styles
+                            , endStyles = end2Styles
+                            }
+                    in
+                    [ ( 1, [] )
+                    , ( 2, [ mark1 ] )
+                    , ( 3, [ mark2 ] )
+                    , ( 4, [] )
+                    ]
+                        |> testOverlappingStyles
+                        |> Expect.equalLists
+                            [ ( 1, [] )
+                            , ( 2, markStyles ++ endStyles )
+                            , ( 3, mark2Styles ++ end2Styles )
+                            , ( 4, [] )
+                            ]
+            , test "two marks full overlap" <|
+                \_ ->
+                    let
+                        mark1 =
+                            { name = Just "mark1"
+                            , startStyles = startStyles
+                            , styles = markStyles
+                            , endStyles = endStyles
+                            }
+
+                        mark2 =
+                            { name = Just "mark2"
+                            , startStyles = start2Styles
+                            , styles = mark2Styles
+                            , endStyles = end2Styles
+                            }
+                    in
+                    [ ( 1, [] )
+                    , ( 2, [ mark1, mark2 ] )
+                    , ( 3, [] )
+                    ]
+                        |> testOverlappingStyles
+                        |> Expect.equalLists
+                            [ ( 1, [] )
+                            , ( 2, markStyles ++ mark2Styles ++ end2Styles ++ endStyles )
+                            , ( 3, [] )
+                            ]
+            , test "two marks partial overlap" <|
+                \_ ->
+                    let
+                        mark1 =
+                            { name = Just "mark1"
+                            , startStyles = startStyles
+                            , styles = markStyles
+                            , endStyles = endStyles
+                            }
+
+                        mark2 =
+                            { name = Just "mark2"
+                            , startStyles = start2Styles
+                            , styles = mark2Styles
+                            , endStyles = end2Styles
+                            }
+                    in
+                    [ ( 1, [] )
+                    , ( 2, [ mark1, mark2 ] )
+                    , ( 3, [ mark2 ] )
+                    , ( 4, [] )
+                    ]
+                        |> testOverlappingStyles
+                        |> Expect.equalLists
+                            [ ( 1, [] )
+                            , ( 2, markStyles ++ mark2Styles ++ endStyles )
+                            , ( 3, mark2Styles ++ end2Styles )
+                            , ( 4, [] )
+                            ]
+            , test "two marks containment" <|
+                \_ ->
+                    let
+                        mark1 =
+                            { name = Just "mark1"
+                            , startStyles = startStyles
+                            , styles = markStyles
+                            , endStyles = endStyles
+                            }
+
+                        mark2 =
+                            { name = Just "mark2"
+                            , startStyles = start2Styles
+                            , styles = mark2Styles
+                            , endStyles = end2Styles
+                            }
+                    in
+                    [ ( 1, [] )
+                    , ( 2, [ mark1 ] )
+                    , ( 3, [ mark1, mark2 ] )
+                    , ( 4, [ mark1 ] )
+                    , ( 5, [] )
+                    ]
+                        |> testOverlappingStyles
+                        |> Expect.equalLists
+                            [ ( 1, [] )
+                            , ( 2, markStyles )
+                            , ( 3, markStyles ++ mark2Styles ++ end2Styles )
+                            , ( 4, markStyles ++ endStyles )
+                            , ( 5, [] )
                             ]
             ]
         ]

--- a/tests/Spec/Nri/Ui/Mark.elm
+++ b/tests/Spec/Nri/Ui/Mark.elm
@@ -1,5 +1,6 @@
 module Spec.Nri.Ui.Mark exposing (..)
 
+import Css
 import Expect
 import Nri.Ui.Mark.V6 as Mark
 import Test exposing (..)
@@ -20,6 +21,66 @@ tests =
                             [ ( 1, Nothing, [] )
                             , ( 2, Nothing, [] )
                             , ( 3, Nothing, [] )
+                            ]
+            , test "mark on single segment" <|
+                \_ ->
+                    let
+                        startStyles =
+                            [ Css.color (Css.hex "000000") ]
+
+                        styles =
+                            [ Css.fontWeight Css.bold ]
+
+                        endStyles =
+                            [ Css.position Css.absolute ]
+                    in
+                    [ ( 1, [] )
+                    , ( 2
+                      , [ { name = Nothing
+                          , startStyles = startStyles
+                          , styles = styles
+                          , endStyles = endStyles
+                          }
+                        ]
+                      )
+                    , ( 3, [] )
+                    ]
+                        |> Mark.overlappingStyles
+                        |> Expect.equalLists
+                            [ ( 1, Nothing, [] )
+                            , ( 2, Nothing, startStyles ++ styles ++ endStyles )
+                            , ( 3, Nothing, [] )
+                            ]
+            , test "mark spanning multiple segments" <|
+                \_ ->
+                    let
+                        startStyles =
+                            [ Css.color (Css.hex "000000") ]
+
+                        styles =
+                            [ Css.fontWeight Css.bold ]
+
+                        endStyles =
+                            [ Css.position Css.absolute ]
+
+                        mark =
+                            { name = Nothing
+                            , startStyles = startStyles
+                            , styles = styles
+                            , endStyles = endStyles
+                            }
+                    in
+                    [ ( 1, [] )
+                    , ( 2, [ mark ] )
+                    , ( 3, [ mark ] )
+                    , ( 4, [] )
+                    ]
+                        |> Mark.overlappingStyles
+                        |> Expect.equalLists
+                            [ ( 1, Nothing, [] )
+                            , ( 2, Nothing, startStyles ++ styles )
+                            , ( 3, Nothing, styles ++ endStyles )
+                            , ( 4, Nothing, [] )
                             ]
             ]
         ]

--- a/tests/Spec/Nri/Ui/Mark.elm
+++ b/tests/Spec/Nri/Ui/Mark.elm
@@ -1,18 +1,11 @@
 module Spec.Nri.Ui.Mark exposing (..)
 
-import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Style exposing (invisibleStyle)
-import Content
 import Css
 import Expect
-import Html.Styled as Html exposing (Html, span)
-import Html.Styled.Attributes exposing (class, css)
 import Markdown.Block
 import Markdown.Inline
-import Nri.Ui.Colors.V1 as Colors
-import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Mark.V6 as Mark
-import Nri.Ui.MediaQuery.V1 as MediaQuery
 import String.Extra
 import Test exposing (..)
 


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

We have for a long time dreamed of a version of highlighter on the writing team that would allow us to highlight rich text documents with formatting, lists, etc...  The best we could do was some awful hacks to approximate a list like structure which are very broken and most definitely bad for a11y. 

This PR carves a new way forward.  Instead of having a list of `Highlightable` elements that we pass off to the Highlighter library to render into a single `<p>` tag, we now have the control to render the `Highlightable`s one by one if we wish.  This gives the consumer of the Highlighter library the power to render HTML structure on their own and call out to Highlighter only to render individual segments.  

Fixes PHX-1513

I implemented a spike in the following PR to show that an approach where the consumer of the Highlightable library has more power over the rendering of the content.

- https://github.com/NoRedInk/NoRedInk/pull/47982

## :framed_picture: What does this change look like?

No direct changes to view from this.  The video presented [on this PR](https://github.com/NoRedInk/NoRedInk/pull/47982) is a good indication for how we plan to use the new functions in team Phoenix. 

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
