### PR TITLE
Polish component catalog Settings/Code Sample layout.

### DIFF
--- a/component-catalog/src/Debug/Control.elm
+++ b/component-catalog/src/Debug/Control.elm
@@ -442,16 +442,24 @@ view_ msg (Control c) currentLabel =
             if currentLabel /= "" then
                 [ Html.fieldset
                     [ css
-                        [ border3 (px 1) solid Colors.gray75
-                        , borderRadius (px 3)
+                        [ border3 (px 1) solid Colors.gray85
+                        , borderRadius (px 8)
                         , minWidth (pct 45)
+                        , padding3 (px 8) (px 16) (px 16)
+                        , margin zero
+                        , alignSelf flexStart
+                        , backgroundColor Colors.white
                         ]
                     ]
                     (Html.legend
                         [ css
-                            [ fontSize (rem 1)
-                            , color Colors.navy
+                            [ fontSize (px 13)
+                            , fontWeight bold
+                            , letterSpacing (px 0.4)
+                            , textTransform uppercase
+                            , color Colors.gray45
                             , Fonts.baseFont
+                            , padding2 zero (px 6)
                             ]
                         ]
                         [ Html.text currentLabel ]

--- a/component-catalog/src/Debug/Control/View.elm
+++ b/component-catalog/src/Debug/Control/View.elm
@@ -10,17 +10,19 @@ module Debug.Control.View exposing
 -}
 
 import Css exposing (..)
+import Css.Global
 import Css.Media exposing (withMedia)
 import Debug.Control as Control exposing (Control)
 import EllieLink
 import Example
 import Html.Styled exposing (..)
-import Html.Styled.Attributes exposing (css)
+import Html.Styled.Attributes exposing (class, css)
 import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.MediaQuery.V1 exposing (mobile, notMobile)
-import Nri.Ui.Spacing.V1 as Spacing
+import Nri.Ui.Svg.V1 as Svg
+import Nri.Ui.UiIcon.V2 as UiIcon
 
 
 {-| -}
@@ -75,14 +77,16 @@ viewWithCustomControls config =
     in
     div
         [ css
-            [ marginTop Spacing.verticalSpacerPx
-            , displayFlex
+            [ displayFlex
             , withMedia [ mobile ] [ flexDirection column ]
             ]
         ]
         [ Container.view
             [ Container.html
-                [ Heading.h2 [ Heading.plaintext "Settings" ]
+                [ Heading.h2
+                    [ Heading.plaintext "Settings"
+                    , Heading.css [ marginBottom (px 16) ]
+                    ]
                 , config.controls
                 ]
             , Container.css
@@ -120,6 +124,7 @@ viewWithCustomControls config =
 
                     _ ->
                         codeSampleHeading
+                            :: codeSampleStyles
                             :: List.map (\example -> viewCodeDetails (ellieLink example) example)
                                 config.exampleCode
                 )
@@ -151,7 +156,8 @@ codeSampleHeading =
 viewCodeDetails : Html msg -> { sectionName : String, code : String } -> Html msg
 viewCodeDetails ellieLink example =
     details
-        [ css
+        [ class detailsClass
+        , css
             [ paddingTop (px 5)
             , paddingBottom (px 5)
             , borderBottom3 (px 1) solid Colors.gray45
@@ -159,8 +165,30 @@ viewCodeDetails ellieLink example =
             , lastChild [ borderWidth zero, paddingBottom zero ]
             ]
         ]
-        [ summary [ css [ color Colors.mustard ] ]
-            [ Heading.h3
+        [ summary
+            [ css
+                [ color Colors.mustard
+                , cursor pointer
+                , displayFlex
+                , alignItems center
+                , property "gap" "8px"
+                ]
+            ]
+            [ span
+                [ class chevronClass
+                , css
+                    [ displayFlex
+                    , alignItems center
+                    , property "transition" "transform 150ms ease"
+                    ]
+                ]
+                [ UiIcon.arrowRight
+                    |> Svg.withColor Colors.mustard
+                    |> Svg.withWidth (px 12)
+                    |> Svg.withHeight (px 12)
+                    |> Svg.toHtml
+                ]
+            , Heading.h3
                 [ Heading.css [ display inline, color Colors.mustard ]
                 , Heading.plaintext example.sectionName
                 ]
@@ -175,6 +203,28 @@ viewCodeDetails ellieLink example =
                 ]
             ]
             [ viewCode example.code, ellieLink ]
+        ]
+
+
+detailsClass : String
+detailsClass =
+    "code-sample-details"
+
+
+chevronClass : String
+chevronClass =
+    "code-sample-chevron"
+
+
+codeSampleStyles : Html msg
+codeSampleStyles =
+    Css.Global.global
+        [ Css.Global.selector ("." ++ detailsClass ++ " > summary::-webkit-details-marker")
+            [ display none ]
+        , Css.Global.selector ("." ++ detailsClass ++ " > summary")
+            [ property "list-style" "none" ]
+        , Css.Global.selector ("." ++ detailsClass ++ "[open] > summary ." ++ chevronClass)
+            [ transforms [ rotate (deg 90) ] ]
         ]
 
 

--- a/component-catalog/src/Example.elm
+++ b/component-catalog/src/Example.elm
@@ -20,6 +20,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
 import Nri.Ui.Header.V1 as Header
 import Nri.Ui.MediaQuery.V1 exposing (mobile)
+import Nri.Ui.Spacing.V1 as Spacing
 
 
 type alias Example state msg =
@@ -171,18 +172,28 @@ view ellieLinkConfig example state =
 
 view_ : EllieLink.Config -> Example state msg -> state -> List (Html msg)
 view_ ellieLinkConfig example state =
-    [ Html.div
-        [ Attributes.css
-            [ Css.displayFlex
-            , Css.alignItems Css.stretch
-            , Css.flexWrap Css.wrap
-            , Css.property "gap" "10px"
-            , withMedia [ mobile ] [ Css.flexDirection Css.column, Css.alignItems Css.stretch ]
-            ]
-        ]
-        [ ExampleSection.aboutSection example.about
-        , KeyboardSupport.view example.keyboardSupport
-        ]
+    let
+        topSection =
+            case ( example.about, example.keyboardSupport ) of
+                ( [], [] ) ->
+                    Html.text ""
+
+                _ ->
+                    Html.div
+                        [ Attributes.css
+                            [ Css.displayFlex
+                            , Css.alignItems Css.stretch
+                            , Css.flexWrap Css.wrap
+                            , Css.property "gap" "10px"
+                            , Css.marginBottom Spacing.verticalSpacerPx
+                            , withMedia [ mobile ] [ Css.flexDirection Css.column, Css.alignItems Css.stretch ]
+                            ]
+                        ]
+                        [ ExampleSection.aboutSection example.about
+                        , KeyboardSupport.view example.keyboardSupport
+                        ]
+    in
+    [ topSection
     , Html.div [ Attributes.css [ Css.marginBottom (Css.px 200) ] ]
         (example.view ellieLinkConfig state)
     ]


### PR DESCRIPTION
## Context

Quality-of-life improvements to the Component Catalog's Settings panel and Code Sample expanders. No published-component changes.

## What changes

- Replace the native `<details>` disclosure triangle in the Code Sample expanders with a rotating `UiIcon.arrowRight` chevron, and give the `<summary>` a pointer cursor.
- Restyle Settings fieldsets: softer `gray85` border, 8px radius, 16px inner padding, white background, uppercase legend label.
- Add 16px breathing room below the **Settings** heading.
- Top-align fieldsets within the Settings grid (drop the stray `marginTop` on the second fieldset, add `align-self: flex-start`).
- Top-align the Settings/Code Sample container with the sidebar by removing its top margin.

## Screenshots

<img width="1173" height="394" alt="image" src="https://github.com/user-attachments/assets/5ea3e168-b860-420d-bc29-33c9d74894b7" />