### PR TITLE
this makes Tooltip.markdown use markdownInline

### DIFF
--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -37,6 +37,7 @@ module Nri.Ui.Tooltip.V3 exposing
   - adds `helpfullyDisabled` option
   - adds `onTriggerKeyDown` option
   - add `stopTooltipMousePropagation` option
+  - use `Content.markdownInline` instead of `Content.markdown`
 
 Changes from V2:
 

--- a/src/Nri/Ui/Tooltip/V3.elm
+++ b/src/Nri/Ui/Tooltip/V3.elm
@@ -190,8 +190,8 @@ paragraph =
 {-| Provide a string that will be rendered as markdown.
 -}
 markdown : String -> Attribute msg
-markdown =
-    Attribute << Content.markdown
+markdown string =
+    Attribute (\tooltipConfig -> { tooltipConfig | content = Content.markdownInline string })
 
 
 {-| Provide a list of custom HTML.


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

When using Tooltip.markdown, even when there are no paragraphs, we're rendering `<p>`s, which cause non-intentional margins to appear. By using `markdownInline`, we can control that by using a line break at the beginning of the string when we want margins, and not using it when we do not.

## :framed_picture: What does this change look like?

<img width="342" alt="image" src="https://github.com/user-attachments/assets/f9bcdfa7-5c26-478f-9e37-47df51a0cadc">

When using a line break

<img width="360" alt="image" src="https://github.com/user-attachments/assets/610ac05a-9f0b-49b7-96ea-f85bc232bc84">

When not using it

## Component completion checklist

- [X] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [X] Changes are clearly documented
  - [X] Component docs include a changelog
  - [X] Any new exposed functions or properties have docs
- [X] Changes extend to the Component Catalog
  - [X] The Component Catalog is updated to use the newest version, if appropriate
  - [X] The Component Catalog example version number is updated, if appropriate
  - [X] Any new customizations are available from the Component Catalog
  - [X] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [X] Changes to the component are tested/the new version of the component is tested
- [X] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [X] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [X] Please assign the following reviewers:
  - [X] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [X] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [X] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
