### PR TITLE
bump to 28.6.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "28.5.0",
+    "version": "28.6.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `28.6.0`

Part of QUO-630

## What changes does this release include?

Includes only changes from https://github.com/NoRedInk/noredink-ui/pull/1675. This adds the new `Tabs.label` attribute, letting us manually set the label for tab buttons rather than relying on their inner test. The addition of this function should not result in any changes to the behavior of pre-existing code using the library.

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```
This is a MINOR change.

---- Nri.Ui.Tabs.V8 - MINOR ----

    Added:
        label : String.String -> Nri.Ui.Tabs.V8.TabAttribute id msg
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).