### PR TITLE
Polish Container example page.

### DIFF
--- a/component-catalog/src/Examples/Container.elm
+++ b/component-catalog/src/Examples/Container.elm
@@ -16,9 +16,12 @@ import Debug.Control.View as ControlView
 import Example exposing (Example)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes exposing (css)
+import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Container.V2 as Container
+import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Spacing.V1 as Spacing
+import Nri.Ui.Text.V6 as Text
 
 
 moduleName : String
@@ -91,31 +94,40 @@ example =
                 [ Heading.plaintext "Customizable Examples"
                 , Heading.css [ Css.marginTop Spacing.verticalSpacerPx ]
                 ]
-            , viewExample
-                { name = "Default Container"
-                , description = "Your go-to container."
-                }
-                (Container.default :: attributes)
-            , viewExample
-                { name = "Gray Container"
-                , description = "A container that doesn’t draw too much attention to itself."
-                }
-                (Container.gray :: attributes)
-            , viewExample
-                { name = "Pillow Container"
-                , description = "When you want something big and soft."
-                }
-                (Container.pillow :: attributes)
-            , viewExample
-                { name = "Buttony Container"
-                , description = "Used for clickable button card things."
-                }
-                (Container.buttony :: attributes)
-            , viewExample
-                { name = "Disabled Container"
-                , description = "Used to indicate content is locked/inaccessible"
-                }
-                (Container.disabled :: attributes)
+            , Html.div
+                [ css
+                    [ Css.property "display" "grid"
+                    , Css.property "grid-template-columns" "repeat(2, minmax(0, 1fr))"
+                    , Css.property "column-gap" "24px"
+                    , Css.property "row-gap" "8px"
+                    ]
+                ]
+                [ viewExample
+                    { name = "Default Container"
+                    , description = "Your go-to container."
+                    }
+                    (Container.default :: defaultExampleContent :: attributes)
+                , viewExample
+                    { name = "Gray Container"
+                    , description = "A container that doesn’t draw too much attention to itself."
+                    }
+                    (Container.gray :: grayExampleContent :: attributes)
+                , viewExample
+                    { name = "Pillow Container"
+                    , description = "When you want something big and soft."
+                    }
+                    (Container.pillow :: pillowExampleContent :: attributes)
+                , viewExample
+                    { name = "Buttony Container"
+                    , description = "Used for clickable button card things."
+                    }
+                    (Container.buttony :: buttonyExampleContent :: attributes)
+                , viewExample
+                    { name = "Disabled Container"
+                    , description = "Used to indicate content is locked/inaccessible"
+                    }
+                    (Container.disabled :: disabledExampleContent :: attributes)
+                ]
             ]
     }
 
