### PR TITLE
Bump to 33.0.0, Menu `captionedGroup` icons

### DIFF
--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -33,9 +33,10 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Html.Attributes.V2 exposing (safeIdWithPrefix)
-import Nri.Ui.Menu.V4 as Menu
+import Nri.Ui.Menu.V5 as Menu
 import Nri.Ui.RadioButton.V4 as RadioButton
 import Nri.Ui.Spacing.V1 as Spacing
+import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Switch.V3 as Switch
 import Nri.Ui.Table.V8 as Table
 import Nri.Ui.Text.V6 as Text
@@ -842,7 +843,7 @@ In this realistic example, we can't actually pass the correct attributes to Radi
                     ]
                 , Menu.captionedGroup "Guided Draft"
                     "Students draft with the support of tutorials, models, and targeted tips."
-                    [ span [] [text "icon"], span [] [text "icon"] ]
+                    [ UiIcon.home |> Svg.withWidth (Css.px 24) |> Svg.toHtml ]
                     [ Menu.entry "preview-guided-draft" <|
                         \attributes ->
                             ClickableSvg.link "Preview"

--- a/component-catalog/src/Examples/Menu.elm
+++ b/component-catalog/src/Examples/Menu.elm
@@ -820,6 +820,7 @@ In this realistic example, we can't actually pass the correct attributes to Radi
           , entries =
                 [ Menu.captionedGroup "Quick Write"
                     "Students write independently, without lessons or tips."
+                    []
                     [ Menu.entry "preview-quick-write" <|
                         \attributes ->
                             ClickableSvg.link "Preview"
@@ -841,6 +842,7 @@ In this realistic example, we can't actually pass the correct attributes to Radi
                     ]
                 , Menu.captionedGroup "Guided Draft"
                     "Students draft with the support of tutorials, models, and targeted tips."
+                    [ span [] [text "icon"], span [] [text "icon"] ]
                     [ Menu.entry "preview-guided-draft" <|
                         \attributes ->
                             ClickableSvg.link "Preview"

--- a/elm.json
+++ b/elm.json
@@ -53,7 +53,7 @@
         "Nri.Ui.Mark.V6",
         "Nri.Ui.MasteryIcon.V1",
         "Nri.Ui.MediaQuery.V1",
-        "Nri.Ui.Menu.V4",
+        "Nri.Ui.Menu.V5",
         "Nri.Ui.Message.V4",
         "Nri.Ui.Modal.V12",
         "Nri.Ui.Outline.V1",

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "32.0.0",
+    "version": "33.0.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",

--- a/src/Nri/Ui/Menu/V4.elm
+++ b/src/Nri/Ui/Menu/V4.elm
@@ -331,21 +331,21 @@ view focusAndToggle attributes entries =
 -}
 type Entry msg
     = Single String (List (Html.Attribute msg) -> Html msg)
-    | Batch String (Maybe String) (List (Entry msg))
+    | Batch String (Maybe String) (List (Html msg)) (List (Entry msg))
 
 
 {-| Represents a group of entries with a named legend.
 -}
 group : String -> List (Entry msg) -> Entry msg
 group legendName entries =
-    Batch legendName Nothing entries
+    Batch legendName Nothing [] entries
 
 
 {-| Represents a group of entries with a named legend and text caption.
 -}
-captionedGroup : String -> String -> List (Entry msg) -> Entry msg
-captionedGroup legendName caption entries =
-    Batch legendName (Just caption) entries
+captionedGroup : String -> String -> List (Html msg) -> List (Entry msg) -> Entry msg
+captionedGroup legendName caption icons entries =
+    Batch legendName (Just caption) icons entries
 
 
 {-| Represents a single **focusable** entry.
@@ -717,7 +717,7 @@ getFirstIds entries =
                 Single idString _ ->
                     Just idString
 
-                Batch _ _ es ->
+                Batch _ _ _ es ->
                     Maybe.andThen getIdString (List.head es)
     in
     List.filterMap getIdString entries
@@ -731,7 +731,7 @@ getLastIds entries =
                 Single idString _ ->
                     Just idString
 
-                Batch _ _ es ->
+                Batch _ _ _ es ->
                     Maybe.andThen getIdString (List.head (List.reverse es))
     in
     List.filterMap getIdString (List.reverse entries)
@@ -829,7 +829,7 @@ viewEntry config focusAndToggle { upId, downId, entry_ } =
                     ]
                 ]
 
-        Batch title caption childList ->
+        Batch title caption icons childList ->
             let
                 captionId =
                     safeId (title ++ "--caption")
@@ -846,7 +846,7 @@ viewEntry config focusAndToggle { upId, downId, entry_ } =
                                     (styleGroupTitleText config
                                         |> Maybe.cons (Maybe.map (always (Aria.describedBy [ captionId ])) caption)
                                     )
-                                    [ Html.text title ]
+                                    [ Html.text title, span [ css [ marginLeft (Css.px 5), display inlineFlex, Css.property "gap" "5px" ] ] icons ]
                                 ]
                             , viewJust
                                 (\c ->

--- a/src/Nri/Ui/Menu/V5.elm
+++ b/src/Nri/Ui/Menu/V5.elm
@@ -1,4 +1,4 @@
-module Nri.Ui.Menu.V4 exposing
+module Nri.Ui.Menu.V5 exposing
     ( view, Attribute
     , isOpen, isDisabled
     , opensOnHover
@@ -12,24 +12,9 @@ module Nri.Ui.Menu.V4 exposing
     , Entry, group, captionedGroup, entry
     )
 
-{-| Patch changes:
+{-| Changes from V4:
 
-  - improve interoperability with Tooltip (Note that tooltip keyboard events are not fully supported!)
-  - Use Nri.Ui.WhenFocusLeaves.V2
-  - Adjust disabled styles
-  - when the Menu is a dialog or disclosure, _don't_ add role menuitem to the entries
-  - Use ClickableText.medium as the default size when the trigger is `Menu.clickableText`
-  - Adds containerCss, menuCss, groupContainerCss, and entryContainerCss to customize the style of the respective containers
-  - Adds captionedGroup to create a group with a caption
-  - Adds groupTitleCss and groupCaptionCss to customize the style of the group title and caption
-
-Changes from V3:
-
-  - improve composability with Button, ClickableText, and ClickableSvg
-
-A togglable menu view and related buttons.
-
-<https://zpl.io/a75OrE2>
+  - add the icons parameter to the menu captionedGroup function
 
 
 ## Menu rendering
@@ -846,7 +831,7 @@ viewEntry config focusAndToggle { upId, downId, entry_ } =
                                     (styleGroupTitleText config
                                         |> Maybe.cons (Maybe.map (always (Aria.describedBy [ captionId ])) caption)
                                     )
-                                    [ Html.text title, span [ css [ marginLeft (Css.px 5), display inlineFlex, Css.property "gap" "5px" ] ] icons ]
+                                    [ Html.text title, span [ css [ marginLeft (Css.px 5), display inlineFlex, Css.property "gap" "5px", verticalAlign bottom ] ] icons ]
                                 ]
                             , viewJust
                                 (\c ->

--- a/tests/Spec/Nri/Ui/Menu.elm
+++ b/tests/Spec/Nri/Ui/Menu.elm
@@ -5,7 +5,7 @@ import Html.Styled as HtmlStyled
 import Json.Encode as Encode
 import Nri.Test.KeyboardHelpers.V1 as KeyboardHelpers
 import Nri.Ui.ClickableText.V4 as ClickableText
-import Nri.Ui.Menu.V4 as Menu
+import Nri.Ui.Menu.V5 as Menu
 import Nri.Ui.Tooltip.V3 as Tooltip
 import ProgramTest exposing (ProgramTest, ensureViewHas, ensureViewHasNot)
 import Spec.Helpers exposing (nriDescription)
@@ -17,7 +17,7 @@ import Test.Html.Selector as Selector exposing (text)
 
 spec : Test
 spec =
-    describe "Nri.Ui.Menu.V4"
+    describe "Nri.Ui.Menu.V5"
         [ test "Opens when mouse enters" <|
             \() ->
                 program [ Menu.opensOnHover True ]

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -49,7 +49,7 @@
         "Nri.Ui.Mark.V6",
         "Nri.Ui.MasteryIcon.V1",
         "Nri.Ui.MediaQuery.V1",
-        "Nri.Ui.Menu.V4",
+        "Nri.Ui.Menu.V5",
         "Nri.Ui.Message.V4",
         "Nri.Ui.Modal.V12",
         "Nri.Ui.Outline.V1",


### PR DESCRIPTION
Please use the template that's relevant for your situation and delete the other templates. If this is just a noredink-ui repo doc change, you don't need to follow a template.

# :label: Bump for version `33.0.0`

## What changes does this release include?

`Menu.captionedGroup` now includes a `icons` parameter to show icons next to the group title.

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```
This is a MAJOR change.

---- ADDED MODULES - MINOR ----

    Nri.Ui.Menu.V5


---- REMOVED MODULES - MAJOR ----

    Nri.Ui.Menu.V4
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).

---

# :wrench: Modifying a component

## Context

`Menu.captionedGroup` previously did not allow for icons to appear near the group title.  This functionality would allow us to show the grading assistant wand icon next to assignment titles that are grading assistant compatible.

Closes LLM-2068

## :framed_picture: What does this change look like?

The change allows for an optional icon(s) near the menu item title

![image](https://github.com/user-attachments/assets/07f744fb-e53e-4dc2-8333-c677fc9e6470)

In this example from the component-catalog, "Quick Write" does not include an icon, while "Guided Draft" includes a home icon (24px width).

I this example from the deploy

## Component completion checklist

- [ ] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [ ] Changes are clearly documented
  - [x] Component docs include a changelog
  - [ ] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [ ] Changes to the component are tested/the new version of the component is tested
- [ ] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - https://linear.app/noredink/issue/LLM-2026/add-a-ga-wand-to-the-pop-over-for-qw-gsr-assignments-when-the-qw
- [ ] Please assign the following reviewers:
  - [ ] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [ ] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [ ] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
