### PR TITLE
quo 987 sortabletable consistent default padding for header and data

### DIFF
--- a/component-catalog/src/Examples/AnimatedIcon.elm
+++ b/component-catalog/src/Examples/AnimatedIcon.elm
@@ -94,7 +94,7 @@ example =
                 [ Heading.plaintext "Examples"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
-            , Table.view { additionalStyles = [], alternatingRowColors = True }
+            , Table.view []
                 [ Table.custom
                     { header = text "Rendered"
                     , view =

--- a/component-catalog/src/Examples/AnimatedIcon.elm
+++ b/component-catalog/src/Examples/AnimatedIcon.elm
@@ -20,7 +20,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 
 
 moduleName : String

--- a/component-catalog/src/Examples/AnimatedIcon.elm
+++ b/component-catalog/src/Examples/AnimatedIcon.elm
@@ -94,7 +94,7 @@ example =
                 [ Heading.plaintext "Examples"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
-            , Table.view []
+            , Table.view { additionalStyles = [], alternatingRowColors = True }
                 [ Table.custom
                     { header = text "Rendered"
                     , view =

--- a/component-catalog/src/Examples/Balloon.elm
+++ b/component-catalog/src/Examples/Balloon.elm
@@ -248,7 +248,7 @@ view ellieLinkConfig state =
         [ Heading.plaintext "Position & Alignment Examples"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
-    , Table.view { additionalStyles = [], alternatingRowColors = True }
+    , Table.view []
         [ Table.custom
             { header = text "Position"
             , view = Tuple.first >> text
@@ -303,7 +303,7 @@ view ellieLinkConfig state =
         [ Heading.plaintext "Theme Examples"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
-    , Table.view { additionalStyles = [], alternatingRowColors = True }
+    , Table.view []
         [ Table.custom
             { header = text "Theme"
             , view = Tuple.first >> text

--- a/component-catalog/src/Examples/Balloon.elm
+++ b/component-catalog/src/Examples/Balloon.elm
@@ -23,7 +23,7 @@ import Nri.Ui.Balloon.V2 as Balloon
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 
 
 moduleName : String

--- a/component-catalog/src/Examples/Balloon.elm
+++ b/component-catalog/src/Examples/Balloon.elm
@@ -248,7 +248,7 @@ view ellieLinkConfig state =
         [ Heading.plaintext "Position & Alignment Examples"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
-    , Table.view []
+    , Table.view { additionalStyles = [], alternatingRowColors = True }
         [ Table.custom
             { header = text "Position"
             , view = Tuple.first >> text
@@ -303,7 +303,7 @@ view ellieLinkConfig state =
         [ Heading.plaintext "Theme Examples"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
-    , Table.view []
+    , Table.view { additionalStyles = [], alternatingRowColors = True }
         [ Table.custom
             { header = text "Theme"
             , view = Tuple.first >> text

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -26,7 +26,7 @@ import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.Text.V6 as Text
 import Task
 

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -302,7 +302,7 @@ example =
                     , Block.labelPosition (Dict.get dontBreakId offsets)
                     ]
                 ]
-            , Table.view { additionalStyles = [], alternatingRowColors = True }
+            , Table.view []
                 [ Table.custom
                     { header = text "Pattern name & description"
                     , view = .description >> Markdown.toHtml Nothing >> List.map fromUnstyled >> div []
@@ -549,7 +549,7 @@ A labelled blank in the sentence.
             , Text.smallBody [ Text.markdown "If we're looking for a specific length of content to put in the blank, that _must_ be communicated elsewhere on the page to provide an equitable experience." ]
             , Text.smallBody [ Text.markdown "The `widthInChars` parameter uses the number of characters expected in the blank to calculate a rough monospace-based width that visually looks like it _could_ match." ]
             , Table.view
-                { additionalStyles = [], alternatingRowColors = True }
+                []
                 [ Table.custom
                     { header = text "Pattern"
                     , view =

--- a/component-catalog/src/Examples/Block.elm
+++ b/component-catalog/src/Examples/Block.elm
@@ -302,7 +302,7 @@ example =
                     , Block.labelPosition (Dict.get dontBreakId offsets)
                     ]
                 ]
-            , Table.view []
+            , Table.view { additionalStyles = [], alternatingRowColors = True }
                 [ Table.custom
                     { header = text "Pattern name & description"
                     , view = .description >> Markdown.toHtml Nothing >> List.map fromUnstyled >> div []
@@ -549,7 +549,7 @@ A labelled blank in the sentence.
             , Text.smallBody [ Text.markdown "If we're looking for a specific length of content to put in the blank, that _must_ be communicated elsewhere on the page to provide an equitable experience." ]
             , Text.smallBody [ Text.markdown "The `widthInChars` parameter uses the number of characters expected in the blank to calculate a rough monospace-based width that visually looks like it _could_ match." ]
             , Table.view
-                []
+                { additionalStyles = [], alternatingRowColors = True }
                 [ Table.custom
                     { header = text "Pattern"
                     , view =

--- a/component-catalog/src/Examples/BreadCrumbs.elm
+++ b/component-catalog/src/Examples/BreadCrumbs.elm
@@ -200,7 +200,7 @@ example =
                 [ Heading.plaintext "Other Helpers"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
-            , Table.view []
+            , Table.view { additionalStyles = [], alternatingRowColors = True }
                 [ Table.string
                     { header = "Name"
                     , value = .name

--- a/component-catalog/src/Examples/BreadCrumbs.elm
+++ b/component-catalog/src/Examples/BreadCrumbs.elm
@@ -25,7 +25,7 @@ import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 

--- a/component-catalog/src/Examples/BreadCrumbs.elm
+++ b/component-catalog/src/Examples/BreadCrumbs.elm
@@ -200,7 +200,7 @@ example =
                 [ Heading.plaintext "Other Helpers"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
-            , Table.view { additionalStyles = [], alternatingRowColors = True }
+            , Table.view []
                 [ Table.string
                     { header = "Name"
                     , value = .name

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -332,7 +332,7 @@ example =
                 [ Heading.plaintext "Usage examples"
                 , Heading.css [ Css.marginTop (Css.px 30) ]
                 ]
-            , Table.view { additionalStyles = [], alternatingRowColors = True }
+            , Table.view []
                 [ Table.rowHeader
                     { header = text (moduleName ++ " view name")
                     , view = \{ viewName } -> code [] [ text viewName ]

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -33,7 +33,7 @@ import Nri.Ui.FocusRing.V1 as FocusRing
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Html.Attributes.V2 as Attributes
 import Nri.Ui.Html.V3 exposing (viewJust)
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Routes

--- a/component-catalog/src/Examples/Carousel.elm
+++ b/component-catalog/src/Examples/Carousel.elm
@@ -332,7 +332,7 @@ example =
                 [ Heading.plaintext "Usage examples"
                 , Heading.css [ Css.marginTop (Css.px 30) ]
                 ]
-            , Table.view []
+            , Table.view { additionalStyles = [], alternatingRowColors = True }
                 [ Table.rowHeader
                     { header = text (moduleName ++ " view name")
                     , view = \{ viewName } -> code [] [ text viewName ]

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -87,7 +87,7 @@ example =
                 [ Heading.plaintext "State Examples"
                 , Heading.css [ Css.marginTop (Css.px 30) ]
                 ]
-            , Table.view []
+            , Table.view { additionalStyles = [], alternatingRowColors = True }
                 [ Table.string
                     { header = "State"
                     , value = .state
@@ -120,7 +120,7 @@ example =
                 [ Heading.plaintext "Guidance Examples"
                 , Heading.css [ Css.marginTop (Css.px 30) ]
                 ]
-            , Table.view []
+            , Table.view { additionalStyles = [], alternatingRowColors = True }
                 [ Table.custom
                     { header = text "Attribute"
                     , view = .name >> text

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -87,7 +87,7 @@ example =
                 [ Heading.plaintext "State Examples"
                 , Heading.css [ Css.marginTop (Css.px 30) ]
                 ]
-            , Table.view { additionalStyles = [], alternatingRowColors = True }
+            , Table.view []
                 [ Table.string
                     { header = "State"
                     , value = .state
@@ -120,7 +120,7 @@ example =
                 [ Heading.plaintext "Guidance Examples"
                 , Heading.css [ Css.marginTop (Css.px 30) ]
                 ]
-            , Table.view { additionalStyles = [], alternatingRowColors = True }
+            , Table.view []
                 [ Table.custom
                     { header = text "Attribute"
                     , view = .name >> text

--- a/component-catalog/src/Examples/Checkbox.elm
+++ b/component-catalog/src/Examples/Checkbox.elm
@@ -26,7 +26,7 @@ import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Html.Attributes.V2 exposing (safeIdWithPrefix)
 import Nri.Ui.Svg.V1 as Svg
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.Tooltip.V3 as Tooltip
 
 

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -22,7 +22,7 @@ import Html.Styled.Attributes exposing (css)
 import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -276,7 +276,7 @@ viewExamples ellieLinkConfig (State control) =
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
     , Text.caption [ Text.markdown "Be sure to add the `appearsInline` property if the `ClickableText` appears inline. Otherwise, your styles will not match up nicely. You should not add an explicit size." ]
-    , Table.view { additionalStyles = [], alternatingRowColors = True }
+    , Table.view []
         [ Table.custom
             { header = text "Displayed"
             , view = \( view, name ) -> view (inlineExample name)
@@ -388,7 +388,7 @@ sizes =
 
 sizeExamples : Settings Msg -> Html Msg
 sizeExamples settings =
-    Table.view { additionalStyles = [], alternatingRowColors = True }
+    Table.view []
         [ Table.custom
             { header = text "Size"
             , view =

--- a/component-catalog/src/Examples/ClickableText.elm
+++ b/component-catalog/src/Examples/ClickableText.elm
@@ -276,7 +276,7 @@ viewExamples ellieLinkConfig (State control) =
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
     , Text.caption [ Text.markdown "Be sure to add the `appearsInline` property if the `ClickableText` appears inline. Otherwise, your styles will not match up nicely. You should not add an explicit size." ]
-    , Table.view []
+    , Table.view { additionalStyles = [], alternatingRowColors = True }
         [ Table.custom
             { header = text "Displayed"
             , view = \( view, name ) -> view (inlineExample name)
@@ -388,7 +388,7 @@ sizes =
 
 sizeExamples : Settings Msg -> Html Msg
 sizeExamples settings =
-    Table.view []
+    Table.view { additionalStyles = [], alternatingRowColors = True }
         [ Table.custom
             { header = text "Size"
             , view =

--- a/component-catalog/src/Examples/FocusRing.elm
+++ b/component-catalog/src/Examples/FocusRing.elm
@@ -141,7 +141,7 @@ exampleWithBorderAndBG styles =
 
 viewTable : State -> Html Msg
 viewTable model =
-    Table.view []
+    Table.view { additionalStyles = [], alternatingRowColors = True }
         [ Table.rowHeader
             { header = Html.text "Name"
             , view = \{ name } -> code [] [ text name ]

--- a/component-catalog/src/Examples/FocusRing.elm
+++ b/component-catalog/src/Examples/FocusRing.elm
@@ -27,7 +27,7 @@ import Nri.Ui.SegmentedControl.V14 as SegmentedControl
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Switch.V3 as Switch
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Routes

--- a/component-catalog/src/Examples/FocusRing.elm
+++ b/component-catalog/src/Examples/FocusRing.elm
@@ -141,7 +141,7 @@ exampleWithBorderAndBG styles =
 
 viewTable : State -> Html Msg
 viewTable model =
-    Table.view { additionalStyles = [], alternatingRowColors = True }
+    Table.view []
         [ Table.rowHeader
             { header = Html.text "Name"
             , view = \{ name } -> code [] [ text name ]

--- a/component-catalog/src/Examples/Fonts.elm
+++ b/component-catalog/src/Examples/Fonts.elm
@@ -101,7 +101,7 @@ viewFontFailurePatterns =
             , Css.textAlign Css.center
             ]
     in
-    Table.view []
+    Table.view { additionalStyles = [], alternatingRowColors = True }
         [ Table.rowHeader
             { header = Html.text "Example"
             , view = Html.text << .example

--- a/component-catalog/src/Examples/Fonts.elm
+++ b/component-catalog/src/Examples/Fonts.elm
@@ -15,7 +15,7 @@ import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.Text.V6 as Text
 
 

--- a/component-catalog/src/Examples/Fonts.elm
+++ b/component-catalog/src/Examples/Fonts.elm
@@ -101,7 +101,7 @@ viewFontFailurePatterns =
             , Css.textAlign Css.center
             ]
     in
-    Table.view { additionalStyles = [], alternatingRowColors = True }
+    Table.view []
         [ Table.rowHeader
             { header = Html.text "Example"
             , view = Html.text << .example

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -232,7 +232,7 @@ example =
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
             , Text.mediumBody [ Text.plaintext "These are examples of some different ways the highlighter can appear to users." ]
-            , Table.view { additionalStyles = [], alternatingRowColors = True }
+            , Table.view []
                 [ Table.rowHeader
                     { header = text "Highlighter."
                     , view = .viewName >> text

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -232,7 +232,7 @@ example =
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
             , Text.mediumBody [ Text.plaintext "These are examples of some different ways the highlighter can appear to users." ]
-            , Table.view []
+            , Table.view { additionalStyles = [], alternatingRowColors = True }
                 [ Table.rowHeader
                     { header = text "Highlighter."
                     , view = .viewName >> text

--- a/component-catalog/src/Examples/Highlighter.elm
+++ b/component-catalog/src/Examples/Highlighter.elm
@@ -28,7 +28,7 @@ import Nri.Ui.Highlightable.V3 as Highlightable exposing (Highlightable)
 import Nri.Ui.Highlighter.V6 as Highlighter
 import Nri.Ui.HighlighterTool.V1 as Tool
 import Nri.Ui.Spacing.V1 as Spacing
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.Text.V6 as Text
 import Sort exposing (Sorter)
 

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -315,7 +315,7 @@ view ellieLinkConfig state =
         [ Heading.plaintext "Menu types"
         , Heading.css [ Css.margin2 Spacing.verticalSpacerPx Css.zero ]
         ]
-    , Table.view { additionalStyles = [], alternatingRowColors = True }
+    , Table.view []
         [ Table.string
             { header = "Menu type"
             , value = .menu
@@ -502,7 +502,7 @@ You will need to pass in the first and last focusable element in the dialog cont
         [ Heading.plaintext "Menu trigger base styles"
         , Heading.css [ Css.margin2 Spacing.verticalSpacerPx Css.zero ]
         ]
-    , Table.view { additionalStyles = [], alternatingRowColors = True }
+    , Table.view []
         [ Table.string
             { header = "Trigger type"
             , value = .menu
@@ -648,7 +648,7 @@ You will need to pass in the first and last focusable element in the dialog cont
         [ Heading.plaintext "Menu content"
         , Heading.css [ Css.margin2 Spacing.verticalSpacerPx Css.zero ]
         ]
-    , Table.view { additionalStyles = [], alternatingRowColors = True }
+    , Table.view []
         [ Table.string
             { header = "Content"
             , value = .name

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -37,7 +37,7 @@ import Nri.Ui.Menu.V4 as Menu
 import Nri.Ui.RadioButton.V4 as RadioButton
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Switch.V3 as Switch
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.TextInput.V8 as TextInput
 import Nri.Ui.Tooltip.V3 as Tooltip

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -315,7 +315,7 @@ view ellieLinkConfig state =
         [ Heading.plaintext "Menu types"
         , Heading.css [ Css.margin2 Spacing.verticalSpacerPx Css.zero ]
         ]
-    , Table.view []
+    , Table.view { additionalStyles = [], alternatingRowColors = True }
         [ Table.string
             { header = "Menu type"
             , value = .menu
@@ -502,7 +502,7 @@ You will need to pass in the first and last focusable element in the dialog cont
         [ Heading.plaintext "Menu trigger base styles"
         , Heading.css [ Css.margin2 Spacing.verticalSpacerPx Css.zero ]
         ]
-    , Table.view []
+    , Table.view { additionalStyles = [], alternatingRowColors = True }
         [ Table.string
             { header = "Trigger type"
             , value = .menu
@@ -648,7 +648,7 @@ You will need to pass in the first and last focusable element in the dialog cont
         [ Heading.plaintext "Menu content"
         , Heading.css [ Css.margin2 Spacing.verticalSpacerPx Css.zero ]
         ]
-    , Table.view []
+    , Table.view { additionalStyles = [], alternatingRowColors = True }
         [ Table.string
             { header = "Content"
             , value = .name

--- a/component-catalog/src/Examples/Message.elm
+++ b/component-catalog/src/Examples/Message.elm
@@ -248,7 +248,7 @@ viewContentTable name size =
             [ Heading.plaintext name
             , Heading.css [ Css.marginTop (Css.px 30) ]
             ]
-        , Table.view []
+        , Table.view { additionalStyles = [], alternatingRowColors = True }
             [ Table.rowHeader
                 { header = text "Content type"
                 , view = \{ contentType } -> code [] [ text contentType ]

--- a/component-catalog/src/Examples/Message.elm
+++ b/component-catalog/src/Examples/Message.elm
@@ -16,7 +16,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Message.V4 as Message
 import Nri.Ui.Spacing.V1 as Spacing
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import ViewHelpers exposing (viewExamples)
 
 

--- a/component-catalog/src/Examples/Message.elm
+++ b/component-catalog/src/Examples/Message.elm
@@ -248,7 +248,7 @@ viewContentTable name size =
             [ Heading.plaintext name
             , Heading.css [ Css.marginTop (Css.px 30) ]
             ]
-        , Table.view { additionalStyles = [], alternatingRowColors = True }
+        , Table.view []
             [ Table.rowHeader
                 { header = text "Content type"
                 , view = \{ contentType } -> code [] [ text contentType ]

--- a/component-catalog/src/Examples/PremiumCheckbox.elm
+++ b/component-catalog/src/Examples/PremiumCheckbox.elm
@@ -26,7 +26,7 @@ import Nri.Ui.Pennant.V3 as Pennant
 import Nri.Ui.PremiumCheckbox.V8 as PremiumCheckbox
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Set exposing (Set)
 
 

--- a/component-catalog/src/Examples/PremiumCheckbox.elm
+++ b/component-catalog/src/Examples/PremiumCheckbox.elm
@@ -86,7 +86,7 @@ example =
                 [ Heading.plaintext "Premium Examples"
                 , Heading.css [ Css.marginTop (Css.px 30) ]
                 ]
-            , Table.view []
+            , Table.view { additionalStyles = [], alternatingRowColors = True }
                 [ Table.string
                     { header = "Premium Display"
                     , value = \( _, premiumDisplay ) -> Debug.toString premiumDisplay

--- a/component-catalog/src/Examples/PremiumCheckbox.elm
+++ b/component-catalog/src/Examples/PremiumCheckbox.elm
@@ -86,7 +86,7 @@ example =
                 [ Heading.plaintext "Premium Examples"
                 , Heading.css [ Css.marginTop (Css.px 30) ]
                 ]
-            , Table.view { additionalStyles = [], alternatingRowColors = True }
+            , Table.view []
                 [ Table.string
                     { header = "Premium Display"
                     , value = \( _, premiumDisplay ) -> Debug.toString premiumDisplay

--- a/component-catalog/src/Examples/QuestionBox.elm
+++ b/component-catalog/src/Examples/QuestionBox.elm
@@ -128,7 +128,7 @@ view ellieLinkConfig state =
         [ Heading.plaintext "Non-customizable examples"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
-    , Table.view { additionalStyles = [], alternatingRowColors = True }
+    , Table.view []
         [ Table.custom
             { header = text "Pattern name & description"
             , view = .description >> Markdown.toHtml Nothing >> List.map fromUnstyled >> div []

--- a/component-catalog/src/Examples/QuestionBox.elm
+++ b/component-catalog/src/Examples/QuestionBox.elm
@@ -128,7 +128,7 @@ view ellieLinkConfig state =
         [ Heading.plaintext "Non-customizable examples"
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
-    , Table.view []
+    , Table.view { additionalStyles = [], alternatingRowColors = True }
         [ Table.custom
             { header = text "Pattern name & description"
             , view = .description >> Markdown.toHtml Nothing >> List.map fromUnstyled >> div []

--- a/component-catalog/src/Examples/QuestionBox.elm
+++ b/component-catalog/src/Examples/QuestionBox.elm
@@ -27,7 +27,7 @@ import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.QuestionBox.V7 as QuestionBox
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.UiIcon.V1 as UiIcon
 
 

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -36,7 +36,7 @@ import Nri.Ui.Modal.V12 as Modal
 import Nri.Ui.RadioButton.V4 as RadioButton
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.Tooltip.V3 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -172,7 +172,7 @@ view ellieLinkConfig state =
         [ Heading.plaintext "State & Premium Display Examples"
         , Heading.css [ Css.marginTop (Css.px 30) ]
         ]
-    , Table.view { additionalStyles = [], alternatingRowColors = True }
+    , Table.view []
         [ Table.string
             { header = "State"
             , value = .name
@@ -257,7 +257,7 @@ view ellieLinkConfig state =
         [ Heading.plaintext "Extra Content Examples"
         , Heading.css [ Css.marginTop (Css.px 30) ]
         ]
-    , Table.view { additionalStyles = [], alternatingRowColors = True }
+    , Table.view []
         [ Table.custom
             { header = text "Attribute"
             , view = .name >> text

--- a/component-catalog/src/Examples/RadioButton.elm
+++ b/component-catalog/src/Examples/RadioButton.elm
@@ -172,7 +172,7 @@ view ellieLinkConfig state =
         [ Heading.plaintext "State & Premium Display Examples"
         , Heading.css [ Css.marginTop (Css.px 30) ]
         ]
-    , Table.view []
+    , Table.view { additionalStyles = [], alternatingRowColors = True }
         [ Table.string
             { header = "State"
             , value = .name
@@ -257,7 +257,7 @@ view ellieLinkConfig state =
         [ Heading.plaintext "Extra Content Examples"
         , Heading.css [ Css.marginTop (Css.px 30) ]
         ]
-    , Table.view []
+    , Table.view { additionalStyles = [], alternatingRowColors = True }
         [ Table.custom
             { header = text "Attribute"
             , view = .name >> text

--- a/component-catalog/src/Examples/RadioButtonDotless.elm
+++ b/component-catalog/src/Examples/RadioButtonDotless.elm
@@ -300,7 +300,7 @@ view ellieLinkConfig state =
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
     , Table.view
-        []
+        { additionalStyles = [], alternatingRowColors = True }
         [ Table.custom
             { header = text "Description"
             , view = .description >> text

--- a/component-catalog/src/Examples/RadioButtonDotless.elm
+++ b/component-catalog/src/Examples/RadioButtonDotless.elm
@@ -300,7 +300,7 @@ view ellieLinkConfig state =
         , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
         ]
     , Table.view
-        { additionalStyles = [], alternatingRowColors = True }
+        []
         [ Table.custom
             { header = text "Description"
             , view = .description >> text

--- a/component-catalog/src/Examples/RadioButtonDotless.elm
+++ b/component-catalog/src/Examples/RadioButtonDotless.elm
@@ -19,7 +19,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.RadioButtonDotless.V1 as RadioButtonDotless
 import Nri.Ui.Spacing.V1 as Spacing
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.Text.V6 as Text
 import Platform.Sub as Sub
 

--- a/component-catalog/src/Examples/RingGauge.elm
+++ b/component-catalog/src/Examples/RingGauge.elm
@@ -106,7 +106,7 @@ example =
                 |> Svg.withWidth (Css.px 200)
                 |> Svg.withHeight (Css.px 200)
                 |> Svg.toHtml
-            , Table.view { additionalStyles = [], alternatingRowColors = True }
+            , Table.view []
                 [ Table.string
                     { header = "Color contrast against"
                     , value = .name

--- a/component-catalog/src/Examples/RingGauge.elm
+++ b/component-catalog/src/Examples/RingGauge.elm
@@ -20,7 +20,7 @@ import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.RingGauge.V1 as RingGauge
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Round
 import SolidColor.Accessibility
 

--- a/component-catalog/src/Examples/RingGauge.elm
+++ b/component-catalog/src/Examples/RingGauge.elm
@@ -106,7 +106,7 @@ example =
                 |> Svg.withWidth (Css.px 200)
                 |> Svg.withHeight (Css.px 200)
                 |> Svg.toHtml
-            , Table.view []
+            , Table.view { additionalStyles = [], alternatingRowColors = True }
                 [ Table.string
                     { header = "Color contrast against"
                     , value = .name

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -120,6 +120,11 @@ example =
                                         SortableTable.stickyHeaderCustom customConfig
                             )
                             settings.stickyHeader
+                        , if settings.alternatingRowColors then
+                            Nothing
+
+                          else
+                            Just SortableTable.disableAlternatingRowColors
                         ]
 
                 isStickyAtAll =
@@ -168,6 +173,11 @@ example =
                                                         2
                                     )
                                     settings.stickyHeader
+                                , if settings.alternatingRowColors then
+                                    Nothing
+
+                                  else
+                                    Just "SortableTable.disableAlternatingRowColors"
                                 ]
                             )
                             1
@@ -331,6 +341,7 @@ type alias Settings =
     , customizableColumnCellStyles : ( String, List Style )
     , loading : Bool
     , stickyHeader : Maybe StickyHeader
+    , alternatingRowColors : Bool
     }
 
 
@@ -378,6 +389,7 @@ controlSettings =
                 )
                 |> Control.revealed "Sticky Header"
             )
+        |> Control.field "Alternating row colors" (Control.bool True)
 
 
 type ColumnId

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -20,7 +20,7 @@ import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.SortableTable.V4 as SortableTable exposing (Column)
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.UiIcon.V1 as UiIcon
 
 

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -75,7 +75,7 @@ example =
                     |> Svg.withHeight (Css.px 12)
                     |> Svg.toHtml
         in
-        [ Table.view []
+        [ Table.view { additionalStyles = [], alternatingRowColors = True }
             [ Table.custom
                 { header = header "X"
                 , view = .x >> Html.text

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -75,7 +75,7 @@ example =
                     |> Svg.withHeight (Css.px 12)
                     |> Svg.toHtml
         in
-        [ Table.view { additionalStyles = [], alternatingRowColors = True }
+        [ Table.view []
             [ Table.custom
                 { header = header "X"
                 , view = .x >> Html.text

--- a/component-catalog/src/Examples/Spacing.elm
+++ b/component-catalog/src/Examples/Spacing.elm
@@ -253,7 +253,7 @@ view ellieLinkConfig state =
     , Heading.h2 [ Heading.plaintext "Example", Heading.css [ Css.marginTop Spacing.verticalSpacerPx ] ]
     , fakePage [ exampleView ]
     , Heading.h2 [ Heading.plaintext "Content alignment", Heading.css [ Css.marginTop Spacing.verticalSpacerPx ] ]
-    , Table.view { additionalStyles = [], alternatingRowColors = True }
+    , Table.view []
         [ Table.string
             { header = "Name"
             , value = .name
@@ -325,7 +325,7 @@ view ellieLinkConfig state =
           }
         ]
     , Heading.h2 [ Heading.plaintext "Constants", Heading.css [ Css.marginTop Spacing.verticalSpacerPx ] ]
-    , Table.view { additionalStyles = [], alternatingRowColors = True }
+    , Table.view []
         [ Table.string
             { header = "Name"
             , value = .name

--- a/component-catalog/src/Examples/Spacing.elm
+++ b/component-catalog/src/Examples/Spacing.elm
@@ -21,7 +21,7 @@ import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.Text.V6 as Text
 import Svg.Styled
 import Svg.Styled.Attributes

--- a/component-catalog/src/Examples/Spacing.elm
+++ b/component-catalog/src/Examples/Spacing.elm
@@ -253,7 +253,7 @@ view ellieLinkConfig state =
     , Heading.h2 [ Heading.plaintext "Example", Heading.css [ Css.marginTop Spacing.verticalSpacerPx ] ]
     , fakePage [ exampleView ]
     , Heading.h2 [ Heading.plaintext "Content alignment", Heading.css [ Css.marginTop Spacing.verticalSpacerPx ] ]
-    , Table.view []
+    , Table.view { additionalStyles = [], alternatingRowColors = True }
         [ Table.string
             { header = "Name"
             , value = .name
@@ -325,7 +325,7 @@ view ellieLinkConfig state =
           }
         ]
     , Heading.h2 [ Heading.plaintext "Constants", Heading.css [ Css.marginTop Spacing.verticalSpacerPx ] ]
-    , Table.view []
+    , Table.view { additionalStyles = [], alternatingRowColors = True }
         [ Table.string
             { header = "Name"
             , value = .name

--- a/component-catalog/src/Examples/Switch.elm
+++ b/component-catalog/src/Examples/Switch.elm
@@ -108,7 +108,7 @@ example =
                 [ Heading.plaintext "Examples"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
-            , Table.view []
+            , Table.view { additionalStyles = [], alternatingRowColors = True }
                 [ Table.string
                     { header = "State"
                     , value = .state

--- a/component-catalog/src/Examples/Switch.elm
+++ b/component-catalog/src/Examples/Switch.elm
@@ -20,7 +20,7 @@ import KeyboardSupport exposing (Key(..))
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Switch.V3 as Switch
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.Tooltip.V3 as Tooltip
 
 

--- a/component-catalog/src/Examples/Switch.elm
+++ b/component-catalog/src/Examples/Switch.elm
@@ -108,7 +108,7 @@ example =
                 [ Heading.plaintext "Examples"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
-            , Table.view { additionalStyles = [], alternatingRowColors = True }
+            , Table.view []
                 [ Table.string
                     { header = "State"
                     , value = .state

--- a/component-catalog/src/Examples/Table.elm
+++ b/component-catalog/src/Examples/Table.elm
@@ -17,7 +17,7 @@ import Html.Attributes exposing (alt)
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
-import Nri.Ui.Table.V7 as Table exposing (Column)
+import Nri.Ui.Table.V8 as Table exposing (Column)
 
 
 {-| -}
@@ -32,7 +32,7 @@ moduleName =
 
 version : Int
 version =
-    7
+    8
 
 
 {-| -}

--- a/component-catalog/src/Examples/Table.elm
+++ b/component-catalog/src/Examples/Table.elm
@@ -46,7 +46,7 @@ example =
     , categories = [ Layout ]
     , keyboardSupport = []
     , preview =
-        [ Table.view { additionalStyles = [], alternatingRowColors = True }
+        [ Table.view []
             [ Table.string
                 { header = "A"
                 , value = .a
@@ -125,16 +125,16 @@ example =
                 ]
             , case ( showHeader, isLoading ) of
                 ( True, False ) ->
-                    Table.view { additionalStyles = [], alternatingRowColors = alternatingRowColors } columns data
+                    Table.view [] columns data
 
                 ( False, False ) ->
-                    Table.viewWithoutHeader { additionalStyles = [], alternatingRowColors = alternatingRowColors } columns data
+                    Table.viewWithoutHeader [] columns data
 
                 ( True, True ) ->
-                    Table.viewLoading { additionalStyles = [], alternatingRowColors = alternatingRowColors } columns
+                    Table.viewLoading [] columns
 
                 ( False, True ) ->
-                    Table.viewLoadingWithoutHeader { additionalStyles = [], alternatingRowColors = alternatingRowColors } columns
+                    Table.viewLoadingWithoutHeader [] columns
             ]
     }
 

--- a/component-catalog/src/Examples/Table.elm
+++ b/component-catalog/src/Examples/Table.elm
@@ -169,45 +169,6 @@ example =
                     }
                 ]
                 data
-            , Heading.h3 [ Heading.plaintext "Without placeholderColumn", Heading.css [ Css.marginTop (Css.px 30) ] ]
-            , Table.view []
-                [ Table.rowHeader
-                    { header = text "User ID"
-                    , view = text << String.fromInt << .userId
-                    , width = Css.px 80
-                    , cellStyles = always []
-                    , sort = Nothing
-                    }
-                , Table.string
-                    { header = "First Name"
-                    , value = .firstName
-                    , width = Css.calc (Css.pct 50) Css.minus (Css.px 250)
-                    , cellStyles = always []
-                    , sort = Nothing
-                    }
-                , Table.string
-                    { header = "Last Name"
-                    , value = .lastName
-                    , width = Css.calc (Css.pct 50) Css.minus (Css.px 250)
-                    , cellStyles = always []
-                    , sort = Nothing
-                    }
-                , Table.string
-                    { header = "Submitted"
-                    , value = .submitted >> String.fromInt
-                    , width = Css.px 125
-                    , cellStyles = always [ Css.textAlign Css.center ]
-                    , sort = Nothing
-                    }
-                , Table.custom
-                    { header = text "Actions"
-                    , width = Css.px 250
-                    , view = \_ -> Button.button "Action" [ Button.small ]
-                    , cellStyles = always []
-                    , sort = Nothing
-                    }
-                ]
-                data
             ]
     }
 

--- a/component-catalog/src/Examples/Table.elm
+++ b/component-catalog/src/Examples/Table.elm
@@ -13,6 +13,7 @@ import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.View as ControlView
 import Example exposing (Example)
+import Html.Attributes exposing (alt)
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
@@ -73,7 +74,7 @@ example =
     , view =
         \ellieLinkConfig state ->
             let
-                { showHeader, isLoading } =
+                { showHeader, isLoading, alternatingRowColors } =
                     Control.currentValue state
 
                 ( columnsCode, columns ) =
@@ -89,7 +90,7 @@ example =
                 , extraCode = [ "import Nri.Ui.Button.V10 as Button" ]
                 , renderExample = Code.unstyledView
                 , toExampleCode =
-                    \settings ->
+                    \_ ->
                         let
                             codeWithData viewName =
                                 List.map datumToString data
@@ -100,7 +101,14 @@ example =
                                 { sectionName = moduleName ++ "." ++ viewName
                                 , code =
                                     (moduleName ++ "." ++ viewName)
-                                        ++ " [] "
+                                        ++ " "
+                                        ++ Code.list
+                                            (if alternatingRowColors then
+                                                []
+
+                                             else
+                                                [ "Table.disableAlternatingRowColors" ]
+                                            )
                                         ++ Code.list columnsCode
                                         ++ dataStr
                                 }
@@ -117,16 +125,16 @@ example =
                 ]
             , case ( showHeader, isLoading ) of
                 ( True, False ) ->
-                    Table.view { additionalStyles = [], alternatingRowColors = True } columns data
+                    Table.view { additionalStyles = [], alternatingRowColors = alternatingRowColors } columns data
 
                 ( False, False ) ->
-                    Table.viewWithoutHeader { additionalStyles = [], alternatingRowColors = True } columns data
+                    Table.viewWithoutHeader { additionalStyles = [], alternatingRowColors = alternatingRowColors } columns data
 
                 ( True, True ) ->
-                    Table.viewLoading { additionalStyles = [], alternatingRowColors = True } columns
+                    Table.viewLoading { additionalStyles = [], alternatingRowColors = alternatingRowColors } columns
 
                 ( False, True ) ->
-                    Table.viewLoadingWithoutHeader { additionalStyles = [], alternatingRowColors = True } columns
+                    Table.viewLoadingWithoutHeader { additionalStyles = [], alternatingRowColors = alternatingRowColors } columns
             ]
     }
 
@@ -150,6 +158,7 @@ update msg state =
 type alias Settings =
     { showHeader : Bool
     , isLoading : Bool
+    , alternatingRowColors : Bool
     }
 
 
@@ -158,6 +167,7 @@ controlSettings =
     Control.record Settings
         |> Control.field "visible header" (Control.bool True)
         |> Control.field "is loading" (Control.bool False)
+        |> Control.field "alternatingRowColors" (Control.bool True)
 
 
 type alias Datum =

--- a/component-catalog/src/Examples/Table.elm
+++ b/component-catalog/src/Examples/Table.elm
@@ -166,10 +166,9 @@ example =
                         )
                         columns
             , Heading.h2
-                [ Heading.plaintext "Using placeholderColumn for consistent column alignment"
+                [ Heading.plaintext "Using placeholder columns for consistent column alignment"
                 , Heading.css [ Css.marginTop (Css.px 30) ]
                 ]
-            , Heading.h3 [ Heading.plaintext "With placeholderColumn", Heading.css [ Css.marginTop (Css.px 30) ] ]
             , Text.smallBody
                 [ Text.plaintext
                     "By default tables will distribute any remaining space across columns. You can change this behavior to have fixed column widths and leave any remaining blank space to the right by using empty placeholder columns with placeholderColumn. This is particularly useful when you need to align similar columns across multiple tables."

--- a/component-catalog/src/Examples/Table.elm
+++ b/component-catalog/src/Examples/Table.elm
@@ -125,16 +125,46 @@ example =
                 ]
             , case ( showHeader, isLoading ) of
                 ( True, False ) ->
-                    Table.view [] columns data
+                    Table.view
+                        (if alternatingRowColors then
+                            []
+
+                         else
+                            [ Table.disableAlternatingRowColors ]
+                        )
+                        columns
+                        data
 
                 ( False, False ) ->
-                    Table.viewWithoutHeader [] columns data
+                    Table.viewWithoutHeader
+                        (if alternatingRowColors then
+                            []
+
+                         else
+                            [ Table.disableAlternatingRowColors ]
+                        )
+                        columns
+                        data
 
                 ( True, True ) ->
-                    Table.viewLoading [] columns
+                    Table.viewLoading
+                        (if alternatingRowColors then
+                            []
+
+                         else
+                            [ Table.disableAlternatingRowColors ]
+                        )
+                        columns
 
                 ( False, True ) ->
-                    Table.viewLoadingWithoutHeader [] columns
+                    Table.viewLoadingWithoutHeader
+                        (if alternatingRowColors then
+                            []
+
+                         else
+                            [ Table.disableAlternatingRowColors ]
+                        )
+                        columns
             , Heading.h2
                 [ Heading.plaintext "Using placeholderColumn for consistent column alignment"
                 , Heading.css [ Css.marginTop (Css.px 30) ]

--- a/component-catalog/src/Examples/Table.elm
+++ b/component-catalog/src/Examples/Table.elm
@@ -17,6 +17,7 @@ import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Table.V8 as Table exposing (Column)
+import Nri.Ui.Text.V6 as Text
 
 
 {-| -}
@@ -135,10 +136,14 @@ example =
                 ( False, True ) ->
                     Table.viewLoadingWithoutHeader [] columns
             , Heading.h2
-                [ Heading.plaintext "Using placeholderColumn for consistent widths tables"
+                [ Heading.plaintext "Using placeholderColumn for consistent column alignment"
                 , Heading.css [ Css.marginTop (Css.px 30) ]
                 ]
             , Heading.h3 [ Heading.plaintext "With placeholderColumn", Heading.css [ Css.marginTop (Css.px 30) ] ]
+            , Text.smallBody
+                [ Text.plaintext
+                    "By default tables will distribute any remaining space across columns. You can change this behavior to have fixed column widths and leave any remaining blank space to the right by using empty placeholder columns with placeholderColumn. This is particularly useful when you need to align similar columns across multiple tables."
+                ]
             , Table.view []
                 [ Table.rowHeader
                     { header = text "User ID"

--- a/component-catalog/src/Examples/Table.elm
+++ b/component-catalog/src/Examples/Table.elm
@@ -45,7 +45,7 @@ example =
     , categories = [ Layout ]
     , keyboardSupport = []
     , preview =
-        [ Table.view []
+        [ Table.view { additionalStyles = [], alternatingRowColors = True }
             [ Table.string
                 { header = "A"
                 , value = .a
@@ -117,16 +117,16 @@ example =
                 ]
             , case ( showHeader, isLoading ) of
                 ( True, False ) ->
-                    Table.view [] columns data
+                    Table.view { additionalStyles = [], alternatingRowColors = True } columns data
 
                 ( False, False ) ->
-                    Table.viewWithoutHeader [] columns data
+                    Table.viewWithoutHeader { additionalStyles = [], alternatingRowColors = True } columns data
 
                 ( True, True ) ->
-                    Table.viewLoading [] columns
+                    Table.viewLoading { additionalStyles = [], alternatingRowColors = True } columns
 
                 ( False, True ) ->
-                    Table.viewLoadingWithoutHeader [] columns
+                    Table.viewLoadingWithoutHeader { additionalStyles = [], alternatingRowColors = True } columns
             ]
     }
 

--- a/component-catalog/src/Examples/Table.elm
+++ b/component-catalog/src/Examples/Table.elm
@@ -13,7 +13,6 @@ import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.View as ControlView
 import Example exposing (Example)
-import Html.Attributes exposing (alt)
 import Nri.Ui.Button.V10 as Button
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
@@ -135,6 +134,80 @@ example =
 
                 ( False, True ) ->
                     Table.viewLoadingWithoutHeader [] columns
+            , Heading.h2
+                [ Heading.plaintext "Using placeholderColumn for consistent widths tables"
+                , Heading.css [ Css.marginTop (Css.px 30) ]
+                ]
+            , Heading.h3 [ Heading.plaintext "With placeholderColumn", Heading.css [ Css.marginTop (Css.px 30) ] ]
+            , Table.view []
+                [ Table.rowHeader
+                    { header = text "User ID"
+                    , view = text << String.fromInt << .userId
+                    , width = Css.px 80
+                    , cellStyles = always []
+                    , sort = Nothing
+                    }
+                , Table.string
+                    { header = "First Name"
+                    , value = .firstName
+                    , width = Css.calc (Css.pct 50) Css.minus (Css.px 250)
+                    , cellStyles = always []
+                    , sort = Nothing
+                    }
+                , Table.string
+                    { header = "Last Name"
+                    , value = .lastName
+                    , width = Css.calc (Css.pct 50) Css.minus (Css.px 250)
+                    , cellStyles = always []
+                    , sort = Nothing
+                    }
+                , Table.placeholderColumn
+                    { width = Css.px 125
+                    }
+                , Table.placeholderColumn
+                    { width = Css.px 250
+                    }
+                ]
+                data
+            , Heading.h3 [ Heading.plaintext "Without placeholderColumn", Heading.css [ Css.marginTop (Css.px 30) ] ]
+            , Table.view []
+                [ Table.rowHeader
+                    { header = text "User ID"
+                    , view = text << String.fromInt << .userId
+                    , width = Css.px 80
+                    , cellStyles = always []
+                    , sort = Nothing
+                    }
+                , Table.string
+                    { header = "First Name"
+                    , value = .firstName
+                    , width = Css.calc (Css.pct 50) Css.minus (Css.px 250)
+                    , cellStyles = always []
+                    , sort = Nothing
+                    }
+                , Table.string
+                    { header = "Last Name"
+                    , value = .lastName
+                    , width = Css.calc (Css.pct 50) Css.minus (Css.px 250)
+                    , cellStyles = always []
+                    , sort = Nothing
+                    }
+                , Table.string
+                    { header = "Submitted"
+                    , value = .submitted >> String.fromInt
+                    , width = Css.px 125
+                    , cellStyles = always [ Css.textAlign Css.center ]
+                    , sort = Nothing
+                    }
+                , Table.custom
+                    { header = text "Actions"
+                    , width = Css.px 250
+                    , view = \_ -> Button.button "Action" [ Button.small ]
+                    , cellStyles = always []
+                    , sort = Nothing
+                    }
+                ]
+                data
             ]
     }
 

--- a/component-catalog/src/Examples/Tooltip.elm
+++ b/component-catalog/src/Examples/Tooltip.elm
@@ -26,7 +26,7 @@ import Nri.Ui.ClickableText.V4 as ClickableText
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Svg.V1 as Svg
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.Tooltip.V3 as Tooltip
 import Nri.Ui.UiIcon.V1 as UiIcon
 import Routes

--- a/component-catalog/src/Examples/Tooltip.elm
+++ b/component-catalog/src/Examples/Tooltip.elm
@@ -159,7 +159,7 @@ view : EllieLink.Config -> State -> List (Html Msg)
 view ellieLinkConfig model =
     [ viewCustomizableExample ellieLinkConfig model
     , Heading.h2 [ Heading.plaintext "What type of tooltip should I use?" ]
-    , Table.view { additionalStyles = [], alternatingRowColors = True }
+    , Table.view []
         [ Table.string
             { header = "Type"
             , value = .name

--- a/component-catalog/src/Examples/Tooltip.elm
+++ b/component-catalog/src/Examples/Tooltip.elm
@@ -159,7 +159,7 @@ view : EllieLink.Config -> State -> List (Html Msg)
 view ellieLinkConfig model =
     [ viewCustomizableExample ellieLinkConfig model
     , Heading.h2 [ Heading.plaintext "What type of tooltip should I use?" ]
-    , Table.view []
+    , Table.view { additionalStyles = [], alternatingRowColors = True }
         [ Table.string
             { header = "Type"
             , value = .name

--- a/elm.json
+++ b/elm.json
@@ -80,6 +80,7 @@
         "Nri.Ui.Svg.V1",
         "Nri.Ui.Switch.V3",
         "Nri.Ui.Table.V7",
+        "Nri.Ui.Table.V8",
         "Nri.Ui.Tabs.V6",
         "Nri.Ui.Tabs.V9",
         "Nri.Ui.TabsMinimal.V1",

--- a/script/templates/standard-example.elm
+++ b/script/templates/standard-example.elm
@@ -21,7 +21,7 @@ import KeyboardSupport exposing (Key(..))
 import Nri.Ui.COMPONENT_NAME.V1 as COMPONENT_NAME
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
-import Nri.Ui.Table.V7 as Table
+import Nri.Ui.Table.V8 as Table
 import Nri.Ui.Text.V6 as Text
 
 

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -34,7 +34,7 @@ import Nri.Ui.Html.Attributes.V2 exposing (maybe)
 import Nri.Ui.Html.V3 exposing (viewJust)
 import Nri.Ui.MediaQuery.V1 as MediaQuery
 import Nri.Ui.Svg.V1
-import Nri.Ui.Table.V7 as Table exposing (SortDirection(..))
+import Nri.Ui.Table.V8 as Table exposing (SortDirection(..))
 import Nri.Ui.UiIcon.V1
 
 

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -412,7 +412,7 @@ viewSortHeader isSortable header maybeUpdateMsg state_ id =
             [ css
                 [ Css.displayFlex
                 , Css.alignItems Css.center
-                , Css.justifyContent Css.spaceBetween
+                , Css.property "gap" "8px"
                 , CssVendorPrefix.property "user-select" "none"
                 , if state_.column == id then
                     fontWeight bold

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -311,12 +311,12 @@ view attributes columns entries =
                 sorter =
                     findSorter columns state_.column
             in
-            Table.view stickyStyles
+            Table.view { additionalStyles = stickyStyles, alternatingRowColors = True }
                 tableColumns
                 (List.sortWith (sorter state_.sortDirection) entries)
 
         Nothing ->
-            Table.view stickyStyles tableColumns entries
+            Table.view { additionalStyles = stickyStyles, alternatingRowColors = True } tableColumns entries
 
 
 {-| -}
@@ -333,7 +333,7 @@ viewLoading attributes columns =
         tableColumns =
             List.map (buildTableColumn config.updateMsg config.state) columns
     in
-    Table.viewLoading stickyStyles tableColumns
+    Table.viewLoading { additionalStyles = stickyStyles, alternatingRowColors = True } tableColumns
 
 
 findSorter : List (Column id entry msg) -> id -> Sorter entry

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -1,7 +1,7 @@
 module Nri.Ui.SortableTable.V4 exposing
     ( Column, Sorter, State
     , init, initDescending
-    , custom, string
+    , custom, string, placeholderColumn
     , Attribute, updateMsg, state, stickyHeader, disableAlternatingRowColors, stickyHeaderCustom, StickyConfig, view, viewLoading
     , invariantSort, simpleSort, combineSorters
     )
@@ -14,7 +14,7 @@ module Nri.Ui.SortableTable.V4 exposing
 
 @docs Column, Sorter, State
 @docs init, initDescending
-@docs custom, string
+@docs custom, string, placeholderColumn
 @docs Attribute, updateMsg, state, stickyHeader, disableAlternatingRowColors, stickyHeaderCustom, StickyConfig, view, viewLoading
 @docs invariantSort, simpleSort, combineSorters
 
@@ -52,6 +52,7 @@ type Column id entry msg
         , sorter : Maybe (Sorter entry)
         , width : Int
         , cellStyles : entry -> List Style
+        , hidden : Bool
         }
 
 
@@ -218,6 +219,7 @@ string { id, header, value, width, cellStyles } =
         , sorter = Just (simpleSort value)
         , width = width
         , cellStyles = cellStyles
+        , hidden = False
         }
 
 
@@ -239,6 +241,24 @@ custom config =
         , sorter = config.sorter
         , width = config.width
         , cellStyles = config.cellStyles
+        , hidden = False
+        }
+
+
+{-| Creates a placeholder column which will reserve the space for the column,
+this can be used when multiple tables have similar data and we want to keep
+the size consistent.
+-}
+placeholderColumn : { id : id, width : Int } -> Column id entry msg
+placeholderColumn config =
+    Column
+        { id = config.id
+        , header = Html.text ""
+        , view = always (Html.text "")
+        , sorter = Nothing
+        , width = config.width
+        , cellStyles = always []
+        , hidden = True
         }
 
 

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -333,6 +333,9 @@ view attributes columns entries =
 
         tableColumns =
             List.map (buildTableColumn config.updateMsg config.state) columns
+
+        hasHiddenColumns =
+            List.any (\(Column column) -> column.hidden) columns
     in
     case config.state of
         Just state_ ->
@@ -340,12 +343,12 @@ view attributes columns entries =
                 sorter =
                     findSorter columns state_.column
             in
-            Table.view { additionalStyles = stickyStyles, alternatingRowColors = config.alternatingRowColors }
+            Table.view { additionalStyles = stickyStyles, alternatingRowColors = config.alternatingRowColors, hasHiddenColumns = hasHiddenColumns }
                 tableColumns
                 (List.sortWith (sorter state_.sortDirection) entries)
 
         Nothing ->
-            Table.view { additionalStyles = stickyStyles, alternatingRowColors = config.alternatingRowColors } tableColumns entries
+            Table.view { additionalStyles = stickyStyles, alternatingRowColors = config.alternatingRowColors, hasHiddenColumns = hasHiddenColumns } tableColumns entries
 
 
 {-| -}
@@ -361,8 +364,11 @@ viewLoading attributes columns =
 
         tableColumns =
             List.map (buildTableColumn config.updateMsg config.state) columns
+
+        hasHiddenColumns =
+            List.any (\(Column column) -> column.hidden) columns
     in
-    Table.viewLoading { additionalStyles = stickyStyles, alternatingRowColors = config.alternatingRowColors } tableColumns
+    Table.viewLoading { additionalStyles = stickyStyles, alternatingRowColors = config.alternatingRowColors, hasHiddenColumns = hasHiddenColumns } tableColumns
 
 
 findSorter : List (Column id entry msg) -> id -> Sorter entry

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -340,12 +340,32 @@ view attributes columns entries =
                 sorter =
                     findSorter columns state_.column
             in
-            Table.view { additionalStyles = stickyStyles, alternatingRowColors = config.alternatingRowColors }
+            Table.view
+                (List.filterMap identity
+                    [ Just (Table.css stickyStyles)
+                    , if config.alternatingRowColors then
+                        Nothing
+
+                      else
+                        Just Table.disableAlternatingRowColors
+                    ]
+                )
                 tableColumns
                 (List.sortWith (sorter state_.sortDirection) entries)
 
         Nothing ->
-            Table.view { additionalStyles = stickyStyles, alternatingRowColors = config.alternatingRowColors } tableColumns entries
+            Table.view
+                (List.filterMap identity
+                    [ Just (Table.css stickyStyles)
+                    , if config.alternatingRowColors then
+                        Nothing
+
+                      else
+                        Just Table.disableAlternatingRowColors
+                    ]
+                )
+                tableColumns
+                entries
 
 
 {-| -}
@@ -362,7 +382,17 @@ viewLoading attributes columns =
         tableColumns =
             List.map (buildTableColumn config.updateMsg config.state) columns
     in
-    Table.viewLoading { additionalStyles = stickyStyles, alternatingRowColors = config.alternatingRowColors } tableColumns
+    Table.viewLoading
+        (List.filterMap identity
+            [ Just (Table.css stickyStyles)
+            , if config.alternatingRowColors then
+                Nothing
+
+              else
+                Just Table.disableAlternatingRowColors
+            ]
+        )
+        tableColumns
 
 
 findSorter : List (Column id entry msg) -> id -> Sorter entry

--- a/src/Nri/Ui/SortableTable/V4.elm
+++ b/src/Nri/Ui/SortableTable/V4.elm
@@ -2,7 +2,7 @@ module Nri.Ui.SortableTable.V4 exposing
     ( Column, Sorter, State
     , init, initDescending
     , custom, string
-    , Attribute, updateMsg, state, stickyHeader, stickyHeaderCustom, StickyConfig, view, viewLoading
+    , Attribute, updateMsg, state, stickyHeader, disableAlternatingRowColors, stickyHeaderCustom, StickyConfig, view, viewLoading
     , invariantSort, simpleSort, combineSorters
     )
 
@@ -15,7 +15,7 @@ module Nri.Ui.SortableTable.V4 exposing
 @docs Column, Sorter, State
 @docs init, initDescending
 @docs custom, string
-@docs Attribute, updateMsg, state, stickyHeader, stickyHeaderCustom, StickyConfig, view, viewLoading
+@docs Attribute, updateMsg, state, stickyHeader, disableAlternatingRowColors, stickyHeaderCustom, StickyConfig, view, viewLoading
 @docs invariantSort, simpleSort, combineSorters
 
 -}
@@ -67,6 +67,7 @@ type alias Config id msg =
     { updateMsg : Maybe (State id -> msg)
     , state : Maybe (State id)
     , stickyHeader : Maybe StickyConfig
+    , alternatingRowColors : Bool
     }
 
 
@@ -75,6 +76,7 @@ defaultConfig =
     { updateMsg = Nothing
     , state = Nothing
     , stickyHeader = Nothing
+    , alternatingRowColors = True
     }
 
 
@@ -166,6 +168,13 @@ background color on the header as well.
 stickyHeader : Attribute id msg
 stickyHeader =
     Attribute (\config -> { config | stickyHeader = Just defaultStickyConfig })
+
+
+{-| Disable alternatingRowColors
+-}
+disableAlternatingRowColors : Attribute id msg
+disableAlternatingRowColors =
+    Attribute (\config -> { config | alternatingRowColors = False })
 
 
 {-| Does the same thing as `stickyHeader`, but with adaptations for your
@@ -311,12 +320,12 @@ view attributes columns entries =
                 sorter =
                     findSorter columns state_.column
             in
-            Table.view { additionalStyles = stickyStyles, alternatingRowColors = True }
+            Table.view { additionalStyles = stickyStyles, alternatingRowColors = config.alternatingRowColors }
                 tableColumns
                 (List.sortWith (sorter state_.sortDirection) entries)
 
         Nothing ->
-            Table.view { additionalStyles = stickyStyles, alternatingRowColors = True } tableColumns entries
+            Table.view { additionalStyles = stickyStyles, alternatingRowColors = config.alternatingRowColors } tableColumns entries
 
 
 {-| -}
@@ -333,7 +342,7 @@ viewLoading attributes columns =
         tableColumns =
             List.map (buildTableColumn config.updateMsg config.state) columns
     in
-    Table.viewLoading { additionalStyles = stickyStyles, alternatingRowColors = True } tableColumns
+    Table.viewLoading { additionalStyles = stickyStyles, alternatingRowColors = config.alternatingRowColors } tableColumns
 
 
 findSorter : List (Column id entry msg) -> id -> Sorter entry

--- a/src/Nri/Ui/Table/V7.elm
+++ b/src/Nri/Ui/Table/V7.elm
@@ -1,4 +1,4 @@
-module Nri.Ui.Table.V8 exposing
+module Nri.Ui.Table.V7 exposing
     ( Column, SortDirection(..), custom, string, rowHeader
     , view, viewWithoutHeader
     , viewLoading, viewLoadingWithoutHeader

--- a/src/Nri/Ui/Table/V7.elm
+++ b/src/Nri/Ui/Table/V7.elm
@@ -110,15 +110,15 @@ rowHeader options =
 
 {-| Displays a table of data without a header row
 -}
-viewWithoutHeader : { additionalStyles : List Style, alternatingRowColors : Bool } -> List (Column data msg) -> List data -> Html msg
-viewWithoutHeader { additionalStyles, alternatingRowColors } columns =
+viewWithoutHeader : { additionalStyles : List Style, alternatingRowColors : Bool, hasHiddenColumns : Bool } -> List (Column data msg) -> List data -> Html msg
+viewWithoutHeader { additionalStyles, alternatingRowColors, hasHiddenColumns } columns =
     tableWithoutHeader additionalStyles columns (viewRow columns alternatingRowColors)
 
 
 {-| Displays a table of data based on the provided column definitions
 -}
-view : { additionalStyles : List Style, alternatingRowColors : Bool } -> List (Column data msg) -> List data -> Html msg
-view { additionalStyles, alternatingRowColors } columns =
+view : { additionalStyles : List Style, alternatingRowColors : Bool, hasHiddenColumns : Bool } -> List (Column data msg) -> List data -> Html msg
+view { additionalStyles, alternatingRowColors, hasHiddenColumns } columns =
     tableWithHeader additionalStyles columns (viewRow columns alternatingRowColors)
 
 
@@ -145,8 +145,8 @@ viewColumn data (Column _ renderer width cellStyles _ cellType) =
 out text with an interesting animation. This view lets the user know that
 data is on its way and what it will look like when it arrives.
 -}
-viewLoading : { additionalStyles : List Style, alternatingRowColors : Bool } -> List (Column data msg) -> Html msg
-viewLoading { additionalStyles, alternatingRowColors } columns =
+viewLoading : { additionalStyles : List Style, alternatingRowColors : Bool, hasHiddenColumns : Bool } -> List (Column data msg) -> Html msg
+viewLoading { additionalStyles, alternatingRowColors, hasHiddenColumns } columns =
     tableWithHeader (loadingTableStyles ++ additionalStyles) columns (viewLoadingRow columns alternatingRowColors) (List.range 0 8)
 
 

--- a/src/Nri/Ui/Table/V7.elm
+++ b/src/Nri/Ui/Table/V7.elm
@@ -110,22 +110,22 @@ rowHeader options =
 
 {-| Displays a table of data without a header row
 -}
-viewWithoutHeader : List Style -> List (Column data msg) -> List data -> Html msg
-viewWithoutHeader additionalStyles columns =
-    tableWithoutHeader additionalStyles columns (viewRow columns)
+viewWithoutHeader : { additionalStyles : List Style, alternatingRowColors : Bool } -> List (Column data msg) -> List data -> Html msg
+viewWithoutHeader { additionalStyles, alternatingRowColors } columns =
+    tableWithoutHeader additionalStyles columns (viewRow columns alternatingRowColors)
 
 
 {-| Displays a table of data based on the provided column definitions
 -}
-view : List Style -> List (Column data msg) -> List data -> Html msg
-view additionalStyles columns =
-    tableWithHeader additionalStyles columns (viewRow columns)
+view : { additionalStyles : List Style, alternatingRowColors : Bool } -> List (Column data msg) -> List data -> Html msg
+view { additionalStyles, alternatingRowColors } columns =
+    tableWithHeader additionalStyles columns (viewRow columns alternatingRowColors)
 
 
-viewRow : List (Column data msg) -> data -> Html msg
-viewRow columns data =
+viewRow : List (Column data msg) -> Bool -> data -> Html msg
+viewRow columns alternatingRowColors data =
     tr
-        [ css rowStyles ]
+        [ css (rowStyles alternatingRowColors) ]
         (List.map (viewColumn data) columns)
 
 
@@ -145,22 +145,22 @@ viewColumn data (Column _ renderer width cellStyles _ cellType) =
 out text with an interesting animation. This view lets the user know that
 data is on its way and what it will look like when it arrives.
 -}
-viewLoading : List Style -> List (Column data msg) -> Html msg
-viewLoading additionalStyles columns =
-    tableWithHeader (loadingTableStyles ++ additionalStyles) columns (viewLoadingRow columns) (List.range 0 8)
+viewLoading : { additionalStyles : List Style, alternatingRowColors : Bool } -> List (Column data msg) -> Html msg
+viewLoading { additionalStyles, alternatingRowColors } columns =
+    tableWithHeader (loadingTableStyles ++ additionalStyles) columns (viewLoadingRow columns alternatingRowColors) (List.range 0 8)
 
 
 {-| Display the loading table without a header row
 -}
-viewLoadingWithoutHeader : List Style -> List (Column data msg) -> Html msg
-viewLoadingWithoutHeader additionalStyles columns =
-    tableWithoutHeader (loadingTableStyles ++ additionalStyles) columns (viewLoadingRow columns) (List.range 0 8)
+viewLoadingWithoutHeader : { additionalStyles : List Style, alternatingRowColors : Bool } -> List (Column data msg) -> Html msg
+viewLoadingWithoutHeader { additionalStyles, alternatingRowColors } columns =
+    tableWithoutHeader (loadingTableStyles ++ additionalStyles) columns (viewLoadingRow columns alternatingRowColors) (List.range 0 8)
 
 
-viewLoadingRow : List (Column data msg) -> Int -> Html msg
-viewLoadingRow columns index =
+viewLoadingRow : List (Column data msg) -> Bool -> Int -> Html msg
+viewLoadingRow columns alternatingRowColors index =
     tr
-        [ css rowStyles ]
+        [ css (rowStyles alternatingRowColors) ]
         (List.indexedMap (viewLoadingColumn index) columns)
 
 
@@ -265,13 +265,17 @@ headerStyles =
     ]
 
 
-rowStyles : List Style
-rowStyles =
+rowStyles : Bool -> List Style
+rowStyles alternatingRowColors =
     [ height (px 45)
     , fontSize (px 14)
     , color gray20
-    , pseudoClass "nth-child(odd)"
-        [ backgroundColor gray96 ]
+    , if alternatingRowColors then
+        pseudoClass "nth-child(odd)"
+            [ backgroundColor gray96 ]
+
+      else
+        Css.batch []
     ]
 
 

--- a/src/Nri/Ui/Table/V7.elm
+++ b/src/Nri/Ui/Table/V7.elm
@@ -2,6 +2,7 @@ module Nri.Ui.Table.V7 exposing
     ( Column, SortDirection(..), custom, string, rowHeader
     , view, viewWithoutHeader
     , viewLoading, viewLoadingWithoutHeader
+    , placeholderColumn
     )
 
 {-| Upgrading from V6:
@@ -34,7 +35,7 @@ import Nri.Ui.Fonts.V1 exposing (baseFont)
 in the table
 -}
 type Column data msg
-    = Column (Html msg) (data -> Html msg) Style (data -> List Style) (Maybe SortDirection) CellType
+    = Column (Html msg) (data -> Html msg) Style (data -> List Style) (Maybe SortDirection) CellType Bool
 
 
 {-| Which direction is a table column sorted? Only set these on columns that
@@ -73,7 +74,19 @@ string :
     }
     -> Column data msg
 string { header, value, width, cellStyles, sort } =
-    Column (Html.text header) (value >> Html.text) (Css.width width) cellStyles sort DataCell
+    Column (Html.text header) (value >> Html.text) (Css.width width) cellStyles sort DataCell False
+
+
+{-| Creates a placeholder column which will reserve the space for the column,
+this can be used when multiple tables have similar data and we want to keep
+the size consistent.
+-}
+placeholderColumn :
+    { width : LengthOrAuto compatible
+    }
+    -> Column data msg
+placeholderColumn options =
+    Column (Html.text "") (always (Html.text "")) (Css.width options.width) (always []) Nothing DataCell False
 
 
 {-| A column that renders however you want it to
@@ -87,7 +100,7 @@ custom :
     }
     -> Column data msg
 custom options =
-    Column options.header options.view (Css.width options.width) options.cellStyles options.sort DataCell
+    Column options.header options.view (Css.width options.width) options.cellStyles options.sort DataCell True
 
 
 {-| A column whose cells are row headers
@@ -101,7 +114,7 @@ rowHeader :
     }
     -> Column data msg
 rowHeader options =
-    Column options.header options.view (Css.width options.width) options.cellStyles options.sort RowHeaderCell
+    Column options.header options.view (Css.width options.width) options.cellStyles options.sort RowHeaderCell False
 
 
 
@@ -110,15 +123,15 @@ rowHeader options =
 
 {-| Displays a table of data without a header row
 -}
-viewWithoutHeader : { additionalStyles : List Style, alternatingRowColors : Bool, hasHiddenColumns : Bool } -> List (Column data msg) -> List data -> Html msg
-viewWithoutHeader { additionalStyles, alternatingRowColors, hasHiddenColumns } columns =
+viewWithoutHeader : { additionalStyles : List Style, alternatingRowColors : Bool } -> List (Column data msg) -> List data -> Html msg
+viewWithoutHeader { additionalStyles, alternatingRowColors } columns =
     tableWithoutHeader additionalStyles columns (viewRow columns alternatingRowColors)
 
 
 {-| Displays a table of data based on the provided column definitions
 -}
-view : { additionalStyles : List Style, alternatingRowColors : Bool, hasHiddenColumns : Bool } -> List (Column data msg) -> List data -> Html msg
-view { additionalStyles, alternatingRowColors, hasHiddenColumns } columns =
+view : { additionalStyles : List Style, alternatingRowColors : Bool } -> List (Column data msg) -> List data -> Html msg
+view { additionalStyles, alternatingRowColors } columns =
     tableWithHeader additionalStyles columns (viewRow columns alternatingRowColors)
 
 
@@ -130,7 +143,7 @@ viewRow columns alternatingRowColors data =
 
 
 viewColumn : data -> Column data msg -> Html msg
-viewColumn data (Column _ renderer width cellStyles _ cellType) =
+viewColumn data (Column _ renderer width cellStyles _ cellType _) =
     cell cellType
         [ css ([ width, verticalAlign middle, padding4 (px 11) (px 12) (px 14) (px 12), textAlign left ] ++ cellStyles data)
         ]
@@ -145,8 +158,8 @@ viewColumn data (Column _ renderer width cellStyles _ cellType) =
 out text with an interesting animation. This view lets the user know that
 data is on its way and what it will look like when it arrives.
 -}
-viewLoading : { additionalStyles : List Style, alternatingRowColors : Bool, hasHiddenColumns : Bool } -> List (Column data msg) -> Html msg
-viewLoading { additionalStyles, alternatingRowColors, hasHiddenColumns } columns =
+viewLoading : { additionalStyles : List Style, alternatingRowColors : Bool } -> List (Column data msg) -> Html msg
+viewLoading { additionalStyles, alternatingRowColors } columns =
     tableWithHeader (loadingTableStyles ++ additionalStyles) columns (viewLoadingRow columns alternatingRowColors) (List.range 0 8)
 
 
@@ -165,7 +178,7 @@ viewLoadingRow columns alternatingRowColors index =
 
 
 viewLoadingColumn : Int -> Int -> Column data msg -> Html msg
-viewLoadingColumn rowIndex colIndex (Column _ _ width _ _ cellType) =
+viewLoadingColumn rowIndex colIndex (Column _ _ width _ _ cellType _) =
     cell cellType
         [ css (stylesLoadingColumn rowIndex colIndex width ++ [ verticalAlign middle ] ++ loadingCellStyles)
         ]
@@ -185,7 +198,7 @@ stylesLoadingColumn rowIndex colIndex width =
 
 tableWithoutHeader : List Style -> List (Column data msg) -> (a -> Html msg) -> List a -> Html msg
 tableWithoutHeader styles columns toRow data =
-    table styles
+    table styles columns
         [ thead [] [ tr Style.invisible (List.map tableColHeader columns) ]
         , tableBody toRow data
         ]
@@ -193,15 +206,15 @@ tableWithoutHeader styles columns toRow data =
 
 tableWithHeader : List Style -> List (Column data msg) -> (a -> Html msg) -> List a -> Html msg
 tableWithHeader styles columns toRow data =
-    table styles
+    table styles columns
         [ tableHeader columns
         , tableBody toRow data
         ]
 
 
-table : List Style -> List (Html msg) -> Html msg
-table styles =
-    Html.table [ css (styles ++ tableStyles) ]
+table : List Style -> List (Column data msg) -> List (Html msg) -> Html msg
+table styles columns =
+    Html.table [ css (styles ++ tableStyles columns) ]
 
 
 tableHeader : List (Column data msg) -> Html msg
@@ -213,7 +226,7 @@ tableHeader columns =
 
 
 tableColHeader : Column data msg -> Html msg
-tableColHeader (Column header _ width _ sort _) =
+tableColHeader (Column header _ width _ sort _ _) =
     th
         [ Attributes.scope "col"
         , css (width :: headerStyles)
@@ -301,11 +314,20 @@ loadingTableStyles =
     fadeInAnimation
 
 
-tableStyles : List Style
-tableStyles =
+tableStyles : List (Column data msg) -> List Style
+tableStyles columns =
+    let
+        hasPlaceholderColumns =
+            List.any (\(Column _ _ _ _ _ _ h) -> h) columns
+    in
     [ borderCollapse collapse
     , baseFont
     , Css.width (Css.pct 100)
+    , if hasPlaceholderColumns then
+        Css.tableLayout Css.fixed
+
+      else
+        Css.batch []
     ]
 
 

--- a/src/Nri/Ui/Table/V7.elm
+++ b/src/Nri/Ui/Table/V7.elm
@@ -132,7 +132,7 @@ viewRow columns data =
 viewColumn : data -> Column data msg -> Html msg
 viewColumn data (Column _ renderer width cellStyles _ cellType) =
     cell cellType
-        [ css ([ width, verticalAlign middle ] ++ cellStyles data)
+        [ css ([ width, verticalAlign middle, padding4 (px 11) (px 12) (px 14) (px 12), textAlign left ] ++ cellStyles data)
         ]
         [ renderer data ]
 

--- a/src/Nri/Ui/Table/V8.elm
+++ b/src/Nri/Ui/Table/V8.elm
@@ -1,6 +1,6 @@
 module Nri.Ui.Table.V8 exposing
     ( Column, SortDirection(..), custom, string, rowHeader, placeholderColumn
-    , disableAlternatingRowColors, css, Attr
+    , disableAlternatingRowColors, css, Attribute
     , view, viewWithoutHeader
     , viewLoading, viewLoadingWithoutHeader
     )
@@ -129,8 +129,8 @@ type alias Config =
 
 {-| Attribute to configure the table
 -}
-type Attr
-    = Attr (Config -> Config)
+type Attribute
+    = Attribute (Config -> Config)
 
 
 defaultConfig : Config
@@ -140,18 +140,18 @@ defaultConfig =
 
 {-| Add a CSS style to the table
 -}
-css : List Style -> Attr
+css : List Style -> Attribute
 css styles =
-    Attr <|
+    Attribute <|
         \config ->
             { config | css = styles ++ config.css }
 
 
 {-| disable alternating row colors, default behavior alternates row colors
 -}
-disableAlternatingRowColors : Attr
+disableAlternatingRowColors : Attribute
 disableAlternatingRowColors =
-    Attr <|
+    Attribute <|
         \config ->
             { config | alternatingRowColors = False }
 
@@ -162,14 +162,14 @@ disableAlternatingRowColors =
 
 {-| Displays a table of data without a header row
 -}
-viewWithoutHeader : List Attr -> List (Column data msg) -> List data -> Html msg
+viewWithoutHeader : List Attribute -> List (Column data msg) -> List data -> Html msg
 viewWithoutHeader attrs columns =
     let
         config =
             List.foldl
                 (\attr soFar ->
                     case attr of
-                        Attr f ->
+                        Attribute f ->
                             f soFar
                 )
                 defaultConfig
@@ -180,14 +180,14 @@ viewWithoutHeader attrs columns =
 
 {-| Displays a table of data based on the provided column definitions
 -}
-view : List Attr -> List (Column data msg) -> List data -> Html msg
+view : List Attribute -> List (Column data msg) -> List data -> Html msg
 view attrs columns =
     let
         config =
             List.foldl
                 (\attr soFar ->
                     case attr of
-                        Attr f ->
+                        Attribute f ->
                             f soFar
                 )
                 defaultConfig
@@ -226,14 +226,14 @@ viewColumn data column =
 out text with an interesting animation. This view lets the user know that
 data is on its way and what it will look like when it arrives.
 -}
-viewLoading : List Attr -> List (Column data msg) -> Html msg
+viewLoading : List Attribute -> List (Column data msg) -> Html msg
 viewLoading attrs columns =
     let
         config =
             List.foldl
                 (\attr soFar ->
                     case attr of
-                        Attr f ->
+                        Attribute f ->
                             f soFar
                 )
                 defaultConfig
@@ -244,14 +244,14 @@ viewLoading attrs columns =
 
 {-| Display the loading table without a header row
 -}
-viewLoadingWithoutHeader : List Attr -> List (Column data msg) -> Html msg
+viewLoadingWithoutHeader : List Attribute -> List (Column data msg) -> Html msg
 viewLoadingWithoutHeader attrs columns =
     let
         config =
             List.foldl
                 (\attr soFar ->
                     case attr of
-                        Attr f ->
+                        Attribute f ->
                             f soFar
                 )
                 defaultConfig

--- a/src/Nri/Ui/Table/V8.elm
+++ b/src/Nri/Ui/Table/V8.elm
@@ -345,7 +345,7 @@ tableColHeader column =
                 [ header ]
 
         PlaceholderColumn width ->
-            th [ Attributes.css [ width ] ] []
+            th [ Attributes.css [ width ], Aria.hidden True ] []
 
 
 tableBody : (a -> Html msg) -> List a -> Html msg

--- a/src/Nri/Ui/Table/V8.elm
+++ b/src/Nri/Ui/Table/V8.elm
@@ -14,7 +14,7 @@ module Nri.Ui.Table.V8 exposing
     upgrades easier.
 
 @docs Column, SortDirection, custom, string, rowHeader, placeholderColumn
-@docs disableAlternatingRowColors, css, Attr
+@docs disableAlternatingRowColors, css, Attribute
 
 @docs view, viewWithoutHeader
 

--- a/src/Nri/Ui/Table/V8.elm
+++ b/src/Nri/Ui/Table/V8.elm
@@ -21,6 +21,7 @@ module Nri.Ui.Table.V8 exposing
 
 -}
 
+import Accessibility.Styled.Aria as Aria
 import Accessibility.Styled.Style as Style
 import Css exposing (..)
 import Css.Animations
@@ -213,7 +214,7 @@ viewColumn data column =
 
         PlaceholderColumn width ->
             cell DataCell
-                [ Attributes.css [ width, verticalAlign middle ] ]
+                [ Attributes.css [ width, verticalAlign middle ], Aria.hidden True ]
                 []
 
 

--- a/src/Nri/Ui/Table/V8.elm
+++ b/src/Nri/Ui/Table/V8.elm
@@ -8,7 +8,7 @@ module Nri.Ui.Table.V8 exposing
 
 {-| Upgrading from V7:
 
-  - New attribute added to define `alternatingRowColors`, set it to true to get default behavior.
+  - New API using list of attributes. If you don't set any custom css just use an empty list, otherwise use the css attribute to set the custom css.
   - Consider moving to `SortableTable`, as in V4 a non-interactive table renders
     just the same but has additional flexibility in the API and will make future
     upgrades easier.

--- a/src/Nri/Ui/Table/V8.elm
+++ b/src/Nri/Ui/Table/V8.elm
@@ -1,8 +1,7 @@
 module Nri.Ui.Table.V8 exposing
-    ( Column, SortDirection(..), custom, string, rowHeader
+    ( Column, SortDirection(..), custom, string, rowHeader, placeholderColumn
     , view, viewWithoutHeader
     , viewLoading, viewLoadingWithoutHeader
-    , placeholderColumn
     )
 
 {-| Upgrading from V7:
@@ -12,7 +11,7 @@ module Nri.Ui.Table.V8 exposing
     just the same but has additional flexibility in the API and will make future
     upgrades easier.
 
-@docs Column, SortDirection, custom, string, rowHeader
+@docs Column, SortDirection, custom, string, rowHeader, placeholderColumn
 
 @docs view, viewWithoutHeader
 

--- a/src/Nri/Ui/Table/V8.elm
+++ b/src/Nri/Ui/Table/V8.elm
@@ -146,7 +146,7 @@ viewColumn data column =
     case column of
         Column _ renderer width cellStyles _ cellType ->
             cell cellType
-                [ css ([ width, verticalAlign middle, padding4 (px 11) (px 12) (px 14) (px 12), textAlign left ] ++ cellStyles data)
+                [ css ([ width, verticalAlign middle, Css.paddingLeft (Css.px 12), Css.paddingRight (Css.px 12), textAlign left ] ++ cellStyles data)
                 ]
                 [ renderer data ]
 

--- a/src/Nri/Ui/Table/V8.elm
+++ b/src/Nri/Ui/Table/V8.elm
@@ -1,9 +1,8 @@
 module Nri.Ui.Table.V8 exposing
     ( Column, SortDirection(..), custom, string, rowHeader, placeholderColumn
-    , disableAlternatingRowColors, css
+    , disableAlternatingRowColors, css, Attribute
     , view, viewWithoutHeader
     , viewLoading, viewLoadingWithoutHeader
-    , Attribute
     )
 
 {-| Upgrading from V7:

--- a/src/Nri/Ui/Table/V8.elm
+++ b/src/Nri/Ui/Table/V8.elm
@@ -197,7 +197,8 @@ stylesLoadingColumn rowIndex colIndex width =
 
 tableWithoutHeader : List Style -> List (Column data msg) -> (a -> Html msg) -> List a -> Html msg
 tableWithoutHeader styles columns toRow data =
-    table styles columns
+    table styles
+        columns
         [ thead [] [ tr Style.invisible (List.map tableColHeader columns) ]
         , tableBody toRow data
         ]
@@ -205,7 +206,8 @@ tableWithoutHeader styles columns toRow data =
 
 tableWithHeader : List Style -> List (Column data msg) -> (a -> Html msg) -> List a -> Html msg
 tableWithHeader styles columns toRow data =
-    table styles columns
+    table styles
+        columns
         [ tableHeader columns
         , tableBody toRow data
         ]

--- a/src/Nri/Ui/Table/V8.elm
+++ b/src/Nri/Ui/Table/V8.elm
@@ -1,8 +1,9 @@
 module Nri.Ui.Table.V8 exposing
     ( Column, SortDirection(..), custom, string, rowHeader, placeholderColumn
-    , disableAlternatingRowColors, css, Attribute
+    , disableAlternatingRowColors, css
     , view, viewWithoutHeader
     , viewLoading, viewLoadingWithoutHeader
+    , Attribute
     )
 
 {-| Upgrading from V7:
@@ -144,7 +145,7 @@ css : List Style -> Attribute
 css styles =
     Attribute <|
         \config ->
-            { config | css = styles ++ config.css }
+            { config | css = config.css ++ styles }
 
 
 {-| disable alternating row colors, default behavior alternates row colors
@@ -279,7 +280,7 @@ viewLoadingColumn rowIndex colIndex column =
         PlaceholderColumn width ->
             cell DataCell
                 [ Attributes.css (stylesLoadingColumn rowIndex colIndex width ++ [ verticalAlign middle ] ++ loadingCellStyles) ]
-                [ span [ Attributes.css loadingContentStyles ] [] ]
+                []
 
 
 stylesLoadingColumn : Int -> Int -> Style -> List Style

--- a/src/Nri/Ui/Table/V8.elm
+++ b/src/Nri/Ui/Table/V8.elm
@@ -391,7 +391,7 @@ rowStyles alternatingRowColors =
             [ backgroundColor gray96 ]
 
       else
-        Css.batch []
+        Css.batch [ Css.borderBottom3 (Css.px 1) Css.solid gray92 ]
     ]
 
 

--- a/tests/Spec/Nri/Ui/SortableTable.elm
+++ b/tests/Spec/Nri/Ui/SortableTable.elm
@@ -3,7 +3,7 @@ module Spec.Nri.Ui.SortableTable exposing (spec)
 import Expect
 import Html.Styled
 import Nri.Ui.SortableTable.V4 as SortableTable
-import Nri.Ui.Table.V7 exposing (SortDirection)
+import Nri.Ui.Table.V8 exposing (SortDirection)
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector


### PR DESCRIPTION
# :wrench: Modifying a component

## Context
This adds more flexibility to the table api and add better table defaults, which includes:
- Disable alternating row columns.
- Add placeholder columns
- Add consistent default padding for header.
- Show sorting indicator next to label.

## :framed_picture: What does this change look like?
![image](https://github.com/user-attachments/assets/89681dcb-14d3-4518-b433-cd0f1051ba90)
![Screenshot 2024-11-01 at 17 55 38](https://github.com/user-attachments/assets/d2795e9b-b27c-4524-ac09-c01cce3db0e5)

![image](https://github.com/user-attachments/assets/f1a15adc-f4eb-4c9c-8d72-b0fd019f8ca0)


## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [x] Component docs include a changelog
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)

closes: quo-987
closes: quo-989
closes: quo-990
closes: quo-991
