### PR TITLE
Bump to 30.0.1

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "30.0.0",
+    "version": "30.0.1",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `30.0.1`

## What changes does this release include?

- https://github.com/NoRedInk/noredink-ui/pull/1699
  - gradingAssistant and manuallyGraded icon colors has changed to use currentColor.

## How has the API changed?

No API changes. 

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).
