### PR TITLE
add id to question box action

### DIFF
--- a/component-catalog/src/Examples/QuestionBox.elm
+++ b/component-catalog/src/Examples/QuestionBox.elm
@@ -24,7 +24,7 @@ import Nri.Ui.CharacterIcon.V2 as CharacterIcon
 import Nri.Ui.ClickableSvg.V2 as ClickableSvg
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
-import Nri.Ui.QuestionBox.V6 as QuestionBox
+import Nri.Ui.QuestionBox.V7 as QuestionBox
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Table.V7 as Table
@@ -162,9 +162,9 @@ view ellieLinkConfig state =
                 tableExample
                     [ QuestionBox.markdown "**Adjectives describe nouns.** <br/><br/>Which word describes the noun **lollipop**?"
                     , QuestionBox.actions
-                        [ { label = "won", theme = Button.secondary, onClick = NoOp }
-                        , { label = "huge", theme = Button.secondary, onClick = NoOp }
-                        , { label = "T’Challa", theme = Button.secondary, onClick = NoOp }
+                        [ { label = "won", theme = Button.secondary, onClick = NoOp, id = Nothing }
+                        , { label = "huge", theme = Button.secondary, onClick = NoOp, id = Nothing }
+                        , { label = "T’Challa", theme = Button.secondary, onClick = NoOp, id = Nothing }
                         ]
                     ]
           , pattern =
@@ -185,7 +185,7 @@ view ellieLinkConfig state =
                     [ QuestionBox.markdown "**That's right!** 🎉 <br/><br/> **Scary** tells us **what kind** of painting. <br/> That means **scary** is an **adjective**."
                     , QuestionBox.correct
                     , QuestionBox.actions
-                        [ { label = "try this question again", theme = Button.primary, onClick = NoOp }
+                        [ { label = "try this question again", theme = Button.primary, onClick = NoOp, id = Nothing }
                         ]
                     ]
           , pattern =
@@ -205,7 +205,7 @@ view ellieLinkConfig state =
                     [ QuestionBox.markdown "**Not quite.** <br/><br /> **Past** doesn't tell us **what kind** of painting it is. <br/><br/> Look for word like these: \n- funny \n- pretty"
                     , QuestionBox.incorrect
                     , QuestionBox.actions
-                        [ { label = "Try again", theme = Button.secondary, onClick = NoOp }
+                        [ { label = "Try again", theme = Button.secondary, onClick = NoOp, id = Nothing }
                         ]
                     ]
           , pattern =
@@ -238,8 +238,8 @@ view ellieLinkConfig state =
                     , QuestionBox.incorrect
                     , QuestionBox.actionsHorizontal
                     , QuestionBox.actions
-                        [ { label = "Next question", theme = Button.primary, onClick = NoOp }
-                        , { label = "Review tutorial", theme = Button.secondary, onClick = NoOp }
+                        [ { label = "Next question", theme = Button.primary, onClick = NoOp, id = Nothing }
+                        , { label = "Review tutorial", theme = Button.secondary, onClick = NoOp, id = Nothing }
                         ]
                     ]
           , pattern =
@@ -445,6 +445,7 @@ initAttributes =
                                                         else
                                                             Button.secondary
                                                   , onClick = NoOp
+                                                  , id = Nothing
                                                   }
                                                 )
                                             )

--- a/component-catalog/src/Examples/QuestionBox.elm
+++ b/component-catalog/src/Examples/QuestionBox.elm
@@ -271,12 +271,12 @@ tableExampleCode questionBoxAttributes =
 
 primaryButtonCode : String -> String
 primaryButtonCode label =
-    Code.recordMultiline [ ( "label", Code.string label ), ( "theme", Code.fromModule "Button" "primary" ), ( "onClick", "NoOp" ) ] 3
+    Code.recordMultiline [ ( "label", Code.string label ), ( "theme", Code.fromModule "Button" "primary" ), ( "onClick", "NoOp" ), ( "id", "Nothing" ) ] 3
 
 
 secondaryButtonCode : String -> String
 secondaryButtonCode label =
