### PR TITLE
Fix highlighter behavior on mobile

### DIFF
--- a/component-catalog/index.html
+++ b/component-catalog/index.html
@@ -51,7 +51,8 @@
           var data;
 
           if (realTarget) {
-            data = realTarget.getAttribute("data-highlighter-item-index"); // each word has a data attribute with its index.
+            // each word has a data attribute with its index.
+            data = realTarget.getAttribute("data-highlighter-item-index");
           }
 
           // we only want to be informed for touchmove-events in the current highlighter.

--- a/component-catalog/index.html
+++ b/component-catalog/index.html
@@ -55,8 +55,8 @@
             data = realTarget.getAttribute("data-highlighter-item-index");
           }
 
-          // we only want to be informed for touchmove-events in the current highlighter.
-          if (data && id === realTarget.parentNode.id) {
+          // we only want to be informed for touchmove-events in highlightables
+          if (data) {
             app.ports.highlighterOnTouch.send([type, id, parseInt(data, 10)]);
           }
         };

--- a/component-catalog/index.html
+++ b/component-catalog/index.html
@@ -24,6 +24,7 @@
           var highlighter = document.getElementById(id);
           if (!id || !highlighter) {
             // in a real application, report an error at this point.
+            console.log("highlighter not found", id);
             return;
           }
 

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -50,7 +50,13 @@ example =
     , version = version
     , init = init
     , update = update
-    , subscriptions = \_ -> Sub.map HighlighterMsg subscriptions
+    , subscriptions =
+        \_ ->
+            Sub.batch
+                [ Sub.map HighlighterMsg subscriptions
+                , Sub.map OverlappingHighlighterMsg subscriptions
+                , Sub.map FoldHighlighterMsg subscriptions
+                ]
     , preview =
         [ div [ css [ Fonts.baseFont, Css.lineHeight (Css.num 2), Css.Global.children [ Css.Global.p [ Css.margin Css.zero ] ] ] ]
             [ Highlighter.static

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -202,6 +202,8 @@ example =
                     , Css.lineHeight (Css.num 1.75)
                     , Fonts.ugFont
                     ]
+                , Html.Styled.Attributes.id state.foldHighlightsState.id
+                , Html.Styled.Attributes.class "highlighter-container"
                 ]
                 [ viewFoldHighlights state.foldHighlightsState
                     |> map FoldHighlighterMsg

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -812,10 +812,15 @@ update msg state =
 
         FoldHighlighterMsg highlighterMsg ->
             let
-                ( highlighterModel, highlighterCmd, _ ) =
+                ( highlighterModel, highlighterCmd, intent ) =
                     Highlighter.update highlighterMsg state.foldHighlightsState
             in
-            ( { state | foldHighlightsState = highlighterModel }, Cmd.map FoldHighlighterMsg highlighterCmd )
+            ( { state | foldHighlightsState = highlighterModel }
+            , Cmd.batch
+                [ Cmd.map FoldHighlighterMsg highlighterCmd
+                , perform intent
+                ]
+            )
 
 
 perform : Highlighter.Intent -> Cmd msg

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -1434,7 +1434,7 @@ viewHighlightable { renderMarkdown, overlaps } config highlightable =
                 , eventListeners =
                     [ onPreventDefault "mouseover" (Pointer <| Over highlightable.index)
                     , onPreventDefault "mouseleave" (Pointer <| Out)
-                    , onPreventDefault "mouseup" (Pointer <| Up Nothing)
+                    , onPreventDefault "mouseup" (Pointer <| Up <| Just config.id)
                     , onPreventDefault "mousedown" (Pointer <| Down highlightable.index)
                     , onPreventDefault "touchstart" (Pointer <| Down highlightable.index)
                     , attribute "data-interactive" ""
@@ -1476,7 +1476,7 @@ viewHighlightable { renderMarkdown, overlaps } config highlightable =
                     -- should see the entire highlight change to hover styles.
                     [ onPreventDefault "mouseover" (Pointer <| Over highlightable.index)
                     , onPreventDefault "mouseleave" (Pointer <| Out)
-                    , onPreventDefault "mouseup" (Pointer <| Up Nothing)
+                    , onPreventDefault "mouseup" (Pointer <| Up <| Just config.id)
                     , onPreventDefault "mousedown" (Pointer <| Down highlightable.index)
                     , onPreventDefault "touchstart" (Pointer <| Down highlightable.index)
                     , attribute "data-static" ""

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -28,6 +28,7 @@ Highlighter provides a view/model/update to display a view to highlight text and
   - Added `FoldState`, `initFoldState`, `viewFoldHighlighter`, and `viewFoldStatic`
   - Exposed KeyboardMsg(..) to allow for fine-tuning keyboard interactions
   - Made keyboard selection use hinting state too
+  - Fixed mobile interaction bugs (see #1694)
 
 
 # Types


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Part of https://linear.app/noredink/issue/PHX-1796/investigate-double-click-to-highlight-individual-words#comment-3a9f6403

We noticed users were commonly creating highlights and deleting them within 5s, and deemed those "accidental highlights".

We suspected the accidental highlights were coming from mobile devices, and investiating it opened a bit of a pandora's box for mobile issues with highlighting. The ones relevant to noredink-ui are:
- When you tap over a highlightable in the middle of a scrolling motion, it trigger a highlight

https://github.com/user-attachments/assets/6240ac86-ba5f-43d9-8481-dde2638bb2bd


- Tap+move to highlight sentences was being processed for all highlights in the page

https://github.com/user-attachments/assets/ac856b66-c45b-4c17-8a5e-310fb0683f52

- Tap+move to highlight sentences wasn't working at all for `viewFold`, because:
  - There is no highlight container enforced
  - Elements are not necessarily direct descendants of the container

https://github.com/user-attachments/assets/6f1e14b7-17fa-4d04-9185-176dcbcc6e46

This fixes the 2nd and 3rd issues. The first one will be harder, so I'll do it in a follow-up PR.

I chose not to make `viewFold` create a container, which might be a mistake, because it'll be easy for folks to forget that's necessary for mobile, like we forgot to set up highlighter ports at all in project Text Response. I'm super open to forcing a generic `div` container inside `viewFold`.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [ ] Please assign the following reviewers:
  - [x] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [ ] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [ ] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
