### PR TITLE
Add SelectElement

### DIFF
--- a/component-catalog/index.html
+++ b/component-catalog/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -9,6 +9,67 @@
       rel="stylesheet"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      [hidden] {
+        display: none !important;
+      }
+
+      select-element [role="option"]:hover {
+        background-color: #f5f5f5;
+      }
+
+      select-element [role="option"].active-descendant {
+        background-color: #e6f2ff;
+        color: #005a9e;
+      }
+
+      select-element [role="option"][aria-selected="true"] {
+        background-color: #eef0ff;
+        font-weight: bold;
+      }
+
+      select-element {
+        view-transition-name: select-element-popover;
+        backface-visibility: hidden;
+        will-change: opacity, transform;
+      }
+
+      select-element.initial-positioning {
+        view-transition-name: none !important;
+      }
+
+      @keyframes fade-in {
+        from {
+          opacity: 0;
+          transform: translateY(-8px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      @keyframes fade-out {
+        from {
+          opacity: 1;
+          transform: translateY(0);
+        }
+        to {
+          opacity: 0;
+          transform: translateY(-8px);
+        }
+      }
+
+      ::view-transition-old(select-element-popover) {
+        animation: 250ms cubic-bezier(0.42, 0, 0.58, 1) both fade-out;
+        backface-visibility: hidden;
+      }
+
+      ::view-transition-new(select-element-popover) {
+        animation: 250ms cubic-bezier(0.42, 0, 0.58, 1) both fade-in;
+        backface-visibility: hidden;
+      }
+    </style>
   </head>
   <body>
     <div id="svg-target"></div>
@@ -67,27 +128,27 @@
           // Also 4. Handle drag-to-select on touch devices, when in scroll-friendly mode
           highlighter.addEventListener(
             "touchstart",
-            handleTouchStartScrollFriendly(id),
+            handleTouchStartScrollFriendly(id)
           );
         });
         /*
-        * This simulates "long-press to highlight" behavior that's native to mobile devices.
-        *
-        * We can't respect native long-press delays, unfortunately, because iOS does not implement
-        * an event that relies on long-press that we can intercept, like Android's `contextmenu`.
-        *
-        * The trick to make this work and be scroll friendly:
-        * - On touchstart, start a 500ms timer
-        * - If touch moves of ends before timer is done, undo everything (it's not a long-press)
-        * - If 500ms timer succeeds..
-        *   - send a longpress event to Elm so we start hinting
-        *   - add a touchmove listener
-        *     - on touchmove, tell Elm which element is currently under the finger
-        *   - add a touchend listener so we can stop hinting regardless of where we are in the page
-        *
-        * How this makes it scroll friendly: preventDefault on touchmove is only triggered after
-        * the longpress, so simple swipes up and down are not affected.
-        */
+         * This simulates "long-press to highlight" behavior that's native to mobile devices.
+         *
+         * We can't respect native long-press delays, unfortunately, because iOS does not implement
+         * an event that relies on long-press that we can intercept, like Android's `contextmenu`.
+         *
+         * The trick to make this work and be scroll friendly:
+         * - On touchstart, start a 500ms timer
+         * - If touch moves of ends before timer is done, undo everything (it's not a long-press)
+         * - If 500ms timer succeeds..
+         *   - send a longpress event to Elm so we start hinting
+         *   - add a touchmove listener
+         *     - on touchmove, tell Elm which element is currently under the finger
+         *   - add a touchend listener so we can stop hinting regardless of where we are in the page
+         *
+         * How this makes it scroll friendly: preventDefault on touchmove is only triggered after
+         * the longpress, so simple swipes up and down are not affected.
+         */
         function handleTouchStartScrollFriendly(id) {
           return (e) => {
             console.log("longpress start", id);
@@ -119,9 +180,9 @@
         }
 
         /*
-        * Touchmove event always fire on the element that got the initial touchstart event.
-        * We need the element under the finger to highlight a section though.
-        */
+         * Touchmove event always fire on the element that got the initial touchstart event.
+         * We need the element under the finger to highlight a section though.
+         */
         function handleTouchEvents(type, id) {
           return function (e) {
             e.preventDefault();
@@ -139,8 +200,8 @@
         }
 
         /*
-        * inform elm when we receive a mouseup/touchend event.
-        */
+         * inform elm when we receive a mouseup/touchend event.
+         */
         function onDocumentUp(id, device) {
           return function () {
             app.ports.highlighterTouchPointerRelease.send([id, device]);
@@ -167,7 +228,10 @@
           if (!loc) throw "touch event unexpectedly didn't have any touches!";
 
           // get the element under the finger
-          const realTarget = document.elementFromPoint(loc.clientX, loc.clientY);
+          const realTarget = document.elementFromPoint(
+            loc.clientX,
+            loc.clientY
+          );
 
           if (realTarget) {
             // each word has a data attribute with its index.
@@ -181,6 +245,658 @@
           return null;
         }
       });
+
+      class SelectElement extends HTMLElement {
+        static observedAttributes = ["data-trigger-id", "value"];
+
+        constructor() {
+          super();
+          this.activeIndex = -1;
+          this._activeOptionId = null;
+          const shadow = this.attachShadow({ mode: "open" });
+
+          const internalContainer = document.createElement("div");
+          internalContainer.part = "listbox-shell";
+          internalContainer.appendChild(document.createElement("slot"));
+          shadow.appendChild(internalContainer);
+
+          this._repositionFrameId = null;
+          this._handleWindowResizeOrScroll =
+            this._handleWindowResizeOrScroll.bind(this);
+
+          this.searchString = "";
+          this.searchClearTimer = null;
+          this._initialPositioningComplete = false;
+
+          this.getAllOptions = () => [];
+          this.getEnabledOptions = () => [];
+
+          this.options = () => [];
+          this._triggerIdToAttach = null;
+        }
+
+        connectedCallback() {
+          this.role = "listbox";
+          this.tabIndex = -1;
+          this.removeAttribute("aria-activedescendant");
+
+          if (!this.hasAttribute("popover")) {
+            this.popover = "auto";
+          }
+
+          this.getAllOptions = () =>
+            Array.from(this.querySelectorAll('[role="option"]'));
+          this.getEnabledOptions = () =>
+            Array.from(
+              this.querySelectorAll(
+                '[role="option"]:not([aria-disabled="true"])'
+              )
+            );
+
+          if (!this.trigger && this._triggerIdToAttach) {
+            const triggerElement = document.getElementById(
+              this._triggerIdToAttach
+            );
+            if (triggerElement) {
+              this.trigger = triggerElement;
+              this.attachTrigger();
+            } else {
+              console.warn(
+                `SelectElement: Trigger with ID "${this._triggerIdToAttach}" still not found in connectedCallback for popover "${this.id}".`
+              );
+            }
+          }
+
+          this.addEventListener("click", (e) => {
+            const option = e.target.closest("[role=option]");
+            if (option) {
+              this.selectOption(option);
+              e.stopPropagation();
+            }
+          });
+
+          this.addEventListener("keydown", (e) => {
+            switch (e.key) {
+              case "ArrowDown":
+                e.preventDefault();
+                e.stopPropagation();
+                this.clearSearchString();
+                this.moveFocus(1);
+                break;
+              case "ArrowUp":
+                e.preventDefault();
+                e.stopPropagation();
+                this.clearSearchString();
+                this.moveFocus(-1);
+                break;
+              case "Home":
+                e.preventDefault();
+                e.stopPropagation();
+                this.clearSearchString();
+                this.moveFocus("start");
+                break;
+              case "End":
+                e.preventDefault();
+                e.stopPropagation();
+                this.clearSearchString();
+                this.moveFocus("end");
+                break;
+              case "Enter":
+              case " ":
+                if (this.searchString === "" && e.key === " ") {
+                  e.preventDefault();
+                  const activeOpt = this.getAllOptions()[this.activeIndex];
+                  if (
+                    activeOpt &&
+                    activeOpt.getAttribute("aria-disabled") !== "true"
+                  ) {
+                    this.selectOption(activeOpt);
+                  }
+                } else if (e.key === "Enter") {
+                  e.preventDefault();
+                  const activeOpt = this.getAllOptions()[this.activeIndex];
+                  if (
+                    activeOpt &&
+                    activeOpt.getAttribute("aria-disabled") !== "true"
+                  ) {
+                    this.selectOption(activeOpt);
+                  }
+                }
+                break;
+              case "Backspace":
+                e.preventDefault();
+                this.searchString = this.searchString.slice(0, -1);
+                this.handleTypeaheadSearch();
+                this.resetSearchClearTimer();
+                return;
+            }
+
+            if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+              if (e.key === " " && this.searchString === "") {
+              }
+
+              e.preventDefault();
+              this.searchString += e.key.toLowerCase();
+              this.handleTypeaheadSearch();
+              this.resetSearchClearTimer();
+            }
+          });
+
+          this.addEventListener("toggle", (event) => {
+            if (event.newState === "open") {
+              if (!this.trigger) {
+                const triggerId =
+                  this.dataset.triggerId || this._triggerIdToAttach;
+                if (triggerId) {
+                  this.trigger = document.getElementById(triggerId);
+                  if (this.trigger) {
+                    this.attachTrigger();
+                  } else {
+                    console.warn(
+                      `SelectElement: Trigger with ID "${triggerId}" not found for popover "${this.id}" during toggle event (final attempt).`
+                    );
+                  }
+                }
+              }
+
+              if (this.trigger) {
+                this.trigger.setAttribute("aria-expanded", "true");
+              } else {
+                console.warn(
+                  `SelectElement: Cannot set aria-expanded on trigger for popover "${this.id}" as trigger is not found.`
+                );
+              }
+
+              this.classList.add("initial-positioning");
+              this._initialPositioningComplete = false;
+
+              window.addEventListener(
+                "resize",
+                this._handleWindowResizeOrScroll
+              );
+              document.addEventListener(
+                "scroll",
+                this._handleWindowResizeOrScroll,
+                true
+              );
+
+              requestAnimationFrame(() => {
+                if (this.trigger) {
+                  this.positionUnderTrigger();
+                }
+                this.style.visibility = "visible";
+
+                this.focus();
+
+                const currentValue = this.getAttribute("value");
+                let initialFocusIndex = -1;
+                if (currentValue) {
+                  initialFocusIndex = this.getAllOptions().findIndex(
+                    (o) => o.dataset.value === currentValue
+                  );
+                }
+
+                if (
+                  initialFocusIndex < 0 ||
+                  (this.getAllOptions()[initialFocusIndex] &&
+                    this.getAllOptions()[initialFocusIndex].getAttribute(
+                      "aria-disabled"
+                    ) === "true")
+                ) {
+                  initialFocusIndex = this.getAllOptions().findIndex(
+                    (o) => o.getAttribute("aria-disabled") !== "true"
+                  );
+                }
+
+                if (this.getAllOptions().length > 0 && initialFocusIndex > -1) {
+                  this.setActiveOptionByIndex(initialFocusIndex, false);
+                } else {
+                  this.clearActiveOption();
+                }
+
+                requestAnimationFrame(() => {
+                  this._initialPositioningComplete = true;
+                  this.classList.remove("initial-positioning");
+                });
+              });
+            } else {
+              if (
+                document.startViewTransition &&
+                this._initialPositioningComplete
+              ) {
+                const transition = document.startViewTransition(() => {
+                  this._hidePopoverInternal();
+                });
+              } else {
+                this._hidePopoverInternal();
+              }
+            }
+          });
+        }
+
+        disconnectedCallback() {
+          window.removeEventListener(
+            "resize",
+            this._handleWindowResizeOrScroll
+          );
+          document.removeEventListener(
+            "scroll",
+            this._handleWindowResizeOrScroll,
+            true
+          );
+          if (this._repositionFrameId) {
+            cancelAnimationFrame(this._repositionFrameId);
+            this._repositionFrameId = null;
+          }
+        }
+
+        _hidePopoverInternal() {
+          if (this.trigger) {
+            this.trigger.setAttribute("aria-expanded", "false");
+          }
+          this.style.visibility = "";
+          this.clearSearchString();
+          this.clearActiveOption();
+
+          window.removeEventListener(
+            "resize",
+            this._handleWindowResizeOrScroll
+          );
+          document.removeEventListener(
+            "scroll",
+            this._handleWindowResizeOrScroll,
+            true
+          );
+          if (this._repositionFrameId) {
+            cancelAnimationFrame(this._repositionFrameId);
+            this._repositionFrameId = null;
+          }
+        }
+
+        _handleWindowResizeOrScroll() {
+          if (!this.matches(":popover-open") || !this.trigger) {
+            return;
+          }
+
+          if (this._repositionFrameId) {
+            cancelAnimationFrame(this._repositionFrameId);
+          }
+
+          this._repositionFrameId = requestAnimationFrame(() => {
+            this.positionUnderTrigger();
+            this._repositionFrameId = null;
+          });
+        }
+
+        attributeChangedCallback(name, oldVal, newVal) {
+          if (name === "data-trigger-id" && newVal) {
+            const triggerElement = document.getElementById(newVal);
+            if (triggerElement) {
+              this.trigger = triggerElement;
+              this.attachTrigger();
+              this._triggerIdToAttach = null;
+            } else {
+              this._triggerIdToAttach = newVal;
+            }
+          }
+          if (name === "value" && newVal !== oldVal) {
+            for (const opt of this.getAllOptions()) {
+              opt.setAttribute("aria-selected", opt.dataset.value === newVal);
+            }
+          }
+        }
+
+        attachTrigger() {
+          if (!this.trigger || this.trigger._arrowKeyListenerAttached) return;
+
+          if (!this.id) {
+            console.warn(
+              "select-element (popover) should have an ID for popovertarget to work reliably from Elm."
+            );
+          }
+          if (!this.getAttribute("aria-labelledby") && this.trigger.id) {
+            this.setAttribute("aria-labelledby", this.trigger.id);
+          }
+
+          this.trigger.addEventListener("keydown", (e) => {
+            if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+              e.preventDefault();
+              e.stopPropagation();
+              if (!this.matches(":popover-open")) {
+                if (document.startViewTransition) {
+                  document.startViewTransition(() => {
+                    this.showPopover();
+                  });
+                } else {
+                  this.showPopover();
+                }
+              }
+            }
+          });
+
+          const originalClickEvent = this.trigger.onclick;
+          this.trigger.onclick = (e) => {
+            if (!this.matches(":popover-open")) {
+              if (document.startViewTransition) {
+                e.preventDefault();
+                document.startViewTransition(() => {
+                  this.showPopover();
+                });
+              }
+            }
+            if (originalClickEvent) originalClickEvent(e);
+          };
+
+          this.trigger._arrowKeyListenerAttached = true;
+        }
+
+        positionUnderTrigger() {
+          if (!this.trigger) return;
+
+          const triggerRect = this.trigger.getBoundingClientRect();
+          const wasHidden = this.style.display === "none";
+          if (wasHidden) {
+            this.style.display = "";
+          }
+          const popoverRect = this.getBoundingClientRect();
+          if (wasHidden) {
+            this.style.display = "none";
+          }
+
+          const viewportWidth = window.innerWidth;
+          const viewportHeight = window.innerHeight;
+          const scrollX = window.scrollX;
+          const scrollY = window.scrollY;
+
+          this.style.position = "absolute";
+          this.style.inset = "auto";
+          this.style.transform = "none";
+          this.style.minWidth = triggerRect.width + "px";
+
+          const shellPart = this.shadowRoot.querySelector(
+            '[part="listbox-shell"]'
+          );
+          let cssGap = 0;
+          if (shellPart) {
+            const computedShellStyle = getComputedStyle(shellPart);
+            cssGap = parseFloat(computedShellStyle.marginTop) || 0;
+          }
+
+          this.style.marginTop = "0px";
+          this.style.marginBottom = "0px";
+
+          let newTop;
+          let newLeft;
+
+          const popoverHeightForFitting = popoverRect.height;
+          const spaceBelow = viewportHeight - triggerRect.bottom;
+          const spaceAbove = triggerRect.top;
+
+          if (popoverHeightForFitting + cssGap <= spaceBelow) {
+            newTop = triggerRect.bottom + scrollY + cssGap;
+          } else if (popoverHeightForFitting + cssGap <= spaceAbove) {
+            newTop =
+              triggerRect.top + scrollY - popoverHeightForFitting - cssGap;
+          } else {
+            if (spaceBelow >= spaceAbove) {
+              newTop = triggerRect.bottom + scrollY + cssGap;
+            } else {
+              newTop =
+                triggerRect.top + scrollY - popoverHeightForFitting - cssGap;
+            }
+          }
+
+          newLeft = triggerRect.left + scrollX;
+
+          if (newLeft + popoverRect.width > viewportWidth + scrollX) {
+            let rightAlignedLeft =
+              triggerRect.right + scrollX - popoverRect.width;
+
+            if (rightAlignedLeft >= scrollX) {
+              newLeft = rightAlignedLeft;
+            } else {
+              newLeft = scrollX;
+            }
+          }
+
+          if (newLeft < scrollX) {
+            newLeft = scrollX;
+          }
+
+          this.style.top = Math.round(newTop) + "px";
+          this.style.left = Math.round(newLeft) + "px";
+        }
+
+        selectOption(option) {
+          if (!option || option.getAttribute("aria-disabled") === "true") {
+            return;
+          }
+          const value = option.dataset.value;
+          this.setAttribute("value", value);
+
+          const optionIndex = this.getAllOptions().indexOf(option);
+          if (optionIndex > -1) {
+            this.activeIndex = optionIndex;
+            this.getAllOptions().forEach((opt) => {
+              opt.setAttribute("aria-selected", opt.dataset.value === value);
+            });
+          }
+
+          this.dispatchEvent(
+            new CustomEvent("select-change", {
+              detail: { value },
+              bubbles: true,
+            })
+          );
+
+          if (
+            document.startViewTransition &&
+            this._initialPositioningComplete
+          ) {
+            document.startViewTransition(() => {
+              this.hidePopover();
+              if (this.trigger) {
+                this.trigger.focus();
+              }
+            });
+          } else {
+            this.hidePopover();
+            if (this.trigger) {
+              this.trigger.focus();
+            }
+          }
+        }
+
+        moveFocus(step, absolute = false) {
+          const allOpts = this.getAllOptions();
+          if (!allOpts.length) return;
+
+          const enabledOpts = this.getEnabledOptions();
+          if (!enabledOpts.length) return;
+
+          let currentEnabledIndex = -1;
+          if (
+            this.activeIndex > -1 &&
+            allOpts[this.activeIndex] &&
+            allOpts[this.activeIndex].getAttribute("aria-disabled") !== "true"
+          ) {
+            currentEnabledIndex = enabledOpts.indexOf(
+              allOpts[this.activeIndex]
+            );
+          }
+
+          let newEnabledIndex;
+
+          if (absolute) {
+            const targetOpt = allOpts[step];
+            if (
+              targetOpt &&
+              targetOpt.getAttribute("aria-disabled") !== "true"
+            ) {
+              this.setActiveOptionByIndex(step);
+            }
+            return;
+          }
+
+          if (step === "start") {
+            newEnabledIndex = 0;
+          } else if (step === "end") {
+            newEnabledIndex = enabledOpts.length - 1;
+          } else {
+            if (currentEnabledIndex === -1) {
+              newEnabledIndex = step === 1 ? 0 : enabledOpts.length - 1;
+            } else {
+              newEnabledIndex =
+                (currentEnabledIndex + step + enabledOpts.length) %
+                enabledOpts.length;
+            }
+          }
+
+          if (newEnabledIndex >= 0 && newEnabledIndex < enabledOpts.length) {
+            const newFocusOption = enabledOpts[newEnabledIndex];
+            const newFocusOptionIndexInAll = allOpts.indexOf(newFocusOption);
+            if (newFocusOptionIndexInAll > -1) {
+              this.setActiveOptionByIndex(newFocusOptionIndexInAll);
+            }
+          }
+        }
+
+        clearSearchString() {
+          this.searchString = "";
+          if (this.searchClearTimer) {
+            clearTimeout(this.searchClearTimer);
+            this.searchClearTimer = null;
+          }
+        }
+
+        resetSearchClearTimer() {
+          if (this.searchClearTimer) {
+            clearTimeout(this.searchClearTimer);
+          }
+          this.searchClearTimer = setTimeout(() => {
+            this.searchString = "";
+          }, 750);
+        }
+
+        handleTypeaheadSearch() {
+          if (!this.searchString) return;
+
+          const opts = this.getAllOptions();
+          const enabledOpts = this.getEnabledOptions();
+          const currentSearch = this.searchString;
+
+          let searchStartIndex = (this.activeIndex + 1) % opts.length;
+          if (
+            this.activeIndex === -1 ||
+            (opts[this.activeIndex] &&
+              opts[this.activeIndex].getAttribute("aria-disabled") === "true")
+          ) {
+            const firstEnabledMatch = enabledOpts.find((opt) =>
+              (opt.textContent || "")
+                .trim()
+                .toLowerCase()
+                .startsWith(currentSearch)
+            );
+            if (firstEnabledMatch) {
+              this.setActiveOptionByIndex(opts.indexOf(firstEnabledMatch));
+              return;
+            }
+          } else {
+            for (let i = 0; i < opts.length; i++) {
+              const optIdx = (searchStartIndex + i) % opts.length;
+              const option = opts[optIdx];
+              if (option.getAttribute("aria-disabled") === "true") continue;
+
+              const optionText = (option.textContent || "")
+                .trim()
+                .toLowerCase();
+              if (optionText.startsWith(currentSearch)) {
+                this.setActiveOptionByIndex(optIdx);
+                return;
+              }
+            }
+          }
+          const firstEnabledMatchOverall = enabledOpts.find((opt) =>
+            (opt.textContent || "")
+              .trim()
+              .toLowerCase()
+              .startsWith(currentSearch)
+          );
+          if (firstEnabledMatchOverall) {
+            this.setActiveOptionByIndex(opts.indexOf(firstEnabledMatchOverall));
+            return;
+          }
+        }
+
+        clearActiveOption() {
+          if (this._activeOptionId) {
+            const previouslyActive = this.querySelector(
+              `#${this._activeOptionId}`
+            );
+            if (previouslyActive) {
+              previouslyActive.classList.remove("active-descendant");
+            }
+          }
+          this.removeAttribute("aria-activedescendant");
+          this._activeOptionId = null;
+        }
+
+        setActiveOptionByIndex(index, shouldScroll = true) {
+          const opts = this.getAllOptions();
+          if (index < 0 || index >= opts.length) {
+            this.clearActiveOption();
+            this.activeIndex = -1;
+            return;
+          }
+
+          this.clearActiveOption();
+
+          const newActiveOption = opts[index];
+
+          if (!newActiveOption.id) {
+            console.warn(
+              "SelectElement: Option is missing an ID, cannot set aria-activedescendant.",
+              newActiveOption
+            );
+            return;
+          }
+
+          newActiveOption.classList.add("active-descendant");
+          this.setAttribute("aria-activedescendant", newActiveOption.id);
+          this._activeOptionId = newActiveOption.id;
+          this.activeIndex = index;
+
+          if (shouldScroll) {
+            const optgroup = newActiveOption.closest('[role="group"]');
+            if (optgroup) {
+              const groupOptions = Array.from(
+                optgroup.querySelectorAll('[role="option"]')
+              );
+
+              if (
+                groupOptions.length > 0 &&
+                groupOptions[0] === newActiveOption
+              ) {
+                const groupLabel = optgroup.querySelector(".optgroup-label");
+                if (groupLabel) {
+                  groupLabel.scrollIntoView({
+                    block: "nearest",
+                    scrollMode: "if-needed",
+                  });
+                  return;
+                }
+              }
+            }
+
+            newActiveOption.scrollIntoView({
+              block: "nearest",
+              scrollMode: "if-needed",
+            });
+          }
+        }
+      }
+
+      customElements.define("select-element", SelectElement);
     </script>
     <script src="bundle.js"></script>
   </body>

--- a/component-catalog/src/Examples.elm
+++ b/component-catalog/src/Examples.elm
@@ -43,6 +43,7 @@ import Examples.RadioButtonDotless as RadioButtonDotless
 import Examples.RingGauge as RingGauge
 import Examples.SegmentedControl as SegmentedControl
 import Examples.Select as Select
+import Examples.SelectElement as SelectElement
 import Examples.Shadows as Shadows
 import Examples.SideNav as SideNav
 import Examples.SortableTable as SortableTable
@@ -803,6 +804,25 @@ all =
                     _ ->
                         Nothing
             )
+    , SelectElement.example
+        |> Example.wrapMsg SelectElementMsg
+            (\msg ->
+                case msg of
+                    SelectElementMsg childMsg ->
+                        Just childMsg
+
+                    _ ->
+                        Nothing
+            )
+        |> Example.wrapState SelectElementState
+            (\msg ->
+                case msg of
+                    SelectElementState childState ->
+                        Just childState
+
+                    _ ->
+                        Nothing
+            )
     , Shadows.example
         |> Example.wrapMsg ShadowsMsg
             (\msg ->
@@ -1131,6 +1151,7 @@ type State
     | RingGaugeState RingGauge.State
     | SegmentedControlState SegmentedControl.State
     | SelectState Select.State
+    | SelectElementState SelectElement.State
     | ShadowsState Shadows.State
     | SideNavState SideNav.State
     | SortableTableState SortableTable.State
@@ -1188,6 +1209,7 @@ type Msg
     | RingGaugeMsg RingGauge.Msg
     | SegmentedControlMsg SegmentedControl.Msg
     | SelectMsg Select.Msg
+    | SelectElementMsg SelectElement.Msg
     | ShadowsMsg Shadows.Msg
     | SideNavMsg SideNav.Msg
     | SortableTableMsg SortableTable.Msg

--- a/component-catalog/src/Examples/SelectElement.elm
+++ b/component-catalog/src/Examples/SelectElement.elm
@@ -1,0 +1,765 @@
+module Examples.SelectElement exposing (Msg, State, example)
+
+{-|
+
+@docs Msg, State, example
+
+-}
+
+import Category exposing (Category(..))
+import Code
+import Css
+import Debug.Control as Control exposing (Control)
+import Debug.Control.View as ControlView
+import EllieLink
+import Example exposing (Example)
+import Guidance
+import Html.Styled exposing (Html, div, p, span, text)
+import Html.Styled.Attributes as Attributes exposing (css)
+import KeyboardSupport
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Heading.V3 as Heading
+import Nri.Ui.SelectElement.V1 as SelectElement
+import Nri.Ui.Spacing.V1 as Spacing
+import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.Text.V6 as Text
+import Nri.Ui.Tooltip.V3 as Tooltip
+import Nri.Ui.UiIcon.V1 as UiIcon
+
+
+moduleName : String
+moduleName =
+    "SelectElement"
+
+
+version : Int
+version =
+    1
+
+
+type SampleItem
+    = Mercury
+    | Venus
+    | Earth
+    | Mars
+    | Jupiter
+    | Saturn
+    | Uranus
+    | Neptune
+    | Pluto
+
+
+sampleItemToString : SampleItem -> String
+sampleItemToString sampleItem =
+    case sampleItem of
+        Mercury ->
+            "Mercury"
+
+        Venus ->
+            "Venus"
+
+        Earth ->
+            "Earth"
+
+        Mars ->
+            "Mars"
+
+        Jupiter ->
+            "Jupiter"
+
+        Saturn ->
+            "Saturn"
+
+        Uranus ->
+            "Uranus"
+
+        Neptune ->
+            "Neptune"
+
+        Pluto ->
+            "Pluto"
+
+
+stringToSampleItem : String -> Maybe SampleItem
+stringToSampleItem str =
+    case str of
+        "Mercury" ->
+            Just Mercury
+
+        "Venus" ->
+            Just Venus
+
+        "Earth" ->
+            Just Earth
+
+        "Mars" ->
+            Just Mars
+
+        "Jupiter" ->
+            Just Jupiter
+
+        "Saturn" ->
+            Just Saturn
+
+        "Uranus" ->
+            Just Uranus
+
+        "Neptune" ->
+            Just Neptune
+
+        "Pluto" ->
+            Just Pluto
+
+        _ ->
+            Nothing
+
+
+sampleItemToLabel : SampleItem -> String
+sampleItemToLabel =
+    sampleItemToString
+
+
+type TooltipId
+    = EarthGradingTooltip
+
+
+exampleOptionItems : State -> List (SelectElement.OptionItem SampleItem Msg)
+exampleOptionItems state =
+    [ SelectElement.Group "Inner Planets"
+        [ { content = Html.Styled.text (sampleItemToLabel Mercury)
+          , triggerLabel = sampleItemToLabel Mercury
+          , value = Mercury
+          }
+        , { content = Html.Styled.text (sampleItemToLabel Venus)
+          , triggerLabel = sampleItemToLabel Venus
+          , value = Venus
+          }
+        , { content =
+                div [ css [ Css.displayFlex, Css.alignItems Css.center ] ]
+                    [ span [ css [ Css.marginRight (Css.px 8) ] ]
+                        [ Tooltip.view
+                            { id = "earth-tooltip"
+                            , trigger =
+                                \attrs ->
+                                    span
+                                        (css [ Css.cursor Css.pointer ] :: attrs)
+                                        [ UiIcon.gradingAssistant
+                                            |> Svg.withColor Colors.azure
+                                            |> Svg.withWidth (Css.px 16)
+                                            |> Svg.withHeight (Css.px 16)
+                                            |> Svg.toHtml
+                                        ]
+                            }
+                            [ Tooltip.plaintext "Our home planet."
+                            , Tooltip.onToggle (ToggleTooltip EarthGradingTooltip)
+                            , Tooltip.open (state.openTooltip == Just EarthGradingTooltip)
+                            , Tooltip.smallPadding
+                            , Tooltip.onRight
+                            , Tooltip.disclosure { triggerId = "earth-tooltip", lastId = Nothing }
+                            ]
+                        ]
+                    , text (sampleItemToLabel Earth)
+                    ]
+          , triggerLabel = sampleItemToLabel Earth
+          , value = Earth
+          }
+        , { content = Html.Styled.text (sampleItemToLabel Mars)
+          , triggerLabel = sampleItemToLabel Mars
+          , value = Mars
+          }
+        ]
+    , SelectElement.Group "Gas Giants"
+        [ { content = Html.Styled.text (sampleItemToLabel Jupiter)
+          , triggerLabel = sampleItemToLabel Jupiter
+          , value = Jupiter
+          }
+        , { content = Html.Styled.text (sampleItemToLabel Saturn)
+          , triggerLabel = sampleItemToLabel Saturn
+          , value = Saturn
+          }
+        , { content = Html.Styled.text (sampleItemToLabel Uranus)
+          , triggerLabel = sampleItemToLabel Uranus
+          , value = Uranus
+          }
+        , { content = Html.Styled.text (sampleItemToLabel Neptune)
+          , triggerLabel = sampleItemToLabel Neptune
+          , value = Neptune
+          }
+        ]
+    , SelectElement.Item
+        { content = Html.Styled.text (sampleItemToLabel Pluto)
+        , triggerLabel = sampleItemToLabel Pluto
+        , value = Pluto
+        }
+    ]
+
+
+previewOptionItems : List (SelectElement.OptionItem SampleItem Never)
+previewOptionItems =
+    [ SelectElement.Group "Inner Planets"
+        [ { content = Html.Styled.div [] []
+          , triggerLabel = "Mercury"
+          , value = Mercury
+          }
+        , { content = Html.Styled.div [] []
+          , triggerLabel = "Venus"
+          , value = Venus
+          }
+        , { content = Html.Styled.div [] []
+          , triggerLabel = "Earth"
+          , value = Earth
+          }
+        , { content = Html.Styled.div [] []
+          , triggerLabel = "Mars"
+          , value = Mars
+          }
+        ]
+    , SelectElement.Group "Gas Giants"
+        [ { content = Html.Styled.div [] []
+          , triggerLabel = "Jupiter"
+          , value = Jupiter
+          }
+        , { content = Html.Styled.div [] []
+          , triggerLabel = "Saturn"
+          , value = Saturn
+          }
+        , { content = Html.Styled.div [] []
+          , triggerLabel = "Uranus"
+          , value = Uranus
+          }
+        , { content = Html.Styled.div [] []
+          , triggerLabel = "Neptune"
+          , value = Neptune
+          }
+        ]
+    , SelectElement.Item
+        { content = Html.Styled.div [] []
+        , triggerLabel = "Pluto"
+        , value = Pluto
+        }
+    ]
+
+
+disabledOptionsList : List SampleItem
+disabledOptionsList =
+    [ Jupiter, Saturn ]
+
+
+firstSelectableSampleItem : List (SelectElement.OptionItem SampleItem Msg) -> Maybe SampleItem
+firstSelectableSampleItem items =
+    case items of
+        [] ->
+            Nothing
+
+        (SelectElement.Item opt) :: _ ->
+            Just opt.value
+
+        (SelectElement.Group _ subOptions) :: rest ->
+            case subOptions of
+                [] ->
+                    firstSelectableSampleItem rest
+
+                opt :: _ ->
+                    Just opt.value
+
+
+{-| -}
+example : Example State Msg
+example =
+    { name = moduleName
+    , version = version
+    , init = ( init, Cmd.none )
+    , update = update
+    , subscriptions = \_ -> Sub.none
+    , categories = [ Inputs ]
+    , keyboardSupport =
+        [ -- Trigger Button (when dropdown is closed)
+          { keys = [ KeyboardSupport.Enter ]
+          , result = "Opens the dropdown. Focus moves to the first enabled option (or the currently selected option if enabled)."
+          }
+        , { keys = [ KeyboardSupport.Space ]
+          , result = "Opens the dropdown. Focus moves to the first enabled option (or the currently selected option if enabled)."
+          }
+        , { keys = [ KeyboardSupport.Arrow KeyboardSupport.Down ]
+          , result = "Opens the dropdown. Focus moves to the first enabled option (or selected if enabled)."
+          }
+        , { keys = [ KeyboardSupport.Arrow KeyboardSupport.Up ]
+          , result = "Opens the dropdown. Focus moves to the last enabled option (or selected if enabled)."
+          }
+
+        -- Dropdown / Listbox (when open)
+        , { keys = [ KeyboardSupport.Arrow KeyboardSupport.Down ]
+          , result = "Moves focus to the next enabled option, wrapping from last to first."
+          }
+        , { keys = [ KeyboardSupport.Arrow KeyboardSupport.Up ]
+          , result = "Moves focus to the previous enabled option, wrapping from first to last."
+          }
+        , { keys = []
+          , result = "Home: Moves focus to the first enabled option."
+          }
+        , { keys = []
+          , result = "End: Moves focus to the last enabled option."
+          }
+        , { keys = [ KeyboardSupport.Enter ]
+          , result = "Selects the focused option, closes the dropdown, and returns focus to the trigger button."
+          }
+        , { keys = [ KeyboardSupport.Space ]
+          , result = "Selects the focused option (if not typing in search), closes the dropdown, and returns focus to the trigger button."
+          }
+        , { keys = []
+          , result = "Printable Characters (e.g. 'a', 'b', '1'): Typeahead - Moves focus to the next enabled option starting with the typed characters. Search clears after a short delay."
+          }
+        , { keys = [ KeyboardSupport.Esc ]
+          , result = "Closes the dropdown. Focus returns to the trigger button."
+          }
+        , { keys = [ KeyboardSupport.Tab ]
+          , result = "Closes the dropdown and moves focus to the next focusable element in the document order."
+          }
+        ]
+    , preview =
+        [ SelectElement.view "Select..."
+            [ SelectElement.optionItems previewOptionItems
+            , SelectElement.valueToString sampleItemToString
+            , SelectElement.stringToValue stringToSampleItem
+            , SelectElement.triggerId "preview-trigger"
+            , SelectElement.popoverId "preview-popover"
+            , SelectElement.label "Preview Select"
+            , SelectElement.customHtmlAttributesForTrigger [ Attributes.tabindex -1 ]
+            , SelectElement.disabled True
+            ]
+        ]
+    , about =
+        [ Text.smallBody [ Text.markdown "This component uses a `<select-element>` custom HTML element to provide an accessible select/listbox." ]
+        , Text.smallBody [ Text.markdown "The custom element handles ARIA attributes, keyboard navigation, and popover behavior." ]
+        , Guidance.message moduleName
+        ]
+    , view = viewExamplePage
+    }
+
+
+viewExamplePage : EllieLink.Config -> State -> List (Html Msg)
+viewExamplePage ellieLinkConfig state =
+    let
+        settings =
+            Control.currentValue state.control
+
+        attrs =
+            [ SelectElement.optionItems (exampleOptionItems state)
+            , SelectElement.valueToString sampleItemToString
+            , SelectElement.stringToValue stringToSampleItem
+            , SelectElement.selectedValue state.currentSelection
+            , SelectElement.onSelect OptionSelectedMsg
+            , SelectElement.triggerId settings.triggerId
+            , SelectElement.popoverId settings.popoverId
+            , SelectElement.label "My Dynamic Select"
+            , SelectElement.hideLabel settings.hideLabel
+            , SelectElement.disabled settings.disabled
+            , SelectElement.loading settings.loading
+            , SelectElement.disableWhen (\item -> List.member item disabledOptionsList || settings.disableAllOptions)
+            , if settings.icon then
+                SelectElement.icon UiIcon.checkmark
+
+              else
+                SelectElement.Attribute identity
+            , if String.isEmpty settings.error then
+                SelectElement.Attribute identity
+
+              else
+                SelectElement.error settings.error
+            , if String.isEmpty settings.guidance then
+                SelectElement.Attribute identity
+
+              else
+                SelectElement.guidance settings.guidance
+            , SelectElement.containerCss
+                (if settings.containerCss then
+                    [ Css.backgroundColor (Css.hex "FFFACD") ]
+
+                 else
+                    []
+                )
+            , SelectElement.noMargin settings.noMargin
+            ]
+                ++ (if settings.title then
+                        [ SelectElement.title "My Customizable Select (Title)" ]
+
+                    else
+                        []
+                   )
+    in
+    [ ControlView.view
+        { ellieLinkConfig = ellieLinkConfig
+        , name = moduleName
+        , version = version
+        , update = UpdateControl
+        , settings = state.control
+        , mainType = Just "Html Msg"
+        , extraCode =
+            [ Code.unionType "SampleItem" (List.map sampleItemToString [ Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus, Neptune, Pluto ])
+            , """
+sampleItemToString : SampleItem -> String
+sampleItemToString sampleItem =
+    case sampleItem of
+        Mercury -> "Mercury"
+        Venus   -> "Venus"
+        Earth   -> "Earth"
+        Mars    -> "Mars"
+        Jupiter -> "Jupiter"
+        Saturn  -> "Saturn"
+        Uranus  -> "Uranus"
+        Neptune -> "Neptune"
+        Pluto   -> "Pluto"
+
+stringToSampleItem : String -> Maybe SampleItem
+stringToSampleItem str =
+    case str of
+        "Mercury" -> Just Mercury
+        "Venus"   -> Just Venus
+        "Earth"   -> Just Earth
+        "Mars"    -> Just Mars
+        "Jupiter" -> Just Jupiter
+        "Saturn"  -> Just Saturn
+        "Uranus"  -> Just Uranus
+        "Neptune" -> Just Neptune
+        "Pluto"   -> Just Pluto
+        _         -> Nothing
+
+-- Tooltip ID type for managing tooltip state
+type TooltipId = EarthGradingTooltip 
+
+-- Function to create options with tooltips, taking the current state
+exampleOptionItems : State -> List (SelectElement.OptionItem SampleItem Msg)
+exampleOptionItems state =
+    [ SelectElement.Group "Inner Planets"
+        [ { content = Html.Styled.text "Mercury"
+          , triggerLabel = "Mercury"
+          , value = Mercury
+          }
+        , { content = Html.Styled.text "Venus"
+          , triggerLabel = "Venus"
+          , value = Venus
+          }
+        , { content = 
+                div [ css [ Css.displayFlex, Css.alignItems Css.center ] ]
+                    [ span [ css [ Css.marginRight (Css.px 8) ] ]
+                        [ Tooltip.view
+                            { id = "earth-tooltip" 
+                            , trigger = \\attrs -> 
+                                span 
+                                    (css [ Css.cursor Css.pointer ] :: attrs) 
+                                    [ UiIcon.gradingAssistant
+                                        |> Svg.withColor Colors.azure
+                                        |> Svg.withWidth (Css.px 16)
+                                        |> Svg.withHeight (Css.px 16)
+                                        |> Svg.toHtml
+                                    ]
+                            }
+                            [ Tooltip.plaintext "Mostly harmless. Occasionally requires adult supervision."
+                            , Tooltip.onToggle (ToggleTooltip EarthGradingTooltip)
+                            , Tooltip.open (state.openTooltip == Just EarthGradingTooltip)
+                            , Tooltip.smallPadding
+                            , Tooltip.onRight
+                            , Tooltip.disclosure { triggerId = "earth-tooltip", lastId = Nothing }
+                            ]
+                      ]
+                    , text "Earth" 
+                    ]
+          , triggerLabel = "Earth"
+          , value = Earth 
+          }
+        , { content = Html.Styled.text "Mars"
+          , triggerLabel = "Mars"
+          , value = Mars
+          }
+        ]
+    , SelectElement.Group "Gas Giants"
+        [ { content = Html.Styled.text "Jupiter"
+          , triggerLabel = "Jupiter"
+          , value = Jupiter
+          }
+        , { content = Html.Styled.text "Saturn"
+          , triggerLabel = "Saturn"
+          , value = Saturn
+          }
+        , { content = Html.Styled.text "Uranus"
+          , triggerLabel = "Uranus"
+          , value = Uranus
+          }
+        , { content = Html.Styled.text "Neptune"
+          , triggerLabel = "Neptune"
+          , value = Neptune
+          }
+        ]
+    , SelectElement.Item
+        { content = Html.Styled.text "Pluto"
+        , triggerLabel = "Pluto"
+        , value = Pluto
+        }
+    ]
+"""
+            ]
+        , renderExample = Code.unstyledView
+        , toExampleCode =
+            \currentSettings ->
+                let
+                    selectedValCode =
+                        case state.currentSelection of
+                            Just s ->
+                                "Just " ++ sampleItemToString s
+
+                            Nothing ->
+                                "Nothing"
+
+                    titleAttrCode =
+                        if currentSettings.title then
+                            [ "SelectElement.title \"My Customizable Select (Title)\"" ]
+
+                        else
+                            []
+
+                    labelAttrCode =
+                        [ "SelectElement.label \"My Dynamic Select\""
+                        ]
+                            ++ (if currentSettings.hideLabel then
+                                    [ "SelectElement.hideLabel " ++ Code.bool currentSettings.hideLabel ]
+
+                                else
+                                    []
+                               )
+
+                    stateAttrCode =
+                        (if currentSettings.disabled then
+                            [ "SelectElement.disabled " ++ Code.bool currentSettings.disabled ]
+
+                         else
+                            []
+                        )
+                            ++ (if currentSettings.loading then
+                                    [ "SelectElement.loading " ++ Code.bool currentSettings.loading ]
+
+                                else
+                                    []
+                               )
+
+                    disableWhenCode =
+                        if currentSettings.disableAllOptions then
+                            [ "SelectElement.disableWhen (\\item -> List.member item [ Jupiter, Saturn ] || " ++ Code.bool currentSettings.disableAllOptions ++ ")" ]
+
+                        else
+                            [ "SelectElement.disableWhen (\\item -> List.member item [ Jupiter, Saturn ])" ]
+
+                    iconCode =
+                        if currentSettings.icon then
+                            [ "SelectElement.icon UiIcon.checkmark" ]
+
+                        else
+                            []
+
+                    errorGuidanceCode =
+                        (if not (String.isEmpty currentSettings.error) then
+                            [ "SelectElement.error " ++ Code.string currentSettings.error ]
+
+                         else
+                            []
+                        )
+                            ++ (if not (String.isEmpty currentSettings.guidance) && String.isEmpty currentSettings.error then
+                                    [ "SelectElement.guidance " ++ Code.string currentSettings.guidance ]
+
+                                else
+                                    []
+                               )
+
+                    layoutCode =
+                        (if currentSettings.containerCss then
+                            [ "SelectElement.containerCss [ Css.backgroundColor (Css.hex \"FFFACD\") ]" ]
+
+                         else
+                            []
+                        )
+                            ++ (if currentSettings.noMargin then
+                                    [ "SelectElement.noMargin " ++ Code.bool currentSettings.noMargin ]
+
+                                else
+                                    []
+                               )
+
+                    attrCodeList =
+                        [ "SelectElement.optionItems (exampleOptionItems state)"
+                        , "SelectElement.valueToString sampleItemToString"
+                        , "SelectElement.stringToValue stringToSampleItem"
+                        ]
+                            ++ (case state.currentSelection of
+                                    Just _ ->
+                                        [ "SelectElement.selectedValue (" ++ selectedValCode ++ ")" ]
+
+                                    Nothing ->
+                                        []
+                               )
+                            ++ [ "SelectElement.onSelect OptionSelectedMsg"
+                               , "SelectElement.triggerId " ++ Code.string currentSettings.triggerId
+                               , "SelectElement.popoverId " ++ Code.string currentSettings.popoverId
+                               ]
+                            ++ titleAttrCode
+                            ++ labelAttrCode
+                            ++ stateAttrCode
+                            ++ disableWhenCode
+                            ++ iconCode
+                            ++ errorGuidanceCode
+                            ++ layoutCode
+                in
+                [ { sectionName = "Example"
+                  , code =
+                        Code.fromModule moduleName "view "
+                            ++ Code.string "Select an option..."
+                            ++ Code.listMultiline attrCodeList 1
+                  }
+                ]
+        }
+    , Heading.h2
+        [ Heading.plaintext "Customizable Example"
+        , Heading.css [ Css.marginTop Spacing.verticalSpacerPx, Css.marginBottom (Css.px 16) ]
+        ]
+    , div [ Attributes.css [ Css.maxWidth (Css.px 400) ] ]
+        [ SelectElement.view "Select an option..." attrs
+        , p [] [ text ("Selected: " ++ Maybe.withDefault "None" (Maybe.map sampleItemToString state.currentSelection)) ]
+        ]
+    ]
+
+
+type alias Model =
+    { options : List (SelectElement.OptionItem SampleItem Msg)
+    , triggerId : String
+    , popoverId : String
+    , title : Bool
+    , hideLabel : Bool
+    , disabled : Bool
+    , loading : Bool
+    , icon : Bool
+    , disableAllOptions : Bool
+    , error : String
+    , guidance : String
+    , containerCss : Bool
+    , noMargin : Bool
+    }
+
+
+{-| -}
+type alias State =
+    { control : Control Model
+    , currentSelection : Maybe SampleItem
+    , openTooltip : Maybe TooltipId
+    }
+
+
+{-| -}
+init : State
+init =
+    let
+        placeholderOptions =
+            [ SelectElement.Group "Inner Planets"
+                [ { content = Html.Styled.text (sampleItemToLabel Mercury)
+                  , triggerLabel = sampleItemToLabel Mercury
+                  , value = Mercury
+                  }
+                , { content = Html.Styled.text (sampleItemToLabel Venus)
+                  , triggerLabel = sampleItemToLabel Venus
+                  , value = Venus
+                  }
+                , { content = Html.Styled.text (sampleItemToLabel Earth)
+                  , triggerLabel = sampleItemToLabel Earth
+                  , value = Earth
+                  }
+                , { content = Html.Styled.text (sampleItemToLabel Mars)
+                  , triggerLabel = sampleItemToLabel Mars
+                  , value = Mars
+                  }
+                ]
+            , SelectElement.Group "Gas Giants"
+                [ { content = Html.Styled.text (sampleItemToLabel Jupiter)
+                  , triggerLabel = sampleItemToLabel Jupiter
+                  , value = Jupiter
+                  }
+                , { content = Html.Styled.text (sampleItemToLabel Saturn)
+                  , triggerLabel = sampleItemToLabel Saturn
+                  , value = Saturn
+                  }
+                , { content = Html.Styled.text (sampleItemToLabel Uranus)
+                  , triggerLabel = sampleItemToLabel Uranus
+                  , value = Uranus
+                  }
+                , { content = Html.Styled.text (sampleItemToLabel Neptune)
+                  , triggerLabel = sampleItemToLabel Neptune
+                  , value = Neptune
+                  }
+                ]
+            , SelectElement.Item
+                { content = Html.Styled.text (sampleItemToLabel Pluto)
+                , triggerLabel = sampleItemToLabel Pluto
+                , value = Pluto
+                }
+            ]
+
+        initialModel =
+            { options = placeholderOptions
+            , triggerId = "custom-select-trigger-1"
+            , popoverId = "custom-select-popover-1"
+            , title = True
+            , hideLabel = False
+            , disabled = False
+            , loading = False
+            , icon = False
+            , disableAllOptions = False
+            , error = ""
+            , guidance = "This is some helpful guidance."
+            , containerCss = False
+            , noMargin = False
+            }
+    in
+    { control =
+        Control.record Model
+            |> Control.field "options" (Control.value placeholderOptions)
+            |> Control.field "triggerId" (Control.string initialModel.triggerId)
+            |> Control.field "popoverId" (Control.string initialModel.popoverId)
+            |> Control.field "title" (Control.bool initialModel.title)
+            |> Control.field "hideLabel" (Control.bool initialModel.hideLabel)
+            |> Control.field "disabled" (Control.bool initialModel.disabled)
+            |> Control.field "loading" (Control.bool initialModel.loading)
+            |> Control.field "icon" (Control.bool initialModel.icon)
+            |> Control.field "disable all options (using disableWhen)" (Control.bool initialModel.disableAllOptions)
+            |> Control.field "error" (Control.string initialModel.error)
+            |> Control.field "guidance" (Control.string initialModel.guidance)
+            |> Control.field "containerCss" (Control.bool initialModel.containerCss)
+            |> Control.field "noMargin" (Control.bool initialModel.noMargin)
+    , currentSelection = firstSelectableSampleItem placeholderOptions
+    , openTooltip = Nothing
+    }
+
+
+{-| -}
+type Msg
+    = UpdateControl (Control Model)
+    | OptionSelectedMsg SampleItem
+    | ToggleTooltip TooltipId Bool
+
+
+{-| -}
+update : Msg -> State -> ( State, Cmd Msg )
+update msg state =
+    case msg of
+        UpdateControl newControl ->
+            ( { state | control = newControl }, Cmd.none )
+
+        OptionSelectedMsg newSelection ->
+            ( { state | currentSelection = Just newSelection }, Cmd.none )
+
+        ToggleTooltip tooltipId isOpen ->
+            ( { state
+                | openTooltip =
+                    if isOpen then
+                        Just tooltipId
+
+                    else
+                        Nothing
+              }
+            , Cmd.none
+            )

--- a/component-catalog/src/Examples/SelectElement.elm
+++ b/component-catalog/src/Examples/SelectElement.elm
@@ -24,7 +24,7 @@ import Nri.Ui.Spacing.V1 as Spacing
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Text.V6 as Text
 import Nri.Ui.Tooltip.V3 as Tooltip
-import Nri.Ui.UiIcon.V1 as UiIcon
+import Nri.Ui.UiIcon.V2 as UiIcon
 
 
 moduleName : String

--- a/component-catalog/src/KeyboardSupport.elm
+++ b/component-catalog/src/KeyboardSupport.elm
@@ -17,6 +17,7 @@ import ExampleSection
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Nri.Ui.Fonts.V1 as Fonts
+import String
 
 
 {-| -}
@@ -44,9 +45,28 @@ viewKeyboardActionsDl keyboardSupport =
 
 viewKeyboardActions : KeyboardSupport -> List (Html msg)
 viewKeyboardActions { keys, result } =
-    [ dt [ css [ Css.fontWeight Css.bold ] ] [ text (String.join "+" (List.map keyToString keys) ++ ": ") ]
-    , dd [ css [ Css.margin Css.zero, Css.marginBottom (Css.px 8) ] ] [ text result ]
-    ]
+    if List.isEmpty keys then
+        case String.split ":" result of
+            keyPart :: rest ->
+                let
+                    descriptionText =
+                        String.trim (String.join ":" rest)
+                in
+                if String.isEmpty descriptionText then
+                    [ dt [ css [ Css.fontWeight Css.bold, Css.marginBottom (Css.px 8) ] ] [ text keyPart ] ]
+
+                else
+                    [ dt [ css [ Css.fontWeight Css.bold ] ] [ text (keyPart ++ ":") ]
+                    , dd [ css [ Css.margin Css.zero, Css.marginBottom (Css.px 8) ] ] [ text descriptionText ]
+                    ]
+
+            _ ->
+                [ dt [ css [ Css.fontWeight Css.bold, Css.marginBottom (Css.px 8) ] ] [ text result ] ]
+
+    else
+        [ dt [ css [ Css.fontWeight Css.bold ] ] [ text (String.join "+" (List.map keyToString keys) ++ ":") ]
+        , dd [ css [ Css.margin Css.zero, Css.marginBottom (Css.px 8) ] ] [ text result ]
+        ]
 
 
 {-| -}

--- a/elm.json
+++ b/elm.json
@@ -71,6 +71,7 @@
         "Nri.Ui.RingGauge.V1",
         "Nri.Ui.SegmentedControl.V14",
         "Nri.Ui.Select.V9",
+        "Nri.Ui.SelectElement.V1",
         "Nri.Ui.Shadows.V1",
         "Nri.Ui.SideNav.V5",
         "Nri.Ui.SortableTable.V5",

--- a/src/Nri/Ui/SelectElement/V1.elm
+++ b/src/Nri/Ui/SelectElement/V1.elm
@@ -56,6 +56,20 @@ import Nri.Ui.Svg.V1 as Svg
 -- MODEL
 
 
+{-| Represents a single selectable option.
+
+  - `content`: The HTML to display in the dropdown.
+  - `triggerLabel`: The plain text label to show in the trigger button when selected.
+  - `value`: The value associated with this option.
+
+Example:
+
+    { content = Html.Styled.text "Earth"
+    , triggerLabel = "Earth"
+    , value = Earth
+    }
+
+-}
 type alias SingleOption value msg =
     { content : Html msg
     , value : value
@@ -63,11 +77,46 @@ type alias SingleOption value msg =
     }
 
 
+{-| Represents an item in the select dropdown.
+
+You can use `Item` for a single option, or `Group` to group related options under a label.
+
+    SelectElement.Item
+        { content = Html.Styled.text "Earth"
+        , triggerLabel = "Earth"
+        , value = Earth
+        }
+
+    SelectElement.Group "Gas Giants"
+        [ { content = Html.Styled.text "Jupiter"
+          , triggerLabel = "Jupiter"
+          , value = Jupiter
+          }
+        , { content = Html.Styled.text "Saturn"
+          , triggerLabel = "Saturn"
+          , value = Saturn
+          }
+        ]
+
+-}
 type OptionItem value msg
     = Item (SingleOption value msg)
     | Group String (List (SingleOption value msg))
 
 
+{-| An attribute for configuring the SelectElement component.
+
+You can use attributes to set options, handle selection, customize appearance, and more.
+
+    SelectElement.view "Choose a planet"
+        [ SelectElement.optionItems myOptions
+        , SelectElement.selectedValue (Just Earth)
+        , SelectElement.onSelect SelectPlanet
+        , SelectElement.label "Planets"
+        , SelectElement.disabled False
+        ]
+
+-}
 type Attribute value msg
     = Attribute (Config value msg -> Config value msg)
 

--- a/src/Nri/Ui/SelectElement/V1.elm
+++ b/src/Nri/Ui/SelectElement/V1.elm
@@ -1,0 +1,730 @@
+module Nri.Ui.SelectElement.V1 exposing
+    ( view
+    , Attribute(..)
+    , OptionItem(..), SingleOption
+    , optionItems, selectedValue, onSelect
+    , title, triggerId, popoverId
+    , label, hideLabel
+    , disabled, loading
+    , icon
+    , disableWhen
+    , error, guidance
+    , containerCss, noMargin
+    , valueToString, stringToValue
+    , customHtmlAttributesForTrigger, customHtmlAttributesForPopover
+    )
+
+{-| A select component powered by a custom HTML element `<select-element>`.
+
+This component allows for a dropdown selection with optional grouping.
+The underlying custom element handles popover behavior, keyboard navigation,
+and accessibility.
+
+@docs view
+
+@docs Attribute
+
+@docs OptionItem, SingleOption
+
+@docs optionItems, selectedValue, onSelect
+@docs title, triggerId, popoverId
+@docs label, hideLabel
+@docs disabled, loading
+@docs icon
+@docs disableWhen
+@docs error, guidance
+@docs containerCss, noMargin
+@docs valueToString, stringToValue
+
+@docs customHtmlAttributesForTrigger, customHtmlAttributesForPopover
+
+-}
+
+import Css exposing (..)
+import Html.Styled exposing (Attribute, Html, button, div, h3, node, span, text)
+import Html.Styled.Attributes as Attributes exposing (attribute, class, for, id, tabindex)
+import Html.Styled.Events as Events
+import Json.Decode as Decode
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.CssVendorPrefix.V1 as VendorPrefixed
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Shadows.V1 as Shadows
+import Nri.Ui.Svg.V1 as Svg
+
+
+
+-- MODEL
+
+
+type alias SingleOption value msg =
+    { content : Html msg
+    , value : value
+    , triggerLabel : String
+    }
+
+
+type OptionItem value msg
+    = Item (SingleOption value msg)
+    | Group String (List (SingleOption value msg))
+
+
+type Attribute value msg
+    = Attribute (Config value msg -> Config value msg)
+
+
+type alias Config value msg =
+    { optionItems : List (OptionItem value msg)
+    , selectedValue : Maybe value
+    , onSelect : Maybe (value -> msg)
+    , triggerId : String
+    , popoverId : String
+    , title : Maybe String
+    , label : Maybe String
+    , hideLabel : Bool
+    , disabled : Bool
+    , loading : Bool
+    , icon : Maybe Svg.Svg
+    , disableWhen : value -> Bool
+    , error : Maybe String
+    , guidance : Maybe String
+    , containerCss : List Style
+    , noMargin : Bool
+    , valueToString : value -> String
+    , stringToValue : String -> Maybe value
+    , customTriggerAttrs : List (Html.Styled.Attribute msg)
+    , customPopoverAttrs : List (Html.Styled.Attribute msg)
+    }
+
+
+defaultConfig : Config value msg
+defaultConfig =
+    { optionItems = []
+    , selectedValue = Nothing
+    , onSelect = Nothing
+    , triggerId = "select-element-trigger-default"
+    , popoverId = "select-element-popover-default"
+    , title = Nothing
+    , label = Nothing
+    , hideLabel = False
+    , disabled = False
+    , loading = False
+    , icon = Nothing
+    , disableWhen = \_ -> False
+    , error = Nothing
+    , guidance = Nothing
+    , containerCss = []
+    , noMargin = False
+    , valueToString = \_ -> ""
+    , stringToValue = \_ -> Nothing
+    , customTriggerAttrs = []
+    , customPopoverAttrs = []
+    }
+
+
+applyConfig : List (Attribute value msg) -> Config value msg
+applyConfig attributes =
+    List.foldl (\(Attribute update) config -> update config) defaultConfig attributes
+
+
+
+-- ATTRIBUTES
+
+
+{-| Defines the list of options and option groups to display in the select dropdown.
+-}
+optionItems : List (OptionItem value msg) -> Attribute value msg
+optionItems items =
+    Attribute (\config -> { config | optionItems = items })
+
+
+{-| Sets the currently selected value.
+-}
+selectedValue : Maybe value -> Attribute value msg
+selectedValue val =
+    Attribute (\config -> { config | selectedValue = val })
+
+
+{-| The message to send when an option is selected.
+It receives the newly selected value.
+-}
+onSelect : (value -> msg) -> Attribute value msg
+onSelect handler =
+    Attribute (\config -> { config | onSelect = Just handler })
+
+
+{-| An optional title to display above the select component.
+-}
+title : String -> Attribute value msg
+title t =
+    Attribute (\config -> { config | title = Just t })
+
+
+{-| The HTML ID for the trigger button.
+This ID is used by the `select-element` to associate with its trigger.
+Defaults to "select-element-trigger-default".
+-}
+triggerId : String -> Attribute value msg
+triggerId newId =
+    Attribute (\config -> { config | triggerId = newId })
+
+
+{-| The HTML ID for the `select-element` popover.
+Defaults to "select-element-popover-default".
+-}
+popoverId : String -> Attribute value msg
+popoverId newId =
+    Attribute (\config -> { config | popoverId = newId })
+
+
+{-| A function to convert your custom `value` type to a String.
+This is necessary for setting `data-value` attributes on options and for
+generating unique option IDs.
+-}
+valueToString : (value -> String) -> Attribute value msg
+valueToString fn =
+    Attribute (\config -> { config | valueToString = fn })
+
+
+{-| A function to convert a String (from the `select-change` event detail)
+back to your custom `value` type.
+-}
+stringToValue : (String -> Maybe value) -> Attribute value msg
+stringToValue fn =
+    Attribute (\config -> { config | stringToValue = fn })
+
+
+{-| Add custom HTML attributes to the trigger button.
+-}
+customHtmlAttributesForTrigger : List (Html.Styled.Attribute msg) -> Attribute value msg
+customHtmlAttributesForTrigger attrs =
+    Attribute (\config -> { config | customTriggerAttrs = config.customTriggerAttrs ++ attrs })
+
+
+{-| Add custom HTML attributes to the `select-element` (popover).
+-}
+customHtmlAttributesForPopover : List (Html.Styled.Attribute msg) -> Attribute value msg
+customHtmlAttributesForPopover attrs =
+    Attribute (\config -> { config | customPopoverAttrs = config.customPopoverAttrs ++ attrs })
+
+
+{-| Sets the accessible label for the select trigger.
+This is important for screen readers. Use `hideLabel` to control visual display.
+-}
+label : String -> Attribute value msg
+label l =
+    Attribute (\config -> { config | label = Just l })
+
+
+{-| If `True`, the label provided via the `label` attribute will be visually hidden
+(but still available to assistive technologies). Defaults to `False`.
+-}
+hideLabel : Bool -> Attribute value msg
+hideLabel hidden =
+    Attribute (\config -> { config | hideLabel = hidden })
+
+
+{-| Disables the select component, preventing interaction.
+-}
+disabled : Bool -> Attribute value msg
+disabled isDisabled =
+    Attribute (\config -> { config | disabled = isDisabled })
+
+
+{-| Puts the select component in a loading state.
+This disables interaction and changes the visual appearance.
+-}
+loading : Bool -> Attribute value msg
+loading isLoading =
+    Attribute (\config -> { config | loading = isLoading })
+
+
+{-| Adds an SVG icon to the trigger button.
+The icon will be placed before the text.
+-}
+icon : Svg.Svg -> Attribute value msg
+icon i =
+    Attribute (\config -> { config | icon = Just i })
+
+
+{-| A predicate function to determine if an individual option should be disabled.
+Disabled options are not selectable and visually distinct.
+-}
+disableWhen : (value -> Bool) -> Attribute value msg
+disableWhen predicate =
+    Attribute (\config -> { config | disableWhen = predicate })
+
+
+{-| Sets an error message to be displayed below the component.
+If set, it overrides any guidance message.
+-}
+error : String -> Attribute value msg
+error errMsg =
+    Attribute (\config -> { config | error = Just errMsg, guidance = Nothing })
+
+
+{-| Sets a guidance message to be displayed below the component.
+This message is not shown if an error message is present.
+-}
+guidance : String -> Attribute value msg
+guidance guidMsg =
+    Attribute
+        (\config ->
+            { config
+                | guidance =
+                    if config.error == Nothing then
+                        Just guidMsg
+
+                    else
+                        config.guidance
+            }
+        )
+
+
+{-| Custom CSS styles for the main container div wrapping the component.
+-}
+containerCss : List Style -> Attribute value msg
+containerCss styles =
+    Attribute (\config -> { config | containerCss = config.containerCss ++ styles })
+
+
+{-| If `True`, removes the default top margin from the component container.
+-}
+noMargin : Bool -> Attribute value msg
+noMargin noMrg =
+    Attribute (\config -> { config | noMargin = noMrg })
+
+
+
+-- STYLES
+
+
+popoverHostStyles : List Style
+popoverHostStyles =
+    [ Css.border3 (px 1) solid Colors.gray85
+    , backgroundColor Colors.white
+    , borderRadius (px 8)
+    , maxHeight (px 300)
+    , overflowY auto
+    , padding2 (px 10) zero
+    , Shadows.high
+    ]
+
+
+optionBaseStyles : List Style
+optionBaseStyles =
+    [ padding2 (px 8) (px 16)
+    , cursor pointer
+    , Css.fontFamilies [ "Muli", "sans-serif" ]
+    , fontSize (px 14)
+    , color Colors.navy
+    , display block
+    , whiteSpace noWrap
+    , overflow hidden
+    , textOverflow ellipsis
+    , borderRadius (px 4)
+    , margin2 zero (px 8)
+    ]
+
+
+optgroupContainerStyles : List Style
+optgroupContainerStyles =
+    [ paddingTop (px 8)
+    , marginBottom (px 8)
+    , borderBottom3 (px 1) solid Colors.gray92
+    , paddingBottom (px 8)
+    ]
+
+
+optgroupLabelStyles : List Style
+optgroupLabelStyles =
+    [ padding2 (px 4) (px 16)
+    , Css.fontFamilies [ "Muli", "sans-serif" ]
+    , fontSize (px 13)
+    , fontWeight (int 600)
+    , color Colors.gray20
+    , display block
+    , marginBottom (px 4)
+    , backgroundColor Colors.gray96
+    , borderBottom3 (px 1) solid Colors.gray92
+    ]
+
+
+optionDisabledStyles : List Style
+optionDisabledStyles =
+    [ color Colors.gray45
+    , cursor notAllowed
+    ]
+
+
+
+-- VIEW LOGIC
+
+
+getLabelForValue : (value -> String) -> value -> List (OptionItem value msg) -> Maybe String
+getLabelForValue valToString valueToFind optionItems_ =
+    let
+        findLabel optItem =
+            case optItem of
+                Item opt ->
+                    if valToString opt.value == valToString valueToFind then
+                        Just opt.triggerLabel
+
+                    else
+                        Nothing
+
+                Group _ subOpts ->
+                    List.filterMap
+                        (\opt ->
+                            if valToString opt.value == valToString valueToFind then
+                                Just opt.triggerLabel
+
+                            else
+                                Nothing
+                        )
+                        subOpts
+                        |> List.head
+    in
+    List.filterMap findLabel optionItems_
+        |> List.head
+
+
+renderSingleOption : Config value msg -> String -> (value -> String) -> SingleOption value msg -> Html msg
+renderSingleOption config popoverIdForOption valToString option =
+    let
+        isOptionDisabled =
+            config.disableWhen option.value
+
+        optionSpecificStyles =
+            if isOptionDisabled then
+                optionDisabledStyles
+
+            else
+                []
+    in
+    div
+        ([ attribute "role" "option"
+         , attribute "data-value" (valToString option.value)
+         , id (popoverIdForOption ++ "-option-" ++ valToString option.value)
+         , tabindex -1
+         , Attributes.css (optionBaseStyles ++ optionSpecificStyles)
+         ]
+            ++ (if isOptionDisabled then
+                    [ attribute "aria-disabled" "true"
+                    ]
+
+                else
+                    []
+               )
+        )
+        [ option.content ]
+
+
+renderOptionItems : Config value msg -> String -> (value -> String) -> List (OptionItem value msg) -> List (Html msg)
+renderOptionItems config popoverIdForOptions valToString items =
+    List.concatMap
+        (\item ->
+            case item of
+                Item singleOpt ->
+                    [ renderSingleOption config popoverIdForOptions valToString singleOpt ]
+
+                Group groupLabel optList ->
+                    if List.isEmpty optList then
+                        []
+
+                    else
+                        [ div
+                            [ attribute "role" "group"
+                            , attribute "aria-label" groupLabel
+                            , class "optgroup"
+                            , Attributes.css optgroupContainerStyles
+                            ]
+                            ([ div
+                                [ class "optgroup-label"
+                                , Attributes.css optgroupLabelStyles
+                                ]
+                                [ text groupLabel ]
+                             ]
+                                ++ List.map (renderSingleOption config popoverIdForOptions valToString) optList
+                            )
+                        ]
+        )
+        items
+
+
+triggerStyles : Config value msg -> List Style
+triggerStyles config =
+    let
+        isEffectivelyDisabled =
+            config.disabled || config.loading
+
+        baseBorderColor =
+            Colors.gray75
+
+        borderColor =
+            if isEffectivelyDisabled then
+                Colors.gray85
+
+            else if config.error /= Nothing then
+                Colors.purple
+
+            else
+                baseBorderColor
+
+        borderBottomWidth =
+            if isEffectivelyDisabled then
+                Css.px 1
+
+            else
+                Css.px 3
+    in
+    [ Css.border3 (Css.px 1) Css.solid borderColor
+    , Css.borderBottomWidth borderBottomWidth
+    , Css.borderRadius (Css.px 8)
+    , Css.pseudoClass "focus-within"
+        [ Css.borderColor Colors.azure
+        , Css.borderRadius (Css.px 8) |> Css.important
+        ]
+    , Fonts.baseFont
+    , Css.fontSize (Css.px 15)
+    , Css.fontWeight (Css.int 600)
+    , Css.color
+        (if isEffectivelyDisabled then
+            Colors.gray45
+
+         else
+            Colors.navy
+        )
+    , Css.cursor
+        (if isEffectivelyDisabled then
+            Css.notAllowed
+
+         else
+            Css.pointer
+        )
+    , Css.height (Css.px 45)
+    , Css.width (Css.pct 100)
+    , Css.paddingLeft
+        (if config.icon /= Nothing then
+            Css.px 35
+
+         else
+            Css.px 15
+        )
+    , Css.paddingRight (Css.px 15)
+    , Css.position Css.relative
+    , Css.displayFlex
+    , Css.alignItems Css.center
+    , Css.justifyContent Css.spaceBetween
+    , selectElementVisualResets
+    , if isEffectivelyDisabled then
+        backgroundColor Colors.gray85
+
+      else
+        backgroundColor Colors.white
+    , if config.loading then
+        Css.opacity (Css.num 0.7)
+
+      else
+        Css.batch []
+    ]
+
+
+selectElementVisualResets : Style
+selectElementVisualResets =
+    Css.batch
+        [ VendorPrefixed.property "appearance" "none"
+        , Css.backgroundColor Css.transparent
+        ]
+
+
+
+-- VIEW
+
+
+{-| Renders the SelectElement component.
+The `defaultTriggerText` is used as the content of the trigger button
+if no `selectedValue` provides a label, or if no `label` attribute is set.
+-}
+view : String -> List (Attribute value msg) -> Html msg
+view defaultTriggerText attributes =
+    let
+        config =
+            applyConfig attributes
+
+        isEffectivelyDisabled =
+            config.disabled || config.loading
+
+        labelFromSelectedValue : Maybe String
+        labelFromSelectedValue =
+            Maybe.andThen
+                (\sVal -> getLabelForValue config.valueToString sVal config.optionItems)
+                config.selectedValue
+
+        buttonLabelText : String
+        buttonLabelText =
+            case labelFromSelectedValue of
+                Just selectedLabel ->
+                    selectedLabel
+
+                Nothing ->
+                    defaultTriggerText
+
+        componentValueAttributes =
+            case config.selectedValue of
+                Just val ->
+                    [ attribute "value" (config.valueToString val) ]
+
+                Nothing ->
+                    []
+
+        selectChangeHandlerAttributeList =
+            case config.onSelect of
+                Just onSel ->
+                    [ Events.on "select-change"
+                        (Decode.at [ "detail", "value" ] Decode.string
+                            |> Decode.andThen
+                                (\strVal ->
+                                    case config.stringToValue strVal of
+                                        Just actualVal ->
+                                            Decode.succeed (onSel actualVal)
+
+                                        Nothing ->
+                                            Decode.fail ("SelectElement.V1: Could not convert string '" ++ strVal ++ "' back to value type.")
+                                )
+                        )
+                    ]
+
+                Nothing ->
+                    []
+
+        popoverAttributes =
+            [ id config.popoverId
+            , attribute "popover" "auto"
+            , attribute "data-trigger-id" config.triggerId
+            , Attributes.css popoverHostStyles
+            ]
+                ++ componentValueAttributes
+                ++ config.customPopoverAttrs
+                ++ selectChangeHandlerAttributeList
+
+        triggerBaseAttributes =
+            [ id config.triggerId
+            , attribute "aria-haspopup" "listbox"
+            , attribute "aria-expanded" "false"
+            , Attributes.attribute "popovertarget" config.popoverId
+            , Attributes.css (triggerStyles config)
+            ]
+                ++ config.customTriggerAttrs
+
+        triggerDisabledAttributes =
+            if isEffectivelyDisabled then
+                [ Attributes.disabled True
+                , attribute "aria-disabled" "true"
+                ]
+
+            else
+                []
+
+        finalTriggerAttributes =
+            triggerBaseAttributes ++ triggerDisabledAttributes
+
+        labelNodeCss config_ =
+            if config_.hideLabel then
+                [ Css.display none ]
+
+            else
+                [ Fonts.baseFont
+                , Css.fontSize (Css.px 12)
+                , Css.fontWeight (Css.int 600)
+                , Css.color Colors.navy
+                , Css.marginBottom (Css.px 4)
+                , Css.display block
+                ]
+
+        labelNodeAttributes labelId config_ =
+            [ for labelId
+            , Attributes.css (labelNodeCss config_)
+            ]
+
+        renderIcon =
+            case config.icon of
+                Nothing ->
+                    []
+
+                Just i ->
+                    let
+                        iconHtml =
+                            i
+                                |> Svg.withWidth (Css.px 20)
+                                |> Svg.withHeight (Css.px 20)
+                                |> Svg.toHtml
+                                |> Html.Styled.map never
+                    in
+                    [ span
+                        [ Attributes.css
+                            [ Css.marginRight (Css.px 8)
+                            , displayFlex
+                            , alignItems center
+                            ]
+                        ]
+                        [ iconHtml ]
+                    ]
+
+        renderErrorOrGuidance =
+            case ( config.error, config.guidance ) of
+                ( Just errMsg, _ ) ->
+                    div [ Attributes.css [ color Colors.red, fontSize (px 12), paddingTop (px 4) ] ] [ text errMsg ]
+
+                ( Nothing, Just guidMsg ) ->
+                    div [ Attributes.css [ color Colors.gray20, fontSize (px 12), paddingTop (px 4) ] ] [ text guidMsg ]
+
+                _ ->
+                    Html.Styled.text ""
+
+        containerStyles =
+            (if config.noMargin then
+                []
+
+             else
+                [ Css.marginTop (Css.px 16) ]
+            )
+                ++ config.containerCss
+    in
+    div [ Attributes.css containerStyles ]
+        ((Maybe.map
+            (\t ->
+                h3
+                    [ Attributes.css
+                        [ Fonts.baseFont
+                        , Css.fontSize (Css.px 15)
+                        , Css.fontWeight (Css.int 700)
+                        , Css.color Colors.navy
+                        , Css.marginBottom (Css.px 8)
+                        ]
+                    ]
+                    [ text t ]
+            )
+            config.title
+            |> Maybe.map List.singleton
+            |> Maybe.withDefault []
+         )
+            ++ (case config.label of
+                    Just lblString ->
+                        [ node "label" (labelNodeAttributes config.triggerId config) [ text lblString ] ]
+
+                    Nothing ->
+                        []
+               )
+            ++ [ button
+                    finalTriggerAttributes
+                    (renderIcon
+                        ++ [ span [ Attributes.css [ Css.flexGrow (Css.int 1), Css.textAlign Css.left ] ] [ text buttonLabelText ]
+                           , span [ class "arrow", Attributes.css [ Css.marginLeft (Css.px 5) ] ] [ text "▾" ]
+                           ]
+                    )
+               , node "select-element"
+                    popoverAttributes
+                    (renderOptionItems config config.popoverId config.valueToString config.optionItems)
+               , renderErrorOrGuidance
+               ]
+        )

--- a/tests/Spec/Nri/Ui/SelectElement.elm
+++ b/tests/Spec/Nri/Ui/SelectElement.elm
@@ -1,0 +1,559 @@
+module Spec.Nri.Ui.SelectElement exposing (spec)
+
+import Accessibility.Aria as Aria
+import Expect
+import Html.Attributes as UnstyledAttributes
+import Html.Styled
+import Html.Styled.Attributes as Attributes
+import Json.Encode
+import Nri.Ui.SelectElement.V1 as SelectElement
+import Nri.Ui.UiIcon.V1 as UiIcon
+import ProgramTest exposing (..)
+import Test exposing (..)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (..)
+
+
+
+-- SAMPLE DATA
+
+
+type SampleItem
+    = Alpha
+    | Beta
+    | Gamma
+    | Delta
+
+
+sampleItemToString : SampleItem -> String
+sampleItemToString item =
+    case item of
+        Alpha ->
+            "Alpha"
+
+        Beta ->
+            "Beta"
+
+        Gamma ->
+            "Gamma"
+
+        Delta ->
+            "Delta"
+
+
+stringToSampleItem : String -> Maybe SampleItem
+stringToSampleItem str =
+    case str of
+        "Alpha" ->
+            Just Alpha
+
+        "Beta" ->
+            Just Beta
+
+        "Gamma" ->
+            Just Gamma
+
+        "Delta" ->
+            Just Delta
+
+        _ ->
+            Nothing
+
+
+testOptions : List (SelectElement.OptionItem SampleItem Msg)
+testOptions =
+    [ SelectElement.Item
+        { content = Html.Styled.text "Alpha Item Content"
+        , value = Alpha
+        , triggerLabel = "Alpha Trigger Label"
+        }
+    , SelectElement.Item
+        { content = Html.Styled.text "Beta Item Content"
+        , value = Beta
+        , triggerLabel = "Beta Trigger Label"
+        }
+    ]
+
+
+testOptionsWithGroup : List (SelectElement.OptionItem SampleItem Msg)
+testOptionsWithGroup =
+    [ SelectElement.Group "Group One"
+        [ { content = Html.Styled.text "Alpha Item Content"
+          , value = Alpha
+          , triggerLabel = "Alpha Trigger Label"
+          }
+        , { content = Html.Styled.text "Beta Item Content"
+          , value = Beta
+          , triggerLabel = "Beta Trigger Label"
+          }
+        ]
+    , SelectElement.Item
+        { content = Html.Styled.text "Gamma Item Content"
+        , value = Gamma
+        , triggerLabel = "Gamma Trigger Label"
+        }
+    ]
+
+
+
+-- MODEL, MSG, UPDATE for tests
+
+
+type alias Model =
+    { selectedValue : Maybe SampleItem
+    , lastMsgReceived : Maybe Msg
+    }
+
+
+initialModel : Model
+initialModel =
+    { selectedValue = Nothing
+    , lastMsgReceived = Nothing
+    }
+
+
+type Msg
+    = ItemSelected SampleItem
+
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        ItemSelected item ->
+            { model | selectedValue = Just item, lastMsgReceived = Just msg }
+
+
+
+-- THE SPEC
+
+
+spec : Test
+spec =
+    describe "Nri.Ui.SelectElement.V1"
+        [ test "renders with default trigger text and options" <|
+            \() ->
+                ProgramTest.createSandbox
+                    { init = initialModel
+                    , update = update
+                    , view =
+                        \_ ->
+                            SelectElement.view "Pick One"
+                                [ SelectElement.optionItems testOptions
+                                , SelectElement.valueToString sampleItemToString
+                                , SelectElement.stringToValue stringToSampleItem
+                                , SelectElement.onSelect ItemSelected
+                                , SelectElement.triggerId "trigger-1"
+                                , SelectElement.popoverId "popover-1"
+                                ]
+                                |> Html.Styled.toUnstyled
+                    }
+                    |> ProgramTest.start ()
+                    |> ensureViewHas
+                        [ tag "button"
+                        , id "trigger-1"
+                        , containing [ text "Pick One" ]
+                        , attribute (UnstyledAttributes.attribute "popovertarget" "popover-1")
+                        , attribute (UnstyledAttributes.attribute "aria-haspopup" "listbox")
+                        ]
+                    |> ensureViewHas
+                        [ tag "select-element"
+                        , id "popover-1"
+                        , attribute (UnstyledAttributes.attribute "data-trigger-id" "trigger-1")
+                        , attribute (UnstyledAttributes.attribute "popover" "auto")
+                        , containing [ tag "div", attribute (UnstyledAttributes.attribute "role" "option"), attribute (UnstyledAttributes.attribute "data-value" "Alpha"), containing [ text "Alpha Item Content" ] ]
+                        , containing [ tag "div", attribute (UnstyledAttributes.attribute "role" "option"), attribute (UnstyledAttributes.attribute "data-value" "Beta"), containing [ text "Beta Item Content" ] ]
+                        ]
+                    |> done
+        , test "renders selected value's triggerLabel on button and value on select-element" <|
+            \() ->
+                ProgramTest.createSandbox
+                    { init = { initialModel | selectedValue = Just Alpha }
+                    , update = update
+                    , view =
+                        \model_ ->
+                            SelectElement.view "Pick One"
+                                [ SelectElement.optionItems testOptions
+                                , SelectElement.valueToString sampleItemToString
+                                , SelectElement.stringToValue stringToSampleItem
+                                , SelectElement.onSelect ItemSelected
+                                , SelectElement.selectedValue model_.selectedValue
+                                , SelectElement.triggerId "trigger-selected"
+                                , SelectElement.popoverId "popover-selected"
+                                ]
+                                |> Html.Styled.toUnstyled
+                    }
+                    |> ProgramTest.start ()
+                    |> ensureViewHas
+                        [ tag "button"
+                        , id "trigger-selected"
+                        , containing [ text "Alpha Trigger Label" ]
+                        ]
+                    |> ensureViewHas
+                        [ tag "select-element"
+                        , id "popover-selected"
+                        , attribute (UnstyledAttributes.attribute "value" "Alpha")
+                        ]
+                    |> done
+        , test "handles onSelect when 'select-change' event occurs" <|
+            \() ->
+                let
+                    eventPayload =
+                        Json.Encode.object
+                            [ ( "detail"
+                              , Json.Encode.object [ ( "value", Json.Encode.string "Beta" ) ]
+                              )
+                            ]
+
+                    program =
+                        ProgramTest.createSandbox
+                            { init = initialModel
+                            , update = update
+                            , view =
+                                \_ ->
+                                    SelectElement.view "Pick One"
+                                        [ SelectElement.optionItems testOptions
+                                        , SelectElement.valueToString sampleItemToString
+                                        , SelectElement.stringToValue stringToSampleItem
+                                        , SelectElement.onSelect ItemSelected
+                                        , SelectElement.triggerId "trigger-event"
+                                        , SelectElement.popoverId "popover-event"
+                                        ]
+                                        |> Html.Styled.toUnstyled
+                            }
+                            |> ProgramTest.start ()
+                in
+                program
+                    |> ProgramTest.simulateDomEvent
+                        (Query.find [ tag "select-element", id "popover-event" ])
+                        (Event.custom "select-change" eventPayload)
+                    |> ProgramTest.expectModel
+                        (\model_ ->
+                            Expect.equal ( model_.selectedValue, model_.lastMsgReceived ) ( Just Beta, Just (ItemSelected Beta) )
+                        )
+        , test "is disabled when disabled attribute is true" <|
+            \() ->
+                ProgramTest.createSandbox
+                    { init = initialModel
+                    , update = update
+                    , view =
+                        \_ ->
+                            SelectElement.view "Pick One"
+                                [ SelectElement.optionItems testOptions
+                                , SelectElement.valueToString sampleItemToString
+                                , SelectElement.stringToValue stringToSampleItem
+                                , SelectElement.triggerId "trigger-disabled"
+                                , SelectElement.popoverId "popover-disabled"
+                                , SelectElement.disabled True
+                                ]
+                                |> Html.Styled.toUnstyled
+                    }
+                    |> ProgramTest.start ()
+                    |> ensureViewHas
+                        [ tag "button"
+                        , id "trigger-disabled"
+                        , attribute (UnstyledAttributes.disabled True)
+                        , attribute (Aria.disabled True)
+                        ]
+                    |> done
+        , test "is in loading state (and disabled) when loading attribute is true" <|
+            \() ->
+                ProgramTest.createSandbox
+                    { init = initialModel
+                    , update = update
+                    , view =
+                        \_ ->
+                            SelectElement.view "Pick One"
+                                [ SelectElement.optionItems testOptions
+                                , SelectElement.valueToString sampleItemToString
+                                , SelectElement.stringToValue stringToSampleItem
+                                , SelectElement.triggerId "trigger-loading"
+                                , SelectElement.popoverId "popover-loading"
+                                , SelectElement.loading True
+                                ]
+                                |> Html.Styled.toUnstyled
+                    }
+                    |> ProgramTest.start ()
+                    |> ensureViewHas
+                        [ tag "button"
+                        , id "trigger-loading"
+                        , attribute (UnstyledAttributes.disabled True)
+                        , attribute (Aria.disabled True)
+                        ]
+                    |> done
+        , test "disables individual options based on disableWhen" <|
+            \() ->
+                ProgramTest.createSandbox
+                    { init = initialModel
+                    , update = update
+                    , view =
+                        \_ ->
+                            SelectElement.view "Pick One"
+                                [ SelectElement.optionItems testOptions
+                                , SelectElement.valueToString sampleItemToString
+                                , SelectElement.stringToValue stringToSampleItem
+                                , SelectElement.triggerId "trigger-dw"
+                                , SelectElement.popoverId "popover-dw"
+                                , SelectElement.disableWhen (\item -> item == Alpha)
+                                ]
+                                |> Html.Styled.toUnstyled
+                    }
+                    |> ProgramTest.start ()
+                    |> ensureViewHas
+                        [ tag "select-element"
+                        , id "popover-dw"
+                        , containing [ tag "div", attribute (UnstyledAttributes.attribute "data-value" "Alpha"), attribute (UnstyledAttributes.attribute "aria-disabled" "true") ]
+                        ]
+                    |> ensureViewHasNot
+                        [ tag "select-element"
+                        , id "popover-dw"
+                        , containing [ tag "div", attribute (UnstyledAttributes.attribute "data-value" "Beta"), attribute (UnstyledAttributes.attribute "aria-disabled" "true") ]
+                        ]
+                    |> done
+        , test "renders an icon when provided" <|
+            \() ->
+                let
+                    dummyIcon =
+                        UiIcon.checkmark
+                in
+                ProgramTest.createSandbox
+                    { init = initialModel
+                    , update = update
+                    , view =
+                        \_ ->
+                            SelectElement.view "Pick One"
+                                [ SelectElement.optionItems testOptions
+                                , SelectElement.valueToString sampleItemToString
+                                , SelectElement.stringToValue stringToSampleItem
+                                , SelectElement.triggerId "trigger-icon"
+                                , SelectElement.popoverId "popover-icon"
+                                , SelectElement.icon dummyIcon
+                                ]
+                                |> Html.Styled.toUnstyled
+                    }
+                    |> ProgramTest.start ()
+                    |> ensureViewHas
+                        [ tag "button"
+                        , id "trigger-icon"
+                        , containing [ tag "span" ]
+                        ]
+                    |> done
+        , test "renders a title when provided" <|
+            \() ->
+                ProgramTest.createSandbox
+                    { init = initialModel
+                    , update = update
+                    , view =
+                        \_ ->
+                            SelectElement.view "Pick One"
+                                [ SelectElement.optionItems testOptions
+                                , SelectElement.valueToString sampleItemToString
+                                , SelectElement.stringToValue stringToSampleItem
+                                , SelectElement.triggerId "trigger-title"
+                                , SelectElement.popoverId "popover-title"
+                                , SelectElement.title "My Select Title"
+                                ]
+                                |> Html.Styled.toUnstyled
+                    }
+                    |> ProgramTest.start ()
+                    |> ensureViewHas
+                        [ tag "h3"
+                        , containing [ text "My Select Title" ]
+                        ]
+                    |> done
+        , test "renders a visible label when provided" <|
+            \() ->
+                ProgramTest.createSandbox
+                    { init = initialModel
+                    , update = update
+                    , view =
+                        \_ ->
+                            SelectElement.view "Pick One"
+                                [ SelectElement.optionItems testOptions
+                                , SelectElement.valueToString sampleItemToString
+                                , SelectElement.stringToValue stringToSampleItem
+                                , SelectElement.triggerId "trigger-label"
+                                , SelectElement.popoverId "popover-label"
+                                , SelectElement.label "My Awesome Label"
+                                ]
+                                |> Html.Styled.toUnstyled
+                    }
+                    |> ProgramTest.start ()
+                    |> ensureViewHas
+                        [ tag "label"
+                        , attribute (UnstyledAttributes.for "trigger-label")
+                        , containing [ text "My Awesome Label" ]
+                        ]
+                    |> done
+        , test "renders a hidden label when hideLabel is true" <|
+            \() ->
+                ProgramTest.createSandbox
+                    { init = initialModel
+                    , update = update
+                    , view =
+                        \_ ->
+                            SelectElement.view "Pick One"
+                                [ SelectElement.optionItems testOptions
+                                , SelectElement.valueToString sampleItemToString
+                                , SelectElement.stringToValue stringToSampleItem
+                                , SelectElement.triggerId "trigger-hidden-label"
+                                , SelectElement.popoverId "popover-hidden-label"
+                                , SelectElement.label "My Hidden Label"
+                                , SelectElement.hideLabel True
+                                ]
+                                |> Html.Styled.toUnstyled
+                    }
+                    |> ProgramTest.start ()
+                    |> ensureViewHas
+                        [ tag "label"
+                        , attribute (UnstyledAttributes.for "trigger-hidden-label")
+                        , containing [ text "My Hidden Label" ]
+                        ]
+                    |> done
+        , test "renders an error message" <|
+            \() ->
+                ProgramTest.createSandbox
+                    { init = initialModel
+                    , update = update
+                    , view =
+                        \_ ->
+                            SelectElement.view "Pick One"
+                                [ SelectElement.optionItems testOptions
+                                , SelectElement.valueToString sampleItemToString
+                                , SelectElement.stringToValue stringToSampleItem
+                                , SelectElement.triggerId "trigger-err"
+                                , SelectElement.popoverId "popover-err"
+                                , SelectElement.error "This is an error!"
+                                ]
+                                |> Html.Styled.toUnstyled
+                    }
+                    |> ProgramTest.start ()
+                    |> ensureViewHas
+                        [ tag "div"
+                        , containing [ text "This is an error!" ]
+                        ]
+                    |> done
+        , test "renders a guidance message" <|
+            \() ->
+                ProgramTest.createSandbox
+                    { init = initialModel
+                    , update = update
+                    , view =
+                        \_ ->
+                            SelectElement.view "Pick One"
+                                [ SelectElement.optionItems testOptions
+                                , SelectElement.valueToString sampleItemToString
+                                , SelectElement.stringToValue stringToSampleItem
+                                , SelectElement.triggerId "trigger-guide"
+                                , SelectElement.popoverId "popover-guide"
+                                , SelectElement.guidance "This is helpful guidance."
+                                ]
+                                |> Html.Styled.toUnstyled
+                    }
+                    |> ProgramTest.start ()
+                    |> ensureViewHas
+                        [ tag "div"
+                        , containing [ text "This is helpful guidance." ]
+                        ]
+                    |> done
+        , test "error message overrides guidance message" <|
+            \() ->
+                ProgramTest.createSandbox
+                    { init = initialModel
+                    , update = update
+                    , view =
+                        \_ ->
+                            SelectElement.view "Pick One"
+                                [ SelectElement.optionItems testOptions
+                                , SelectElement.valueToString sampleItemToString
+                                , SelectElement.stringToValue stringToSampleItem
+                                , SelectElement.triggerId "trigger-override"
+                                , SelectElement.popoverId "popover-override"
+                                , SelectElement.guidance "This guidance should be hidden."
+                                , SelectElement.error "This error should show."
+                                ]
+                                |> Html.Styled.toUnstyled
+                    }
+                    |> ProgramTest.start ()
+                    |> ensureViewHas
+                        [ tag "div"
+                        , containing [ text "This error should show." ]
+                        ]
+                    |> ensureViewHasNot
+                        [ containing [ text "This guidance should be hidden." ] ]
+                    |> done
+        , test "applies custom HTML attributes to the trigger" <|
+            \() ->
+                ProgramTest.createSandbox
+                    { init = initialModel
+                    , update = update
+                    , view =
+                        \_ ->
+                            SelectElement.view "Pick One"
+                                [ SelectElement.optionItems testOptions
+                                , SelectElement.valueToString sampleItemToString
+                                , SelectElement.stringToValue stringToSampleItem
+                                , SelectElement.triggerId "trigger-custom-attr"
+                                , SelectElement.popoverId "popover-custom-attr"
+                                , SelectElement.customHtmlAttributesForTrigger [ Attributes.attribute "data-custom-trigger" "trigger-val" ]
+                                ]
+                                |> Html.Styled.toUnstyled
+                    }
+                    |> ProgramTest.start ()
+                    |> ensureViewHas
+                        [ tag "button"
+                        , id "trigger-custom-attr"
+                        , attribute (UnstyledAttributes.attribute "data-custom-trigger" "trigger-val")
+                        ]
+                    |> done
+        , test "applies custom HTML attributes to the popover" <|
+            \() ->
+                ProgramTest.createSandbox
+                    { init = initialModel
+                    , update = update
+                    , view =
+                        \_ ->
+                            SelectElement.view "Pick One"
+                                [ SelectElement.optionItems testOptions
+                                , SelectElement.valueToString sampleItemToString
+                                , SelectElement.stringToValue stringToSampleItem
+                                , SelectElement.triggerId "trigger-custom-pop"
+                                , SelectElement.popoverId "popover-custom-pop"
+                                , SelectElement.customHtmlAttributesForPopover [ Attributes.attribute "data-custom-popover" "popover-val" ]
+                                ]
+                                |> Html.Styled.toUnstyled
+                    }
+                    |> ProgramTest.start ()
+                    |> ensureViewHas
+                        [ tag "select-element"
+                        , id "popover-custom-pop"
+                        , attribute (UnstyledAttributes.attribute "data-custom-popover" "popover-val")
+                        ]
+                    |> done
+        , test "renders grouped options correctly" <|
+            \() ->
+                ProgramTest.createSandbox
+                    { init = initialModel
+                    , update = update
+                    , view =
+                        \_ ->
+                            SelectElement.view "Pick One"
+                                [ SelectElement.optionItems testOptionsWithGroup
+                                , SelectElement.valueToString sampleItemToString
+                                , SelectElement.stringToValue stringToSampleItem
+                                , SelectElement.triggerId "trigger-group"
+                                , SelectElement.popoverId "popover-group"
+                                ]
+                                |> Html.Styled.toUnstyled
+                    }
+                    |> ProgramTest.start ()
+                    |> ensureViewHas
+                        [ tag "select-element"
+                        , id "popover-group"
+                        , containing [ tag "div", attribute (UnstyledAttributes.attribute "role" "group"), attribute (UnstyledAttributes.attribute "aria-label" "Group One") ]
+                        , containing [ tag "div", attribute (UnstyledAttributes.attribute "role" "option"), attribute (UnstyledAttributes.attribute "data-value" "Alpha"), containing [ text "Alpha Item Content" ] ]
+                        , containing [ tag "div", attribute (UnstyledAttributes.attribute "role" "option"), attribute (UnstyledAttributes.attribute "data-value" "Beta"), containing [ text "Beta Item Content" ] ]
+                        , containing [ tag "div", attribute (UnstyledAttributes.attribute "role" "option"), attribute (UnstyledAttributes.attribute "data-value" "Gamma"), containing [ text "Gamma Item Content" ] ]
+                        ]
+                    |> done
+        ]

--- a/tests/Spec/Nri/Ui/SelectElement.elm
+++ b/tests/Spec/Nri/Ui/SelectElement.elm
@@ -7,7 +7,7 @@ import Html.Styled
 import Html.Styled.Attributes as Attributes
 import Json.Encode
 import Nri.Ui.SelectElement.V1 as SelectElement
-import Nri.Ui.UiIcon.V1 as UiIcon
+import Nri.Ui.UiIcon.V2 as UiIcon
 import ProgramTest exposing (..)
 import Test exposing (..)
 import Test.Html.Event as Event

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -67,6 +67,7 @@
         "Nri.Ui.RingGauge.V1",
         "Nri.Ui.SegmentedControl.V14",
         "Nri.Ui.Select.V9",
+        "Nri.Ui.SelectElement.V1",
         "Nri.Ui.Shadows.V1",
         "Nri.Ui.SideNav.V5",
         "Nri.Ui.SortableTable.V5",


### PR DESCRIPTION
# :star2: Adding a new component

## About the component

https://docs.google.com/document/d/1yKckillOhVRMkxmjgwNInWm7XTdQsmPO1XvhHL7H410/edit?tab=t.0#heading=h.lks91lgabqnu

Fixes LLM-2333

## :framed_picture: What does this change look like?

<img width="408" alt="Screenshot 2025-05-21 at 12 38 17" src="https://github.com/user-attachments/assets/cbdae567-a3a9-4fb2-be0b-36ac058a7c35" />

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with this component in mind
- [x] Component has clear documentation
- [x] Component is in the Component Catalog
  - [x] I've used [the script to add the component to the Component Catalog](https://github.com/NoRedInk/noredink-ui?tab=readme-ov-file#-adding-a-component-to-the-component-catalog).
  - [x] Component is categorized reasonably (see [Category](https://github.com/NoRedInk/noredink-ui/blob/master/component-catalog-app/Category.elm) for all the currently available categories). The component can be in multiple categories, if appropriate.
  - [x] Component has a representative preview for the Component Catalog cards (bonus points for making it delightful!)
  - [x] Component has a customizable example. Aim for having _every_ possible supported version of the component displayable through the configuration on this page. (Protip: This is handy for testing expected behavior!)
  - [x] The customizable example produces sample code
  - [x] The component's example page includes keyboard behavior, if any
  - [x] The component's example page includes guidance around how to use the component, if necessary
- [x] Component is tested
  - axe checks and percy snapshots will be automatically added for every component. However, if you want to customize _when_ the checks and snapshots are made, you will need to make changes to [script/puppeteer-tests.js](https://github.com/NoRedInk/noredink-ui/blob/master/script/puppeteer-tests.js).
  - there are 2 ways to add Elm tests:
    - if you want to test the Component Catalog example directly, add ProgramTest-style tests under `component-catalog/tests`
    - if you want to test the component directly, add tests under `tests/Spec`. Historically, this has been the more popular Elm testing strategy for noredink-ui.
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [ ] Please assign the following reviewers:
  - [ ] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [ ] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [ ] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)

---