### PR TITLE
Implemented html code display in text examples

### DIFF
--- a/component-catalog/src/CommonControls.elm
+++ b/component-catalog/src/CommonControls.elm
@@ -9,8 +9,8 @@ module CommonControls exposing
     , content
     , httpError, badBodyString
     , guidanceAndErrorMessage
-    , quickBrownFox, exampleHtmlString
-    , disabledListItem, premiumDisplay
+    , quickBrownFox
+    , disabledListItem, exampleHtmlString, premiumDisplay
     )
 
 {-|

--- a/component-catalog/src/CommonControls.elm
+++ b/component-catalog/src/CommonControls.elm
@@ -9,7 +9,7 @@ module CommonControls exposing
     , content
     , httpError, badBodyString
     , guidanceAndErrorMessage
-    , quickBrownFox
+    , quickBrownFox, exampleHtmlString
     , disabledListItem, premiumDisplay
     )
 
@@ -264,6 +264,26 @@ exampleHtml =
         [ Html.text "darkness of the movie house " ]
     , Html.text "I had only two things on my mind: Paul Newman, and a ride home."
     ]
+
+
+exampleHtmlString : String
+exampleHtmlString =
+    """
+    [ Html.text "This is a "
+    , Html.strong [] [ Html.text "bolded phrase" ]
+    , Html.text ". "
+    , ClickableText.link quickBrownFox
+        [ ClickableText.icon UiIcon.starFilled
+        , ClickableText.href "http://www.noredink.com"
+        , ClickableText.appearsInline
+        ]
+    , Html.text " When I stepped out, into the bright sunlight from the "
+    , Html.a
+        [ Attributes.href "https://example.com" ]
+        [ Html.text "darkness of the movie house " ]
+    , Html.text "I had only two things on my mind: Paul Newman, and a ride home."
+    ]
+    """
 
 
 icon :

--- a/component-catalog/src/Debug/Control/View.elm
+++ b/component-catalog/src/Debug/Control/View.elm
@@ -1,4 +1,7 @@
-module Debug.Control.View exposing (view, viewCode, viewWithCustomControls)
+module Debug.Control.View exposing
+    ( view, viewWithCustomControls
+    , viewCode
+    )
 
 {-|
 

--- a/component-catalog/src/Debug/Control/View.elm
+++ b/component-catalog/src/Debug/Control/View.elm
@@ -1,4 +1,4 @@
-module Debug.Control.View exposing (view, viewWithCustomControls)
+module Debug.Control.View exposing (view, viewCode, viewWithCustomControls)
 
 {-|
 

--- a/component-catalog/src/Examples/Text.elm
+++ b/component-catalog/src/Examples/Text.elm
@@ -9,17 +9,17 @@ module Examples.Text exposing (example, State, Msg)
 import Category exposing (Category(..))
 import Code
 import CommonControls
-import Css.Media exposing (withMedia)
 import Css
+import Css.Media exposing (withMedia)
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
-import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
+import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.MediaQuery.V1 exposing (mobile, notMobile)
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Text.V6 as Text
@@ -117,7 +117,7 @@ example =
                 ]
                 attributes
             , if String.startsWith "Text.html" contentString then
-                Html.div 
+                Html.div
                     []
                     [ Heading.h3
                         [ Heading.plaintext "Html Code"
@@ -125,6 +125,7 @@ example =
                         ]
                     , viewCodeContainer <| CommonControls.exampleHtmlString
                     ]
+
               else
                 Html.text ""
             ]

--- a/component-catalog/src/Examples/Text.elm
+++ b/component-catalog/src/Examples/Text.elm
@@ -9,6 +9,7 @@ module Examples.Text exposing (example, State, Msg)
 import Category exposing (Category(..))
 import Code
 import CommonControls
+import Css.Media exposing (withMedia)
 import Css
 import Debug.Control as Control exposing (Control)
 import Debug.Control.Extra as ControlExtra
@@ -17,6 +18,9 @@ import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Container.V2 as Container
+import Nri.Ui.MediaQuery.V1 exposing (mobile, notMobile)
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Text.V6 as Text
 
@@ -53,6 +57,9 @@ example =
             let
                 attributes =
                     List.map Tuple.second (Control.currentValue state.control)
+
+                contentString =
+                    String.concat <| List.map Tuple.first (Control.currentValue state.control)
             in
             [ ControlView.view
                 { ellieLinkConfig = ellieLinkConfig
@@ -109,8 +116,41 @@ example =
                 , ( "ugSmallBody", Text.ugSmallBody )
                 ]
                 attributes
+            , if String.startsWith "Text.html" contentString then
+                Html.div 
+                    []
+                    [ Heading.h3
+                        [ Heading.plaintext "Html Code"
+                        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
+                        ]
+                    , viewCodeContainer <| CommonControls.exampleHtmlString
+                    ]
+              else
+                Html.text ""
             ]
     }
+
+
+viewCodeContainer : String -> Html msg
+viewCodeContainer code =
+    Container.view
+        [ Container.html
+            [ ControlView.viewCode code
+            ]
+        , Container.css
+            [ Css.padding (Css.px 20)
+            , Css.flexGrow (Css.num 1)
+            , Css.backgroundColor Colors.gray20
+            , withMedia [ mobile ]
+                [ Css.borderTopLeftRadius Css.zero
+                , Css.borderTopRightRadius Css.zero
+                ]
+            , withMedia [ notMobile ]
+                [ Css.borderTopLeftRadius Css.zero
+                , Css.borderBottomLeftRadius Css.zero
+                ]
+            ]
+        ]
 
 
 viewExamples : List ( String, List (Text.Attribute msg) -> Html msg ) -> List (Text.Attribute msg) -> Html msg


### PR DESCRIPTION
This PR adds a code block to the HTML view of the Text examples page, showing how to style text as shown

![Screenshot 2025-01-30 at 16 13 43](https://github.com/user-attachments/assets/c702847d-ed3d-4a32-9eed-078d9286d128)