### PR TITLE
Bump noredink-ui to 29.1.0 to include new StickerIcons and UiIcons for annotations

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "29.0.0",
+    "version": "29.1.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",

--- a/src/Nri/Ui/StickerIcon/V1.elm
+++ b/src/Nri/Ui/StickerIcon/V1.elm
@@ -43,6 +43,7 @@ strokePath path x y =
         []
 
 
+{-| -}
 exclamation : StickerIcon
 exclamation =
     let
@@ -126,6 +127,7 @@ exclamation =
     }
 
 
+{-| -}
 lightBulb : StickerIcon
 lightBulb =
     let
@@ -198,6 +200,7 @@ lightBulb =
     }
 
 
+{-| -}
 questionMark : StickerIcon
 questionMark =
     let
@@ -281,6 +284,7 @@ questionMark =
     }
 
 
+{-| -}
 heart : StickerIcon
 heart =
     let
@@ -357,6 +361,7 @@ heart =
     }
 
 
+{-| -}
 star : StickerIcon
 star =
     let

--- a/src/Nri/Ui/UiIcon/V1.elm
+++ b/src/Nri/Ui/UiIcon/V1.elm
@@ -1866,7 +1866,7 @@ sync =
             ]
         ]
 
-
+{-| -}
 delete : Nri.Ui.Svg.V1.Svg
 delete =
     Nri.Ui.Svg.V1.init "0 0 14 16"
@@ -1882,7 +1882,7 @@ delete =
             []
         ]
 
-
+{-| -}
 addSticker : Nri.Ui.Svg.V1.Svg
 addSticker =
     Nri.Ui.Svg.V1.init "0 0 16 16"
@@ -1897,7 +1897,7 @@ addSticker =
             ]
         ]
 
-
+{-| -}
 circle : Nri.Ui.Svg.V1.Svg
 circle =
     Nri.Ui.Svg.V1.init "0 0 16 16"


### PR DESCRIPTION
# :label: Bump for version `29.1.0`

## What changes does this release include?

- #1683
- #1684

## How has the API changed?

```
---- Nri.Ui.UiIcon.V1 - MINOR ----

    Added:
        addSticker : Nri.Ui.Svg.V1.Svg
        circle : Nri.Ui.Svg.V1.Svg
        delete : Nri.Ui.Svg.V1.Svg
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).