### PR TITLE
bump to 32.0.0, removing deprecations, adding icons

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "31.1.0",
+    "version": "32.0.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `32.0.0`

## What changes does this release include?

- #1711 removed deprecated `SortableTable.V4`
- #1713 add icons for `EssayGuidedDraft` and `ShortResponseGuidedDraft`

## How has the API changed?

see what has changed

Please paste the output of `elm diff` run on latest master in the code block:

```
This is a MAJOR change.

---- REMOVED MODULES - MAJOR ----

    Nri.Ui.SortableTable.V4


---- Nri.Ui.AssignmentIcon.V2 - MINOR ----

    Added:
        guidedEssay : Nri.Ui.Svg.V1.Svg
        guidedEssayCircled : Nri.Ui.Svg.V1.Svg
        guidedShortResponse : Nri.Ui.Svg.V1.Svg
        guidedShortResponseCircled : Nri.Ui.Svg.V1.Svg
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).

related: KRA-2094