### PR TITLE
bump to 34.0.0 (review icon + arbitrary HTML in Switch label)

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "33.0.0",
+    "version": "34.0.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `34.0.0`

## What changes does this release include?

Includes:
  - https://github.com/NoRedInk/noredink-ui/pull/1723
    - adds `Nri.Ui.UiIcon.V1.review` icon
  - https://github.com/NoRedInk/noredink-ui/pull/1725
    - new `Nri.Ui.Switch.V4` which is just like the previous one except that it supports arbitrary HTML in the label
    - deletes `Nri.Ui.Switch.V3`, since the migration path is trivial

Part of QUO-1108
Part of QUO-1121


## How has the API changed?

```
This is a MAJOR change.

---- ADDED MODULES - MINOR ----

    Nri.Ui.Switch.V4


---- REMOVED MODULES - MAJOR ----

    Nri.Ui.Switch.V3


---- Nri.Ui.UiIcon.V1 - MINOR ----

    Added:
        review : Nri.Ui.Svg.V1.Svg
```