### PR TITLE
Bump to nri-ui 31.0.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "30.1.0",
+    "version": "31.0.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `31.0.0`

## What changes does this release include?

Delete Table v7 api. https://github.com/NoRedInk/noredink-ui/pull/1707

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```
This is a MAJOR change.

---- REMOVED MODULES - MAJOR ----

    Nri.Ui.Table.V7



```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).

