### PR TITLE
Highlighter: Fix hinting state for keyboard-based selection

### DIFF
--- a/src/Nri/Test/KeyboardHelpers/V1.elm
+++ b/src/Nri/Test/KeyboardHelpers/V1.elm
@@ -1,6 +1,6 @@
 module Nri.Test.KeyboardHelpers.V1 exposing
     ( pressKey, releaseKey
-    , pressTab, pressTabBack, pressEsc, pressSpace, pressDownArrow, pressRightArrow, pressLeftArrow, pressShiftRight, pressShiftLeft, releaseRightArrow, releaseLeftArrow, releaseShiftRight, releaseShiftLeft
+    , pressTab, pressTabBack, pressEsc, pressSpace, pressDownArrow, pressRightArrow, pressLeftArrow, pressShiftRight, pressShiftLeft, releaseRightArrow, releaseLeftArrow, releaseShiftRight, releaseShiftLeft, releaseShift
     )
 
 {-| `KeyboardHelpers` provides a set of functions to simulate keyboard events for testing Elm programs.
@@ -13,7 +13,7 @@ module Nri.Test.KeyboardHelpers.V1 exposing
 
 # Common helpers
 
-@docs pressTab, pressTabBack, pressEsc, pressSpace, pressDownArrow, pressRightArrow, pressLeftArrow, pressShiftRight, pressShiftLeft, releaseRightArrow, releaseLeftArrow, releaseShiftRight, releaseShiftLeft
+@docs pressTab, pressTabBack, pressEsc, pressSpace, pressDownArrow, pressRightArrow, pressLeftArrow, pressShiftRight, pressShiftLeft, releaseRightArrow, releaseLeftArrow, releaseShiftRight, releaseShiftLeft, releaseShift
 
 -}
 
@@ -217,3 +217,12 @@ releaseShiftLeft :
     -> ProgramTest.ProgramTest model msg effect
 releaseShiftLeft { targetDetails } =
     releaseKey { targetDetails = targetDetails, keyCode = 37, shiftKey = True }
+
+
+releaseShift :
+    { targetDetails : List ( String, Encode.Value ) }
+    -> List Selector
+    -> ProgramTest.ProgramTest model msg effect
+    -> ProgramTest.ProgramTest model msg effect
+releaseShift { targetDetails } =
+    releaseKey { targetDetails = targetDetails, keyCode = 16, shiftKey = False }

--- a/src/Nri/Test/KeyboardHelpers/V1.elm
+++ b/src/Nri/Test/KeyboardHelpers/V1.elm
@@ -219,6 +219,8 @@ releaseShiftLeft { targetDetails } =
     releaseKey { targetDetails = targetDetails, keyCode = 37, shiftKey = True }
 
 
+{-| Simulat shift key being released while focusing on the given element.
+-}
 releaseShift :
     { targetDetails : List ( String, Encode.Value ) }
     -> List Selector

--- a/src/Nri/Test/KeyboardHelpers/V1.elm
+++ b/src/Nri/Test/KeyboardHelpers/V1.elm
@@ -219,7 +219,7 @@ releaseShiftLeft { targetDetails } =
     releaseKey { targetDetails = targetDetails, keyCode = 37, shiftKey = True }
 
 
-{-| Simulat shift key being released while focusing on the given element.
+{-| Simulate shift key being released while focusing on the given element.
 -}
 releaseShift :
     { targetDetails : List ( String, Encode.Value ) }

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -206,7 +206,6 @@ type KeyboardMsg
     | SelectionExpandLeft Int
     | SelectionExpandRight Int
     | SelectionApplyTool Int
-    | SelectionReset Int
     | ToggleHighlight Int
 
 
@@ -400,9 +399,6 @@ keyboardEventToActions msg model =
 
                 Tool.Eraser _ ->
                     [ RemoveHint, ResetSelection, Focus index ]
-
-        SelectionReset index ->
-            [ ResetSelection, RemoveHint, Focus index ]
 
         ToggleHighlight index ->
             case model.marker of

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -1438,16 +1438,13 @@ viewHighlightable { renderMarkdown, overlaps } config highlightable =
                         , Key.shiftLeft (Keyboard <| SelectionExpandLeft highlightable.index)
                         ]
                     , Key.onKeyUpPreventDefault