-    Code.recordMultiline [ ( "label", Code.string label ), ( "theme", Code.fromModule "Button" "secondary" ), ( "onClick", "NoOp" ) ] 3
+    Code.recordMultiline [ ( "label", Code.string label ), ( "theme", Code.fromModule "Button" "secondary" ), ( "onClick", "NoOp" ), ( "id", "Nothing" ) ] 3
 
 
 leftActionIconsCode : List ( String, String ) -> String
@@ -436,6 +436,7 @@ initAttributes =
                                                             Code.fromModule "Button" "secondary"
                                                       )
                                                     , ( "onClick", "NoOp" )
+                                                    , ( "id", "Nothing" )
                                                     ]
                                                 , { label = "Button " ++ String.fromInt i_
                                                   , theme =

--- a/elm.json
+++ b/elm.json
@@ -64,6 +64,7 @@
         "Nri.Ui.Pennant.V3",
         "Nri.Ui.PremiumCheckbox.V8",
         "Nri.Ui.QuestionBox.V6",
+        "Nri.Ui.QuestionBox.V7",
         "Nri.Ui.RadioButton.V4",
         "Nri.Ui.RadioButtonDotless.V1",
         "Nri.Ui.RingGauge.V1",

--- a/src/Nri/Ui/QuestionBox/V7.elm
+++ b/src/Nri/Ui/QuestionBox/V7.elm
@@ -1,0 +1,535 @@
+module Nri.Ui.QuestionBox.V7 exposing
+    ( view, Attribute
+    , id, markdown, html
+    , character, characterPosition
+    , actions, actionsVertical, actionsHorizontal
+    , neutral, correct, incorrect, tip
+    , containerCss
+    , leftActions
+    , guidanceId
+    )
+
+{-| Patch Changes
+
+  - Background color in Tip theme changed from white to sunshine yellow
+  - added html function
+  - Increase `minHeight` for tip question box so character fits
+
+Changes from V5:
+
+  - ???
+
+@docs view, Attribute
+
+@docs id, markdown, html
+@docs character, characterPosition
+@docs actions, actionsVertical, actionsHorizontal
+@docs neutral, correct, incorrect, tip
+@docs containerCss
+@docs leftActions
+
+@docs guidanceId
+
+-}
+
+import Content
+import Css
+import Css.Global
+import Html.Styled as Html exposing (..)
+import Html.Styled.Attributes as Attributes exposing (css)
+import Nri.Ui.Button.V10 as Button
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Html.Attributes.V2 as AttributesExtra
+import Nri.Ui.Svg.V1 as Svg exposing (Svg)
+
+
+{-| -}
+type Attribute msg
+    = Attribute (Config msg -> Config msg)
+
+
+type alias Config msg =
+    { id : Maybe String
+    , content : Maybe Content
+    , actions : List (Action msg)
+    , actionOrientation : ActionOrientation
+    , theme : QuestionBoxTheme
+    , character : Maybe { name : String, icon : Svg }
+    , containerCss : List Css.Style
+    , leftActions : Maybe (Html msg)
+    , characterPosition : Maybe CharacterPosition
+    }
+
+
+type alias CharacterPosition =
+    { width : Float
+    , height : Float
+    , top : Float
+    }
+
+
+type alias Action msg =
+    { label : String, theme : Button.Attribute msg, onClick : msg }
+
+
+type ActionOrientation
+    = Horizontal
+    | Vertical
+
+
+type QuestionBoxTheme
+    = Neutral
+    | Correct
+    | Incorrect
+    | Tip
+
+
+type Content
+    = MarkdownContent String
+    | HtmlContent (Html Never)
+
+
+defaultConfig : Config msg
+defaultConfig =
+    { id = Nothing
+    , content = Nothing
+    , actions = []
+    , actionOrientation = Vertical
+    , theme = Neutral
+    , character = Nothing
+    , containerCss = []
+    , leftActions = Nothing
+    , characterPosition = Nothing
+    }
+
+
+{-| -}
+id : String -> Attribute msg
+id id_ =
+    Attribute (\config -> { config | id = Just id_ })
+
+
+{-| Content inside the question box, just before the buttons, is rendered from markdown syntax
+-}
+markdown : String -> Attribute msg
+markdown content =
+    Attribute (\config -> { config | content = Just (MarkdownContent content) })
+
+
+{-| Content inside the question box, just before the buttons, is rendered as HTML.
+We purposely don't allow the html to be interactive.
+-}
+html : Html Never -> Attribute msg
+html content =
+    Attribute (\config -> { config | content = Just (HtmlContent content) })
+
+
+{-| -}
+actions : List (Action msg) -> Attribute msg
+actions actions_ =
+    Attribute (\config -> { config | actions = actions_ })
+
+
+{-| Arranges the buttons horizontally on the QuestionBox.
+-}
+actionsHorizontal : Attribute msg
+actionsHorizontal =
+    Attribute (\config -> { config | actionOrientation = Horizontal })
+
+
+{-| Arranges the buttons vertically on the QuestionBox. This is the default behavior.
+-}
+actionsVertical : Attribute msg
+actionsVertical =
+    Attribute (\config -> { config | actionOrientation = Vertical })
+
+
+{-| Note that the character _only_ appears when the theme is `tip`!
+-}
+character : { name : String, icon : Svg } -> Attribute msg
+character details =
+    Attribute (\config -> { config | character = Just details })
+
+
+{-| -}
+characterPosition : CharacterPosition -> Attribute msg
+characterPosition characterPosition_ =
+    Attribute (\config -> { config | characterPosition = Just characterPosition_ })
+
+
+{-| -}
+containerCss : List Css.Style -> Attribute msg
+containerCss styles =
+    Attribute (\config -> { config | containerCss = config.containerCss ++ styles })
+
+
+{-| Adds an arbitrary HTML on the left of the question box for the text to speech button
+-}
+leftActions : Html msg -> Attribute msg
+leftActions leftActions_ =
+    Attribute (\config -> { config | leftActions = Just leftActions_ })
+
+
+{-| A neutral box that should prompt the user with a question. This is the default theme.
+
+This dialog DOES NOT show the character icon (they should be showed as part of the `CharacterStage`)
+
+-}
+neutral : Attribute msg
+neutral =
+    setTheme Neutral
+
+
+{-| A box that signifies that an answer was correct.
+
+This dialog DOES NOT show the character icon (they should be showed as part of the `CharacterStage`)
+
+-}
+correct : Attribute msg
+correct =
+    setTheme Correct
+
+
+{-| A box that signifies that an answer was incorrect.
+
+This dialog DOES NOT show the character icon (they should be showed as part of the `CharacterStage`)
+
+-}
+incorrect : Attribute msg
+incorrect =
+    setTheme Incorrect
+
+
+{-| An informational box that shows the character icon.
+-}
+tip : Attribute msg
+tip =
+    setTheme Tip
+
+
+setTheme : QuestionBoxTheme -> Attribute msg
+setTheme theme =
+    Attribute (\config -> { config | theme = theme })
+
+
+{-| This helper is how we create an id for the guidance speech bubble element based on the `QuestionBox.id` value. Use this helper to manage focus.
+
+When showing multiple questions in a sequence based on the user's answer, we want to move the user's focus to the guidance so that:
+
+  - Screenreader users are alerted to a new context -- the new question!
+  - Keyboard users's focus is somewhere convenient to answer the question (but not _on_ an answer, since we don't want accidental submissions or for the user to hit enter straight and miss the guidance!)
+
+-}
+guidanceId : String -> String
+guidanceId id_ =
+    id_ ++ "__guidance-speech"
+
+
+{-|
+
+    QuestionBox.view
+        [ QuestionBox.markdown "**WOW**, great component!"
+        ]
+
+-}
+view : List (Attribute msg) -> Html msg
+view attributes =
+    let
+        config =
+            List.foldl (\(Attribute f) a -> f a) defaultConfig attributes
+    in
+    viewContainer config
+
+
+viewContainer : Config msg -> Html msg
+viewContainer config =
+    let
+        { backgroundColor, shadowColor } =
+            themeToColor config.theme
+
+        maybeCharacter =
+            case config.theme of
+                Tip ->
+                    config.character
+
+                _ ->
+                    Nothing
+    in
+    styled div
+        [ Css.backgroundColor backgroundColor
+        , case config.theme of
+            Tip ->
+                Css.batch
+                    [ Css.maxWidth (Css.px 443)
+                    , Css.borderRadius (Css.px borderRounding)
+                    , Css.border3 (Css.px 1) Css.solid Colors.gray85
+                    ]
+
+            _ ->
+                Css.batch
+                    [ Css.maxWidth (Css.px 500)
+                    , Css.borderTopLeftRadius (Css.px borderRounding)
+                    , Css.borderTopRightRadius (Css.px borderRounding)
+                    , Css.borderBottomLeftRadius (Css.px (borderRounding * 2))
+                    , Css.borderBottomRightRadius (Css.px (borderRounding * 2))
+                    , Css.borderBottom3 (Css.px 8) Css.solid shadowColor
+                    ]
+        , Css.width (Css.pct 100)
+        , Css.batch config.containerCss
+        ]
+        [ AttributesExtra.nriDescription "question-box-container"
+        , case config.id of
+            Nothing ->
+                AttributesExtra.none
+
+            Just id_ ->
+                Attributes.id id_
+        ]
+        [ styled div
+            [ Css.lineHeight (Css.num 1.4)
+            , Css.textAlign Css.left
+            , Css.position Css.relative
+            , Css.color Colors.gray20
+            , Fonts.baseFont
+            , Css.fontSize (Css.px 18)
+            , Css.displayFlex
+            , Css.property "gap" "30px"
+            , Css.flexDirection Css.column
+            , case config.theme of
+                Tip ->
+                    Css.batch
+                        [ -- Enough space that the character circle fits in the box
+                          Css.minHeight (Css.px 80)
+                        , Css.padding2 (Css.px 15) (Css.px 25)
+                        ]
+
+                _ ->
+                    Css.batch
+                        [ -- Approximately one line of text
+                          Css.minHeight (Css.px 53)
+                        , Css.borderLeft3 (Css.px 1) Css.solid Colors.gray85
+                        , Css.borderTop3 (Css.px 1) Css.solid Colors.gray85
+                        , Css.borderRight3 (Css.px 1) Css.solid Colors.gray85
+                        , Css.borderTopLeftRadius (Css.px borderRounding)
+                        , Css.borderTopRightRadius (Css.px borderRounding)
+                        , Css.padding4 (Css.px 15) (Css.px 25) (Css.px 9) (Css.px 25)
+                        , Css.marginBottom (Css.px 6)
+                        ]
+            ]
+            []
+            (List.filterMap identity
+                [ Maybe.map viewLeftActions config.leftActions
+                , Maybe.map (viewGuidance config maybeCharacter config.characterPosition) config.content
+                , viewActions config.actions config.actionOrientation
+                ]
+            )
+        ]
+
+
+viewLeftActions : Html msg -> Html msg
+viewLeftActions contents =
+    styled div
+        [ Css.display Css.inlineBlock
+        , Css.position Css.absolute
+        , Css.top (Css.px 16)
+        , Css.left (Css.px 0)
+        , Css.transform (Css.translateX (Css.pct -50))
+        ]
+        []
+        [ contents ]
+
+
+borderRounding : Float
+borderRounding =
+    8
+
+
+themeToColor : QuestionBoxTheme -> { backgroundColor : Css.Color, shadowColor : Css.Color }
+themeToColor theme =
+    case theme of
+        Neutral ->
+            { backgroundColor = Colors.cornflowerLight, shadowColor = Colors.cornflower }
+
+        Correct ->
+            { backgroundColor = Colors.greenLightest, shadowColor = Colors.green }
+
+        Incorrect ->
+            { backgroundColor = Colors.purpleLight, shadowColor = Colors.purple }
+
+        Tip ->
+            { backgroundColor = Colors.sunshine, shadowColor = Colors.white }
+
+
+viewGuidance :
+    { config | id : Maybe String }
+    -> Maybe { name : String, icon : Svg }
+    -> Maybe CharacterPosition
+    -> Content
+    -> Html msg
+viewGuidance config maybeCharacter maybeCharacterPosition content =
+    case maybeCharacter of
+        Just character_ ->
+            div
+                [ css
+                    [ Css.displayFlex
+                    , Css.flexDirection Css.rowReverse
+                    , Css.width (Css.pct 100)
+                    , Css.property "gap" "10px"
+                    , Css.alignItems Css.center
+                    , Css.justifyContent Css.spaceBetween
+                    ]
+                ]
+                -- We intentionally render the character first and use "rowReverse" so
+                -- that a11y content is presented as "Pands says ..." even
+                -- though the character is floating on the right.
+                [ viewCharacter character_ maybeCharacterPosition
+                , viewContents config content
+                ]
+
+        Nothing ->
+            viewContents config content
+
+
+viewContents : { config | id : Maybe String } -> Content -> Html msg
+viewContents config content =
+    styled div
+        [ Css.alignSelf Css.flexStart
+        , Css.width (Css.pct 100)
+        , Css.lineHeight (Css.px 28)
+        , Css.Global.children
+            [ Css.Global.p
+                [ Css.margin Css.zero
+                , Css.marginBottom (Css.px 10)
+                , Css.lastOfType [ Css.marginBottom Css.zero ]
+                ]
+            , Css.Global.ul
+                [ Css.marginTop (Css.px 5)
+                , Css.marginBottom (Css.px 10)
+                ]
+            ]
+        ]
+        [ AttributesExtra.maybe (guidanceId >> Attributes.id) config.id ]
+        (case content of
+            MarkdownContent markdown_ ->
+                Content.markdownInline markdown_
+
+            HtmlContent html_ ->
+                [ Html.map never html_ ]
+        )
+
+
+viewCharacter : { name : String, icon : Svg } -> Maybe CharacterPosition -> Html msg
+viewCharacter { name, icon } maybePosition =
+    case maybePosition of
+        Just position ->
+            div [ css [ Css.width (Css.px position.width) ] ]
+                [ div
+                    [ css
+                        [ Css.position Css.relative
+                        ]
+                    ]
+                    [ icon
+                        |> Svg.withLabel (name ++ " says, ")
+                        |> Svg.withWidth (Css.px 60)
+                        |> Svg.withCss
+                            [ Css.right (Css.px -15)
+                            , Css.top (Css.px position.top)
+                            , Css.width (Css.px position.width)
+                            , Css.height (Css.px position.height)
+                            , Css.position Css.absolute
+                            ]
+                        |> Svg.toHtml
+                    ]
+                ]
+
+        Nothing ->
+            icon
+                |> Svg.withLabel (name ++ " says, ")
+                |> Svg.withWidth (Css.px 60)
+                |> Svg.withCss
+                    [ Css.position Css.relative
+                    , Css.right (Css.px -15)
+                    ]
+                |> Svg.toHtml
+
+
+viewActions : List (Action msg) -> ActionOrientation -> Maybe (Html msg)
+viewActions actions_ actionOrientation =
+    let
+        containerStyles =
+            [ Css.margin Css.zero
+            , Css.listStyle Css.none
+            , Css.padding Css.zero
+            ]
+                ++ orientationStyles
+
+        orientationStyles =
+            case actionOrientation of
+                Horizontal ->
+                    [ Css.displayFlex
+                    , Css.property "gap" "10px"
+                    , Css.flexDirection Css.row
+                    ]
+
+                Vertical ->
+                    [ Css.displayFlex
+                    , Css.property "gap" "15px"
+                    , Css.flexDirection Css.column
+                    ]
+
+        buttonSize =
+            case ( actions_, actionOrientation ) of
+                ( _, Horizontal ) ->
+                    Button.medium
+
+                ( _ :: [], _ ) ->
+                    Button.medium
+
+                _ ->
+                    Button.small
+
+        buttonAlignment =
+            case ( actions_, actionOrientation ) of
+                ( _ :: _ :: _, Vertical ) ->
+                    -- With multiple vertically stacked buttons we want the text to be left aligned.
+                    [ Css.justifyContent Css.flexStart ]
+
+                _ ->
+                    []
+    in
+    case actions_ of
+        [] ->
+            Nothing
+
+        { label, theme, onClick } :: [] ->
+            div [ css (Css.alignItems Css.center :: containerStyles) ]
+                [ Button.button label
+                    [ Button.onClick onClick
+                    , Button.fillContainerWidth
+                    , buttonSize
+                    , Button.css buttonAlignment
+                    , theme
+                    ]
+                ]
+                |> Just
+
+        _ ->
+            ul [ css containerStyles ]
+                (List.map
+                    (\{ label, theme, onClick } ->
+                        li
+                            [ css [ Css.flexGrow (Css.num 1) ]
+                            ]
+                            [ Button.button label
+                                [ Button.onClick onClick
+                                , Button.fillContainerWidth
+                                , buttonSize
+                                , Button.css buttonAlignment
+                                , theme
+                                ]
+                            ]
+                    )
+                    actions_
+                )
+                |> Just

