### PR TITLE
use variable for readaloud icon backgrounds

### DIFF
--- a/src/Nri/Ui/UiIcon/V2.elm
+++ b/src/Nri/Ui/UiIcon/V2.elm
@@ -1529,7 +1529,7 @@ playInCircle =
             [ Attributes.d "M11 21C16.5228 21 21 16.5228 21 11C21 5.47715 16.5228 1 11 1C5.47715 1 1 5.47715 1 11C1 16.5228 5.47715 21 11 21Z"
             , Attributes.stroke "currentColor"
             , Attributes.strokeWidth "2"
-            , Attributes.fill "none"
+            , Attributes.fill "var(--circle-fill-color, none)"
             ]
             []
         , Svg.path
@@ -1565,7 +1565,7 @@ stopInCircle =
             [ Attributes.d "M11 21C16.5228 21 21 16.5228 21 11C21 5.47715 16.5228 1 11 1C5.47715 1 1 5.47715 1 11C1 16.5228 5.47715 21 11 21Z"
             , Attributes.stroke "currentColor"
             , Attributes.strokeWidth "2"
-            , Attributes.fill "none"
+            , Attributes.fill "var(--circle-fill-color, none)"
             ]
             []
         , Svg.path
@@ -1585,7 +1585,7 @@ pauseInCircle =
             [ Attributes.d "M11 21C16.5228 21 21 16.5228 21 11C21 5.47715 16.5228 1 11 1C5.47715 1 1 5.47715 1 11C1 16.5228 5.47715 21 11 21Z"
             , Attributes.stroke "currentColor"
             , Attributes.strokeWidth "2"
-            , Attributes.fill "none"
+            , Attributes.fill "var(--circle-fill-color, none)"
             ]
             []
         , Svg.path


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

https://linear.app/noredink/issue/QUO-1697/ux-qa-tts-icon-white-border

The problem in the issue above is caused by the circle element's having `fill=none`. This makes it so that we need to add a background-color + border-radius.

By using CSS variables, we can achieve the white fill without needing to modify the component's default appearance. 

## :framed_picture: What does this change look like?

Without setting the element's `--circle-fill-color`, there won't be any change.
When it's set, we can see the color has changed:
<img width="582" height="155" alt="image" src="https://github.com/user-attachments/assets/d2144ce7-52bb-4946-b3f0-96cbe82ff072" />

## Component completion checklist

- [X] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [X] Changes are clearly documented
  - [X] Component docs include a changelog
  - [X] Any new exposed functions or properties have docs
- [X] Changes extend to the Component Catalog
  - [X] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [ ] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
