### PR TITLE
add vendor prefix to highlighter

### DIFF
--- a/src/Nri/Ui/Highlighter/V5.elm
+++ b/src/Nri/Ui/Highlighter/V5.elm
@@ -82,6 +82,7 @@ import Json.Decode
 import List.Extra
 import Markdown.Block
 import Markdown.Inline
+import Nri.Ui.CssVendorPrefix.V1 as CssVendorPrefix
 import Nri.Ui.Highlightable.V3 as Highlightable exposing (Highlightable)
 import Nri.Ui.HighlighterTool.V1 as Tool
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
@@ -1670,7 +1671,7 @@ unmarkedHighlightableStyles config highlightable =
                     isHovered =
                         directlyHoveringInteractiveSegment config highlightable
                 in
-                Css.property "user-select" "none"
+                CssVendorPrefix.property "user-select" "none"
                     :: (case tool of
                             Tool.Marker marker ->
                                 if isHinted_ then
@@ -1767,7 +1768,7 @@ markedHighlightableStyles ({ maybeTool, mouseOverIndex, hintingIndices } as conf
             in
             case tool of
                 Tool.Marker marker ->
-                    [ Css.property "user-select" "none"
+                    [ CssVendorPrefix.property "user-select" "none"
                     , case List.head marked of
                         Just markedWith ->
                             if isHinted_ then
@@ -1801,7 +1802,7 @@ markedHighlightableStyles ({ maybeTool, mouseOverIndex, hintingIndices } as conf
                 Tool.Eraser eraser_ ->
                     case List.head marked of
                         Just markedWith ->
-                            [ Css.property "user-select" "none"
+                            [ CssVendorPrefix.property "user-select" "none"
                             , Css.batch markedWith.highlightClass
                             , Css.batch
                                 (if isHinted_ then
@@ -1816,7 +1817,7 @@ markedHighlightableStyles ({ maybeTool, mouseOverIndex, hintingIndices } as conf
                             ]
 
                         Nothing ->
-                            [ Css.property "user-select" "none", Css.backgroundColor Css.transparent ]
+                            [ CssVendorPrefix.property "user-select" "none", Css.backgroundColor Css.transparent ]
 
 
 {-| Helper for `on` to preventDefault.

--- a/src/Nri/Ui/Highlighter/V6.elm
+++ b/src/Nri/Ui/Highlighter/V6.elm
@@ -74,6 +74,7 @@ import List.Extra
 import Markdown.Block
 import Markdown.Inline
 import Maybe.Extra
+import Nri.Ui.CssVendorPrefix.V1 as CssVendorPrefix
 import Nri.Ui.Highlightable.V3 as Highlightable exposing (Highlightable)
 import Nri.Ui.HighlighterTool.V1 as Tool
 import Nri.Ui.Html.Attributes.V2 as AttributesExtra
@@ -2016,7 +2017,7 @@ unmarkedHighlightableStyles config highlightable =
                     isHovered =
                         directlyHoveringInteractiveSegment config highlightable
                 in
-                Css.property "user-select" "none"
+                CssVendorPrefix.property "user-select" "none"
                     :: (case tool of
                             Tool.Marker marker ->
                                 if isHinted_ then
@@ -2113,7 +2114,7 @@ markedHighlightableStyles ({ maybeTool, mouseOverIndex, hintingIndices } as conf
             in
             case tool of
                 Tool.Marker marker ->
-                    [ Css.property "user-select" "none"
+                    [ CssVendorPrefix.property "user-select" "none"
                     , case List.head marked of
                         Just markedWith ->
                             if isHinted_ then
@@ -2147,7 +2148,7 @@ markedHighlightableStyles ({ maybeTool, mouseOverIndex, hintingIndices } as conf
                 Tool.Eraser eraser_ ->
                     case List.head marked of
                         Just markedWith ->
-                            [ Css.property "user-select" "none"
+                            [ CssVendorPrefix.property "user-select" "none"
                             , Css.batch markedWith.highlightClass
                             , Css.batch
                                 (if isHinted_ then
@@ -2162,7 +2163,7 @@ markedHighlightableStyles ({ maybeTool, mouseOverIndex, hintingIndices } as conf
                             ]
 
                         Nothing ->
-                            [ Css.property "user-select" "none", Css.backgroundColor Css.transparent ]
+                            [ CssVendorPrefix.property "user-select" "none", Css.backgroundColor Css.transparent ]
 
 
 {-| Helper for `on` to preventDefault.


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

We had problems on the Highlighter with Word Lookup, because students were able to select words freely in Highlighting assignments.

## :framed_picture: What does this change look like?

There are absolutely no visual changes in this PR, aside from fixing a Safari bug.

## Component completion checklist

- [X] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [X] Changes are clearly documented
  - [] Component docs include a changelog
  - [ ] Any new exposed functions or properties have docs
- [X] Changes extend to the Component Catalog
  - [ ] The Component Catalog is updated to use the newest version, if appropriate
  - [ ] The Component Catalog example version number is updated, if appropriate
  - [ ] Any new customizations are available from the Component Catalog
  - [ ] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [X] Changes to the component are tested/the new version of the component is tested
- [X] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [X] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [X] Please assign the following reviewers:
  - [ ] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [ ] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [ ] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
