### PR TITLE
Delete .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
Dependabot is disabled on this repo, so this file does nothing. Removing it to prevent confusion.