### PR TITLE
bump to 31.1.0 to include new table toggles

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "31.0.0",
+    "version": "31.1.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `31.1.0`

## What changes does this release include?

Includes only https://github.com/NoRedInk/noredink-ui/pull/1709, which simplifies the API for configuring `Nri.Ui.Table` when using the `Nri.Ui.SortableTable` wrapper, and adds the ability to highlight rows on hover to `Nri.Ui.Table`.

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```
This is a MINOR change.

---- ADDED MODULES - MINOR ----

    Nri.Ui.SortableTable.V5


---- Nri.Ui.Table.V8 - MINOR ----

    Added:
        backgroundChangeOnRowHover : Nri.Ui.Table.V8.Attribute
```