### PR TITLE
Add tooltips to icons

### DIFF
--- a/component-catalog/src/IconExamples.elm
+++ b/component-catalog/src/IconExamples.elm
@@ -298,69 +298,48 @@ viewWithCustomStyles { showIconName, openedTooltip } headerText icons =
 viewIcon : { openedTooltip : Maybe String } -> Bool -> ( String, Svg.Svg, List Css.Style ) -> Html Msg
 viewIcon { openedTooltip } showIconName ( name, icon, style ) =
     let
-        iconCss =
-            if List.isEmpty style then
-                [ Css.height (Css.px 25)
-                , Css.width (Css.px 25)
-                , Css.margin (Css.px 4)
-                , Css.color Colors.gray45
-                ]
+        iconHtml =
+            icon
+                |> Svg.withCss
+                    (if List.isEmpty style then
+                        [ Css.height (Css.px 25)
+                        , Css.width (Css.px 25)
+                        , Css.margin (Css.px 4)
+                        , Css.color Colors.gray45
+                        ]
 
-            else
-                style
-    in
-    if showIconName then
-        Html.div
-            [ css
-                [ Css.displayFlex
-                , Css.alignItems Css.center
-                , Css.backgroundColor Colors.gray96
-                , Css.borderRadius (Css.px 8)
-                , Css.padding2 (Css.px 5) (Css.px 10)
-                , Css.hover
-                    [ Css.backgroundColor Colors.glacier
-                    , Css.color Colors.azure
-                    , Css.Global.descendants
-                        [ Css.Global.selector "svg"
-                            [ Css.color Colors.azure
-                            ]
+                     else
+                        style
+                    )
+                |> Svg.toHtml
+
+        styles =
+            [ Css.displayFlex
+            , Css.alignItems Css.center
+            , Css.backgroundColor Colors.gray96
+            , Css.borderRadius (Css.px 8)
+            , Css.padding2 (Css.px 5) (Css.px 10)
+            , Css.hover
+                [ Css.backgroundColor Colors.glacier
+                , Css.color Colors.azure
+                , Css.Global.descendants
+                    [ Css.Global.selector "svg"
+                        [ Css.color Colors.azure
                         ]
                     ]
                 ]
             ]
-            [ icon
-                |> Svg.withCss iconCss
-                |> Svg.toHtml
+    in
+    if showIconName then
+        Html.div [ css styles ]
+            [ iconHtml
             , Text.smallBody [ Text.plaintext name ]
             ]
 
     else
         Tooltip.view
-            { trigger =
-                \_ ->
-                    Html.div
-                        [ css
-                            [ Css.displayFlex
-                            , Css.alignItems Css.center
-                            , Css.backgroundColor Colors.gray96
-                            , Css.borderRadius (Css.px 8)
-                            , Css.padding2 (Css.px 5) (Css.px 10)
-                            , Css.hover
-                                [ Css.backgroundColor Colors.glacier
-                                , Css.color Colors.azure
-                                , Css.Global.descendants
-                                    [ Css.Global.selector "svg"
-                                        [ Css.color Colors.azure
-                                        ]
-                                    ]
-                                ]
-                            ]
-                        ]
-                        [ icon
-                            |> Svg.withCss iconCss
-                            |> Svg.toHtml
-                        ]
-            , id = ""
+            { trigger = \_ -> Html.div [ css styles ] [ iconHtml ]
+            , id = "icon-tooltip__" ++ name
             }
             [ Tooltip.open (openedTooltip == Just name)
             , Tooltip.onToggle (ToggleTooltip name)

--- a/component-catalog/src/IconExamples.elm
+++ b/component-catalog/src/IconExamples.elm
@@ -339,7 +339,7 @@ viewIcon { openedTooltip } showIconName ( name, icon, style ) =
     else
         Tooltip.view
             { trigger = \_ -> Html.div [ css styles ] [ iconHtml ]
-            , id = "icon-tooltip__" ++ name
+            , id = safeIdWithPrefix "icon-tooltip" name
             }
             [ Tooltip.open (openedTooltip == Just name)
             , Tooltip.onToggle (ToggleTooltip name)

--- a/component-catalog/src/IconExamples.elm
+++ b/component-catalog/src/IconExamples.elm
@@ -313,32 +313,35 @@ viewIcon { openedTooltip } showIconName ( name, icon, style ) =
                     )
                 |> Svg.toHtml
 
-        styles =
-            [ Css.displayFlex
-            , Css.alignItems Css.center
-            , Css.backgroundColor Colors.gray96
-            , Css.borderRadius (Css.px 8)
-            , Css.padding2 (Css.px 5) (Css.px 10)
-            , Css.hover
-                [ Css.backgroundColor Colors.glacier
-                , Css.color Colors.azure
-                , Css.Global.descendants
-                    [ Css.Global.selector "svg"
-                        [ Css.color Colors.azure
+        container =
+            Html.div
+                [ css
+                    [ Css.displayFlex
+                    , Css.alignItems Css.center
+                    , Css.backgroundColor Colors.gray96
+                    , Css.borderRadius (Css.px 8)
+                    , Css.padding2 (Css.px 5) (Css.px 10)
+                    , Css.hover
+                        [ Css.backgroundColor Colors.glacier
+                        , Css.color Colors.azure
+                        , Css.Global.descendants
+                            [ Css.Global.selector "svg"
+                                [ Css.color Colors.azure
+                                ]
+                            ]
                         ]
                     ]
                 ]
-            ]
     in
     if showIconName then
-        Html.div [ css styles ]
+        container
             [ iconHtml
             , Text.smallBody [ Text.plaintext name ]
             ]
 
     else
         Tooltip.view
-            { trigger = \_ -> Html.div [ css styles ] [ iconHtml ]
+            { trigger = \_ -> container [ iconHtml ]
             , id = safeIdWithPrefix "icon-tooltip" name
             }
             [ Tooltip.open (openedTooltip == Just name)


### PR DESCRIPTION
This PR adds tooltips to icons when names are not displayed:

<img width="1271" height="697" alt="Screenshot 2026-04-22 at 10 31 29" src="https://github.com/user-attachments/assets/8bdfc306-cdc9-4289-b069-1222510a26ff" />
