### PR TITLE
bump to 28.7.0 (adds Pennant.V4 and Tabs.V9)

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "28.6.0",
+    "version": "28.7.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version 28.7.0

## What changes does this release include?

Includes two new versions of pre-existing components:
  - `Nri.Ui.Pennant.V4` (https://github.com/NoRedInk/noredink-ui/pull/1674)
  - `Nri.Ui.Tabs.V9` (https://github.com/NoRedInk/noredink-ui/pull/1678)

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```
This is a MINOR change.

---- ADDED MODULES - MINOR ----

    Nri.Ui.Pennant.V4
    Nri.Ui.Tabs.V9
```