### PR TITLE
Elm bump to 31.1.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "34.0.0",
+    "version": "34.1.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `34.1.0`

## What changes does this release include?
#1728
#1729
#1731

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```

This is a MINOR change.

---- Nri.Ui.UiIcon.V1 - MINOR ----

    Added:
        duplicate : Nri.Ui.Svg.V1.Svg
        publish : Nri.Ui.Svg.V1.Svg
        retire : Nri.Ui.Svg.V1.Svg
        unpublish : Nri.Ui.Svg.V1.Svg
        unretire : Nri.Ui.Svg.V1.Svg

```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).