-                        [ -- Key.shift doesn't work on keyUp, bc `shiftKey` is False on keyUp
-                          { keyCode = 16
-                          , shiftKey = False
-                          , msg = Keyboard <| SelectionApplyTool highlightable.index
-                          }
+                        [ Key.shift (Keyboard <| SelectionApplyTool highlightable.index)
+                            -- Key.shift has `shiftKey` set to True, but the keyUp event
+                            -- for releasing the shift key has `shiftKey` set to False.
+                            |> (\k -> { k | shiftKey = False })
                         , -- Escape while shift is down cancels selection
-                          { keyCode = 27
-                          , shiftKey = True
-                          , msg = Keyboard <| SelectionReset highlightable.index
-                          }
+                          Key.escape (Keyboard <| SelectionReset highlightable.index)
+                            |> (\k -> { k | shiftKey = True })
                         ]
                     ]
                 , renderMarkdown = renderMarkdown

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -1552,6 +1552,11 @@ viewHighlightableSegment ({ interactiveHighlighterId, focusIndex, eventListeners
 
                     _ ->
                         AttributesExtra.none
+               , if isHinted config.hintingIndices highlightable then
+                    class "highlighter-hinted"
+
+                 else
+                    AttributesExtra.none
                , if isInteractive then
                     Key.tabbable
                         (case focusIndex of

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -1426,9 +1426,11 @@ viewHighlightable { renderMarkdown, overlaps } config highlightable =
                         , Key.shiftLeft (Keyboard <| SelectionExpandLeft highlightable.index)
                         ]
                     , Key.onKeyUpPreventDefault
-                        [ Key.shiftRight (Keyboard <| SelectionApplyTool highlightable.index)
-                        , Key.shiftLeft (Keyboard <| SelectionApplyTool highlightable.index)
-                        , Key.shift (Keyboard <| SelectionReset highlightable.index)
+                        [ -- Key.shift doesn't work on keyUp, bc `shiftKey` is False on keyUp
+                          { keyCode = 16
+                          , shiftKey = False
+                          , msg = Keyboard <| SelectionApplyTool highlightable.index
+                          }
                         ]
                     ]
                 , renderMarkdown = renderMarkdown

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -1717,7 +1717,7 @@ hintStartEndAnnouncer marker =
     Css.after
         [ Css.property
             "content"
-            ("\" (selecting "
+            ("\" (selecting text for "
                 ++ (Maybe.map
                         (\name -> stripMarkdownSyntax name)
                         marker.name

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -27,6 +27,7 @@ Highlighter provides a view/model/update to display a view to highlight text and
   - Optimized `selectShortest` for the normal case of 0 or 1 highlight.
   - Added `FoldState`, `initFoldState`, `viewFoldHighlighter`, and `viewFoldStatic`
   - Exposed KeyboardMsg(..) to allow for fine-tuning keyboard interactions
+  - Made keyboard selection use hinting state too
 
 
 # Types

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -572,8 +572,8 @@ performAction action ( model, cmds ) =
             ( { model | selectionStartIndex = Nothing, selectionEndIndex = Nothing }, cmds )
 
 
-isFirstLastHinted : Maybe ( Int, Int ) -> Highlightable marker -> Bool
-isFirstLastHinted hintingIndices { index } =
+isFirstOrLastHinted : Maybe ( Int, Int ) -> Highlightable marker -> Bool
+isFirstOrLastHinted hintingIndices { index } =
     case hintingIndices of
         Just ( start, end ) ->
             start == index || end == index
@@ -1678,7 +1678,7 @@ unmarkedHighlightableStyles config highlightable =
                             Tool.Marker marker ->
                                 if isHinted_ then
                                     [ Css.batch marker.hintClass
-                                    , if isFirstLastHinted config.hintingIndices highlightable then
+                                    , if isFirstOrLastHinted config.hintingIndices highlightable then
                                         -- only announce first or last hinted bc that's where
                                         -- keyboard focus will be
                                         hintStartEndAnnouncer marker

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -207,6 +207,7 @@ type KeyboardMsg
     | SelectionExpandLeft Int
     | SelectionExpandRight Int
     | SelectionApplyTool Int
+    | SelectionReset Int
     | ToggleHighlight Int
 
 
@@ -400,6 +401,9 @@ keyboardEventToActions msg model =
 
                 Tool.Eraser _ ->
                     [ RemoveHint, ResetSelection, Focus index ]
+
+        SelectionReset index ->
+            [ ResetSelection, RemoveHint, Focus index ]
 
         ToggleHighlight index ->
             case model.marker of
@@ -1437,6 +1441,11 @@ viewHighlightable { renderMarkdown, overlaps } config highlightable =
                           { keyCode = 16
                           , shiftKey = False
                           , msg = Keyboard <| SelectionApplyTool highlightable.index
+                          }
+                        , -- Escape while shift is down cancels selection
+                          { keyCode = 27
+                          , shiftKey = True
+                          , msg = Keyboard <| SelectionReset highlightable.index
                           }
                         ]
                     ]

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -153,13 +153,13 @@ keyboardTests =
             Highlightable.initFragments "Pothos indirect light"
                 |> program { markerName = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> shiftRight
-                |> releaseShiftRight
+                |> releaseShift
                 |> ensureMarked [ "Pothos", " ", "indirect" ]
                 |> shiftRight
-                |> releaseShiftRight
+                |> releaseShift
                 |> ensureMarked [ "Pothos", " ", "indirect", " ", "light" ]
                 |> shiftRight
-                |> releaseShiftRight
+                |> releaseShift
                 |> ensureMarked [ "Pothos", " ", "indirect", " ", "light" ]
                 |> done
     , test "expands selection one element to the left on shift + left arrow and highlight selected elements" <|
@@ -169,13 +169,13 @@ keyboardTests =
                 |> rightArrow
                 |> rightArrow
                 |> shiftLeft
-                |> releaseShiftLeft
+                |> releaseShift
                 |> ensureMarked [ "indirect", " ", "light" ]
                 |> shiftLeft
-                |> releaseShiftLeft
+                |> releaseShift
                 |> ensureMarked [ "Pothos", " ", "indirect", " ", "light" ]
                 |> shiftLeft
-                |> releaseShiftLeft
+                |> releaseShift
                 |> ensureMarked [ "Pothos", " ", "indirect", " ", "light" ]
                 |> done
     , test "merges highlights" <|
@@ -184,13 +184,13 @@ keyboardTests =
                 |> program { markerName = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> ensureTabbable "Pothos"
                 |> shiftRight
-                |> releaseShiftRight
+                |> releaseShift
                 |> ensureMarked [ "Pothos", " ", "indirect" ]
                 |> ensureTabbable "indirect"
                 |> rightArrow
                 |> ensureTabbable "light"
                 |> shiftLeft
-                |> releaseShiftLeft
+                |> releaseShift
                 |> ensureMarked [ "Pothos", " ", "indirect", " ", "light" ]
                 |> done
     , test "selects element on MouseDown and highlights selected element on MouseUp" <|
@@ -237,7 +237,7 @@ keyboardTests =
                 |> program { markerName = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> ensureTabbable "Pothos"
                 |> shiftRight
-                |> releaseShiftRight
+                |> releaseShift
                 |> ensureMarked [ "Pothos", " ", "indirect" ]
                 |> mouseDown "indirect"
                 |> mouseUp "indirect"
@@ -259,7 +259,7 @@ keyboardTests =
                     |> program { markerName = Nothing, joinAdjacentInteractiveHighlights = False }
                     |> rightArrow
                     |> shiftRight
-                    |> releaseShiftRight
+                    |> releaseShift
                     |> ensureMarked [ "indirect" ]
                     |> expectView (hasBefore "start highlight" "indirect")
         , test "specific start announcement is made when mark does not include first element" <|
@@ -269,7 +269,7 @@ keyboardTests =
                     |> rightArrow
                     |> ensureTabbable "indirect"
                     |> shiftRight
-                    |> releaseShiftRight
+                    |> releaseShift
                     |> ensureMarked [ "indirect" ]
                     |> expectView (hasBefore "start banana highlight" "indirect")
         ]
@@ -281,7 +281,7 @@ keyboardTests =
                 Highlightable.initFragments "Sir Walter Elliot, of Kellynch Hall, in Somersetshire..."
                     |> program { markerName = Just "Claim", joinAdjacentInteractiveHighlights = False }
                     |> shiftRight
-                    |> releaseShiftRight
+                    |> releaseShift
                     |> ensureMarked [ "Sir", " ", "Walter" ]
                     |> ensureTabbable "Walter"
                     |> rightArrow
@@ -554,16 +554,9 @@ shiftLeft =
         [ Selector.attribute (Key.tabbable True) ]
 
 
-releaseShiftRight : TestContext -> TestContext
-releaseShiftRight =
-    KeyboardHelpers.releaseShiftRight
-        { targetDetails = [] }
-        [ Selector.attribute (Key.tabbable True) ]
-
-
-releaseShiftLeft : TestContext -> TestContext
-releaseShiftLeft =
-    KeyboardHelpers.releaseShiftLeft
+releaseShift : TestContext -> TestContext
+releaseShift =
+    KeyboardHelpers.releaseShift
         { targetDetails = [] }
         [ Selector.attribute (Key.tabbable True) ]
 

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -295,8 +295,8 @@ keyboardTests =
                 |> program { markerName = Nothing, joinAdjacentInteractiveHighlights = False }
                 |> shiftRight
                 |> ensureHinted [ "Pothos", " ", "indirect" ]
-                |> ensureView (hasAfter "\\(selecting highlight\\)" "Pothos")
-                |> ensureView (hasAfter "\\(selecting highlight\\)" "indirect")
+                |> ensureView (hasAfter "\\(selecting text for highlight\\)" "Pothos")
+                |> ensureView (hasAfter "\\(selecting text for highlight\\)" "indirect")
                 |> done
     , describe "Regression tests for A11-1767"
         [ test "generic start announcement is made when mark does not include first element" <|

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -14,7 +14,6 @@ import Nri.Ui.Highlighter.V5 as Highlighter
 import Nri.Ui.HighlighterTool.V1 as Tool exposing (Tool)
 import ProgramTest exposing (..)
 import Sort
-import Spec.Helpers exposing (nriDescription)
 import Spec.PseudoElements exposing (..)
 import Test exposing (..)
 import Test.Html.Query as Query

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -290,6 +290,15 @@ keyboardTests =
                 |> ensureTabbable "Pothos"
                 |> space
                 |> expectViewHasNot [ Selector.tag "mark" ]
+    , test "Adds ::after element with screenreader cues while hinting" <|
+        \() ->
+            Highlightable.initFragments "Pothos indirect light"
+                |> program { markerName = Nothing, joinAdjacentInteractiveHighlights = False }
+                |> shiftRight
+                |> ensureHinted [ "Pothos", " ", "indirect" ]
+                |> ensureView (hasAfter "\\(selecting highlight\\)" "Pothos")
+                |> ensureView (hasAfter "\\(selecting highlight\\)" "indirect")
+                |> done
     , describe "Regression tests for A11-1767"
         [ test "generic start announcement is made when mark does not include first element" <|
             \() ->


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

TL;DR: Shift+arrow now only apply the highlight when shift is released. "Hinting" mode is used while shift is pressed.

The way Highlighter keyboard-based selection worked made it very difficult to implement annotation functionality for writing.

Successive focus messages after each shift+arrow would throw a wrench on our code, and immediate creation of highlights would force us create+expand+expand+expand highlights, which would generate backend messages on each cycle.

Making kb-based selection work like the mouse, using hinting first, then applying marks to hinted segments all at once, when shift is released, is an elegant solution that not only completely solves our problems at the writing annotations side, but also opens the door to add friendlier screenreader cues to hinting state.

**Specific things I want feedback on:** Is the hinting screenreader cue ok?

## :framed_picture: What does this change look like?


https://github.com/user-attachments/assets/db6fa025-26bf-4184-aeb8-8b3bf674d739


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [ x Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