--- a/src/Nri/Ui/QuestionBox/V7.elm
+++ b/src/Nri/Ui/QuestionBox/V7.elm
@@ -537,4 +537,3 @@ viewActions actions_ actionOrientation =
                     actions_
                 )
                 |> Just
-

--- a/src/Nri/Ui/QuestionBox/V7.elm
+++ b/src/Nri/Ui/QuestionBox/V7.elm
@@ -9,15 +9,9 @@ module Nri.Ui.QuestionBox.V7 exposing
     , guidanceId
     )
 
-{-| Patch Changes
+{-| Changes from V6:
 
-  - Background color in Tip theme changed from white to sunshine yellow
-  - added html function
-  - Increase `minHeight` for tip question box so character fits
-
-Changes from V5:
-
-  - ???
+  - add an optional id to action
 
 @docs view, Attribute
 
@@ -37,6 +31,7 @@ import Css
 import Css.Global
 import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes as Attributes exposing (css)
+import Maybe.Extra
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
@@ -70,7 +65,11 @@ type alias CharacterPosition =
 
 
 type alias Action msg =
-    { label : String, theme : Button.Attribute msg, onClick : msg }
+    { label : String
+    , theme : Button.Attribute msg
+    , onClick : msg
+    , id : Maybe String
+    }
 
 
 type ActionOrientation
@@ -502,15 +501,20 @@ viewActions actions_ actionOrientation =
         [] ->
             Nothing
 
-        { label, theme, onClick } :: [] ->
+        ({ label, theme, onClick } as action) :: [] ->
             div [ css (Css.alignItems Css.center :: containerStyles) ]
                 [ Button.button label
-                    [ Button.onClick onClick
-                    , Button.fillContainerWidth
-                    , buttonSize
-                    , Button.css buttonAlignment
-                    , theme
-                    ]
+                    ((action.id
+                        |> Maybe.map Button.id
+                        |> Maybe.Extra.toList
+                     )
+                        ++ [ Button.onClick onClick
+                           , Button.fillContainerWidth
+                           , buttonSize
+                           , Button.css buttonAlignment
+                           , theme
+                           ]
+                    )
                 ]
                 |> Just
 
@@ -533,3 +537,4 @@ viewActions actions_ actionOrientation =
                     actions_
                 )
                 |> Just
+


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

[Quo-683](https://linear.app/noredink/issue/QUO-683/focus-the-modal-button-rather-than-text-after-keyboard-navigating ) we need to focus on the question box button, instead of the outer container
## :framed_picture: What does this change look like?
No visual changes

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - Quo-683
- [x] Please assign the following reviewers:
  - [x] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
