### PR TITLE
Bump version to 35.0.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "34.6.0",
+    "version": "35.0.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `35.0.0`

## What changes does this release include?

Migrates Pennant V3→V4 with smaller icons (25px→17px), adds doubleArrow icon, redesigns SelectElement with floating labels and modern styling, updates gradingAssistant/manuallyGraded icons, and improves disabled state colors across multiple components

#1762 
#1771 
#1772 
#1773

## How has the API changed?

```
This is a MAJOR change.

---- REMOVED MODULES - MAJOR ----

    Nri.Ui.Pennant.V3


---- Nri.Ui.UiIcon.V2 - MINOR ----

    Added:
        doubleArrow : Nri.Ui.Svg.V1.Svg

```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).