### PR TITLE
sideNav icon size tweaks

### DIFF
--- a/src/Nri/Ui/SideNav/V5.elm
+++ b/src/Nri/Ui/SideNav/V5.elm
@@ -641,8 +641,8 @@ viewLeftIcon config =
     viewJust
         (\icon_ ->
             icon_
-                |> Svg.withWidth (px 20)
-                |> Svg.withHeight (px 20)
+                |> Svg.withWidth (px 17)
+                |> Svg.withHeight (px 17)
                 |> Svg.withCss [ marginRight (px 5) ]
                 |> Svg.toHtml
         )
@@ -654,8 +654,8 @@ viewRightIcon config =
     viewJust
         (\icon_ ->
             icon_
-                |> Svg.withWidth (px 20)
-                |> Svg.withHeight (px 20)
+                |> Svg.withWidth (px 15)
+                |> Svg.withHeight (px 15)
                 |> Svg.withCss [ marginLeft (px 5) ]
                 |> Svg.toHtml
         )
@@ -680,8 +680,8 @@ viewLockedEntry extraStyles entryConfig =
                 entryConfig.customAttributes
         )
         [ Pennant.contentPremiumFlag
-            |> Svg.withWidth (px 15)
-            |> Svg.withHeight (px 15)
+            |> Svg.withWidth (px 17)
+            |> Svg.withHeight (px 17)
             |> Svg.withCss [ marginRight (px 5), minWidth (px 15) ]
             |> Svg.toHtml
         , text entryConfig.title


### PR DESCRIPTION
<img width="329" alt="Screenshot 2025-03-25 at 2 25 56 PM" src="https://github.com/user-attachments/assets/c0c3eaa0-2b20-41cf-a9ce-321bb1281024" />
<img width="345" alt="Screenshot 2025-03-25 at 2 26 10 PM" src="https://github.com/user-attachments/assets/41d8a1f1-d17f-4f30-89df-cbf34372cf7f" />