### PR TITLE
faster sortable table

### DIFF
--- a/component-catalog/src/Code.elm
+++ b/component-catalog/src/Code.elm
@@ -3,8 +3,7 @@ module Code exposing
     , maybe
     , bool
     , commentInline
-    , list, listMultiline
-    , tuple
+    , list, listMultiline, listMultilineFlat
     , pipelineMultiline
     , record, recordMultiline
     , listOfRecordsMultiline
@@ -12,13 +11,13 @@ module Code exposing
     , withParens, withParensMultiline
     , anonymousFunction, always
     , caseExpression
-    , browserElement, unstyledView
+    , browserElement, unstyledView, unstyledViewWithIndent
     , fromModule
     , var, varWithTypeAnnotation
     , funcWithType
     , unionType
     , apply
-    , int
+    , int, tuple, tupleMultiline
     )
 
 {-|
@@ -27,8 +26,8 @@ module Code exposing
 @docs maybe
 @docs bool
 @docs commentInline
-@docs list, listMultiline
-@docs tuple
+@docs list, listMultiline, listMultilineFlat
+@docs tuple tupleMultiline
 @docs pipelineMultiline
 @docs record, recordMultiline
 @docs listOfRecordsMultiline
@@ -36,7 +35,7 @@ module Code exposing
 @docs withParens, withParensMultiline
 @docs anonymousFunction, always
 @docs caseExpression
-@docs browserElement, unstyledView
+@docs browserElement, unstyledView, unstyledViewWithIndent
 @docs always
 @docs fromModule
 @docs var, varWithTypeAnnotation
@@ -141,6 +140,12 @@ tuple a b =
 
 
 {-| -}
+tupleMultiline : String -> String -> Int -> String
+tupleMultiline a b =
+    structureMultiline "(" ")" [ a, b ]
+
+
+{-| -}
 list : List String -> String
 list =
     structure "[" "]"
@@ -150,6 +155,12 @@ list =
 listMultiline : List String -> Int -> String
 listMultiline =
     structureMultiline "[" "]"
+
+
+{-| -}
+listMultilineFlat : List String -> Int -> String
+listMultilineFlat =
+    structureMultilineFlat "[" "]"
 
 
 recordValues : List ( String, String ) -> List String
@@ -221,12 +232,19 @@ newline =
 {-| -}
 newlineWithIndent : Int -> String
 newlineWithIndent indent =
-    "\n" ++ String.repeat indent tab
+    "\n" ++ prefixIndent indent
 
 
 tab : String
 tab =
     "    "
+
+
+{-| this is called prefix indent becaue normally you should use newlineWithIndent
+-}
+prefixIndent : Int -> String
+prefixIndent indent =
+    String.repeat indent tab
 
 
 {-| -}
@@ -296,6 +314,12 @@ unstyledView view =
 
 
 {-| -}
+unstyledViewWithIndent : Int -> String -> String
+unstyledViewWithIndent indent view =
+    pipelineMultiline [ newlineWithIndent indent ++ view, "toUnstyled" ] indent
+
+
+{-| -}
 fromModule : String -> String -> String
 fromModule moduleName name =
     moduleName ++ "." ++ name
@@ -310,7 +334,7 @@ varWithTypeAnnotation name typeValue body =
 {-| -}
 varWithTypeMultiline : String -> String -> String -> Int -> String
 varWithTypeMultiline name typeValue body indent =
-    String.repeat indent tab
+    prefixIndent indent
         ++ typeAnnotation name typeValue
         ++ newlineWithIndent indent
         ++ var name (indent + 1) body
@@ -325,7 +349,7 @@ funcWithType name typeValue vars body =
 {-| -}
 funcWithTypeMultiline : String -> String -> String -> String -> Int -> String
 funcWithTypeMultiline name typeValue vars body indent =
-    String.repeat indent tab
+    prefixIndent indent
         ++ typeAnnotation name typeValue
         ++ newlineWithIndent indent
         ++ var (name ++ " " ++ vars) (indent + 1) body

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -168,6 +168,7 @@ viewWithCode ({ sortModel } as model) =
     in
     ( \indentOffset ->
         ([ Code.fromModule moduleName "view"
+         , Code.record [ ( "model", "model" ), ( "msgWrapper", "identity" ) ]
          , Code.listMultilineFlat
             (List.concat
                 [ case settings.stickyHeader of
@@ -202,9 +203,6 @@ viewWithCode ({ sortModel } as model) =
 
                   else
                     []
-                , [ "SortableTable.msgWrapper identity"
-                  , "SortableTable.model model"
-                  ]
                 ]
             )
             (indentOffset + 2)
@@ -214,11 +212,11 @@ viewWithCode ({ sortModel } as model) =
         )
             |> Code.unstyledViewWithIndent (indentOffset + 1)
     , SortableTable.view
+        { model = sortModel
+        , msgWrapper = SortableTableMsg
+        }
         (List.concat
-            [ [ SortableTable.msgWrapper SortableTableMsg
-              , SortableTable.model sortModel
-              ]
-            , case settings.stickyHeader of
+            [ case settings.stickyHeader of
                 Nothing ->
                     []
 

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -212,9 +212,7 @@ example =
                 SortableTable.viewLoading attrs columns
 
               else
-                SortableTable.view attrs
-                    columns
-
+                SortableTable.view attrs columns
             ]
     }
 
@@ -325,8 +323,7 @@ type alias State =
 {-| -}
 init : State
 init =
-    { sortState = SortableTable.init FirstName (Tuple.second (List.unzip dataWithCode))
-
+    { sortState = SortableTable.init FirstName (Tuple.second (List.unzip (columnsWithCode (Control.currentValue controlSettings)))) (Tuple.second (List.unzip dataWithCode))
     , settings = controlSettings
     }
 

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -17,7 +17,7 @@ import Html.Styled as Html exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
-import Nri.Ui.SortableTable.V5 as SortableTable exposing (Column)
+import Nri.Ui.SortableTable.V6 as SortableTable exposing (Column)
 import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg exposing (Svg)
 import Nri.Ui.Table.V8 as Table
@@ -31,7 +31,7 @@ moduleName =
 
 version : Int
 version =
-    5
+    6
 
 
 {-| -}

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -137,15 +137,15 @@ example =
                                             ++ Code.anonymousFunction
                                                 "msg model"
                                                 (Code.tuple
-                                                    (Code.fromModule moduleName "update msg model")
+                                                    "table.update msg model"
                                                     "Cmd.none"
                                                 )
                                     , view =
                                         Code.newlineWithIndent 2 ++ Code.anonymousFunction "model " (viewCode 2)
                                     , subscriptions = Code.always "Sub.none"
                                     }
-                                , Code.var "columns" 1 <|
-                                    Code.listMultilineFlat (columnsWithCode settings |> codeWithIndent 1) 1
+                                , Code.var "table" 1 <|
+                                    (Code.fromModule moduleName "table" ++ Code.listMultiline (columnsWithCode settings |> codeWithIndent 2) 2)
                                 ]
                                     |> String.join Code.newlines
                           }
@@ -167,7 +167,7 @@ viewWithCode ({ sortModel } as model) =
             Control.currentValue model.settings
     in
     ( \indentOffset ->
-        ([ Code.fromModule moduleName "view"
+        ([ "table.view"
          , Code.record [ ( "model", "model" ), ( "msgWrapper", "identity" ) ]
          , Code.listMultilineFlat
             (List.concat
@@ -206,7 +206,6 @@ viewWithCode ({ sortModel } as model) =
                 ]
             )
             (indentOffset + 2)
-         , "columns"
          ]
             |> String.join (Code.newlineWithIndent (indentOffset + 2))
         )
@@ -236,9 +235,11 @@ viewWithCode ({ sortModel } as model) =
         )
     )
 
+
 table : Settings -> SortableTable.SortableTable ColumnId Datum Msg
 table settings =
     SortableTable.table (columnsWithCode settings |> Tuple.second)
+
 
 initWithCode : Settings -> ( Int -> String, SortableTable.Model ColumnId Datum )
 initWithCode settings =
@@ -247,13 +248,12 @@ initWithCode settings =
             List.unzip dataWithCode
     in
     ( \indentOffset ->
-        [ Code.fromModule moduleName "init"
+        [ "table.init"
         , "FirstName"
-        , "columns"
         , Code.listMultilineFlat dataCode indentOffset
         ]
             |> String.join (Code.newlineWithIndent indentOffset)
-    , (table  settings).init FirstName
+    , (table settings).init FirstName
         (if settings.loading then
             Nothing
 

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -143,7 +143,7 @@ example =
                                                     "Cmd.none"
                                                 )
                                     , view =
-                                        Code.newlineWithIndent 2 ++ Code.always (viewCode 2)
+                                        Code.newlineWithIndent 2 ++ Code.anonymousFunction "model" (viewCode 2)
                                     , subscriptions = Code.always "Sub.none"
                                     }
                                 , Code.var "columns" 1 <|
@@ -207,6 +207,11 @@ viewWithCode ({ sortModel } as model) =
 
                   else
                     []
+                , ["SortableTable.msgWrapper identity"]
+                , if settings.loading then
+                    []
+                  else
+                    [ "SortableTable.model model" ]
                 ]
             )
             (indentOffset + 2)
@@ -217,9 +222,13 @@ viewWithCode ({ sortModel } as model) =
             |> Code.unstyledViewWithIndent (indentOffset + 1)
     , SortableTable.view
         (List.concat
-            [ [ SortableTable.msgWrapper SortableTableMsg
-              , SortableTable.model sortModel
-              ]
+            [ SortableTable.msgWrapper SortableTableMsg
+                :: (if settings.loading then
+                        []
+
+                    else
+                        [ SortableTable.model sortModel ]
+                   )
             , case settings.stickyHeader of
                 Nothing ->
                     []

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -135,7 +135,7 @@ example =
                 ( columnsCode, columns ) =
                     List.unzip (columnsWithCode settings)
 
-                toExampleCode viewName finalArgs =
+                toExampleCode viewName =
                     { sectionName = viewName
                     , code =
                         [ moduleName ++ "." ++ viewName
@@ -185,7 +185,6 @@ example =
                             )
                             1
                         , Code.listMultiline columnsCode 1
-                        , finalArgs
                         ]
                             |> String.join ""
                     }
@@ -202,17 +201,13 @@ example =
                     , "type Msg = SortableTableWrapper (SortableTable.Msg ColumnId)"
                     ]
                 , renderExample = Code.unstyledView
-                , toExampleCode = \_ -> [ toExampleCode "view" (Code.list dataCode), toExampleCode "viewLoading" "" ]
+                , toExampleCode = \_ -> [ toExampleCode "view" ]
                 }
             , Heading.h2
                 [ Heading.plaintext "Customizable Example"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
-            , if settings.loading then
-                SortableTable.viewLoading attrs columns
-
-              else
-                SortableTable.view attrs columns
+            , SortableTable.view attrs columns
             ]
     }
 

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -460,7 +460,11 @@ update : Msg -> State -> ( State, Cmd Msg )
 update msg state =
     case msg of
         SortableTableMsg sortableTableMsg ->
