### PR TITLE
add rightIcon to Switch

### DIFF
--- a/component-catalog/src/Examples/Switch.elm
+++ b/component-catalog/src/Examples/Switch.elm
@@ -19,6 +19,7 @@ import Html.Styled exposing (..)
 import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
+import Nri.Ui.Svg.V1 exposing (Svg)
 import Nri.Ui.Switch.V3 as Switch
 import Nri.Ui.Table.V7 as Table
 import Nri.Ui.Tooltip.V3 as Tooltip
@@ -234,6 +235,7 @@ initAttributes : Control (List ( String, Switch.Attribute msg ))
 initAttributes =
     Control.list
         |> CommonControls.disabledListItem moduleName Switch.disabled
+        |> CommonControls.icon "rightIcon" (Nri.Ui.Svg.V1.withHeight (Css.px 18) >> Nri.Ui.Svg.V1.withWidth (Css.px 18) >> Switch.rightIcon)
 
 
 {-| -}

--- a/src/Nri/Ui/Switch/V3.elm
+++ b/src/Nri/Ui/Switch/V3.elm
@@ -9,6 +9,11 @@ module Nri.Ui.Switch.V3 exposing
 {-|
 
 
+### Patch changes:
+
+  - add `rightIcon` property
+
+
 ### Changes from V2:
 
     - Replace underlying checkbox input with a custom implementation

--- a/src/Nri/Ui/Switch/V3.elm
+++ b/src/Nri/Ui/Switch/V3.elm
@@ -2,7 +2,7 @@ module Nri.Ui.Switch.V3 exposing
     ( view
     , Attribute
     , selected
-    , containerCss, labelCss, custom, nriDescription, testId
+    , containerCss, labelCss, custom, nriDescription, testId, rightIcon
     , onSwitch, disabled
     )
 
@@ -21,7 +21,7 @@ module Nri.Ui.Switch.V3 exposing
 
 @docs Attribute
 @docs selected
-@docs containerCss, labelCss, custom, nriDescription, testId
+@docs containerCss, labelCss, custom, nriDescription, testId, rightIcon
 @docs onSwitch, disabled
 
 -}
@@ -39,6 +39,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as Extra
+import Nri.Ui.Html.V3 as Html
 import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Nri.Ui.Svg.V1 exposing (Svg)
 import Svg.Styled as Svg
@@ -114,12 +115,20 @@ labelCss styles =
     Attribute <| \config -> { config | labelCss = config.labelCss ++ styles }
 
 
+{-| Adds an icon to the right of the switch.
+-}
+rightIcon : Svg -> Attribute msg
+rightIcon icon =
+    Attribute <| \config -> { config | rightIcon = Just icon }
+
+
 type alias Config msg =
     { onSwitch : Maybe (Bool -> msg)
     , containerCss : List Style
     , labelCss : List Style
     , isDisabled : Bool
     , isSelected : Bool
+    , rightIcon : Maybe Svg
     , custom : List (Html.Attribute msg)
     }
 
@@ -131,6 +140,7 @@ defaultConfig =
     , labelCss = []
     , isDisabled = False
     , isSelected = False
+    , rightIcon = Nothing
     , custom = []
     }
 
@@ -198,6 +208,7 @@ view { label, id } attrs =
                 ]
             ]
             [ Html.text label ]
+        , Html.viewJust (Nri.Ui.Svg.V1.withCss [ Css.marginLeft (Css.px 5) ] >> Nri.Ui.Svg.V1.toHtml) config.rightIcon
         ]
 
 


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

https://linear.app/noredink/issue/QUO-920/alert-when-pasted-text-percentage-is-above-threshold

## :framed_picture: What does this change look like?

![image](https://github.com/user-attachments/assets/b75f6297-e0b7-4df0-95f2-0f33ae23efdd)

## Component completion checklist

- [X] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [X] Changes are clearly documented
  - [X] Component docs include a changelog
  - [X] Any new exposed functions or properties have docs
- [X] Changes extend to the Component Catalog
  - [X] The Component Catalog is updated to use the newest version, if appropriate
  - [X] The Component Catalog example version number is updated, if appropriate
  - [X] Any new customizations are available from the Component Catalog
  - [X] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [X] Changes to the component are tested/the new version of the component is tested
- [X] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [X] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [X] Please assign the following reviewers:
  - [X] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [X] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [X] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
