### PR TITLE
Bump version to 34.5.0: Standardize UI components, styling tweaks, new icons & npm bump docs

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "34.4.0",
+    "version": "34.5.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `34.5.0`

## What changes does this release include?

- #1751
- #1753 
- #1754
- #1755
- #1756
- #1757

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```
This is a MINOR change.

---- Nri.Ui.UiIcon.V2 - MINOR ----

    Added:
        practiceIcon : Nri.Ui.Svg.V1.Svg

```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).