-            ( { state | sortModel = SortableTable.update sortableTableMsg state.sortModel }, Cmd.none )
+            let
+                settings =
+                    Control.currentValue state.settings
+            in
+            ( { state | sortModel = SortableTable.update (columnsWithCode settings |> Tuple.second) sortableTableMsg state.sortModel }, Cmd.none )
 
         UpdateControls controls ->
             let
@@ -477,6 +481,7 @@ update msg state =
                 | settings = controls
                 , sortModel =
                     SortableTable.rebuild
+                        (columnsWithCode settings |> Tuple.second)
                         sortModel
                         (case ( settings.loading, settings.stickyHeader ) of
                             ( True, _ ) ->

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -129,10 +129,8 @@ example =
                             []
                         ]
 
-                isStickyAtAll =
-                    settings.stickyHeader /= Nothing
 
-                ( dataCode, data ) =
+                ( dataCode, _ ) =
                     List.unzip dataWithCode
 
                 ( columnsCode, columns ) =
@@ -216,14 +214,7 @@ example =
               else
                 SortableTable.view attrs
                     columns
-                    (if isStickyAtAll then
-                        data
-                            |> List.repeat 10
-                            |> List.concat
 
-                     else
-                        data
-                    )
             ]
     }
 
@@ -326,7 +317,7 @@ dataWithCode =
 
 {-| -}
 type alias State =
-    { sortState : SortableTable.State ColumnId
+    { sortState : SortableTable.State ColumnId Datum
     , settings : Control Settings
     }
 
@@ -334,7 +325,8 @@ type alias State =
 {-| -}
 init : State
 init =
-    { sortState = SortableTable.init FirstName
+    { sortState = SortableTable.init FirstName (Tuple.second (List.unzip dataWithCode))
+
     , settings = controlSettings
     }
 
@@ -417,4 +409,25 @@ update msg state =
             ( { state | sortState = SortableTable.update sortableTableMsg state.sortState }, Cmd.none )
 
         UpdateControls controls ->
-            ( { state | settings = controls }, Cmd.none )
+            let
+                sortState = state.sortState
+
+                ( _, data ) =
+                    List.unzip dataWithCode
+            in
+
+              ( { state |
+                  settings = controls,
+                  sortState = { sortState |
+                    entries = (if (Control.currentValue controls).stickyHeader /= Nothing then
+                                  data
+                                      |> List.repeat 10
+                                      |> List.concat
+
+                               else
+                                    data
+                              )
+                  }
+                }
+              , Cmd.none
+              )

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -145,7 +145,7 @@ example =
                                   , "-- The SortableTable's state should be stored on the model, rather than initialized in the view"
                                         ++ "\n      "
                                         ++ "SortableTable.state (SortableTable.init "
-                                        ++ Debug.toString model.sortState.column
+                                        ++ Debug.toString model.sortState -- TODO fix this!
                                         ++ ")"
                                   ]
                                 , case settings.stickyHeader of

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -101,7 +101,7 @@ example =
         ]
     , about = []
     , view =
-        \ellieLinkConfig ({ sortState } as model) ->
+        \ellieLinkConfig ({ sortModel } as model) ->
             let
                 settings =
                     Control.currentValue model.settings
