### PR TITLE
Bump to `35.7.0`

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "35.6.0",
+    "version": "35.7.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
# :label: Bump for version `35.7.0`

## What changes does this release include?

- Backports the `dictionary` icon.
- Add tooltips to icons in the components catalog.

## How has the API changed?

```
This is a MINOR change.

---- Nri.Ui.UiIcon.V2 - MINOR ----

    Added:
        dictionary : Nri.Ui.Svg.V1.Svg
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).