### PR TITLE
Bump to 29.0.0 - drop Tabs.V8, add new light and darklight highlight colors

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "28.7.0",
+    "version": "29.0.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `29.0.0`

## What changes does this release include?

- #1680
- #1681

## How has the API changed?

```
This is a MAJOR change.

---- REMOVED MODULES - MAJOR ----

    Nri.Ui.Tabs.V8


---- Nri.Ui.Colors.V1 - MINOR ----

    Added:
        highlightBlueDarkLight : Css.Color
        highlightBlueLight : Css.Color
        highlightBrownDarkLight : Css.Color
        highlightBrownLight : Css.Color
        highlightCyanDarkLight : Css.Color
        highlightCyanLight : Css.Color
        highlightGreenDarkLight : Css.Color
        highlightGreenLight : Css.Color
        highlightMagentaDarkLight : Css.Color
        highlightMagentaLight : Css.Color
        highlightPurpleDarkLight : Css.Color
        highlightPurpleLight : Css.Color
        highlightYellowDarkLight : Css.Color
        highlightYellowLight : Css.Color


```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).
