### PR TITLE
Add tabs label override

### DIFF
--- a/component-catalog/src/Examples/Tabs.elm
+++ b/component-catalog/src/Examples/Tabs.elm
@@ -255,6 +255,9 @@ buildTab config id =
 
         labelledById =
             idString ++ "-label"
+
+        fixedLabelOverride =
+            tabName ++ " custom label"
     in
     ( String.join ""
         [ "Tabs.build { id = " ++ String.fromInt id ++ ", idString = " ++ Code.string tabIdString ++ " }"
@@ -280,7 +283,7 @@ buildTab config id =
                 "\n\t    , Tabs.labelledBy " ++ Code.string labelledById
 
             FixedLabel ->
-                "\n\t    , Tabs.label " ++ Code.string tabName
+                "\n\t    , Tabs.label " ++ Code.string fixedLabelOverride
         , "\n\t    ]"
         ]
     , Tabs.build { id = id, idString = tabIdString }
@@ -306,7 +309,7 @@ buildTab config id =
                     [ Tabs.labelledBy labelledById ]
 
                 FixedLabel ->
-                    [ Tabs.label tabName ]
+                    [ Tabs.label fixedLabelOverride ]
             ]
         )
     )

--- a/component-catalog/src/Examples/Tabs.elm
+++ b/component-catalog/src/Examples/Tabs.elm
@@ -252,6 +252,9 @@ buildTab config id =
 
         panelName =
             "Panel " ++ idString
+
+        labelledById =
+            idString ++ "-label"
     in
     ( String.join ""
         [ "Tabs.build { id = " ++ String.fromInt id ++ ", idString = " ++ Code.string tabIdString ++ " }"
@@ -269,6 +272,15 @@ buildTab config id =
 
           else
             ""
+        , case config.labelSource of
+            FromInnerText ->
+                ""
+
+            LabelledBy ->
+                "\n\t    , Tabs.labelledBy " ++ Code.string labelledById
+
+            FixedLabel ->
+                "\n\t    , Tabs.label " ++ Code.string tabName
         , "\n\t    ]"
         ]
     , Tabs.build { id = id, idString = tabIdString }
@@ -291,7 +303,7 @@ buildTab config id =
                     []
 
                 LabelledBy ->
-                    [ Tabs.labelledBy (idString ++ "-label") ]
+                    [ Tabs.labelledBy labelledById ]
 
                 FixedLabel ->
                     [ Tabs.label tabName ]

--- a/src/Nri/Ui/SegmentedControl/V14.elm
+++ b/src/Nri/Ui/SegmentedControl/V14.elm
@@ -205,7 +205,7 @@ view config =
             , tabView = [ viewIcon option.icon, option.label ]
             , panelView = option.content
             , spaHref = Maybe.map (\toUrl -> toUrl option.value) config.toUrl
-            , labelledBy = Nothing
+            , label = TabsInternal.FromInnerText
             , describedBy = []
             }
 

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -17,6 +17,7 @@ module Nri.Ui.Tabs.V8 exposing
   - Adds background color in the tab list (for use with sticky positioning)
   - Adds the ability to make the background of the active tab fade into the background of the panel below it
   - Adds an `data-nri-description='Nri-Ui__tabs'` attribute to the tabs container
+  - Adds the ability to explicitly set the label of the tab (rather than using its inner text)
 
 
 ### Attributes

--- a/src/Nri/Ui/Tabs/V8.elm
+++ b/src/Nri/Ui/Tabs/V8.elm
@@ -5,7 +5,7 @@ module Nri.Ui.Tabs.V8 exposing
     , tabListSticky, TabListStickyConfig, tabListStickyCustom
     , view
     , Tab, TabAttribute, build
-    , tabString, tabHtml, withTooltip, labelledBy, describedBy
+    , tabString, tabHtml, withTooltip, label, labelledBy, describedBy
     , panelHtml
     , spaHref
     )
@@ -31,7 +31,7 @@ module Nri.Ui.Tabs.V8 exposing
 ### Tabs
 
 @docs Tab, TabAttribute, build
-@docs tabString, tabHtml, withTooltip, labelledBy, describedBy
+@docs tabString, tabHtml, withTooltip, label, labelledBy, describedBy
 @docs panelHtml
 @docs spaHref
 
@@ -81,12 +81,20 @@ withTooltip attributes =
     TabAttribute (\tab -> { tab | tabTooltip = attributes })
 
 
-{-| Sets an overriding labelledBy on the tab for an external tooltip.
+{-| Sets an overriding label attribute on the tab for an external tooltip.
+This assumes an external tooltip is set and disables any internal tooltip configured.
+-}
+label : String -> TabAttribute id msg
+label label_ =
+    TabAttribute (\tab -> { tab | label = TabsInternal.FixedLabel label_ })
+
+
+{-| Sets an overriding labelled-by attribute on the tab for an external tooltip.
 This assumes an external tooltip is set and disables any internal tooltip configured.
 -}
 labelledBy : String -> TabAttribute id msg
 labelledBy labelledById =
-    TabAttribute (\tab -> { tab | labelledBy = Just labelledById })
+    TabAttribute (\tab -> { tab | label = TabsInternal.LabelledBy labelledById })
 
 
 {-| Like [`labelledBy`](#labelledBy), but it describes the given element

--- a/src/TabsInternal/V2.elm
+++ b/src/TabsInternal/V2.elm
@@ -1,7 +1,7 @@
 module TabsInternal.V2 exposing
     ( Config, views
     , Tab, fromList
-    , Label(..)
+    , LabelSource(..)
     )
 
 {-|
@@ -46,7 +46,7 @@ type alias Tab id msg =
     , tabView : List (Html msg)
     , panelView : Html msg
     , spaHref : Maybe String
-    , label : Label
+    , label : LabelSource
     , describedBy : List String
     }
 
@@ -63,7 +63,7 @@ set up, you could end up with no accessible labels, or native OS tooltips
 showing in addition to our own. See QUO-630.
 
 -}
-type Label
+type LabelSource
     = FromInnerText
     | FixedLabel String
     | LabelledBy String


### PR DESCRIPTION
## Context

Part of QUO-630.

Summary of the problem:
  - The writing sidebar uses icon-only tabs
  - We set an `Svg.withLabel` attribute on the icon to make up for the lack of text and keep the tab accessible
  - `Svg.withLabel` adds a `title` tag to the SVG
  - In Firefox, the `title` tag makes the browser display a native OS tooltip in addition to the ones controlled by us, and there doesn't seem to be a way to avoid it.
  
This PR adds a `Tabs.label` attribute for tabs, which lets us add an `aria-label` attribute to the tab itself (in a similar fashion to what we were already supporting with `Tabs.labelledBy`). This will let us skip the `Svg.withLabel` attribute, as the tab itself will provide its own accessible label (meaning we won't rely on the svg's internal text).

## :framed_picture: What does this change look like?


https://github.com/NoRedInk/noredink-ui/assets/753421/539637a5-8853-4f95-897d-d48fe6ed37a4



## Component completion checklist

- [X] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [X] Changes are clearly documented
  - [X] Component docs include a changelog
  - [X] Any new exposed functions or properties have docs
- [X] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [X] The Component Catalog example version number is updated, if appropriate
  - [X] Any new customizations are available from the Component Catalog
  - [X] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [X] Changes to the component are tested/the new version of the component is tested
- [X] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [X] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
