### PR TITLE
Increase contrast of highlightYellowDarkLight against highlightYellowLight

### DIFF
--- a/src/Nri/Ui/Colors/V1.elm
+++ b/src/Nri/Ui/Colors/V1.elm
@@ -282,7 +282,7 @@ highlightYellowDark =
 -}
 highlightYellowDarkLight : Css.Color
 highlightYellowDarkLight =
-    hex "#A18E4D"
+    hex "#9A884A"
 
 
 {-| See <https://noredink-ui.netlify.com/#/doodad/Colors>


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Change highlightYellowDarkLight from #A18E4D to #9A884A.
This will ensure there's enough contrast when it's used on highlightYellowLight:

https://linear.app/noredink/issue/PHX-1937/update-highlightyellowdarklight-color-value

## :framed_picture: What does this change look like?

### Old

![image (13)](https://github.com/user-attachments/assets/248e94ed-70e0-4655-bffc-1f41ecd070c8)

### New

![image (14)](https://github.com/user-attachments/assets/6e827418-9ded-4558-8671-32293a35c495)

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [x] Changes are clearly documented
  - [ ] Component docs include a changelog
  - [ ] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [ ] The Component Catalog is updated to use the newest version, if appropriate
  - [ ] The Component Catalog example version number is updated, if appropriate
  - [ ] Any new customizations are available from the Component Catalog
  - [ ] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [ ] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [ ] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [ ] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
