### PR TITLE
New highlight ux experiment

### DIFF
--- a/component-catalog/index.html
+++ b/component-catalog/index.html
@@ -51,7 +51,8 @@
           var data;
 
           if (realTarget) {
-            data = realTarget.getAttribute("data-highlighter-item-index"); // each word has a data attribute with its index.
+            // each word has a data attribute with its index.
+            data = realTarget.getAttribute("data-highlighter-item-index");
           }
 
           // we only want to be informed for touchmove-events in the current highlighter.

--- a/component-catalog/index.html
+++ b/component-catalog/index.html
@@ -19,7 +19,9 @@
       // HIGHLIGHTER
 
       // start listening to events when the user starts dragging/clickingdown
-      app.ports.highlighterListen.subscribe(function (id) {
+      app.ports.highlighterListen.subscribe(([id, scrollFriendly]) => {
+        const touchEventListener = handleTouchEvents("move", id);
+
         window.requestAnimationFrame(() => {
           var highlighter = document.getElementById(id);
           if (!id || !highlighter) {
@@ -28,13 +30,42 @@
             return;
           }
 
-          document.addEventListener("mouseup", onDocumentUp(id, "mouse"));
-          document.addEventListener("touchend", onDocumentUp(id, "touch"));
+          document.addEventListener("mouseup", onDocumentUp(id, "mouse", touchEventListener));
+          document.addEventListener("touchend", onDocumentUp(id, "touch", touchEventListener));
+          if (!scrollFriendly) {
+            // scroll-friendly mode only registers a touchmove listener after a longpress
+            highlighter.addEventListener("touchmove", touchEventListener);
+          }
           highlighter.addEventListener(
-            "touchmove",
-            handleTouchEvents("move", id)
+            "touchstart",
+            handleTouchStartScrollFriendly(id)
           );
         });
+
+        function handleTouchStartScrollFriendly(id) {
+          return function (e) {
+            const idx = getTouchEventIndex(e);
+
+            if (!idx) return;
+
+            const longpressTimeout = setTimeout(() => {
+              document.getElementById(id).addEventListener("touchmove", touchEventListener);
+              document.removeEventListener("touchmove", cancelLongpress);
+              document.removeEventListener("touchend", cancelLongpress);
+              app.ports.highlighterOnTouch.send(["longpress", id, idx]);
+            }, 500);
+
+            // on touchmove or touchend, cancel the longpress timeout
+            function cancelLongpress() {
+              clearTimeout(longpressTimeout);
+              document.removeEventListener("touchmove", cancelLongpress);
+              document.removeEventListener("touchend", cancelLongpress);
+            }
+
+            document.addEventListener("touchmove", cancelLongpress);
+            document.addEventListener("touchend", cancelLongpress);
+          };
+        }
       });
 
       /*
@@ -65,10 +96,30 @@
       /*
        * inform elm when we receive a mouseup/touchend event.
        */
-      function onDocumentUp(id, device) {
+      function onDocumentUp(id, device, touchEventListener) {
         return function () {
           app.ports.highlighterOnDocumentUp.send([id, device]);
+          if (device === "touch") {
+            document.getElementById(id)?.removeEventListener(
+              "touchmove",
+              touchEventListener
+            );
+          }
         };
+      }
+
+      function getTouchEventIndex(e) {
+        if (e.touches.length > 1) return; // we don't care about multitouch
+          var loc = e.changedTouches[0];
+          var realTarget = document.elementFromPoint(loc.clientX, loc.clientY); // get the element under the finger
+
+          if (realTarget) {
+            // each word has a data attribute with its index.
+            const data = realTarget.getAttribute("data-highlighter-item-index");
+            if (data) {
+              return parseInt(data, 10);
+            }
+          }
       }
     </script>
     <script src="bundle.js"></script>

--- a/component-catalog/index.html
+++ b/component-catalog/index.html
@@ -21,8 +21,6 @@
       // start listening to events when the user starts dragging/clickingdown
       app.ports.highlighterListen.subscribe(([id, scrollFriendly]) => {
         const touchMoveListener = handleTouchEvents("move", id);
-        const mouseUpHandler = onDocumentUp(id, "mouse");
-        const touchEndHandler = onDocumentUp(id, "touch");
 
         window.requestAnimationFrame(() => {
           var highlighter = document.getElementById(id);
@@ -38,11 +36,11 @@
           // Register global listeners for when we release the mouse/touchpad outside a highlighter
           highlighter.addEventListener("mousedown", (_) => {
             console.log("registering mouseup handler");
-            document.addEventListener("mouseup", mouseUpHandler);
+            document.addEventListener("mouseup", onDocumentUp(id, "mouse"), {once: true});
           });
           highlighter.addEventListener("touchstart", (_) => {
             console.log("registering touchend handler");
-            document.addEventListener("touchend", touchEndHandler);
+            document.addEventListener("touchend", onDocumentUp(id, "touch"), {once: true});
           });
           if (!scrollFriendly) {
             // scroll-friendly mode only registers a touchmove listener after a longpress
@@ -141,14 +139,6 @@
               // This helps us not report touchmove when touch starts on one highlighter and moves
               // into another
               document.getElementById(id)?.removeEventListener("touchmove", touchMoveListener);
-              // Deregister onDocumentUp listeners, so we avoid sending unnecessary messages to elm
-              document.removeEventListener("touchend", touchEndHandler);
-            } else if (device === "mouse") {
-              if (window.debugHighlighter) {
-                console.log("deregistering mouse listeners");
-              }
-              // Deregister onDocumentUp listeners, so we avoid sending unnecessary messages to elm
-              document.removeEventListener("mouseup", mouseUpHandler);
             }
           };
         }

--- a/component-catalog/index.html
+++ b/component-catalog/index.html
@@ -20,7 +20,7 @@
 
       // start listening to events when the user starts dragging/clickingdown
       app.ports.highlighterListen.subscribe(([id, scrollFriendly]) => {
-        const touchEventListener = handleTouchEvents("move", id);
+        const touchMoveListener = handleTouchEvents("move", id);
 
         window.requestAnimationFrame(() => {
           var highlighter = document.getElementById(id);
@@ -30,11 +30,11 @@
             return;
           }
 
-          document.addEventListener("mouseup", onDocumentUp(id, "mouse", touchEventListener));
-          document.addEventListener("touchend", onDocumentUp(id, "touch", touchEventListener));
+          document.addEventListener("mouseup", onDocumentUp(id, "mouse", touchMoveListener));
+          document.addEventListener("touchend", onDocumentUp(id, "touch", touchMoveListener));
           if (!scrollFriendly) {
             // scroll-friendly mode only registers a touchmove listener after a longpress
-            highlighter.addEventListener("touchmove", touchEventListener);
+            highlighter.addEventListener("touchmove", touchMoveListener);
           }
           highlighter.addEventListener(
             "touchstart",
@@ -56,7 +56,7 @@
               if (window.debugHighlighter) {
                 console.log("longpress", id, idx);
               }
-              document.getElementById(id).addEventListener("touchmove", touchEventListener);
+              document.getElementById(id).addEventListener("touchmove", touchMoveListener);
               document.removeEventListener("touchmove", cancelLongpress);
               document.removeEventListener("touchend", cancelLongpress);
               app.ports.highlighterOnTouch.send(["longpress", id, idx]);
@@ -101,13 +101,13 @@
       /*
        * inform elm when we receive a mouseup/touchend event.
        */
-      function onDocumentUp(id, device, touchEventListener) {
+      function onDocumentUp(id, device, touchMoveListener) {
         return function () {
           app.ports.highlighterOnDocumentUp.send([id, device]);
           if (device === "touch") {
             document.getElementById(id)?.removeEventListener(
               "touchmove",
-              touchEventListener
+              touchMoveListener
             );
           }
         };

--- a/component-catalog/index.html
+++ b/component-catalog/index.html
@@ -44,11 +44,18 @@
 
         function handleTouchStartScrollFriendly(id) {
           return function (e) {
+            if (window.debugHighlighter) {
+              console.log("touchstart", id);
+            }
+
             const idx = getTouchEventIndex(e);
 
             if (!idx) return;
 
             const longpressTimeout = setTimeout(() => {
+              if (window.debugHighlighter) {
+                console.log("longpress", id, idx);
+              }
               document.getElementById(id).addEventListener("touchmove", touchEventListener);
               document.removeEventListener("touchmove", cancelLongpress);
               document.removeEventListener("touchend", cancelLongpress);
@@ -57,6 +64,9 @@
 
             // on touchmove or touchend, cancel the longpress timeout
             function cancelLongpress() {
+              if (window.debugHighlighter) {
+                console.log("cancel longpress", id, idx);
+              }
               clearTimeout(longpressTimeout);
               document.removeEventListener("touchmove", cancelLongpress);
               document.removeEventListener("touchend", cancelLongpress);
@@ -73,7 +83,13 @@
        * We need the element under the finger to highlight a section though.
        */
       function handleTouchEvents(type, id) {
+        if (window.debugHighlighter) {
+          console.log("handleTouchEvents", type, id);
+        }
         return function (e) {
+          if (window.debugHighlighter) {
+            console.log("touch event:", type, id);
+          }
           e.preventDefault();
           e.stopPropagation();
           if (e.touches.length > 1) return; // we don't care about multitouch

--- a/component-catalog/index.html
+++ b/component-catalog/index.html
@@ -28,8 +28,8 @@
             return;
           }
 
-          document.addEventListener("mouseup", onDocumentUp(id));
-          document.addEventListener("touchend", onDocumentUp(id));
+          document.addEventListener("mouseup", onDocumentUp(id, "mouse"));
+          document.addEventListener("touchend", onDocumentUp(id, "touch"));
           highlighter.addEventListener(
             "touchmove",
             handleTouchEvents("move", id)
@@ -65,9 +65,9 @@
       /*
        * inform elm when we receive a mouseup/touchend event.
        */
-      function onDocumentUp(id) {
+      function onDocumentUp(id, device) {
         return function () {
-          app.ports.highlighterOnDocumentUp.send(id);
+          app.ports.highlighterOnDocumentUp.send([id, device]);
         };
       }
     </script>

--- a/component-catalog/index.html
+++ b/component-catalog/index.html
@@ -21,6 +21,8 @@
       // start listening to events when the user starts dragging/clickingdown
       app.ports.highlighterListen.subscribe(([id, scrollFriendly]) => {
         const touchMoveListener = handleTouchEvents("move", id);
+        const mouseUpHandler = onDocumentUp(id, "mouse");
+        const touchEndHandler = onDocumentUp(id, "touch");
 
         window.requestAnimationFrame(() => {
           var highlighter = document.getElementById(id);
@@ -30,16 +32,23 @@
             return;
           }
 
-          document.addEventListener("mouseup", onDocumentUp(id, "mouse", touchMoveListener));
-          document.addEventListener("touchend", onDocumentUp(id, "touch", touchMoveListener));
+          // TODO: At some point we do not need those event listeners. It would be nice to remove them.
+          // Example: when we send a Guided Draft back for revisions: no highlighters needed anymore!
+          //
+          // Register global listeners for when we release the mouse/touchpad outside a highlighter
+          highlighter.addEventListener("mousedown", (_) => {
+            console.log("registering mouseup handler");
+            document.addEventListener("mouseup", mouseUpHandler);
+          });
+          highlighter.addEventListener("touchstart", (_) => {
+            console.log("registering touchend handler");
+            document.addEventListener("touchend", touchEndHandler);
+          });
           if (!scrollFriendly) {
             // scroll-friendly mode only registers a touchmove listener after a longpress
             highlighter.addEventListener("touchmove", touchMoveListener);
           }
-          highlighter.addEventListener(
-            "touchstart",
-            handleTouchStartScrollFriendly(id)
-          );
+          highlighter.addEventListener("touchstart", handleTouchStartScrollFriendly(id));
         });
 
         /*
@@ -61,7 +70,7 @@
          * the longpress, so simple swipes up and down are not affected.
          */
         function handleTouchStartScrollFriendly(id) {
-          return function (e) {
+          return (e) => {
             if (window.debugHighlighter) {
               console.log("touchstart", id);
             }
@@ -94,60 +103,76 @@
             document.addEventListener("touchend", cancelLongpress);
           };
         }
-      });
 
-      /*
-       * Touchmove event always fire on the element that got the initial touchstart event.
-       * We need the element under the finger to highlight a section though.
-       */
-      function handleTouchEvents(type, id) {
-        if (window.debugHighlighter) {
-          console.log("handleTouchEvents", type, id);
-        }
-        return function (e) {
+
+        /*
+        * Touchmove event always fire on the element that got the initial touchstart event.
+        * We need the element under the finger to highlight a section though.
+        */
+        function handleTouchEvents(type, id) {
           if (window.debugHighlighter) {
-            console.log("touch event:", type, id);
+            console.log("handleTouchEvents", type, id);
           }
-          e.preventDefault();
-          e.stopPropagation();
-          
-          let highlightableIndex = getTouchEventHighlightableIndex(e);
-          app.ports.highlighterOnTouch.send([type, id, highlightableIndex]);
-        };
-      }
+          return function (e) {
+            if (window.debugHighlighter) {
+              console.log("touch event:", type, id);
+            }
+            e.preventDefault();
+            e.stopPropagation();
+            
+            let highlightableIndex = getTouchEventHighlightableIndex(e);
+            if (highlightableIndex) {
+              app.ports.highlighterOnTouch.send([type, id, highlightableIndex]);
+            }
+          };
+        }
 
-      /*
-       * inform elm when we receive a mouseup/touchend event.
-       */
-      function onDocumentUp(id, device, touchMoveListener) {
-        return function () {
-          app.ports.highlighterOnDocumentUp.send([id, device]);
-          if (device === "touch") {
-            document.getElementById(id)?.removeEventListener(
-              "touchmove",
-              touchMoveListener
-            );
-          }
-        };
-      }
+        /*
+        * inform elm when we receive a mouseup/touchend event.
+        */
+        function onDocumentUp(id, device) {
+          return function () {
+            app.ports.highlighterOnDocumentUp.send([id, device]);
+            if (device === "touch") {
+              if (window.debugHighlighter) {
+                console.log("deregistering touch listeners");
+              }
+              // Stop listening to touchmove after touchend
+              // This helps us not report touchmove when touch starts on one highlighter and moves
+              // into another
+              document.getElementById(id)?.removeEventListener("touchmove", touchMoveListener);
+              // Deregister onDocumentUp listeners, so we avoid sending unnecessary messages to elm
+              document.removeEventListener("touchend", touchEndHandler);
+            } else if (device === "mouse") {
+              if (window.debugHighlighter) {
+                console.log("deregistering mouse listeners");
+              }
+              // Deregister onDocumentUp listeners, so we avoid sending unnecessary messages to elm
+              document.removeEventListener("mouseup", mouseUpHandler);
+            }
+          };
+        }
 
-      function getTouchEventHighlightableIndex(e) {
-         // we don't care about multitouch
-        if (e.touches.length > 1) return;
+        function getTouchEventHighlightableIndex(e) {
+          // we don't care about multitouch
+          if (e.touches.length > 1) return;
 
-        var loc = e.changedTouches[0];
+          var loc = e.changedTouches[0];
 
-        // get the element under the finger
-        var realTarget = document.elementFromPoint(loc.clientX, loc.clientY);
+          if (!loc) throw "touch event unexpectedly didn't have any touches!";
 
-        if (realTarget) {
-          // each word has a data attribute with its index.
-          const data = realTarget.getAttribute("data-highlighter-item-index");
-          if (data) {
-            return parseInt(data, 10);
+          // get the element under the finger
+          var realTarget = document.elementFromPoint(loc.clientX, loc.clientY);
+
+          if (realTarget) {
+            // each word has a data attribute with its index.
+            const data = realTarget.getAttribute("data-highlighter-item-index");
+            if (data) {
+              return parseInt(data, 10);
+            }
           }
         }
-      }
+      });
     </script>
     <script src="bundle.js"></script>
   </body>

--- a/component-catalog/index.html
+++ b/component-catalog/index.html
@@ -55,8 +55,8 @@
             data = realTarget.getAttribute("data-highlighter-item-index");
           }
 
-          // we only want to be informed for touchmove-events in the current highlighter.
-          if (data && id === realTarget.parentNode.id) {
+          // we only want to be informed for touchmove-events in highlightables
+          if (data) {
             app.ports.highlighterOnTouch.send([type, id, parseInt(data, 10)]);
           }
         };

--- a/component-catalog/index.html
+++ b/component-catalog/index.html
@@ -114,17 +114,21 @@
       }
 
       function getTouchEventHighlightableIndex(e) {
-        if (e.touches.length > 1) return; // we don't care about multitouch
-          var loc = e.changedTouches[0];
-          var realTarget = document.elementFromPoint(loc.clientX, loc.clientY); // get the element under the finger
+         // we don't care about multitouch
+        if (e.touches.length > 1) return;
 
-          if (realTarget) {
-            // each word has a data attribute with its index.
-            const data = realTarget.getAttribute("data-highlighter-item-index");
-            if (data) {
-              return parseInt(data, 10);
-            }
+        var loc = e.changedTouches[0];
+
+        // get the element under the finger
+        var realTarget = document.elementFromPoint(loc.clientX, loc.clientY);
+
+        if (realTarget) {
+          // each word has a data attribute with its index.
+          const data = realTarget.getAttribute("data-highlighter-item-index");
+          if (data) {
+            return parseInt(data, 10);
           }
+        }
       }
     </script>
     <script src="bundle.js"></script>

--- a/component-catalog/index.html
+++ b/component-catalog/index.html
@@ -24,6 +24,7 @@
           var highlighter = document.getElementById(id);
           if (!id || !highlighter) {
             // in a real application, report an error at this point.
+            console.log("highlighter not found", id);
             return;
           }
 

--- a/component-catalog/index.html
+++ b/component-catalog/index.html
@@ -48,7 +48,7 @@
               console.log("touchstart", id);
             }
 
-            const idx = getTouchEventIndex(e);
+            const idx = getTouchEventHighlightableIndex(e);
 
             if (!idx) return;
 
@@ -92,20 +92,9 @@
           }
           e.preventDefault();
           e.stopPropagation();
-          if (e.touches.length > 1) return; // we don't care about multitouch
-          var loc = e.changedTouches[0];
-          var realTarget = document.elementFromPoint(loc.clientX, loc.clientY); // get the element under the finger
-          var data;
-
-          if (realTarget) {
-            // each word has a data attribute with its index.
-            data = realTarget.getAttribute("data-highlighter-item-index");
-          }
-
-          // we only want to be informed for touchmove-events in highlightables
-          if (data) {
-            app.ports.highlighterOnTouch.send([type, id, parseInt(data, 10)]);
-          }
+          
+          let highlightableIndex = getTouchEventHighlightableIndex(e);
+          app.ports.highlighterOnTouch.send([type, id, highlightableIndex]);
         };
       }
 
@@ -124,7 +113,7 @@
         };
       }
 
-      function getTouchEventIndex(e) {
+      function getTouchEventHighlightableIndex(e) {
         if (e.touches.length > 1) return; // we don't care about multitouch
           var loc = e.changedTouches[0];
           var realTarget = document.elementFromPoint(loc.clientX, loc.clientY); // get the element under the finger

--- a/component-catalog/index.html
+++ b/component-catalog/index.html
@@ -42,6 +42,24 @@
           );
         });
 
+        /*
+         * This simulates "long-press to highlight" behavior that's native to mobile devices.
+         *
+         * We can't respect native long-press delays, unfortunately, because iOS does not implement
+         * an event that relies on long-press that we can intercept, like Android's `contextmenu`.
+         *
+         * The trick to make this work and be scroll friendly:
+         * - On touchstart, start a 500ms timer
+         * - If touch moves of ends before timer is done, undo everything (it's not a long-press)
+         * - If 500ms timer succeeds..
+         *   - send a longpress event to Elm so we start hinting
+         *   - add a touchmove listener
+         *     - on touchmove, tell Elm which element is currently under the finger
+         *   - add a touchend listener so we can stop hinting regardless of where we are in the page
+         *
+         * How this makes it scroll friendly: preventDefault on touchmove is only triggered after
+         * the longpress, so simple swipes up and down are not affected.
+         */
         function handleTouchStartScrollFriendly(id) {
           return function (e) {
             if (window.debugHighlighter) {

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -50,7 +50,13 @@ example =
     , version = version
     , init = init
     , update = update
-    , subscriptions = \_ -> Sub.map HighlighterMsg subscriptions
+    , subscriptions =
+        \_ ->
+            Sub.batch
+                [ Sub.map HighlighterMsg subscriptions
+                , Sub.map OverlappingHighlighterMsg subscriptions
+                , Sub.map FoldHighlighterMsg subscriptions
+                ]
     , preview =
         [ div [ css [ Fonts.baseFont, Css.lineHeight (Css.num 2), Css.Global.children [ Css.Global.p [ Css.margin Css.zero ] ] ] ]
             [ Highlighter.static

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -660,9 +660,9 @@ controlSettings =
                     , highlighterType = d
                     }
                 )
-                |> Control.field "splitOnSentences" (Control.bool True)
+                |> Control.field "splitOnSentences" (Control.bool False)
                 |> Control.field "joinAdjacentInteractiveHighlights" (Control.bool False)
-                |> Control.field "scrollFriendly" (Control.bool False)
+                |> Control.field "scrollFriendly" (Control.bool True)
                 |> Control.field "type"
                     (Control.choice
                         [ ( "Markdown", Control.value Markdown )

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -549,6 +549,7 @@ init =
             , marker = Tool.Marker (inlineCommentMarker "Comment 1")
             , sorter = Sort.alphabetical
             , joinAdjacentInteractiveHighlights = True
+            , scrollFriendly = False
             }
     , foldHighlightsState =
         Highlighter.init
@@ -559,6 +560,7 @@ init =
             , marker = Tool.Marker (inlineCommentMarker "Comment 1")
             , sorter = Sort.alphabetical
             , joinAdjacentInteractiveHighlights = True
+            , scrollFriendly = False
             }
     , overlappingHighlightsIndex = 1
     }
@@ -616,6 +618,7 @@ initHighlighter settings previousHighlightables =
         , marker = Tuple.second settings.tool.tool
         , sorter = sorter
         , joinAdjacentInteractiveHighlights = settings.textSettings.joinAdjacentInteractiveHighlights
+        , scrollFriendly = False
         }
     )
 

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -866,7 +866,17 @@ subscriptions =
 -}
 onDocumentUp : Sub (Highlighter.Msg marker)
 onDocumentUp =
-    highlighterOnDocumentUp (Highlighter.Pointer << Highlighter.Up << Just)
+    highlighterOnDocumentUp <|
+        \( id, device ) ->
+            case device of
+                "mouse" ->
+                    Highlighter.Pointer <| Highlighter.Up <| Just id
+
+                "touch" ->
+                    Highlighter.Touch <| Highlighter.TouchEnd <| Just id
+
+                _ ->
+                    Highlighter.Pointer Highlighter.Ignored
 
 
 {-| Subscribe to touch events
@@ -875,16 +885,16 @@ onTouch : Sub (Highlighter.Msg marker)
 onTouch =
     highlighterOnTouch <|
         \( type_, targetId, index ) ->
-            Highlighter.Pointer <|
+            Highlighter.Touch <|
                 case type_ of
                     "move" ->
-                        Highlighter.Move (Just targetId) index
+                        Highlighter.TouchMove (Just targetId) index
 
                     "end" ->
-                        Highlighter.Up (Just targetId)
+                        Highlighter.TouchEnd (Just targetId)
 
                     _ ->
-                        Highlighter.Ignored
+                        Highlighter.TouchIgnored
 
 
 {-| Start listening to events on a highlighter
@@ -894,7 +904,7 @@ port highlighterListen : String -> Cmd msg
 
 {-| Listen to documentup events, to stop highlighting.
 -}
-port highlighterOnDocumentUp : (String -> msg) -> Sub msg
+port highlighterOnDocumentUp : (( String, String ) -> msg) -> Sub msg
 
 
 {-| Listen to touch events, and get the element under the finger.

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -202,6 +202,8 @@ example =
                     , Css.lineHeight (Css.num 1.75)
                     , Fonts.ugFont
                     ]
+                , Html.Styled.Attributes.id state.foldHighlightsState.id
+                , Html.Styled.Attributes.class "highlighter-container"
                 ]
                 [ viewFoldHighlights state.foldHighlightsState
                     |> map FoldHighlighterMsg

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -604,6 +604,7 @@ initHighlighter settings previousHighlightables =
                 , ( "highlightables", Tuple.first highlightables )
                 , ( "marker", Code.newlineWithIndent 3 ++ Tuple.first settings.tool.tool )
                 , ( "joinAdjacentInteractiveHighlights", Code.bool settings.textSettings.joinAdjacentInteractiveHighlights )
+                , ( "scrollFriendly", Code.bool settings.textSettings.scrollFriendly )
                 , ( "sorter", "Sort.custom (\\() () -> EQ)" )
                 ]
                 2
@@ -618,7 +619,7 @@ initHighlighter settings previousHighlightables =
         , marker = Tuple.second settings.tool.tool
         , sorter = sorter
         , joinAdjacentInteractiveHighlights = settings.textSettings.joinAdjacentInteractiveHighlights
-        , scrollFriendly = False
+        , scrollFriendly = settings.textSettings.scrollFriendly
         }
     )
 
@@ -635,6 +636,7 @@ type alias Settings =
     { textSettings :
         { splitOnSentences : Bool
         , joinAdjacentInteractiveHighlights : Bool
+        , scrollFriendly : Bool
         , highlighterType : HighlighterType
         }
     , tool : { tool : ( String, Tool.Tool () ) }
@@ -650,9 +652,17 @@ controlSettings : Control Settings
 controlSettings =
     Control.record Settings
         |> Control.field "Text settings"
-            (Control.record (\a b c -> { splitOnSentences = a, joinAdjacentInteractiveHighlights = b, highlighterType = c })
+            (Control.record
+                (\a b c d ->
+                    { splitOnSentences = a
+                    , joinAdjacentInteractiveHighlights = b
+                    , scrollFriendly = c
+                    , highlighterType = d
+                    }
+                )
                 |> Control.field "splitOnSentences" (Control.bool True)
                 |> Control.field "joinAdjacentInteractiveHighlights" (Control.bool False)
+                |> Control.field "scrollFriendly" (Control.bool False)
                 |> Control.field "type"
                     (Control.choice
                         [ ( "Markdown", Control.value Markdown )

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -812,10 +812,15 @@ update msg state =
 
         FoldHighlighterMsg highlighterMsg ->
             let
-                ( highlighterModel, highlighterCmd, _ ) =
+                ( highlighterModel, highlighterCmd, intent ) =
                     Highlighter.update highlighterMsg state.foldHighlightsState
             in
-            ( { state | foldHighlightsState = highlighterModel }, Cmd.map FoldHighlighterMsg highlighterCmd )
+            ( { state | foldHighlightsState = highlighterModel }
+            , Cmd.batch
+                [ Cmd.map FoldHighlighterMsg highlighterCmd
+                , perform intent
+                ]
+            )
 
 
 perform : Highlighter.Intent -> Cmd msg

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -749,7 +749,7 @@ update msg state =
                 [ Cmd.map HighlighterMsg effect
                 , case intent.listenTo of
                     Just listenTo ->
-                        highlighterListen listenTo
+                        highlighterListen ( listenTo, state.highlighter.scrollFriendly )
 
                     Nothing ->
                         Cmd.none
@@ -799,7 +799,7 @@ update msg state =
                             ( newComment
                             , Cmd.batch
                                 [ Cmd.map OverlappingHighlighterMsg effect
-                                , perform intent
+                                , perform intent state.highlighter.scrollFriendly
                                 ]
                             )
 
@@ -812,7 +812,7 @@ update msg state =
                                     ( { state | overlappingHighlightsState = withAllCommentIds }
                                     , Cmd.batch
                                         [ Cmd.map OverlappingHighlighterMsg effect
-                                        , perform intent
+                                        , perform intent state.overlappingHighlightsState.scrollFriendly
                                         ]
                                     )
 
@@ -821,7 +821,7 @@ update msg state =
                                     ( { state | overlappingHighlightsState = withAllCommentIds }
                                     , Cmd.batch
                                         [ Cmd.map OverlappingHighlighterMsg effect
-                                        , perform intent
+                                        , perform intent state.overlappingHighlightsState.scrollFriendly
                                         ]
                                     )
 
@@ -833,16 +833,16 @@ update msg state =
             ( { state | foldHighlightsState = highlighterModel }
             , Cmd.batch
                 [ Cmd.map FoldHighlighterMsg highlighterCmd
-                , perform intent
+                , perform intent state.foldHighlightsState.scrollFriendly
                 ]
             )
 
 
-perform : Highlighter.Intent -> Cmd msg
-perform (Highlighter.Intent intent) =
+perform : Highlighter.Intent -> Bool -> Cmd msg
+perform (Highlighter.Intent intent) scrollFriendly =
     case intent.listenTo of
         Just listenTo ->
-            highlighterListen listenTo
+            highlighterListen ( listenTo, scrollFriendly )
 
         Nothing ->
             Cmd.none
@@ -893,13 +893,16 @@ onTouch =
                     "end" ->
                         Highlighter.TouchEnd (Just targetId)
 
+                    "longpress" ->
+                        Highlighter.LongPress (Just targetId) index
+
                     _ ->
                         Highlighter.TouchIgnored
 
 
 {-| Start listening to events on a highlighter
 -}
-port highlighterListen : String -> Cmd msg
+port highlighterListen : ( String, Bool ) -> Cmd msg
 
 
 {-| Listen to documentup events, to stop highlighting.

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -795,7 +795,7 @@ update msg state =
                     -- The Changed action will be triggered on the Highlighter Up event and
                     -- when there is an actual change in the highlightable elements.
                     case Highlighter.hasChanged intent of
-                        Highlighter.Changed ->
+                        Highlighter.Changed _ ->
                             ( newComment
                             , Cmd.batch
                                 [ Cmd.map OverlappingHighlighterMsg effect
@@ -838,7 +838,7 @@ update msg state =
             )
 
 
-perform : Highlighter.Intent -> Bool -> Cmd msg
+perform : Highlighter.Intent marker -> Bool -> Cmd msg
 perform (Highlighter.Intent intent) scrollFriendly =
     case intent.listenTo of
         Just listenTo ->

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -1434,7 +1434,7 @@ viewHighlightable { renderMarkdown, overlaps } config highlightable =
                 , eventListeners =
                     [ onPreventDefault "mouseover" (Pointer <| Over highlightable.index)
                     , onPreventDefault "mouseleave" (Pointer <| Out)
-                    , onPreventDefault "mouseup" (Pointer <| Up Nothing)
+                    , onPreventDefault "mouseup" (Pointer <| Up <| Just config.id)
                     , onPreventDefault "mousedown" (Pointer <| Down highlightable.index)
                     , onPreventDefault "touchstart" (Pointer <| Down highlightable.index)
                     , attribute "data-interactive" ""
@@ -1476,7 +1476,7 @@ viewHighlightable { renderMarkdown, overlaps } config highlightable =
                     -- should see the entire highlight change to hover styles.
                     [ onPreventDefault "mouseover" (Pointer <| Over highlightable.index)
                     , onPreventDefault "mouseleave" (Pointer <| Out)
-                    , onPreventDefault "mouseup" (Pointer <| Up Nothing)
+                    , onPreventDefault "mouseup" (Pointer <| Up <| Just config.id)
                     , onPreventDefault "mousedown" (Pointer <| Down highlightable.index)
                     , onPreventDefault "touchstart" (Pointer <| Down highlightable.index)
                     , attribute "data-static" ""

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -1436,30 +1436,20 @@ view_ config =
 
 viewHighlightable :
     { renderMarkdown : Bool, overlaps : OverlapsSupport marker }
-    ->
-        { config
-            | id : String
-            , focusIndex : Maybe Int
-            , marker : Tool.Tool marker
-            , mouseOverIndex : Maybe Int
-            , mouseDownIndex : Maybe Int
-            , hintingIndices : Maybe ( Int, Int )
-            , sorter : Sorter marker
-            , highlightables : List (Highlightable marker)
-        }
+    -> Model marker
     -> Highlightable marker
     -> List Css.Style
     -> Html (Msg marker)
-viewHighlightable { renderMarkdown, overlaps } config highlightable =
+viewHighlightable { renderMarkdown, overlaps } model highlightable =
     case highlightable.type_ of
         Highlightable.Interactive ->
             viewHighlightableSegment
-                { interactiveHighlighterId = Just config.id
-                , focusIndex = config.focusIndex
+                { interactiveHighlighterId = Just model.id
+                , focusIndex = model.focusIndex
                 , eventListeners =
                     [ onPreventDefault "mouseover" (Pointer <| Over highlightable.index)
                     , onPreventDefault "mouseleave" (Pointer <| Out)
-                    , onPreventDefault "mouseup" (Pointer <| Up <| Just config.id)
+                    , onPreventDefault "mouseup" (Pointer <| Up <| Just model.id)
                     , onPreventDefault "mousedown" (Pointer <| Down highlightable.index)
                     , onClickPreventDefault
                         (\count ->
@@ -1486,11 +1476,11 @@ viewHighlightable { renderMarkdown, overlaps } config highlightable =
                         ]
                     ]
                 , renderMarkdown = renderMarkdown
-                , maybeTool = Just config.marker
-                , mouseOverIndex = config.mouseOverIndex
-                , mouseDownIndex = config.mouseDownIndex
-                , hintingIndices = config.hintingIndices
-                , sorter = Just config.sorter
+                , maybeTool = Just model.marker
+                , mouseOverIndex = model.mouseOverIndex
+                , mouseDownIndex = model.mouseDownIndex
+                , hintingIndices = model.hintingIndices
+                , sorter = Just model.sorter
                 , overlaps = overlaps
                 }
                 highlightable
@@ -1498,7 +1488,7 @@ viewHighlightable { renderMarkdown, overlaps } config highlightable =
         Highlightable.Static ->
             viewHighlightableSegment
                 { interactiveHighlighterId = Nothing
-                , focusIndex = config.focusIndex
+                , focusIndex = model.focusIndex
                 , eventListeners =
                     -- Static highlightables need listeners as well.
                     -- because otherwise we miss mouse events.
@@ -1506,7 +1496,7 @@ viewHighlightable { renderMarkdown, overlaps } config highlightable =
                     -- should see the entire highlight change to hover styles.
                     [ onPreventDefault "mouseover" (Pointer <| Over highlightable.index)
                     , onPreventDefault "mouseleave" (Pointer <| Out)
-                    , onPreventDefault "mouseup" (Pointer <| Up <| Just config.id)
+                    , onPreventDefault "mouseup" (Pointer <| Up <| Just model.id)
                     , onClickPreventDefault
                         (\count ->
                             Pointer <|
@@ -1517,11 +1507,11 @@ viewHighlightable { renderMarkdown, overlaps } config highlightable =
                     , attribute "data-static" ""
                     ]
                 , renderMarkdown = renderMarkdown
-                , maybeTool = Just config.marker
-                , mouseOverIndex = config.mouseOverIndex
-                , mouseDownIndex = config.mouseDownIndex
-                , hintingIndices = config.hintingIndices
-                , sorter = Just config.sorter
+                , maybeTool = Just model.marker
+                , mouseOverIndex = model.mouseOverIndex
+                , mouseDownIndex = model.mouseDownIndex
+                , hintingIndices = model.hintingIndices
+                , sorter = Just model.sorter
                 , overlaps = overlaps
                 }
                 highlightable

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -530,7 +530,7 @@ pointerEventToActions msg model =
                         case ( model.mouseOverIndex, model.mouseDownIndex ) of
                             ( Just overIndex, Just downIndex ) ->
                                 if overIndex == downIndex then
-                                    if model.scrollFriendly then
+                                    if model.scrollFriendly && model.hintingIndices == Nothing then
                                         -- scroll-friendly mode only hints on double-click or drag
                                         []
 
@@ -628,7 +628,6 @@ touchEventToActions msg model =
 
             else
                 []
-
 
         LongPress targetId eventIndex ->
             if Just model.id == targetId then

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -28,6 +28,7 @@ Highlighter provides a view/model/update to display a view to highlight text and
   - Added `FoldState`, `initFoldState`, `viewFoldHighlighter`, and `viewFoldStatic`
   - Exposed KeyboardMsg(..) to allow for fine-tuning keyboard interactions
   - Made keyboard selection use hinting state too
+  - Fixed mobile interaction bugs (see #1694)
 
 
 # Types

--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -452,11 +452,7 @@ pointerEventToActions msg model =
                         ]
 
                     Nothing ->
-                        -- We're dealing with a touch move that hasn't been where
-                        -- the initial touch down was not over a highlightable
-                        -- region. We need to pretend like the first move into the
-                        -- highlightable region was actually a touch down.
-                        pointerEventToActions (Down eventIndex) model
+                        []
 
             else
                 []

--- a/tests/Spec/Nri/Ui/Highlighter.elm
+++ b/tests/Spec/Nri/Ui/Highlighter.elm
@@ -443,6 +443,7 @@ markdownHighlightNameTests =
                 , marker = markerModel Nothing
                 , joinAdjacentInteractiveHighlights = False
                 , sorter = Sort.alphabetical
+                , scrollFriendly = False
                 }
 
         testIt viewName view =
@@ -488,6 +489,7 @@ startWithoutMarker view highlightables =
                 , marker = Tool.Eraser Tool.buildEraser
                 , joinAdjacentInteractiveHighlights = False
                 , sorter = Sort.custom (\() () -> EQ)
+                , scrollFriendly = False
                 }
         , update = \_ m -> m
         , view = view >> toUnstyled
@@ -684,6 +686,7 @@ program config highlightables =
                 , marker = markerModel config.markerName
                 , joinAdjacentInteractiveHighlights = config.joinAdjacentInteractiveHighlights
                 , sorter = Sort.alphabetical
+                , scrollFriendly = False
                 }
         , update =
             \msg model ->
@@ -831,6 +834,7 @@ overlappingHighlightTests =
                         , marker = markerModel (Just "Comment")
                         , joinAdjacentInteractiveHighlights = False
                         , sorter = Sort.alphabetical
+                        , scrollFriendly = False
                         }
                 , update =
                     \msg model ->

--- a/tests/Spec/Nri/Ui/HighlighterOverlaps.elm
+++ b/tests/Spec/Nri/Ui/HighlighterOverlaps.elm
@@ -97,6 +97,7 @@ init2 marker1 marker2 cursor_ =
         , marker = Tool.Marker (mkMarker "unused")
         , joinAdjacentInteractiveHighlights = False
         , sorter = Sort.alphabetical
+        , scrollFriendly = False
         }
         |> Highlighter.update (Highlighter.Pointer (Highlighter.Over cursorIndex))
         |> (\( model, _, _ ) -> model)


### PR DESCRIPTION
Please use the template that's relevant for your situation and delete the other templates. If this is just a noredink-ui repo doc change, you don't need to follow a template.

# :label: Bump for version `VERSION_NUMBER`

## What changes does this release include?

The easiest and most reliable way to find the changes that this release includes is to go through the changes between the last version number and master: `https://github.com/NoRedInk/noredink-ui/compare/VERSION_NUMBER...master`.

Include links to the relevant PRs in a list in this PR. Be sure to note any risky changes or changes that you will want to alert QA to when upgrading to the new version of noredink-ui.

Please update the PR's name to include a quick note about every linked PR.

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```

```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).

---

# :star2: Adding a new component

## About the component

What is the purpose of the new component? When and where will it be used? How will the reviewer know if this component meets the success criteria?

Please link to any relevant context and stories.

## :framed_picture: What does this change look like?

- If there are user facing changes, you will be asked later to add a designer as a reviewer. Please fill in this section by following [the guidelines for an optimal design review](https://paper.dropbox.com/doc/Guidelines-for-Sharing-User-Facing-Changes-with-Design--BpL8hpJLMugy6033aT5m0JdaAg-bdKGQtYH9qO9I00hUkA6k).
- If there are not user facing changes, include any screenshots or videos that would be helpful to reviewers.

## Component completion checklist

- [ ] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with this component in mind
- [ ] Component has clear documentation
- [ ] Component is in the Component Catalog
  - [ ] I've used [the script to add the component to the Component Catalog](https://github.com/NoRedInk/noredink-ui?tab=readme-ov-file#-adding-a-component-to-the-component-catalog).
  - [ ] Component is categorized reasonably (see [Category](https://github.com/NoRedInk/noredink-ui/blob/master/component-catalog-app/Category.elm) for all the currently available categories). The component can be in multiple categories, if appropriate.
  - [ ] Component has a representative preview for the Component Catalog cards (bonus points for making it delightful!)
  - [ ] Component has a customizable example. Aim for having _every_ possible supported version of the component displayable through the configuration on this page. (Protip: This is handy for testing expected behavior!)
  - [ ] The customizable example produces sample code
  - [ ] The component's example page includes keyboard behavior, if any
  - [ ] The component's example page includes guidance around how to use the component, if necessary
- [ ] Component is tested
  - axe checks and percy snapshots will be automatically added for every component. However, if you want to customize _when_ the checks and snapshots are made, you will need to make changes to [script/puppeteer-tests.js](https://github.com/NoRedInk/noredink-ui/blob/master/script/puppeteer-tests.js).
  - there are 2 ways to add Elm tests:
    - if you want to test the Component Catalog example directly, add ProgramTest-style tests under `component-catalog/tests`
    - if you want to test the component directly, add tests under `tests/Spec`. Historically, this has been the more popular Elm testing strategy for noredink-ui.
- [ ] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [ ] Please assign the following reviewers:
  - [ ] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [ ] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [ ] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)

---

# :wrench: Modifying a component

## Context

Please link to any relevant context and stories.

## :framed_picture: What does this change look like?

- If there are user facing changes, you will be asked later to add a designer as a reviewer. Please fill in this section by following [the guidelines for an optimal design review](https://paper.dropbox.com/doc/Guidelines-for-Sharing-User-Facing-Changes-with-Design--BpL8hpJLMugy6033aT5m0JdaAg-bdKGQtYH9qO9I00hUkA6k).
- If there are not user facing changes, include any screenshots or videos that would be helpful to reviewers.

## Component completion checklist

- [ ] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [ ] Changes are clearly documented
  - [ ] Component docs include a changelog
  - [ ] Any new exposed functions or properties have docs
- [ ] Changes extend to the Component Catalog
  - [ ] The Component Catalog is updated to use the newest version, if appropriate
  - [ ] The Component Catalog example version number is updated, if appropriate
  - [ ] Any new customizations are available from the Component Catalog
  - [ ] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [ ] Changes to the component are tested/the new version of the component is tested
- [ ] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [ ] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [ ] Please assign the following reviewers:
  - [ ] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [ ] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [ ] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