@@ -124,12 +136,145 @@ viewExample : { name : String, description : String } -> List (Container.Attribu
 viewExample { name, description } attributes =
     Html.section
         [ css
-            [ Css.marginTop (Css.px 20)
+            [ Css.marginTop (Css.px 32)
             ]
         ]
-        [ Heading.h3 [ Heading.plaintext name ]
-        , Html.text description
+        [ Heading.h3
+            [ Heading.plaintext name
+            , Heading.css [ Css.margin Css.zero ]
+            ]
+        , Text.smallBodyGray
+            [ Text.css [ Css.margin3 (Css.px 2) Css.zero (Css.px 12) ]
+            , Text.plaintext description
+            ]
         , Container.view attributes
+        ]
+
+
+contentStack : List (Html msg) -> Container.Attribute msg
+contentStack children =
+    Container.html
+        [ Html.div
+            [ css
+                [ Css.displayFlex
+                , Css.flexDirection Css.column
+                , Css.property "gap" "8px"
+                ]
+            ]
+            children
+        ]
+
+
+contentTitle : String -> Html msg
+contentTitle text =
+    Heading.h3
+        [ Heading.plaintext text
+        , Heading.css [ Css.margin Css.zero ]
+        ]
+
+
+flushParagraphMargin : Text.Attribute msg
+flushParagraphMargin =
+    Text.css [ Css.margin Css.zero ]
+
+
+defaultExampleContent : Container.Attribute msg
+defaultExampleContent =
+    contentStack
+        [ contentTitle "Persuasive Essay: Should homework be banned?"
+        , Text.smallBodyGray
+            [ flushParagraphMargin
+            , Text.plaintext "Due Friday · 12 of 24 students have started"
+            ]
+        ]
+
+
+grayExampleContent : Container.Attribute msg
+grayExampleContent =
+    Container.html
+        [ Text.mediumBody
+            [ flushParagraphMargin
+            , Text.html
+                [ Html.strong [] [ Html.text "Tip: " ]
+                , Html.text "Students do their best work when assignments are released in small batches."
+                ]
+            ]
+        ]
+
+
+pillowExampleContent : Container.Attribute msg
+pillowExampleContent =
+    contentStack
+        [ Heading.h2
+            [ Heading.plaintext "Quick Write"
+            , Heading.css [ Css.margin Css.zero ]
+            ]
+        , Text.mediumBody
+            [ flushParagraphMargin
+            , Text.plaintext "Describe a tradition that matters to your family. Use vivid details so your reader can picture the scene."
+            ]
+        ]
+
+
+buttonyExampleContent : Container.Attribute msg
+buttonyExampleContent =
+    Container.html
+        [ Html.div
+            [ css
+                [ Css.displayFlex
+                , Css.alignItems Css.center
+                , Css.property "gap" "16px"
+                ]
+            ]
+            [ Html.div
+                [ css
+                    [ Css.flexShrink Css.zero
+                    , Css.width (Css.px 44)
+                    , Css.height (Css.px 44)
+                    , Css.borderRadius (Css.pct 50)
+                    , Css.backgroundColor Colors.frost
+                    , Css.color Colors.azure
+                    , Css.displayFlex
+                    , Css.alignItems Css.center
+                    , Css.justifyContent Css.center
+                    , Css.fontSize (Css.px 18)
+                    , Fonts.baseFont
+                    ]
+                ]
+                [ Html.text "▶" ]
+            , Html.div
+                [ css
+                    [ Css.displayFlex
+                    , Css.flexDirection Css.column
+                    , Css.property "gap" "2px"
+                    ]
+                ]
+                [ Html.div
+                    [ css
+                        [ Fonts.baseFont
+                        , Css.fontWeight Css.bold
+                        , Css.color Colors.navy
+                        , Css.fontSize (Css.px 16)
+                        ]
+                    ]
+                    [ Html.text "Start practice: Comma splices" ]
+                , Text.caption
+                    [ flushParagraphMargin
+                    , Text.plaintext "About 10 minutes · Diagnostic"
+                    ]
+                ]
+            ]
+        ]
+
+
+disabledExampleContent : Container.Attribute msg
+disabledExampleContent =
+    contentStack
+        [ contentTitle "Unit 5: Argument Writing"
+        , Text.smallBody
+            [ flushParagraphMargin
+            , Text.plaintext "🔒 Complete Unit 4 to unlock this lesson."
+            ]
         ]
 
 
@@ -152,7 +297,7 @@ init =
         Control.list
             |> ControlExtra.listItems "Content"
                 (Control.list
-                    |> ControlExtra.listItem "content" controlContent
+                    |> ControlExtra.optionalListItem "content" controlContent
                 )
             |> ControlExtra.listItems "CSS & Style options"
                 (Control.list


### PR DESCRIPTION
## Context

The customizable examples on the Container component catalog page were demoing each variant with a generic "quick brown fox" pangram, which doesn't show off what each variant is actually for. This swaps in realistic NoRedInk-flavored content per variant, adopts our design-system text styles, and tightens the layout.

## :wrench: What changes

- **Realistic per-variant default content:** assignment card (Default), tip note (Gray), "Quick Write" prompt (Pillow), clickable practice card with badge (Buttony), locked unit (Disabled).
- **Content control is now optional** — the realistic defaults render until the user opts into the content control, instead of being permanently overridden by it.
- **Typography uses design-system styles** — `Text.smallBodyGray`, `Text.mediumBody`, `Text.smallBody`, `Text.caption`, and `Heading` instead of inline `Fonts` + `Css.fontSize` / `Css.color`.
- **Tighter, consistent spacing** — 32px between examples, 2px between section heading and blurb, paragraph margins flushed so the flex `gap` controls layout.
- **2-column grid** for the five customizable example cards.

## :framed_picture: What does this change look like?

_(add before/after screenshots — Container page showing the customizable examples grid)_

## Component completion checklist

- [x] Changes are clearly documented (no API changes; component code unchanged)
- [x] Changes extend to the Component Catalog (this PR is component-catalog-only)
- [x] The component example still has an accurate preview, valid sample code, correct keyboard behavior (none), and guidance
- [x] No new major version
- [ ] Reviewers
  - [ ] Component library owner

## Notes for reviewers

- Only `component-catalog/src/Examples/Container.elm` changes; the published `Nri.Ui.Container.V2` module is untouched.
- The customizable controls still override the default content when toggled on, so the page stays useful for experimenting.