@@ -109,7 +109,7 @@ example =
                 attrs =
                     List.concat
                         [ [ SortableTable.msgWrapper SortableTableMsg
-                          , SortableTable.state sortState
+                          , SortableTable.model sortModel
                           ]
                         , case settings.stickyHeader of
                             Nothing ->
@@ -144,8 +144,8 @@ example =
                                 [ [ "SortableTable.msgWrapper SortableTableMsg"
                                   , "-- The SortableTable's state should be stored on the model, rather than initialized in the view"
                                         ++ "\n      "
-                                        ++ "SortableTable.state (SortableTable.init "
-                                        ++ Debug.toString model.sortState -- TODO fix this!
+                                        ++ "SortableTable.model (SortableTable.init "
+                                        ++ Debug.toString model.sortModel -- TODO fix this!
                                         ++ ")"
                                   ]
                                 , case settings.stickyHeader of
@@ -314,7 +314,7 @@ dataWithCode =
 
 {-| -}
 type alias State =
-    { sortState : SortableTable.State ColumnId Datum
+    { sortModel : SortableTable.Model ColumnId Datum
     , settings : Control Settings
     }
 
@@ -322,7 +322,7 @@ type alias State =
 {-| -}
 init : State
 init =
-    { sortState = SortableTable.init FirstName (Tuple.second (List.unzip (columnsWithCode (Control.currentValue controlSettings)))) (Tuple.second (List.unzip dataWithCode))
+    { sortModel = SortableTable.init FirstName (Tuple.second (List.unzip (columnsWithCode (Control.currentValue controlSettings)))) (Tuple.second (List.unzip dataWithCode))
     , settings = controlSettings
     }
 
@@ -401,21 +401,21 @@ update : Msg -> State -> ( State, Cmd Msg )
 update msg state =
     case msg of
         SortableTableMsg sortableTableMsg ->
-            ( { state | sortState = SortableTable.update sortableTableMsg state.sortState }, Cmd.none )
+            ( { state | sortModel = SortableTable.update sortableTableMsg state.sortModel }, Cmd.none )
 
         UpdateControls controls ->
             let
-                sortState =
-                    state.sortState
+                sortModel =
+                    state.sortModel
 
                 ( _, data ) =
                     List.unzip dataWithCode
             in
             ( { state
                 | settings = controls
-                , sortState =
+                , sortModel =
                     SortableTable.updateEntries
-                        sortState
+                        sortModel
                         (if (Control.currentValue controls).stickyHeader /= Nothing then
                             data
                                 |> List.repeat 10

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -117,9 +117,7 @@ example =
                 , settings = model.settings
                 , mainType = Just "RootHtml.Html Msg"
                 , extraCode =
-                    [ "type ColumnId = FirstName | LastName | CustomExample "
-                    , "type Msg = SortableTableWrapper (SortableTable.Msg ColumnId)"
-                    ]
+                    [ "type ColumnId = FirstName | LastName | CustomExample " ]
                 , renderExample = identity
                 , toExampleCode =
                     \_ ->

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -108,7 +108,7 @@ example =
 
                 attrs =
                     List.concat
-                        [ [ SortableTable.updateMsg SetSortState
+                        [ [ SortableTable.msgWrapper SortableTableMsg
                           , SortableTable.state sortState
                           ]
                         , case settings.stickyHeader of
@@ -144,7 +144,7 @@ example =
                         [ moduleName ++ "." ++ viewName
                         , Code.listMultiline
                             (List.concat
-                                [ [ "SortableTable.updateMsg SetSortState"
+                                [ [ "SortableTable.msgWrapper SortableTableMsg"
                                   , "-- The SortableTable's state should be stored on the model, rather than initialized in the view"
                                         ++ "\n      "
                                         ++ "SortableTable.state (SortableTable.init "
@@ -201,7 +201,7 @@ example =
                 , mainType = Just "RootHtml.Html Msg"
                 , extraCode =
                     [ "type ColumnId = FirstName | LastName | CustomExample "
-                    , "type Msg = SetSortState (SortableTable.State ColumnId)"
+                    , "type Msg = SortableTableWrapper (SortableTable.Msg ColumnId)"
                     ]
                 , renderExample = Code.unstyledView
                 , toExampleCode = \_ -> [ toExampleCode "view" (Code.list dataCode), toExampleCode "viewLoading" "" ]
@@ -405,7 +405,7 @@ type ColumnId
 
 {-| -}
 type Msg
-    = SetSortState (SortableTable.State ColumnId)
+    = SortableTableMsg (SortableTable.Msg ColumnId)
     | UpdateControls (Control Settings)
 
 
@@ -413,8 +413,8 @@ type Msg
 update : Msg -> State -> ( State, Cmd Msg )
 update msg state =
     case msg of
-        SetSortState sortState ->
-            ( { state | sortState = sortState }, Cmd.none )
+        SortableTableMsg sortableTableMsg ->
+            ( { state | sortState = SortableTable.update sortableTableMsg state.sortState }, Cmd.none )
 
         UpdateControls controls ->
             ( { state | settings = controls }, Cmd.none )

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -145,7 +145,8 @@ example =
                                   , "-- The SortableTable's state should be stored on the model, rather than initialized in the view"
                                         ++ "\n      "
                                         ++ "SortableTable.model (SortableTable.init "
-                                        ++ Debug.toString model.sortModel -- TODO fix this!
+                                        ++ Debug.toString model.sortModel
+                                        -- TODO fix this!
                                         ++ ")"
                                   ]
                                 , case settings.stickyHeader of
@@ -390,6 +391,7 @@ type ColumnId
     | LastName
     | CustomExample
 
+
 {-| -}
 type Msg
     = SortableTableMsg (SortableTable.Msg ColumnId)
@@ -414,7 +416,7 @@ update msg state =
             ( { state
                 | settings = controls
                 , sortModel =
-                    SortableTable.updateEntries
+                    SortableTable.rebuild
                         sortModel
                         (if (Control.currentValue controls).stickyHeader /= Nothing then
                             data

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -211,7 +211,7 @@ viewWithCode ({ sortModel } as model) =
             |> String.join (Code.newlineWithIndent (indentOffset + 2))
         )
             |> Code.unstyledViewWithIndent (indentOffset + 1)
-    , SortableTable.view
+    , (table settings).view
         { model = sortModel
         , msgWrapper = SortableTableMsg
         }
@@ -234,9 +234,11 @@ viewWithCode ({ sortModel } as model) =
                 []
             ]
         )
-        (columnsWithCode settings |> Tuple.second)
     )
 
+table : Settings -> SortableTable.SortableTable ColumnId Datum Msg
+table settings =
+    SortableTable.table (columnsWithCode settings |> Tuple.second)
 
 initWithCode : Settings -> ( Int -> String, SortableTable.Model ColumnId Datum )
 initWithCode settings =
@@ -251,8 +253,7 @@ initWithCode settings =
         , Code.listMultilineFlat dataCode indentOffset
         ]
             |> String.join (Code.newlineWithIndent indentOffset)
-    , SortableTable.init FirstName
-        (columnsWithCode settings |> Tuple.second)
+    , (table  settings).init FirstName
         (if settings.loading then
             Nothing
 
@@ -464,7 +465,7 @@ update msg state =
                 settings =
                     Control.currentValue state.settings
             in
-            ( { state | sortModel = SortableTable.update (columnsWithCode settings |> Tuple.second) sortableTableMsg state.sortModel }, Cmd.none )
+            ( { state | sortModel = (table settings).update sortableTableMsg state.sortModel }, Cmd.none )
 
         UpdateControls controls ->
             let
@@ -480,8 +481,7 @@ update msg state =
             ( { state
                 | settings = controls
                 , sortModel =
-                    SortableTable.rebuild
-                        (columnsWithCode settings |> Tuple.second)
+                    (table settings).rebuild
                         sortModel
                         (case ( settings.loading, settings.stickyHeader ) of
                             ( True, _ ) ->

--- a/component-catalog/src/Examples/SortableTable.elm
+++ b/component-catalog/src/Examples/SortableTable.elm
@@ -129,7 +129,6 @@ example =
                             []
                         ]
 
-
                 ( dataCode, _ ) =
                     List.unzip dataWithCode
 
@@ -391,7 +390,6 @@ type ColumnId
     | LastName
     | CustomExample
 
-
 {-| -}
 type Msg
     = SortableTableMsg (SortableTable.Msg ColumnId)
@@ -407,24 +405,25 @@ update msg state =
 
         UpdateControls controls ->
             let
-                sortState = state.sortState
+                sortState =
+                    state.sortState
 
                 ( _, data ) =
                     List.unzip dataWithCode
             in
+            ( { state
+                | settings = controls
+                , sortState =
+                    SortableTable.updateEntries
+                        sortState
+                        (if (Control.currentValue controls).stickyHeader /= Nothing then
+                            data
+                                |> List.repeat 10
+                                |> List.concat
 
-              ( { state |
-                  settings = controls,
-                  sortState = { sortState |
-                    entries = (if (Control.currentValue controls).stickyHeader /= Nothing then
-                                  data
-                                      |> List.repeat 10
-                                      |> List.concat
-
-                               else
-                                    data
-                              )
-                  }
-                }
-              , Cmd.none
-              )
+                         else
+                            data
+                        )
+              }
+            , Cmd.none
+            )

--- a/deprecated-modules.csv
+++ b/deprecated-modules.csv
@@ -4,4 +4,5 @@ Nri.Ui.Highlighter.V5,upgrade to V6
 Nri.Ui.Mark.V2,upgrade to V6
 Nri.Ui.Pennant.V3,upgrade to V4
 Nri.Ui.QuestionBox.V6,upgrade to V7
+Nri.Ui.SortableTable.V5,upgrade to V6
 Nri.Ui.Tabs.V6,upgrade to V9

--- a/elm.json
+++ b/elm.json
@@ -74,6 +74,7 @@
         "Nri.Ui.Shadows.V1",
         "Nri.Ui.SideNav.V5",
         "Nri.Ui.SortableTable.V5",
+        "Nri.Ui.SortableTable.V6",
         "Nri.Ui.Spacing.V1",
         "Nri.Ui.Sprite.V1",
         "Nri.Ui.StickerIcon.V1",

--- a/forbidden-imports.toml
+++ b/forbidden-imports.toml
@@ -58,5 +58,8 @@ usages = [
 [forbidden."Nri.Ui.QuestionBox.V6"]
 hint = 'upgrade to V7'
 
+[forbidden."Nri.Ui.SortableTable.V5"]
+hint = 'upgrade to V6'
+
 [forbidden."Nri.Ui.Tabs.V6"]
 hint = 'upgrade to V9'

--- a/src/Nri/Ui/SortableTable/V6.elm
+++ b/src/Nri/Ui/SortableTable/V6.elm
@@ -1,12 +1,12 @@
 module Nri.Ui.SortableTable.V6 exposing
-    ( Column, Sorter, Model
-    , init, initDescending
-    , custom, string, placeholderColumn
-    , Attribute, tableAttribute, model, stickyHeader, stickyHeaderCustom, StickyConfig
-    , view, viewLoading
-    , invariantSort, simpleSort, combineSorters
+    ( Model, init, initDescending, rebuild
+    , entriesSorter
+    , Msg, update
     , encode, decoder
-    , Msg, entriesSorter, msgWrapper, update, updateEntries
+    , Column, custom, string, placeholderColumn
+    , Sorter, invariantSort, simpleSort, combineSorters
+    , view, viewLoading
+    , Attribute, model, msgWrapper, stickyHeader, stickyHeaderCustom, StickyConfig, tableAttribute
     )
 
 {-| Changes from V5:
@@ -16,13 +16,33 @@ module Nri.Ui.SortableTable.V6 exposing
   - Model is is opaque (and because of this, exposes encoder and decoder) (todo: rename to Model)
   - performance: caches sorting in Model instead of performing it in the view.
 
-@docs Column, Sorter, Model
-@docs init, initDescending
-@docs custom, string, placeholderColumn
-@docs Attribute, tableAttribute, model, stickyHeader, stickyHeaderCustom, StickyConfig
-@docs view, viewLoading
-@docs invariantSort, simpleSort, combineSorters
+
+## Initializing the model
+
+@docs Model, init, initDescending, rebuild
+@docs entriesSorter
+@docs Msg, update
+
+
+### Encoding and Decoding
+
 @docs encode, decoder
+
+
+## Columns
+
+@docs Column, custom, string, placeholderColumn
+@docs Sorter, invariantSort, simpleSort, combineSorters
+
+
+## Rendering
+
+@docs view, viewLoading
+
+
+### Attributes
+
+@docs Attribute, model, msgWrapper, stickyHeader, stickyHeaderCustom, StickyConfig, tableAttribute
 
 -}
 
@@ -83,12 +103,13 @@ type Model id entry
         }
 
 
+{-| The function that was used to sort the current sort direction & column in the table.
+-}
 entriesSorter : Model id entry -> entry -> entry -> Order
 entriesSorter (Model { sortDirection, column, sorter }) =
     sorter column sortDirection
 
 
-{-| -}
 type alias Config id entry msg =
     { msgWrapper : Maybe (Msg id -> msg)
     , model : Maybe (Model id entry)
@@ -258,8 +279,10 @@ init_ sortDirection columnId columns entries =
         }
 
 
-updateEntries : Model id entry -> List entry -> Model id entry
-updateEntries (Model model_) entries =
+{-| If you want to change the entries, this will rebuild the model while retaining sort information. Otherwise you can call one of the init funtions.
+-}
+rebuild : Model id entry -> List entry -> Model id entry
+rebuild (Model model_) entries =
     Model
         { model_
             | entries =

--- a/src/Nri/Ui/SortableTable/V6.elm
+++ b/src/Nri/Ui/SortableTable/V6.elm
@@ -14,6 +14,7 @@ module Nri.Ui.SortableTable.V6 exposing
   - Moves update function out of onClick handler and into an explicit `update` function
   - Model is renamed Model
   - Model is is opaque (and because of this, exposes encoder, decoder, and entriesSorter)
+  - removed loading function. Now if view is not passed the model, it will render as loading
   - performance: caches sorting in Model instead of performing it in the view.
 
 

--- a/src/Nri/Ui/SortableTable/V6.elm
+++ b/src/Nri/Ui/SortableTable/V6.elm
@@ -12,7 +12,7 @@ module Nri.Ui.SortableTable.V6 exposing
 {-| Changes from V5:
 
   - Moves update function out of onClick handler and into an explicit `update` function
-  - Model is renamed Model
+  - State is renamed Model
   - Model is is opaque (and because of this, exposes encoder, decoder, and entriesSorter)
   - removed loading function. Now if view is not passed the model, it will render as loading
   - performance: caches sorting in Model instead of performing it in the view.

--- a/src/Nri/Ui/SortableTable/V6.elm
+++ b/src/Nri/Ui/SortableTable/V6.elm
@@ -125,8 +125,8 @@ entriesSorter columns id =
 
 {-| -}
 currentEntriesSorter : TableConfig id entry msg -> Model id entry -> entry -> entry -> Order
-currentEntriesSorter columns (Model { sortDirection, column }) =
-    entriesSorter columns column sortDirection
+currentEntriesSorter tableConfig (Model { sortDirection, column }) =
+    entriesSorter tableConfig column sortDirection
 
 
 {-| -}
@@ -699,7 +699,7 @@ encode columnIdEncoder (Model model) =
 {-| decode model from Json
 -}
 decoder : TableConfig id entry msg -> Decode.Decoder id -> Maybe (List entry) -> Decode.Decoder (Model id entry)
-decoder columns columnIdDecoder maybeEntries =
+decoder tableConfig columnIdDecoder maybeEntries =
     Decode.map2
         (\column sortDirectionAscending ->
             init_
@@ -709,7 +709,7 @@ decoder columns columnIdDecoder maybeEntries =
                  else
                     Descending
                 )
-                columns
+                tableConfig
                 column
                 maybeEntries
         )

--- a/src/Nri/Ui/SortableTable/V6.elm
+++ b/src/Nri/Ui/SortableTable/V6.elm
@@ -1,0 +1,566 @@
+module Nri.Ui.SortableTable.V6 exposing
+    ( Column, Sorter, State
+    , init, initDescending
+    , custom, string, placeholderColumn
+    , Attribute, updateMsg, tableAttribute, state, stickyHeader, stickyHeaderCustom, StickyConfig
+    , view, viewLoading
+    , invariantSort, simpleSort, combineSorters
+    )
+
+{-| Changes from V4:
+
+  - Drops `disableAlternatingRowColors`
+  - Adds `tableAttribute`, which lets us add any attributes for the underlying `Nri.Ui.Table`
+
+@docs Column, Sorter, State
+@docs init, initDescending
+@docs custom, string, placeholderColumn
+@docs Attribute, updateMsg, tableAttribute, state, stickyHeader, stickyHeaderCustom, StickyConfig
+@docs view, viewLoading
+@docs invariantSort, simpleSort, combineSorters
+
+-}
+
+import Accessibility.Styled.Aria as Aria
+import Css exposing (..)
+import Css.Global
+import Css.Media
+import Html.Styled as Html exposing (Html)
+import Html.Styled.Attributes exposing (css)
+import Html.Styled.Events
+import Nri.Ui.Colors.V1
+import Nri.Ui.CssVendorPrefix.V1 as CssVendorPrefix
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Html.Attributes.V2 exposing (maybe)
+import Nri.Ui.Html.V3 exposing (viewJust)
+import Nri.Ui.MediaQuery.V1 as MediaQuery
+import Nri.Ui.Svg.V1
+import Nri.Ui.Table.V8 as Table exposing (SortDirection(..))
+import Nri.Ui.UiIcon.V1
+
+
+{-| -}
+type alias Sorter a =
+    SortDirection -> a -> a -> Order
+
+
+{-| -}
+type Column id entry msg
+    = Column
+        { id : id
+        , header : Html msg
+        , view : entry -> Html msg
+        , sorter : Maybe (Sorter entry)
+        , width : Int
+        , cellStyles : entry -> List Style
+        , hidden : Bool
+        }
+
+
+{-| -}
+type alias State id =
+    { column : id
+    , sortDirection : SortDirection
+    }
+
+
+{-| -}
+type alias Config id msg =
+    { updateMsg : Maybe (State id -> msg)
+    , state : Maybe (State id)
+    , stickyHeader : Maybe StickyConfig
+    , tableAttributes : List Table.Attribute
+    }
+
+
+defaultConfig : Config id msg
+defaultConfig =
+    { updateMsg = Nothing
+    , state = Nothing
+    , stickyHeader = Nothing
+    , tableAttributes = []
+    }
+
+
+{-| How the header will be set up to be sticky.
+
+  - `topOffset` controls how far off the top of the viewport the headers will
+    stick, in pixels. (**Default value:** 0)
+  - `zIndex` controls where in the stacking context the header will end
+    up. Useful to prevent elements in rows from appearing over the header.
+    (**Default value:** 0)
+
+Headers are never sticky on mobile-sized viewports because doing so causes some
+accessibility issues with zooming and panning.
+
+-}
+type alias StickyConfig =
+    { topOffset : Float
+    , zIndex : Int
+    , pageBackgroundColor : Css.Color
+    , hoverZIndex : Maybe Int
+    }
+
+
+defaultStickyConfig : StickyConfig
+defaultStickyConfig =
+    { topOffset = 0
+    , zIndex = 0
+    , pageBackgroundColor = Nri.Ui.Colors.V1.white
+    , hoverZIndex = Nothing
+    }
+
+
+consJust : Maybe a -> List a -> List a
+consJust maybe_ list =
+    case maybe_ of
+        Just value ->
+            value :: list
+
+        Nothing ->
+            list
+
+
+stickyConfigStyles : StickyConfig -> List Style
+stickyConfigStyles { topOffset, zIndex, pageBackgroundColor, hoverZIndex } =
+    [ Css.Media.withMedia
+        [ MediaQuery.notMobile ]
+        [ Css.Global.children
+            [ Css.Global.thead
+                (consJust (Maybe.map (\index -> Css.hover [ Css.zIndex (Css.int index) ]) hoverZIndex)
+                    [ Css.position Css.sticky
+                    , Css.top (Css.px topOffset)
+                    , Css.zIndex (Css.int zIndex)
+                    , Css.backgroundColor pageBackgroundColor
+                    ]
+                )
+            ]
+        ]
+    ]
+
+
+{-| Customize how the table is rendered, for example by adding sorting or
+stickiness.
+-}
+type Attribute id msg
+    = Attribute (Config id msg -> Config id msg)
+
+
+{-| Sort a column. You can get an initial state with `init` or `initDescending`.
+If you make this sorting interactive, you should store the state in your model
+and provide it to this function instead of recreating it on every update.
+-}
+state : State id -> Attribute id msg
+state state_ =
+    Attribute (\config -> { config | state = Just state_ })
+
+
+{-| Add interactivity in sorting columns. When this attribute is provided and
+sorting is enabled, columns will be sortable by clicking the headers.
+-}
+updateMsg : (State id -> msg) -> Attribute id msg
+updateMsg updateMsg_ =
+    Attribute (\config -> { config | updateMsg = Just updateMsg_ })
+
+
+{-| Make the header sticky (that is, it will stick to the top of the viewport
+when it otherwise would have been scrolled off.) You probably will want to set a
+background color on the header as well.
+-}
+stickyHeader : Attribute id msg
+stickyHeader =
+    Attribute (\config -> { config | stickyHeader = Just defaultStickyConfig })
+
+
+{-| Attributes forwarded to the underlying Nri.Ui.Table
+-}
+tableAttribute : Table.Attribute -> Attribute id msg
+tableAttribute attr =
+    Attribute (\config -> { config | tableAttributes = attr :: config.tableAttributes })
+
+
+{-| Does the same thing as `stickyHeader`, but with adaptations for your
+specific use.
+-}
+stickyHeaderCustom : StickyConfig -> Attribute id msg
+stickyHeaderCustom stickyConfig =
+    Attribute (\config -> { config | stickyHeader = Just stickyConfig })
+
+
+{-| -}
+init : id -> State id
+init initialSort =
+    { column = initialSort
+    , sortDirection = Ascending
+    }
+
+
+{-| -}
+initDescending : id -> State id
+initDescending initialSort =
+    { column = initialSort
+    , sortDirection = Descending
+    }
+
+
+{-| -}
+string :
+    { id : id
+    , header : String
+    , value : entry -> String
+    , width : Int
+    , cellStyles : entry -> List Style
+    }
+    -> Column id entry msg
+string { id, header, value, width, cellStyles } =
+    Column
+        { id = id
+        , header = Html.text header
+        , view = value >> Html.text
+        , sorter = Just (simpleSort value)
+        , width = width
+        , cellStyles = cellStyles
+        , hidden = False
+        }
+
+
+{-| -}
+custom :
+    { id : id
+    , header : Html msg
+    , view : entry -> Html msg
+    , sorter : Maybe (Sorter entry)
+    , width : Int
+    , cellStyles : entry -> List Style
+    }
+    -> Column id entry msg
+custom config =
+    Column
+        { id = config.id
+        , header = config.header
+        , view = config.view
+        , sorter = config.sorter
+        , width = config.width
+        , cellStyles = config.cellStyles
+        , hidden = False
+        }
+
+
+{-| Creates a placeholder column which will reserve the space for the column,
+this can be used when multiple tables have similar data and we want to keep
+the size consistent.
+-}
+placeholderColumn : { id : id, width : Int } -> Column id entry msg
+placeholderColumn config =
+    Column
+        { id = config.id
+        , header = Html.text ""
+        , view = always (Html.text "")
+        , sorter = Nothing
+        , width = config.width
+        , cellStyles = always []
+        , hidden = True
+        }
+
+
+{-| Create a sorter function that always orders the entries in the same order.
+For example, this is useful when we want to resolve ties and sort the tied
+entries by name, no matter of the sort direction set on the table.
+-}
+invariantSort : (entry -> comparable) -> Sorter entry
+invariantSort mapper =
+    \_ elem1 elem2 ->
+        compare (mapper elem1) (mapper elem2)
+
+
+{-| Create a simple sorter function that orders entries by mapping a function
+over the collection. It will also reverse it when the sort direction is descending.
+-}
+simpleSort : (entry -> comparable) -> Sorter entry
+simpleSort mapper =
+    \sortDirection elem1 elem2 ->
+        let
+            result =
+                compare (mapper elem1) (mapper elem2)
+        in
+        case sortDirection of
+            Ascending ->
+                result
+
+            Descending ->
+                flipOrder result
+
+
+flipOrder : Order -> Order
+flipOrder order =
+    case order of
+        LT ->
+            GT
+
+        EQ ->
+            EQ
+
+        GT ->
+            LT
+
+
+{-| -}
+combineSorters : List (Sorter entry) -> Sorter entry
+combineSorters sorters =
+    \sortDirection elem1 elem2 ->
+        let
+            folder =
+                \sorter acc ->
+                    case acc of
+                        EQ ->
+                            sorter sortDirection elem1 elem2
+
+                        _ ->
+                            acc
+        in
+        List.foldl folder EQ sorters
+
+
+{-| -}
+view : List (Attribute id msg) -> List (Column id entry msg) -> List entry -> Html msg
+view attributes columns entries =
+    let
+        config =
+            List.foldl (\(Attribute fn) soFar -> fn soFar) defaultConfig attributes
+
+        tableColumns =
+            List.map (buildTableColumn config.updateMsg config.state) columns
+    in
+    Table.view
+        (buildTableAttributes config)
+        tableColumns
+        (case config.state of
+            Just state_ ->
+                List.sortWith
+                    (findSorter columns state_.column state_.sortDirection)
+                    entries
+
+            Nothing ->
+                entries
+        )
+
+
+{-| -}
+viewLoading : List (Attribute id msg) -> List (Column id entry msg) -> Html msg
+viewLoading attributes columns =
+    let
+        config =
+            List.foldl (\(Attribute fn) soFar -> fn soFar) defaultConfig attributes
+
+        tableColumns =
+            List.map (buildTableColumn config.updateMsg config.state) columns
+    in
+    Table.viewLoading
+        (buildTableAttributes config)
+        tableColumns
+
+
+buildTableAttributes : Config id msg -> List Table.Attribute
+buildTableAttributes config =
+    let
+        stickyStyles =
+            Maybe.map stickyConfigStyles config.stickyHeader
+                |> Maybe.withDefault []
+    in
+    List.concat
+        [ [ Table.css stickyStyles ]
+        , List.reverse config.tableAttributes
+        ]
+
+
+findSorter : List (Column id entry msg) -> id -> Sorter entry
+findSorter columns columnId =
+    columns
+        |> listExtraFind (\(Column column) -> column.id == columnId)
+        |> Maybe.andThen (\(Column column) -> column.sorter)
+        |> Maybe.withDefault identitySorter
+
+
+{-| Taken from <https://github.com/elm-community/list-extra/blob/8.2.0/src/List/Extra.elm#L556>
+-}
+listExtraFind : (a -> Bool) -> List a -> Maybe a
+listExtraFind predicate list =
+    case list of
+        [] ->
+            Nothing
+
+        first :: rest ->
+            if predicate first then
+                Just first
+
+            else
+                listExtraFind predicate rest
+
+
+identitySorter : Sorter a
+identitySorter =
+    \_ _ _ ->
+        EQ
+
+
+buildTableColumn : Maybe (State id -> msg) -> Maybe (State id) -> Column id entry msg -> Table.Column entry msg
+buildTableColumn maybeUpdateMsg maybeState (Column column) =
+    if column.hidden then
+        Table.placeholderColumn { width = Css.px (toFloat column.width) }
+
+    else
+        Table.custom
+            { header =
+                case maybeState of
+                    Just state_ ->
+                        viewSortHeader (column.sorter /= Nothing) column.header maybeUpdateMsg state_ column.id
+
+                    Nothing ->
+                        column.header
+            , view = column.view
+            , width = Css.px (toFloat column.width)
+            , cellStyles = column.cellStyles
+            , sort =
+                Maybe.andThen
+                    (\state_ ->
+                        if state_.column == column.id then
+                            Just state_.sortDirection
+
+                        else
+                            Nothing
+                    )
+                    maybeState
+            }
+
+
+viewSortHeader : Bool -> Html msg -> Maybe (State id -> msg) -> State id -> id -> Html msg
+viewSortHeader isSortable header maybeUpdateMsg state_ id =
+    let
+        nextState =
+            nextTableState state_ id
+    in
+    if isSortable then
+        Html.button
+            [ css
+                [ Css.displayFlex
+                , Css.alignItems Css.center
+                , Css.property "gap" "8px"
+                , CssVendorPrefix.property "user-select" "none"
+                , if state_.column == id then
+                    fontWeight bold
+
+                  else
+                    fontWeight normal
+                , cursor pointer
+
+                -- make this look less "buttony"
+                , Css.border Css.zero
+                , Css.backgroundColor Css.transparent
+                , Css.width (Css.pct 100)
+                , Css.height (Css.pct 100)
+                , Css.margin Css.zero
+                , Css.padding Css.zero
+                , Fonts.baseFont
+                , Css.fontSize (Css.em 1)
+                ]
+            , maybe (\updateMsg_ -> Html.Styled.Events.onClick (updateMsg_ nextState)) maybeUpdateMsg
+
+            -- screen readers should know what clicking this button will do
+            , Aria.roleDescription "sort button"
+            ]
+            [ Html.div [] [ header ]
+            , viewJust (\_ -> viewSortButton state_ id) maybeUpdateMsg
+            ]
+
+    else
+        Html.div
+            [ css [ fontWeight normal ]
+            ]
+            [ header ]
+
+
+viewSortButton : State id -> id -> Html msg
+viewSortButton state_ id =
+    let
+        arrows upHighlighted downHighlighted =
+            Html.div
+                [ css
+                    [ Css.displayFlex
+                    , Css.flexDirection Css.column
+                    , Css.alignItems Css.center
+                    , Css.justifyContent Css.center
+                    ]
+                ]
+                [ sortArrow Up upHighlighted
+                , sortArrow Down downHighlighted
+                ]
+
+        buttonContent =
+            case ( state_.column == id, state_.sortDirection ) of
+                ( True, Ascending ) ->
+                    arrows True False
+
+                ( True, Descending ) ->
+                    arrows False True
+
+                ( False, _ ) ->
+                    arrows False False
+    in
+    Html.div [ css [ padding (px 2) ] ] [ buttonContent ]
+
+
+nextTableState : State id -> id -> State id
+nextTableState state_ id =
+    if state_.column == id then
+        { column = id
+        , sortDirection = flipSortDirection state_.sortDirection
+        }
+
+    else
+        { column = id
+        , sortDirection = Ascending
+        }
+
+
+flipSortDirection : SortDirection -> SortDirection
+flipSortDirection order =
+    case order of
+        Ascending ->
+            Descending
+
+        Descending ->
+            Ascending
+
+
+type Direction
+    = Up
+    | Down
+
+
+sortArrow : Direction -> Bool -> Html msg
+sortArrow direction active =
+    let
+        arrow =
+            case direction of
+                Up ->
+                    Nri.Ui.UiIcon.V1.sortArrow
+
+                Down ->
+                    Nri.Ui.UiIcon.V1.sortArrowDown
+
+        color =
+            if active then
+                Nri.Ui.Colors.V1.azure
+
+            else
+                Nri.Ui.Colors.V1.gray75
+    in
+    arrow
+        |> Nri.Ui.Svg.V1.withHeight (px 6)
+        |> Nri.Ui.Svg.V1.withWidth (px 8)
+        |> Nri.Ui.Svg.V1.withColor color
+        |> Nri.Ui.Svg.V1.withCss
+            [ displayFlex
+            , margin2 (px 1) zero
+            ]
+        |> Nri.Ui.Svg.V1.toHtml

--- a/src/Nri/Ui/SortableTable/V6.elm
+++ b/src/Nri/Ui/SortableTable/V6.elm
@@ -489,11 +489,7 @@ buildTableColumn msgWrapper (Model model) (Column column) =
     else
         Table.custom
             { header =
-                if Dict.isEmpty model.entries then
-                    column.header
-
-                else
-                    viewSortHeader (column.sorter /= Nothing) column.header msgWrapper (Model model) column.id
+                viewSortHeader (column.sorter /= Nothing) column.header msgWrapper (Model model) column.id
             , view = column.view
             , width = Css.px (toFloat column.width)
             , cellStyles = column.cellStyles

--- a/src/Nri/Ui/SortableTable/V6.elm
+++ b/src/Nri/Ui/SortableTable/V6.elm
@@ -5,7 +5,7 @@ module Nri.Ui.SortableTable.V6 exposing
     , encode, decoder
     , Column, custom, string, placeholderColumn
     , Sorter, invariantSort, simpleSort, combineSorters
-    , view, viewLoading
+    , view
     , Attribute, model, msgWrapper, stickyHeader, stickyHeaderCustom, StickyConfig, tableAttribute
     )
 
@@ -37,7 +37,7 @@ module Nri.Ui.SortableTable.V6 exposing
 
 ## Rendering
 
-@docs view, viewLoading
+@docs view
 
 
 ### Attributes
@@ -437,28 +437,17 @@ view attributes columns =
         tableColumns =
             List.map (buildTableColumn config.msgWrapper config.model) columns
     in
-    Table.view
-        (buildTableAttributes config)
-        tableColumns
-        (config.model
-            |> Maybe.map (\model_ -> currentEntries model_)
-            |> Maybe.withDefault []
-        )
+    case config.model of
+        Just model_ ->
+            Table.view
+                (buildTableAttributes config)
+                tableColumns
+                (currentEntries model_)
 
-
-{-| -}
-viewLoading : List (Attribute id entry msg) -> List (Column id entry msg) -> Html msg
-viewLoading attributes columns =
-    let
-        config =
-            List.foldl (\(Attribute fn) soFar -> fn soFar) defaultConfig attributes
-
-        tableColumns =
-            List.map (buildTableColumn config.msgWrapper config.model) columns
-    in
-    Table.viewLoading
-        (buildTableAttributes config)
-        tableColumns
+        Nothing ->
+            Table.viewLoading
+                (buildTableAttributes config)
+                tableColumns
 
 
 buildTableAttributes : Config id entry msg -> List Table.Attribute

--- a/src/Nri/Ui/SortableTable/V6.elm
+++ b/src/Nri/Ui/SortableTable/V6.elm
@@ -6,7 +6,7 @@ module Nri.Ui.SortableTable.V6 exposing
     , view, viewLoading
     , invariantSort, simpleSort, combineSorters
     , encode, decoder
-    , Msg, msgWrapper, update, updateEntries
+    , Msg, entriesSorter, msgWrapper, update, updateEntries
     )
 
 {-| Changes from V5:
@@ -81,6 +81,11 @@ type Model id entry
         , entries : Dict.Dict ( id, SortDirection ) (List entry)
         , sorter : id -> Sorter entry
         }
+
+
+entriesSorter : Model id entry -> entry -> entry -> Order
+entriesSorter (Model { sortDirection, column, sorter }) =
+    sorter column sortDirection
 
 
 {-| -}
@@ -260,7 +265,7 @@ updateEntries (Model model_) entries =
                     |> Dict.insert
                         ( model_.column, model_.sortDirection )
                         (List.sortWith
-                            (model_.sorter model_.column model_.sortDirection)
+                            (entriesSorter (Model model_))
                             entries
                         )
         }

--- a/src/Nri/Ui/SortableTable/V6.elm
+++ b/src/Nri/Ui/SortableTable/V6.elm
@@ -93,6 +93,10 @@ type Column id entry msg
         }
 
 
+type alias TableConfig id entry msg =
+    List (Column id entry msg)
+
+
 type LoadingEntries id entry
     = Loaded (Sort.Sorter ( id, SortDirection )) (Dict.Dict ( id, SortDirection ) (List entry))
     | Loading (Sort.Sorter ( id, SortDirection ))
@@ -223,7 +227,7 @@ stickyHeaderCustom stickyConfig =
     Attribute (\config -> { config | stickyHeader = Just stickyConfig })
 
 
-init_ : SortDirection -> id -> List (Column id entry msg) -> Maybe (List entry) -> Model id entry
+init_ : SortDirection -> id -> TableConfig id entry msg -> Maybe (List entry) -> Model id entry
 init_ sortDirection columnId columns maybeEntries =
     let
         entriesSorter_ : id -> Sorter entry
@@ -299,13 +303,13 @@ rebuild (Model model) maybeEntries =
 
 
 {-| -}
-init : id -> List (Column id entry msg) -> Maybe (List entry) -> Model id entry
+init : id -> TableConfig id entry msg -> Maybe (List entry) -> Model id entry
 init =
     init_ Ascending
 
 
 {-| -}
-initDescending : id -> List (Column id entry msg) -> Maybe (List entry) -> Model id entry
+initDescending : id -> TableConfig id entry msg -> Maybe (List entry) -> Model id entry
 initDescending =
     init_ Descending
 
@@ -429,7 +433,7 @@ combineSorters sorters =
 
 
 {-| -}
-view : ViewConfig id entry msg -> List (Attribute id entry msg) -> List (Column id entry msg) -> Html msg
+view : ViewConfig id entry msg -> List (Attribute id entry msg) -> TableConfig id entry msg -> Html msg
 view { msgWrapper, model } attributes columns =
     let
         config =
@@ -691,7 +695,7 @@ encode columnIdEncoder (Model model) =
 
 {-| decode model from Json
 -}
-decoder : Decode.Decoder id -> List (Column id entry msg) -> Maybe (List entry) -> Decode.Decoder (Model id entry)
+decoder : Decode.Decoder id -> TableConfig id entry msg -> Maybe (List entry) -> Decode.Decoder (Model id entry)
 decoder columnIdDecoder columns maybeEntries =
     Decode.map2
         (\column sortDirectionAscending ->

--- a/src/Nri/Ui/SortableTable/V6.elm
+++ b/src/Nri/Ui/SortableTable/V6.elm
@@ -1,6 +1,5 @@
 module Nri.Ui.SortableTable.V6 exposing
     ( Model
-    , currentEntriesSorter
     , Msg
     , encode
     , Column, custom, string, placeholderColumn
@@ -23,13 +22,14 @@ module Nri.Ui.SortableTable.V6 exposing
 ## Initializing the model
 
 @docs Model
-@docs entriesSorter, currentEntriesSorter
-@docs Msg, update
+@docs Msg
 
 
 ### Encoding and Decoding
 
-@docs encode, decoder
+decoder comes from SortableTable type
+
+@docs encode
 
 
 ## Columns
@@ -40,7 +40,7 @@ module Nri.Ui.SortableTable.V6 exposing
 
 ## Rendering
 
-@docs view, ViewConfig
+@docs ViewConfig
 
 
 ### Attributes
@@ -717,6 +717,7 @@ decoder columns columnIdDecoder maybeEntries =
         (Decode.field "sortDirectionAscending" Decode.bool)
 
 
+{-| -}
 type alias SortableTable id entry msg =
     { update : Msg id -> Model id entry -> Model id entry
     , view : ViewConfig id entry msg -> List (Attribute id entry msg) -> Html msg
@@ -728,6 +729,7 @@ type alias SortableTable id entry msg =
     }
 
 
+{-| -}
 table :
     TableConfig id entry msg
     -> SortableTable id entry msg

--- a/src/Nri/Ui/SortableTable/V6.elm
+++ b/src/Nri/Ui/SortableTable/V6.elm
@@ -13,7 +13,7 @@ module Nri.Ui.SortableTable.V6 exposing
 
   - Moves update function out of onClick handler and into an explicit `update` function
   - Model is renamed Model
-  - Model is is opaque (and because of this, exposes encoder and decoder) (todo: rename to Model)
+  - Model is is opaque (and because of this, exposes encoder, decoder, and entriesSorter)
   - performance: caches sorting in Model instead of performing it in the view.
 
 

--- a/src/Nri/Ui/SortableTable/V6.elm
+++ b/src/Nri/Ui/SortableTable/V6.elm
@@ -9,10 +9,12 @@ module Nri.Ui.SortableTable.V6 exposing
     , Msg, msgWrapper, update, updateEntries
     )
 
-{-| Changes from V4:
+{-| Changes from V5:
 
-  - Drops `disableAlternatingRowColors`
-  - Adds `tableAttribute`, which lets us add any attributes for the underlying `Nri.Ui.Table`
+  - Moves update function out of onClick handler and into an explicit `update` function
+  - Model is renamed Model
+  - Model is is opaque (and because of this, exposes encoder and decoder) (todo: rename to Model)
+  - performance: caches sorting in Model instead of performing it in the view.
 
 @docs Column, Sorter, Model
 @docs init, initDescending

--- a/tests/Spec/Nri/Ui/SortableTable.elm
+++ b/tests/Spec/Nri/Ui/SortableTable.elm
@@ -47,9 +47,9 @@ entries =
     ]
 
 
-tableView : SortableTable.Model Column Person -> Query.Single msg
-tableView sortState =
-    SortableTable.view [ SortableTable.model sortState ] columns
+tableView : SortableTable.Model Column Person -> Query.Single (SortableTable.Msg Column)
+tableView sortModel =
+    SortableTable.view { model = sortModel, msgWrapper = identity } [] columns
         |> Html.Styled.toUnstyled
         |> Query.fromHtml
 

--- a/tests/Spec/Nri/Ui/SortableTable.elm
+++ b/tests/Spec/Nri/Ui/SortableTable.elm
@@ -47,21 +47,26 @@ entries =
     ]
 
 
+table : SortableTable.SortableTable Column Person msg
+table =
+    SortableTable.table columns
+
+
 tableView : SortableTable.Model Column Person -> Query.Single (SortableTable.Msg Column)
 tableView sortModel =
-    SortableTable.view { model = sortModel, msgWrapper = identity } [] columns
+    table.view { model = sortModel, msgWrapper = identity } []
         |> Html.Styled.toUnstyled
         |> Query.fromHtml
 
 
 sortBy : Column -> SortableTable.Model Column Person
 sortBy field =
-    SortableTable.init field columns (Just entries)
+    table.init field (Just entries)
 
 
 sortByDescending : Column -> SortableTable.Model Column Person
 sortByDescending field =
-    SortableTable.initDescending field columns (Just entries)
+    table.initDescending field (Just entries)
 
 
 spec : Test

--- a/tests/Spec/Nri/Ui/SortableTable.elm
+++ b/tests/Spec/Nri/Ui/SortableTable.elm
@@ -56,12 +56,12 @@ tableView sortState =
 
 sortBy : Column -> SortableTable.Model Column Person
 sortBy field =
-    SortableTable.init field columns entries
+    SortableTable.init field columns (Just entries)
 
 
 sortByDescending : Column -> SortableTable.Model Column Person
 sortByDescending field =
-    SortableTable.initDescending field columns entries
+    SortableTable.initDescending field columns (Just entries)
 
 
 spec : Test

--- a/tests/Spec/Nri/Ui/SortableTable.elm
+++ b/tests/Spec/Nri/Ui/SortableTable.elm
@@ -2,8 +2,8 @@ module Spec.Nri.Ui.SortableTable exposing (spec)
 
 import Expect
 import Html.Styled
-import Nri.Ui.SortableTable.V5 as SortableTable
-import Nri.Ui.Table.V8 exposing (SortDirection)
+import Nri.Ui.SortableTable.V6 as SortableTable
+import Nri.Ui.Table.V8 exposing (SortDirection(..))
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector
@@ -47,31 +47,21 @@ entries =
     ]
 
 
-tableView : SortableTable.State Column -> Query.Single msg
+tableView : SortableTable.Model Column Person -> Query.Single msg
 tableView sortState =
-    SortableTable.view [ SortableTable.state sortState ] columns entries
+    SortableTable.view [ SortableTable.model sortState ] columns
         |> Html.Styled.toUnstyled
         |> Query.fromHtml
 
 
-sortBy : Column -> SortableTable.State Column
+sortBy : Column -> SortableTable.Model Column Person
 sortBy field =
-    SortableTable.init field
+    SortableTable.init field columns entries
 
 
-sortByDescending : Column -> SortableTable.State Column
+sortByDescending : Column -> SortableTable.Model Column Person
 sortByDescending field =
-    SortableTable.initDescending field
-
-
-ascending : SortDirection
-ascending =
-    sortBy FirstName |> .sortDirection
-
-
-descending : SortDirection
-descending =
-    sortByDescending FirstName |> .sortDirection
+    SortableTable.initDescending field columns entries
 
 
 spec : Test
@@ -84,8 +74,8 @@ spec =
                         sorter =
                             SortableTable.invariantSort .firstName
                     in
-                    List.sortWith (sorter ascending) entries
-                        |> Expect.equal (List.sortWith (sorter descending) entries)
+                    List.sortWith (sorter Ascending) entries
+                        |> Expect.equal (List.sortWith (sorter Descending) entries)
             ]
         , describe "simpleSort"
             [ test "sorts ascending" <|
@@ -94,7 +84,7 @@ spec =
                         sorter =
                             SortableTable.simpleSort .firstName
                     in
-                    List.sortWith (sorter ascending) entries
+                    List.sortWith (sorter Ascending) entries
                         |> List.map .firstName
                         |> Expect.equal [ "Alice", "Bob", "Charlie" ]
             , test "sorts descending" <|
@@ -103,7 +93,7 @@ spec =
                         sorter =
                             SortableTable.simpleSort .firstName
                     in
-                    List.sortWith (sorter descending) entries
+                    List.sortWith (sorter Descending) entries
                         |> List.map .firstName
                         |> Expect.equal [ "Charlie", "Bob", "Alice" ]
             ]
@@ -123,7 +113,7 @@ spec =
                         sorter =
                             SortableTable.combineSorters [ sortByFirstName, sortByLastName ]
                     in
-                    List.sortWith (sorter ascending) newEntries
+                    List.sortWith (sorter Ascending) newEntries
                         |> List.map (\elem -> elem.firstName ++ " " ++ elem.lastName)
                         |> Expect.equal
                             [ "Alice InChains"

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -70,6 +70,7 @@
         "Nri.Ui.Shadows.V1",
         "Nri.Ui.SideNav.V5",
         "Nri.Ui.SortableTable.V5",
+        "Nri.Ui.SortableTable.V6",
         "Nri.Ui.Spacing.V1",
         "Nri.Ui.Sprite.V1",
         "Nri.Ui.StickerIcon.V1",


### PR DESCRIPTION
## What changes does this release include?

Adds a more performant sortable table by caching sorted data in the state.

easiest to review commit-by-commit

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```
This is a MINOR change.

---- ADDED MODULES - MINOR ----

    Nri.Ui.SortableTable.V6
```

Rejiggers the API for SortableTable a bit.

- State becomes opaque, and is renamed Model
- because of this, encoders and decoders are included for the Model
- because of caching & opaque model, implements TEA and exposes an `update` function
- in order to initialize the model, dev now needs to pass in all columns
- when the `SortableTable` has no model attribute, it is "Loading", else it is loaded.
