### PR TITLE
Bump to version 29.2.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "29.1.0",
+    "version": "29.2.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
e7fc51c pinned our 29.1.0 release to a broken master.  This PR bumps again to fix.

# :label: Bump for version `29.2.0`

## What changes does this release include?

Fixes mistakes that were made in:

- #1686
- #1685

## How has the API changed?

```
This is a MINOR change.

---- ADDED MODULES - MINOR ----

    Nri.Ui.StickerIcon.V1
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).