### PR TITLE
Fix focusring not showing up bc of CSS specificity

### DIFF
--- a/src/Nri/Ui/FocusRing/V1.elm
+++ b/src/Nri/Ui/FocusRing/V1.elm
@@ -8,6 +8,11 @@ module Nri.Ui.FocusRing.V1 exposing
 
 {-|
 
+
+### Patch changes
+
+    - Made the :not(.custom-focus-ring) style !important to fix marked highlightables, whose borders are applied through a selector with greater CSS specificity
+
 @docs forKeyboardUsers, forMouseUsers
 @docs styles, tightStyles
 @docs boxShadows, insetBoxShadows, outerBoxShadow, insetBoxShadow
@@ -92,9 +97,9 @@ NOTE: use `boxShadows` instead if your focusable element:
 -}
 styles : List Css.Style
 styles =
-    [ boxShadows []
-    , Css.outline3 (Css.px 2) Css.solid Css.transparent
-    , Css.borderRadius (Css.px 4)
+    [ Css.important <| boxShadows []
+    , Css.important <| Css.outline3 (Css.px 2) Css.solid Css.transparent
+    , Css.important <| Css.borderRadius (Css.px 4)
     ]
 
 


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

We have a new highlighter without elm-css. The styles on that highlighter work like this:

```css
#highlighter-component-id .highlighter-highlightable {
  border: something;
}
```

The id + class result in greater CSS specificity than selector for our focus ring, so they take precedence, and the focus ring decoration does not show up.

In this PR I'm fixing that by making focusring styles `!important`.

My reasoning is the focusring should only not show up when we explicitly tell it not to, by adding a `custom-focus-ring` class to an element. Otherwise, the focusring CSS should always take precedence.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - this is not a new major version
- [ ] Please assign the following reviewers:
  - [x] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
