### PR TITLE
Component regression fixes

### DIFF
--- a/src/Nri/Ui/SegmentedControl/V14.elm
+++ b/src/Nri/Ui/SegmentedControl/V14.elm
@@ -299,6 +299,7 @@ sharedSegmentStyles numEntries index =
     , textDecoration none
     , displayFlex
     , alignItems center
+    , justifyContent center
     , hover [ textDecoration none ]
     , focus [ textDecoration none ]
     ]

--- a/src/Nri/Ui/SegmentedControl/V14.elm
+++ b/src/Nri/Ui/SegmentedControl/V14.elm
@@ -285,7 +285,7 @@ styles focusSelector positioning numEntries index isSelected =
 
 sharedSegmentStyles : Int -> Int -> Style
 sharedSegmentStyles numEntries index =
-    [ padding3 (px 3) (px 15) (px 6)
+    [ padding2 (px 6) (px 15)
     , height (px 45)
     , Fonts.baseFont
     , fontSize (px 15)

--- a/src/Nri/Ui/Tabs/V9.elm
+++ b/src/Nri/Ui/Tabs/V9.elm
@@ -441,7 +441,7 @@ tabStyles customSpacing pageBackgroundColor_ index isSelected =
             , Css.fontWeight (Css.int 600)
             , Css.cursor Css.pointer
             , Css.border zero
-            , Css.height (Css.px 55)
+            , Css.minHeight (Css.px 55)
             ]
 
         stylesTab =


### PR DESCRIPTION
Fixes two regressions in components:
- Left-aligned segmented control labels
- Tabs that don't expand in height

![Screenshot 2025-05-14 at 1 59 54 PM](https://github.com/user-attachments/assets/d27d4943-0534-486d-bdc9-6d0dcaf607c9)
![Screenshot 2025-05-14 at 2 03 37 PM](https://github.com/user-attachments/assets/b70bd0d9-cd31-4a46-9893-bbca1f1399f2)