### PR TITLE
bump version

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "35.1.1",
+    "version": "35.2.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
Please use the template that's relevant for your situation and delete the other templates. If this is just a noredink-ui repo doc change, you don't need to follow a template.

# :label: Bump for version `35.2.0`

## What changes does this release include?

* Adds some icons for Word Lookup
* Make `_InCircle` icons support a fill color set by --circle-fill-color CSS variable

## How has the API changed?

Please paste the output of `elm diff` run on latest master in the code block:

```
---- Nri.Ui.UiIcon.V2 - MINOR ----

    Added:
        translationForPracticeDirectionDisabled : Nri.Ui.Svg.V1.Svg
        translationForPracticeDirectionEnabled : Nri.Ui.Svg.V1.Svg
        wordLookTranslationDisabled : Nri.Ui.Svg.V1.Svg
        wordLookTranslationEnabled : Nri.Ui.Svg.V1.Svg
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).