### PR TITLE
Checkbox z-index

### DIFF
--- a/src/Nri/Ui/Checkbox/V7.elm
+++ b/src/Nri/Ui/Checkbox/V7.elm
@@ -311,7 +311,7 @@ view { label, selected } attributes =
                     |> Maybe.map
                         (\msg ->
                             [ EventExtras.onClickStopPropagation msg
-                            , css [ cursor pointer, zIndex (int 1) ]
+                            , css [ cursor pointer ]
                             ]
                         )
                     |> Maybe.withDefault []


### PR DESCRIPTION
Removes the z-index for checkboxes. A comment suggests that it's in place to ensure click ability but I found no ill effect from removing it.

When bumping noredink-ui, include "Fixes KRA-1473"