### PR TITLE
passed in customAttributes to fix navigation with keyboard

### DIFF
--- a/src/Nri/Ui/SegmentedControl/V14.elm
+++ b/src/Nri/Ui/SegmentedControl/V14.elm
@@ -110,6 +110,7 @@ viewRadioGroup config =
                                         "false"
                                     )
                                 :: Style.invisible
+                                ++ option.attributes
                             )
                         , div [] [ viewIcon option.icon, option.label ]
                         ]


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

During a pairing session with @charbelrami we noticed that we were not able to keyboard navigate to a radio Segmented control inside of a Menu dropdown.
This happened because we were not passing the custom attributes to each radio.

PR fixes that!
## :framed_picture: What does this change look like?
No changes, we can navigate to the segmented control `viewRadioGroup` with the keyboard.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
