### PR TITLE
Tooltip v4

### DIFF
--- a/component-catalog/src/App.elm
+++ b/component-catalog/src/App.elm
@@ -16,7 +16,9 @@ import Html.Styled.Attributes exposing (..)
 import Http
 import InputMethod exposing (InputMethod)
 import Json.Decode as Decode
+import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.CssVendorPrefix.V1 as VendorPrefixed
+import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Header.V1 as Header
 import Nri.Ui.MediaQuery.V1 exposing (mobile)
 import Nri.Ui.Page.V3 as Page
@@ -345,7 +347,12 @@ view model =
                 , Css.Global.global (InputMethod.styles model.inputMethod)
                 , Css.Global.global
                     [ Css.Global.everything [ Css.boxSizing Css.borderBox ]
-                    , Css.Global.body [ Css.margin Css.zero ]
+                    , Css.Global.body
+                        [ Css.margin Css.zero
+                        , Fonts.baseFont
+                        , Css.color Colors.gray20
+                        , Css.lineHeight (Css.num 1.5)
+                        ]
                     ]
                 ]
 

--- a/component-catalog/src/Examples/Tooltip.elm
+++ b/component-catalog/src/Examples/Tooltip.elm
@@ -17,7 +17,10 @@ import Debug.Control.Extra as ControlExtra
 import Debug.Control.View as ControlView
 import EllieLink
 import Example exposing (Example)
+import Html.Styled as RootHtml
 import Html.Styled.Attributes exposing (css, href, id)
+import Html.Styled.Events as Events
+import Json.Decode as Decode
 import KeyboardSupport exposing (Key(..))
 import List.Nonempty exposing (Nonempty(..))
 import Markdown
@@ -28,7 +31,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Heading.V3 as Heading
 import Nri.Ui.Svg.V1 as Svg
 import Nri.Ui.Table.V9 as Table
-import Nri.Ui.Tooltip.V3 as Tooltip
+import Nri.Ui.Tooltip.V4 as Tooltip
 import Nri.Ui.UiIcon.V2 as UiIcon
 import Routes
 import UsageExamples.ClickableCardWithTooltip
@@ -36,7 +39,7 @@ import UsageExamples.ClickableCardWithTooltip
 
 version : Int
 version =
-    3
+    4
 
 
 moduleName : String
@@ -83,7 +86,7 @@ example =
                 }
                 [ Tooltip.plaintext "This is a tooltip."
                 , Tooltip.open True
-                , Tooltip.onTop
+                , Tooltip.above
                 , Tooltip.smallPadding
                 , Tooltip.fitToContent
                 ]
@@ -98,7 +101,23 @@ type alias State =
     { openTooltip : Maybe TooltipId
     , staticExampleSettings : Control (List ( String, Tooltip.Attribute Never ))
     , pageSettings : Control PageSettings
+    , playground : PlaygroundState
     }
+
+
+type alias PlaygroundState =
+    { isOpen : Bool
+    , position : ( Float, Float )
+    , dragOffset : Maybe ( Float, Float )
+    , preferredSide : PreferredSide
+    }
+
+
+type PreferredSide
+    = PreferAbove
+    | PreferBelow
+    | PreferBefore
+    | PreferAfter
 
 
 init : State
@@ -107,13 +126,19 @@ init =
     , staticExampleSettings = initStaticExampleSettings
     , pageSettings =
         Control.record PageSettings
-            |> Control.field "backgroundColor"
+            |> Control.field "Background color"
                 (Control.choice
                     (Nonempty ( "white", Control.value Colors.white )
                         [ ( "azure", Control.value Colors.azure )
                         ]
                     )
                 )
+    , playground =
+        { isOpen = False
+        , position = ( 400, 300 )
+        , dragOffset = Nothing
+        , preferredSide = PreferAbove
+        }
     }
 
 
@@ -126,7 +151,6 @@ type TooltipId
     = PrimaryLabel
     | AuxillaryDescription
     | HelpfullyDisabled
-    | LearnMore
     | Disclosure
 
 
@@ -135,6 +159,12 @@ type Msg
     | SetControl (Control (List ( String, Tooltip.Attribute Never )))
     | UpdatePageSettings (Control PageSettings)
     | Log String
+    | OpenPlayground
+    | ClosePlayground
+    | StartDrag { mouseX : Float, mouseY : Float }
+    | DragMove { mouseX : Float, mouseY : Float }
+    | EndDrag
+    | SetPreferredSide PreferredSide
 
 
 update : Msg -> State -> ( State, Cmd Msg )
@@ -153,13 +183,76 @@ update msg model =
         UpdatePageSettings settings ->
             ( { model | pageSettings = settings }, Cmd.none )
 
-        Log message ->
-            ( Debug.log "Tooltip Log:" |> always model, Cmd.none )
+        Log _ ->
+            ( model, Cmd.none )
+
+        OpenPlayground ->
+            ( { model | playground = setPlaygroundOpen True model.playground }, Cmd.none )
+
+        ClosePlayground ->
+            ( { model | playground = setPlaygroundOpen False model.playground }, Cmd.none )
+
+        StartDrag { mouseX, mouseY } ->
+            let
+                ( px, py ) =
+                    model.playground.position
+
+                playground =
+                    model.playground
+            in
+            ( { model
+                | playground =
+                    { playground
+                        | dragOffset = Just ( mouseX - px, mouseY - py )
+                    }
+              }
+            , Cmd.none
+            )
+
+        DragMove { mouseX, mouseY } ->
+            case model.playground.dragOffset of
+                Just ( ox, oy ) ->
+                    let
+                        playground =
+                            model.playground
+                    in
+                    ( { model
+                        | playground =
+                            { playground
+                                | position = ( mouseX - ox, mouseY - oy )
+                            }
+                      }
+                    , Cmd.none
+                    )
+
+                Nothing ->
+                    ( model, Cmd.none )
+
+        EndDrag ->
+            let
+                playground =
+                    model.playground
+            in
+            ( { model | playground = { playground | dragOffset = Nothing } }, Cmd.none )
+
+        SetPreferredSide side ->
+            let
+                playground =
+                    model.playground
+            in
+            ( { model | playground = { playground | preferredSide = side } }, Cmd.none )
+
+
+setPlaygroundOpen : Bool -> PlaygroundState -> PlaygroundState
+setPlaygroundOpen isOpen playground =
+    { playground | isOpen = isOpen, dragOffset = Nothing }
 
 
 view : EllieLink.Config -> State -> List (Html Msg)
 view ellieLinkConfig model =
     [ viewCustomizableExample ellieLinkConfig model
+    , viewAutoFlipPlaygroundLauncher
+    , viewAutoFlipPlayground model.staticExampleSettings model.playground
     , Heading.h2 [ Heading.plaintext "What type of tooltip should I use?" ]
     , Table.view []
         [ Table.string
@@ -240,9 +333,7 @@ Use when all of the following are true:
 """
           , description =
                 """
-Tooltip.helpfullyDisabled provides information about ***why*** the tooltip trigger is disabled. Learn more about the [helpfully disabled pattern in the docs](https://paper.dropbox.com/doc/Helpfully-disabled-components--CI8Ma_KHKL1CcCWpWG~p_RTwAg-2RUPgKnBsBNI7ScGDHS73) and watch [Charbel's demo on the Helpfully Disabled pattern](https://noredink.zoom.us/rec/play/fwV3mqsxjvF_95N2au0vAN2PmnH2IHZx2yCoAQ76gvZ0fLlrkNcFIuVL6i7ze7y1ivSxq0f6e2EXE-RJ.kHMKX9CBHI1kFM50?canPlayFromShare=true&from=share_recording_detail&continueMode=true&componentName=rec-play&originRequestUrl=https://noredink.zoom.us/rec/share/YvgK0427ADw42fY2edJ_tmkwwvPxz505Kpfhkz5DqF1_eh8sgj7wVfwBQ5FmieM8.P9YlMkM_XY_Kamm6&autoplay=true&startTime=1696520905000&_x_zm_rtaid=VeLjvOzDToKMf1R0XllC7A.1707171050117.67806369f8182aa5b282c10165d75544&_x_zm_rhtaid=323).
-
-
+Tooltip.helpfullyDisabled provides information about ***why*** the tooltip trigger is disabled.
 
 Example:
 - A tooltip might appear on a disabled button to inform the user that the button will become enabled once they've filled out a required form.
@@ -254,7 +345,6 @@ Example:
           , usage = """
 Use when all of the following are true:
 - the tooltip trigger only opens the tooltip without doing anything else
-- the tooltip trigger ***isn't*** a "?" icon (Use Tooltip.viewToggleTip for this case.)
 
 This type may contain interactive elements such as links.
         """
@@ -268,25 +358,6 @@ This type may contain interactive elements such as links.
                     |> String.join ""
           , example = viewDisclosureTooltip model.openTooltip
           , tooltipId = Disclosure
-          }
-        , { name = "Tooltip.viewToggleTip"
-          , usage = """
-Use when all of the following are true:
-- the tooltip trigger only opens the tooltip without doing anything else
-- the tooltip trigger ***is*** a "?" icon
-
-This type may contain interactive elements such as links.
-
-        """
-          , description =
-                [ "This is a helper for using Tooltip.disclosure with a \"?\" icon because it is a commonly used UI pattern. We use this helper when we want to show more information about an element but we don't want the element itself to have its own tooltip. The \"?\" icon typically appears visually adjacent to the element it reveals information about.\n\n"
-                , "Are you trying to use this tooltip type inside a clickable card? Check out [the Clickable Card with Tooltip example]("
-                , Routes.usageExampleHref UsageExamples.ClickableCardWithTooltip.example
-                , ")."
-                ]
-                    |> String.join ""
-          , example = viewToggleTip model.openTooltip
-          , tooltipId = LearnMore
           }
         ]
     ]
@@ -331,7 +402,7 @@ viewAuxillaryDescriptionTooltip openTooltip =
         , Tooltip.open (openTooltip == Just AuxillaryDescription)
         , Tooltip.smallPadding
         , Tooltip.fitToContent
-        , Tooltip.onLeftForMobile
+        , Tooltip.forBreakpoint Tooltip.mobile [ Tooltip.before ]
         ]
 
 
@@ -351,7 +422,7 @@ viewHelpfullyDisabledTooltip openTooltip =
         , Tooltip.helpfullyDisabled
         , Tooltip.onToggle (ToggleTooltip HelpfullyDisabled)
         , Tooltip.open (openTooltip == Just HelpfullyDisabled)
-        , Tooltip.onLeftForMobile
+        , Tooltip.forBreakpoint Tooltip.mobile [ Tooltip.before ]
         ]
 
 
@@ -386,20 +457,7 @@ viewDisclosureTooltip openTooltip =
         , Tooltip.onToggle (ToggleTooltip Disclosure)
         , Tooltip.open (openTooltip == Just Disclosure)
         , Tooltip.smallPadding
-        , Tooltip.alignEndForMobile (Css.px 148)
-        ]
-
-
-viewToggleTip : Maybe TooltipId -> Html Msg
-viewToggleTip openTooltip =
-    Html.span [ css [ Css.displayFlex, Css.alignItems Css.center, Css.justifyContent Css.center ] ]
-        [ Html.text "Mastery"
-        , Tooltip.viewToggleTip { label = "What is mastery?", lastId = Nothing }
-            [ Tooltip.plaintext "Students master topics by correctly answering a series of questions of varying difficulty and scope."
-            , Tooltip.onToggle (ToggleTooltip LearnMore)
-            , Tooltip.open (openTooltip == Just LearnMore)
-            , Tooltip.alignEndForMobile (Css.px 144)
-            ]
+        , Tooltip.forBreakpoint Tooltip.mobile [ Tooltip.alignEnd ]
         ]
 
 
@@ -408,19 +466,11 @@ initStaticExampleSettings =
     Control.list
         |> ControlExtra.listItem "content" controlContent
         |> ControlExtra.optionalBoolListItem "withoutTail" ( "Tooltip.withoutTail", Tooltip.withoutTail )
-        |> ControlExtra.listItems "direction"
+        |> ControlExtra.optionalBoolListItem "noFlip" ( "Tooltip.noFlip", Tooltip.noFlip )
+        |> ControlExtra.listItems "Position"
             (Control.list
-                |> ControlExtra.optionalListItem "direction" controlDirection
-                |> ControlExtra.optionalListItem "direction (viewport <= 1000px)" controlDirectionForMobile
-                |> ControlExtra.optionalListItem "direction (viewport <= 750px)" controlDirectionForQuizEngineMobile
-                |> ControlExtra.optionalListItem "direction (viewport <= 500px)" controlDirectionForNarrowMobile
-            )
-        |> ControlExtra.listItems "alignment"
-            (Control.list
+                |> ControlExtra.optionalListItem "position" controlPosition
                 |> ControlExtra.optionalListItem "alignment" controlAlignment
-                |> ControlExtra.optionalListItem "alignment (viewport <= 1000px)" controlAlignmentForMobile
-                |> ControlExtra.optionalListItem "alignment (viewport <= 750px)" controlAlignmentForQuizEngineMobile
-                |> ControlExtra.optionalListItem "alignment (viewport <= 500px)" controlAlignmentForNarrowMobile
             )
         |> ControlExtra.listItems "Size & Padding"
             (Control.list
@@ -430,10 +480,6 @@ initStaticExampleSettings =
         |> ControlExtra.listItems "CSS"
             (Control.list
                 |> CommonControls.css { moduleName = moduleName, use = Tooltip.css }
-                |> CommonControls.mobileCss { moduleName = moduleName, use = Tooltip.mobileCss }
-                |> CommonControls.quizEngineMobileCss { moduleName = moduleName, use = Tooltip.quizEngineMobileCss }
-                |> CommonControls.narrowMobileCss { moduleName = moduleName, use = Tooltip.narrowMobileCss }
-                |> CommonControls.notMobileCss { moduleName = moduleName, use = Tooltip.notMobileCss }
             )
 
 
@@ -449,108 +495,25 @@ controlContent =
         }
 
 
-controlDirection : Control ( String, Tooltip.Attribute Never )
-controlDirection =
+controlPosition : Control ( String, Tooltip.Attribute Never )
+controlPosition =
     CommonControls.choice "Tooltip"
-        (Nonempty ( "onTop", Tooltip.onTop )
-            [ ( "onBottom", Tooltip.onBottom )
-            , ( "onLeft", Tooltip.onLeft )
-            , ( "onRight", Tooltip.onRight )
+        (Nonempty ( "above", Tooltip.above )
+            [ ( "below", Tooltip.below )
+            , ( "before", Tooltip.before )
+            , ( "after", Tooltip.after )
             ]
-        )
-
-
-controlDirectionForMobile : Control ( String, Tooltip.Attribute Never )
-controlDirectionForMobile =
-    CommonControls.choice "Tooltip"
-        (Nonempty ( "onTopForMobile", Tooltip.onTopForMobile )
-            [ ( "onBottomForMobile", Tooltip.onBottomForMobile )
-            , ( "onLeftForMobile", Tooltip.onLeftForMobile )
-            , ( "onRightForMobile", Tooltip.onRightForMobile )
-            ]
-        )
-
-
-controlDirectionForQuizEngineMobile : Control ( String, Tooltip.Attribute Never )
-controlDirectionForQuizEngineMobile =
-    CommonControls.choice "Tooltip"
-        (Nonempty ( "onTopForQuizEngineMobile", Tooltip.onTopForQuizEngineMobile )
-            [ ( "onBottomForQuizEngineMobile", Tooltip.onBottomForQuizEngineMobile )
-            , ( "onLeftForQuizEngineMobile", Tooltip.onLeftForQuizEngineMobile )
-            , ( "onRightForQuizEngineMobile", Tooltip.onRightForQuizEngineMobile )
-            ]
-        )
-
-
-controlDirectionForNarrowMobile : Control ( String, Tooltip.Attribute Never )
-controlDirectionForNarrowMobile =
-    CommonControls.choice "Tooltip"
-        (Nonempty ( "onTopForNarrowMobile", Tooltip.onTopForNarrowMobile )
-            [ ( "onBottomForNarrowMobile", Tooltip.onBottomForNarrowMobile )
-            , ( "onLeftForNarrowMobile", Tooltip.onLeftForNarrowMobile )
-            , ( "onRightForNarrowMobile", Tooltip.onRightForNarrowMobile )
-            ]
-        )
-
-
-controlAlignment_ :
-    ( String, Tooltip.Attribute Never )
-    -> List ( String, Css.Px -> Tooltip.Attribute Never )
-    -> Control ( String, Tooltip.Attribute Never )
-controlAlignment_ ( middleName, middleValue ) others =
-    Control.choice
-        (Nonempty ( middleName, Control.value ( "Tooltip." ++ middleName, middleValue ) )
-            (List.map
-                (\( name, val ) ->
-                    ( name
-                    , Control.map
-                        (\float ->
-                            ( "Tooltip." ++ name ++ " (Css.px " ++ String.fromFloat float ++ ")"
-                            , val (Css.px float)
-                            )
-                        )
-                        (Control.float 0)
-                    )
-                )
-                others
-            )
         )
 
 
 controlAlignment : Control ( String, Tooltip.Attribute Never )
 controlAlignment =
-    controlAlignment_
-        ( "alignMiddle", Tooltip.alignMiddle )
-        [ ( "alignStart", Tooltip.alignStart )
-        , ( "alignEnd", Tooltip.alignEnd )
-        ]
-
-
-controlAlignmentForMobile : Control ( String, Tooltip.Attribute Never )
-controlAlignmentForMobile =
-    controlAlignment_
-        ( "alignMiddleForMobile", Tooltip.alignMiddleForMobile )
-        [ ( "alignStartForMobile", Tooltip.alignStartForMobile )
-        , ( "alignEndForMobile", Tooltip.alignEndForMobile )
-        ]
-
-
-controlAlignmentForQuizEngineMobile : Control ( String, Tooltip.Attribute Never )
-controlAlignmentForQuizEngineMobile =
-    controlAlignment_
-        ( "alignMiddleForQuizEngineMobile", Tooltip.alignMiddleForQuizEngineMobile )
-        [ ( "alignStartForQuizEngineMobile", Tooltip.alignStartForQuizEngineMobile )
-        , ( "alignEndForQuizEngineMobile", Tooltip.alignEndForQuizEngineMobile )
-        ]
-
-
-controlAlignmentForNarrowMobile : Control ( String, Tooltip.Attribute Never )
-controlAlignmentForNarrowMobile =
-    controlAlignment_
-        ( "alignMiddleForNarrowMobile", Tooltip.alignMiddleForNarrowMobile )
-        [ ( "alignStartForNarrowMobile", Tooltip.alignStartForNarrowMobile )
-        , ( "alignEndForNarrowMobile", Tooltip.alignEndForNarrowMobile )
-        ]
+    CommonControls.choice "Tooltip"
+        (Nonempty ( "alignMiddle", Tooltip.alignMiddle )
+            [ ( "alignStart", Tooltip.alignStart )
+            , ( "alignEnd", Tooltip.alignEnd )
+            ]
+        )
 
 
 controlWidth : Control ( String, Tooltip.Attribute Never )
@@ -625,29 +588,292 @@ viewCustomizableExample ellieLinkConfig ({ staticExampleSettings } as state) =
                       }
                     ]
             }
-        , Control.view UpdatePageSettings state.pageSettings
         , Html.div
             [ css
-                [ Css.displayFlex
-                , Css.justifyContent Css.center
-                , Css.alignItems Css.center
-                , Css.height (Css.px 300)
-                , Css.backgroundColor pageSettings.backgroundColor
+                [ Css.marginTop (Css.px 16)
+                , Css.borderRadius (Css.px 12)
+                , Css.border3 (Css.px 1) Css.solid Colors.gray85
+                , Css.overflow Css.hidden
+                , Css.backgroundColor Colors.white
                 ]
             ]
-            [ Tooltip.view
-                { trigger =
-                    \eventHandlers ->
-                        ClickableSvg.button "Up"
-                            UiIcon.arrowTop
-                            [ ClickableSvg.custom eventHandlers
-                            , ClickableSvg.withBorder
-                            ]
-                , id = "an-id-for-the-tooltip"
-                }
-                (Tooltip.open True
-                    :: List.map Tuple.second (Control.currentValue staticExampleSettings)
-                )
-                |> Html.map never
+            [ Html.div
+                [ css
+                    [ Css.padding2 (Css.px 8) (Css.px 12)
+                    , Css.borderBottom3 (Css.px 1) Css.solid Colors.gray92
+                    , Css.displayFlex
+                    , Css.alignItems Css.center
+                    , Css.justifyContent Css.spaceBetween
+                    ]
+                ]
+                [ Html.span
+                    [ css
+                        [ Css.fontSize (Css.px 12)
+                        , Css.color Colors.gray45
+                        , Css.property "text-transform" "uppercase"
+                        , Css.property "letter-spacing" "0.5px"
+                        , Css.fontWeight Css.bold
+                        ]
+                    ]
+                    [ Html.text "Preview" ]
+                , Control.view UpdatePageSettings state.pageSettings
+                ]
+            , Html.div
+                [ css
+                    [ Css.displayFlex
+                    , Css.justifyContent Css.center
+                    , Css.alignItems Css.center
+                    , Css.minHeight (Css.px 220)
+                    , Css.padding (Css.px 24)
+                    , Css.backgroundColor pageSettings.backgroundColor
+                    ]
+                ]
+                [ Tooltip.view
+                    { trigger =
+                        \eventHandlers ->
+                            ClickableSvg.button "Up"
+                                UiIcon.arrowTop
+                                [ ClickableSvg.custom eventHandlers
+                                , ClickableSvg.withBorder
+                                ]
+                    , id = "an-id-for-the-tooltip"
+                    }
+                    (Tooltip.open True
+                        :: List.map Tuple.second (Control.currentValue staticExampleSettings)
+                    )
+                    |> Html.map never
+                ]
             ]
         ]
+
+
+
+-- AUTO-FLIP PLAYGROUND
+
+
+viewAutoFlipPlaygroundLauncher : Html Msg
+viewAutoFlipPlaygroundLauncher =
+    Html.div
+        [ css
+            [ Css.marginTop (Css.px 32)
+            , Css.marginBottom (Css.px 32)
+            , Css.padding (Css.px 24)
+            , Css.borderRadius (Css.px 12)
+            , Css.border3 (Css.px 1) Css.solid Colors.gray85
+            , Css.backgroundColor Colors.frost
+            , Css.displayFlex
+            , Css.alignItems Css.center
+            , Css.justifyContent Css.spaceBetween
+            , Css.property "gap" "24px"
+            ]
+        ]
+        [ Html.div []
+            [ Heading.h2
+                [ Heading.plaintext "Auto-flip playground"
+                , Heading.css [ Css.margin Css.zero, Css.fontSize (Css.px 18) ]
+                ]
+            , Html.p
+                [ css
+                    [ Css.marginTop (Css.px 6)
+                    , Css.marginBottom Css.zero
+                    , Css.color Colors.gray20
+                    , Css.maxWidth (Css.px 560)
+                    ]
+                ]
+                [ Html.text "Drag a trigger anywhere on the page to watch the tooltip flip sides and re-anchor its tail when it would otherwise clip the viewport." ]
+            ]
+        , Button.button "Open playground"
+            [ Button.onClick OpenPlayground
+            , Button.medium
+            , Button.secondary
+            ]
+        ]
+
+
+viewAutoFlipPlayground :
+    Control (List ( String, Tooltip.Attribute Never ))
+    -> PlaygroundState
+    -> Html Msg
+viewAutoFlipPlayground exampleSettings state =
+    if not state.isOpen then
+        Html.text ""
+
+    else
+        let
+            ( px, py ) =
+                state.position
+
+            preferredAttr =
+                case state.preferredSide of
+                    PreferAbove ->
+                        Tooltip.above
+
+                    PreferBelow ->
+                        Tooltip.below
+
+                    PreferBefore ->
+                        Tooltip.before
+
+                    PreferAfter ->
+                        Tooltip.after
+
+            inheritedAttrs =
+                Control.currentValue exampleSettings
+                    |> List.map Tuple.second
+
+            overlayMouseEvents =
+                case state.dragOffset of
+                    Just _ ->
+                        [ onMouseMovePosition DragMove
+                        , Events.onMouseUp EndDrag
+                        ]
+
+                    Nothing ->
+                        []
+        in
+        RootHtml.div
+            ([ css
+                [ Css.position Css.fixed
+                , Css.top Css.zero
+                , Css.left Css.zero
+                , Css.right Css.zero
+                , Css.bottom Css.zero
+                , Css.backgroundColor (Css.rgba 250 250 250 0.98)
+                , Css.zIndex (Css.int 9999)
+                , Css.property "user-select" "none"
+                ]
+             ]
+                ++ overlayMouseEvents
+            )
+            [ RootHtml.div
+                [ css
+                    [ Css.position Css.absolute
+                    , Css.top (Css.px 16)
+                    , Css.left (Css.px 16)
+                    , Css.padding2 (Css.px 12) (Css.px 16)
+                    , Css.backgroundColor Colors.white
+                    , Css.borderRadius (Css.px 8)
+                    , Css.boxShadow5 Css.zero (Css.px 4) (Css.px 16) Css.zero (Css.rgba 0 0 0 0.2)
+                    , Css.displayFlex
+                    , Css.alignItems Css.center
+                    , Css.property "gap" "12px"
+                    ]
+                ]
+                [ RootHtml.text "Preferred side:"
+                , viewSideButton state.preferredSide PreferAbove "above"
+                , viewSideButton state.preferredSide PreferBelow "below"
+                , viewSideButton state.preferredSide PreferBefore "before"
+                , viewSideButton state.preferredSide PreferAfter "after"
+                , RootHtml.div [ css [ Css.width (Css.px 16) ] ] []
+                , Button.button "Close playground"
+                    [ Button.onClick ClosePlayground
+                    , Button.small
+                    , Button.tertiary
+                    ]
+                ]
+            , RootHtml.div
+                [ css
+                    [ Css.position Css.absolute
+                    , Css.left (Css.px px)
+                    , Css.top (Css.px py)
+                    ]
+                , onMouseDownPosition StartDrag
+                ]
+                [ Tooltip.view
+                    { id = "auto-flip-playground-tooltip"
+                    , trigger =
+                        \attrs ->
+                            RootHtml.div
+                                (attrs
+                                    ++ [ Html.Styled.Attributes.css
+                                            [ Css.width (Css.px 96)
+                                            , Css.height (Css.px 96)
+                                            , Css.borderRadius (Css.pct 50)
+                                            , Css.backgroundColor Colors.azure
+                                            , Css.color Colors.white
+                                            , Css.displayFlex
+                                            , Css.alignItems Css.center
+                                            , Css.justifyContent Css.center
+                                            , Css.fontWeight Css.bold
+                                            , Css.cursor Css.move
+                                            , Css.boxShadow5 Css.zero (Css.px 2) (Css.px 8) Css.zero (Css.rgba 0 0 0 0.3)
+                                            ]
+                                       ]
+                                )
+                                [ RootHtml.text "Drag" ]
+                    }
+                    (inheritedAttrs
+                        ++ [ Tooltip.plaintext
+                                ("I prefer to be \""
+                                    ++ sideLabel state.preferredSide
+                                    ++ "\", but I will flip if I would clip the viewport."
+                                )
+                           , preferredAttr
+                           , Tooltip.open True
+                           ]
+                    )
+                    |> Html.map never
+                ]
+            ]
+
+
+viewSideButton : PreferredSide -> PreferredSide -> String -> RootHtml.Html Msg
+viewSideButton current target label =
+    RootHtml.button
+        [ Events.onClick (SetPreferredSide target)
+        , css
+            [ Css.padding2 (Css.px 4) (Css.px 10)
+            , Css.borderRadius (Css.px 4)
+            , Css.border3 (Css.px 1)
+                Css.solid
+                (if current == target then
+                    Colors.azure
+
+                 else
+                    Colors.gray85
+                )
+            , Css.backgroundColor
+                (if current == target then
+                    Colors.frost
+
+                 else
+                    Colors.white
+                )
+            , Css.cursor Css.pointer
+            , Css.fontSize (Css.px 13)
+            ]
+        ]
+        [ RootHtml.text label ]
+
+
+sideLabel : PreferredSide -> String
+sideLabel side =
+    case side of
+        PreferAbove ->
+            "above"
+
+        PreferBelow ->
+            "below"
+
+        PreferBefore ->
+            "before"
+
+        PreferAfter ->
+            "after"
+
+
+onMouseDownPosition : ({ mouseX : Float, mouseY : Float } -> msg) -> RootHtml.Attribute msg
+onMouseDownPosition toMsg =
+    Events.on "mousedown" (mousePositionDecoder |> Decode.map toMsg)
+
+
+onMouseMovePosition : ({ mouseX : Float, mouseY : Float } -> msg) -> RootHtml.Attribute msg
+onMouseMovePosition toMsg =
+    Events.on "mousemove" (mousePositionDecoder |> Decode.map toMsg)
+
+
+mousePositionDecoder : Decode.Decoder { mouseX : Float, mouseY : Float }
+mousePositionDecoder =
+    Decode.map2 (\x y -> { mouseX = x, mouseY = y })
+        (Decode.field "clientX" Decode.float)
+        (Decode.field "clientY" Decode.float)

--- a/lib/Tooltip/V4.js
+++ b/lib/Tooltip/V4.js
@@ -41,12 +41,23 @@ var OPPOSITE = {
   right: "left",
 };
 
+function rectsEqual(a, b) {
+  if (!a || !b) return false;
+  return (
+    a.top === b.top &&
+    a.left === b.left &&
+    a.right === b.right &&
+    a.bottom === b.bottom
+  );
+}
+
 CustomElement.create({
   tagName: "nri-tooltip-auto",
 
   initialize: function () {
-    this._scheduled = false;
-    this._onScrollOrResize = this._onScrollOrResize.bind(this);
+    this._rafId = null;
+    this._lastTriggerRect = null;
+    this._tick = this._tick.bind(this);
     this._update = this._update.bind(this);
   },
 
@@ -59,46 +70,38 @@ CustomElement.create({
   ],
 
   onAttributeChange: function () {
-    this._schedule();
+    this._lastTriggerRect = null;
   },
 
   onConnect: function () {
-    window.addEventListener("scroll", this._onScrollOrResize, true);
-    window.addEventListener("resize", this._onScrollOrResize);
-
-    if (typeof ResizeObserver === "function") {
-      this._resizeObserver = new ResizeObserver(this._onScrollOrResize);
-      var trigger = this._getTrigger();
-      var tooltip = this._getTooltip();
-      if (trigger) this._resizeObserver.observe(trigger);
-      if (tooltip) this._resizeObserver.observe(tooltip);
-    }
-
-    this._schedule();
+    // requestAnimationFrame loop: cheap (a couple of layout reads + maybe a
+    // setAttribute) and catches every kind of position change, including
+    // ones we can't observe directly (e.g. an ancestor's `left`/`top`
+    // changing during a drag, layout reflows from sibling content, etc.).
+    // Only updates the DOM when the trigger's bounding rect actually
+    // changes, so the cost is mostly the rect read.
+    this._rafId = window.requestAnimationFrame(this._tick);
   },
 
   onDisconnect: function () {
-    window.removeEventListener("scroll", this._onScrollOrResize, true);
-    window.removeEventListener("resize", this._onScrollOrResize);
-    if (this._resizeObserver) {
-      this._resizeObserver.disconnect();
-      this._resizeObserver = null;
+    if (this._rafId !== null) {
+      window.cancelAnimationFrame(this._rafId);
+      this._rafId = null;
     }
+    this._lastTriggerRect = null;
   },
 
   methods: {
-    _onScrollOrResize: function () {
-      this._schedule();
-    },
-
-    _schedule: function () {
-      if (this._scheduled) return;
-      this._scheduled = true;
-      var self = this;
-      window.requestAnimationFrame(function () {
-        self._scheduled = false;
-        self._update();
-      });
+    _tick: function () {
+      var trigger = this._getTrigger();
+      if (trigger) {
+        var rect = trigger.getBoundingClientRect();
+        if (!rectsEqual(rect, this._lastTriggerRect)) {
+          this._lastTriggerRect = rect;
+          this._update(rect);
+        }
+      }
+      this._rafId = window.requestAnimationFrame(this._tick);
     },
 
     _getTrigger: function () {
@@ -111,17 +114,14 @@ CustomElement.create({
       return id ? document.getElementById(id) : null;
     },
 
-    _update: function () {
-      var trigger = this._getTrigger();
+    _update: function (triggerRect) {
       var tooltip = this._getTooltip();
-      if (!trigger || !tooltip) return;
+      if (!triggerRect || !tooltip) return;
 
       var preferredPos = this.getAttribute("data-preferred-position") || "top";
       var preferredAlign =
         this.getAttribute("data-preferred-align") || "middle";
-      var offset = Number(this.getAttribute("data-offset")) || 8;
-
-      var triggerRect = trigger.getBoundingClientRect();
+      var offset = Number(this.getAttribute("data-offset")) || 12;
       // Measure tooltip natural size while neutralizing transforms by
       // reading offsetWidth/Height; getBoundingClientRect would include
       // any transform we apply for the current data-position.

--- a/lib/Tooltip/V4.js
+++ b/lib/Tooltip/V4.js
@@ -1,0 +1,201 @@
+"use strict";
+
+/**
+ * Custom element that powers `Nri.Ui.Tooltip.V4`'s auto-flip mode.
+ *
+ * The Elm view renders a `<nri-tooltip-auto>` wrapper around the trigger
+ * and tooltip when auto-positioning is enabled. This element observes the
+ * trigger's bounding rect and the viewport, and writes
+ * `data-position="top|bottom|left|right"` and
+ * `data-align="start|middle|end"` onto the tooltip element so that
+ * attribute-keyed CSS can flip the rendered position without round-tripping
+ * through Elm.
+ *
+ * Inputs (attributes on the custom element):
+ * - `data-trigger-id`     — id of the trigger element to measure against.
+ * - `data-tooltip-id`     — id of the tooltip element whose data-* attrs
+ *                           we mutate.
+ * - `data-preferred-position` — "top" | "bottom" | "left" | "right".
+ *                               Default: "top".
+ * - `data-preferred-align`    — "start" | "middle" | "end".
+ *                               Default: "middle".
+ * - `data-offset`         — numeric pixel gap between trigger and tooltip.
+ *                           Default: 8.
+ *
+ * Behaviour:
+ * - On connect, after the next paint, and on every viewport / scroll /
+ *   resize event, recompute. If the tooltip's natural bounding box at the
+ *   preferred position would clip the viewport, flip to the opposite side
+ *   (and shift align if the tail would otherwise point off the trigger).
+ * - If the preferred side fits, leave data-position alone — meaning a
+ *   tooltip explicitly positioned `above` only ever moves to `below` if it
+ *   would clip.
+ */
+
+var CustomElement = require("../CustomElement");
+
+var OPPOSITE = {
+  top: "bottom",
+  bottom: "top",
+  left: "right",
+  right: "left",
+};
+
+CustomElement.create({
+  tagName: "nri-tooltip-auto",
+
+  initialize: function () {
+    this._scheduled = false;
+    this._onScrollOrResize = this._onScrollOrResize.bind(this);
+    this._update = this._update.bind(this);
+  },
+
+  observedAttributes: [
+    "data-trigger-id",
+    "data-tooltip-id",
+    "data-preferred-position",
+    "data-preferred-align",
+    "data-offset",
+  ],
+
+  onAttributeChange: function () {
+    this._schedule();
+  },
+
+  onConnect: function () {
+    window.addEventListener("scroll", this._onScrollOrResize, true);
+    window.addEventListener("resize", this._onScrollOrResize);
+
+    if (typeof ResizeObserver === "function") {
+      this._resizeObserver = new ResizeObserver(this._onScrollOrResize);
+      var trigger = this._getTrigger();
+      var tooltip = this._getTooltip();
+      if (trigger) this._resizeObserver.observe(trigger);
+      if (tooltip) this._resizeObserver.observe(tooltip);
+    }
+
+    this._schedule();
+  },
+
+  onDisconnect: function () {
+    window.removeEventListener("scroll", this._onScrollOrResize, true);
+    window.removeEventListener("resize", this._onScrollOrResize);
+    if (this._resizeObserver) {
+      this._resizeObserver.disconnect();
+      this._resizeObserver = null;
+    }
+  },
+
+  methods: {
+    _onScrollOrResize: function () {
+      this._schedule();
+    },
+
+    _schedule: function () {
+      if (this._scheduled) return;
+      this._scheduled = true;
+      var self = this;
+      window.requestAnimationFrame(function () {
+        self._scheduled = false;
+        self._update();
+      });
+    },
+
+    _getTrigger: function () {
+      var id = this.getAttribute("data-trigger-id");
+      return id ? document.getElementById(id) : null;
+    },
+
+    _getTooltip: function () {
+      var id = this.getAttribute("data-tooltip-id");
+      return id ? document.getElementById(id) : null;
+    },
+
+    _update: function () {
+      var trigger = this._getTrigger();
+      var tooltip = this._getTooltip();
+      if (!trigger || !tooltip) return;
+
+      var preferredPos = this.getAttribute("data-preferred-position") || "top";
+      var preferredAlign =
+        this.getAttribute("data-preferred-align") || "middle";
+      var offset = Number(this.getAttribute("data-offset")) || 8;
+
+      var triggerRect = trigger.getBoundingClientRect();
+      // Measure tooltip natural size while neutralizing transforms by
+      // reading offsetWidth/Height; getBoundingClientRect would include
+      // any transform we apply for the current data-position.
+      var tooltipWidth = tooltip.offsetWidth;
+      var tooltipHeight = tooltip.offsetHeight;
+
+      var viewportWidth =
+        document.documentElement.clientWidth || window.innerWidth;
+      var viewportHeight =
+        document.documentElement.clientHeight || window.innerHeight;
+
+      var fits = function (pos) {
+        switch (pos) {
+          case "top":
+            return triggerRect.top - offset - tooltipHeight >= 0;
+          case "bottom":
+            return (
+              triggerRect.bottom + offset + tooltipHeight <= viewportHeight
+            );
+          case "left":
+            return triggerRect.left - offset - tooltipWidth >= 0;
+          case "right":
+            return triggerRect.right + offset + tooltipWidth <= viewportWidth;
+          default:
+            return true;
+        }
+      };
+
+      var resolvedPos = preferredPos;
+      if (!fits(preferredPos) && fits(OPPOSITE[preferredPos])) {
+        resolvedPos = OPPOSITE[preferredPos];
+      }
+
+      // Align: shift if the tail would point off the trigger because the
+      // tooltip got clamped against the viewport edge along the cross axis.
+      var resolvedAlign = preferredAlign;
+      var crossAxisIsHorizontal =
+        resolvedPos === "top" || resolvedPos === "bottom";
+      if (crossAxisIsHorizontal) {
+        var triggerCenterX = (triggerRect.left + triggerRect.right) / 2;
+        var halfTooltip = tooltipWidth / 2;
+        if (
+          preferredAlign === "middle" &&
+          triggerCenterX - halfTooltip < 0
+        ) {
+          resolvedAlign = "start";
+        } else if (
+          preferredAlign === "middle" &&
+          triggerCenterX + halfTooltip > viewportWidth
+        ) {
+          resolvedAlign = "end";
+        }
+      } else {
+        var triggerCenterY = (triggerRect.top + triggerRect.bottom) / 2;
+        var halfTooltipY = tooltipHeight / 2;
+        if (
+          preferredAlign === "middle" &&
+          triggerCenterY - halfTooltipY < 0
+        ) {
+          resolvedAlign = "start";
+        } else if (
+          preferredAlign === "middle" &&
+          triggerCenterY + halfTooltipY > viewportHeight
+        ) {
+          resolvedAlign = "end";
+        }
+      }
+
+      if (tooltip.getAttribute("data-position") !== resolvedPos) {
+        tooltip.setAttribute("data-position", resolvedPos);
+      }
+      if (tooltip.getAttribute("data-align") !== resolvedAlign) {
+        tooltip.setAttribute("data-align", resolvedAlign);
+      }
+    },
+  },
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
 require("./TextArea/V5");
+require("./Tooltip/V4");
 
 exports.CustomElement = require("./CustomElement");

--- a/src/Nri/Ui/Tooltip/V4.elm
+++ b/src/Nri/Ui/Tooltip/V4.elm
@@ -1,0 +1,887 @@
+module Nri.Ui.Tooltip.V4 exposing
+    ( view
+    , Attribute
+    , plaintext, paragraph, markdown, html
+    , above, below, before, after
+    , Align, alignStart, alignMiddle, alignEnd, align
+    , flip, noFlip
+    , offset
+    , withoutTail
+    , forBreakpoint, Breakpoint, mobile, narrowMobile, quizEngineMobile
+    , width, fitToContent, exactWidth
+    , Padding, smallPadding, normalPadding, customPadding, padding
+    , onToggle, onTriggerKeyDown
+    , open
+    , primaryLabel, auxiliaryDescription, helpfullyDisabled, disclosure
+    , css, custom, nriDescription, testId
+    )
+
+{-| A consolidated, auto-flipping rebuild of `Nri.Ui.Tooltip.V3`.
+
+This is a clean break: the API has been simplified considerably. See the
+migration table in the PR description.
+
+Auto-flipping is **on by default**. The direction passed via `above`,
+`below`, `before`, or `after` is the *preferred* placement. If the tooltip
+would clip the viewport on that side, it moves to the opposite side.
+Tail alignment shifts the same way to keep the tail pointing at the
+trigger.
+
+Powers itself with the `<nri-tooltip-auto>` custom element registered in
+`lib/Tooltip/V4.js`. Make sure your bundle requires `noredink-ui/lib`
+or the equivalent.
+
+@docs view
+@docs Attribute
+
+
+## Content
+
+@docs plaintext, paragraph, markdown, html
+
+
+## Position
+
+@docs above, below, before, after
+@docs Align, alignStart, alignMiddle, alignEnd, align
+@docs flip, noFlip
+@docs offset
+@docs withoutTail
+
+
+## Responsive
+
+@docs forBreakpoint, Breakpoint, mobile, narrowMobile, quizEngineMobile
+
+
+## Size & padding
+
+@docs width, fitToContent, exactWidth
+@docs Padding, smallPadding, normalPadding, customPadding, padding
+
+
+## Behaviour
+
+@docs onToggle, onTriggerKeyDown
+@docs open
+
+
+## Purpose (a11y)
+
+@docs primaryLabel, auxiliaryDescription, helpfullyDisabled, disclosure
+
+
+## Escape hatches
+
+@docs css, custom, nriDescription, testId
+
+-}
+
+import Accessibility.Styled as Html exposing (Html)
+import Accessibility.Styled.Aria as Aria
+import Accessibility.Styled.Key as Key
+import Content
+import Css exposing (Color, Px, Style)
+import Css.Global
+import Css.Media
+import EventExtras
+import Html.Styled as Root
+import Html.Styled.Attributes as Attributes
+import Html.Styled.Events as Events
+import Nri.Ui
+import Nri.Ui.Colors.Extra
+import Nri.Ui.Colors.V1 as Colors
+import Nri.Ui.Fonts.V1 as Fonts
+import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
+import Nri.Ui.MediaQuery.V1 as MediaQuery
+import Nri.Ui.WhenFocusLeaves.V2 as WhenFocusLeaves
+
+
+
+-- POSITION TYPES
+
+
+{-| Internal: where the tooltip sits relative to the trigger.
+-}
+type Position
+    = Top
+    | Bottom
+    | Left
+    | Right
+
+
+positionToString : Position -> String
+positionToString p =
+    case p of
+        Top ->
+            "top"
+
+        Bottom ->
+            "bottom"
+
+        Left ->
+            "left"
+
+        Right ->
+            "right"
+
+
+{-| -}
+type Align
+    = AlignStart
+    | AlignMiddle
+    | AlignEnd
+
+
+alignToString : Align -> String
+alignToString a =
+    case a of
+        AlignStart ->
+            "start"
+
+        AlignMiddle ->
+            "middle"
+
+        AlignEnd ->
+            "end"
+
+
+
+-- BREAKPOINTS
+
+
+{-| Named viewport size at which a responsive override applies.
+-}
+type Breakpoint
+    = Mobile
+    | QuizEngineMobile
+    | NarrowMobile
+
+
+{-| -}
+mobile : Breakpoint
+mobile =
+    Mobile
+
+
+{-| -}
+quizEngineMobile : Breakpoint
+quizEngineMobile =
+    QuizEngineMobile
+
+
+{-| -}
+narrowMobile : Breakpoint
+narrowMobile =
+    NarrowMobile
+
+
+breakpointMaxPx : Breakpoint -> Css.Px
+breakpointMaxPx bp =
+    case bp of
+        Mobile ->
+            MediaQuery.mobileBreakpoint
+
+        QuizEngineMobile ->
+            MediaQuery.quizEngineBreakpoint
+
+        NarrowMobile ->
+            MediaQuery.narrowMobileBreakpoint
+
+
+
+-- ATTRIBUTES
+
+
+{-| -}
+type Attribute msg
+    = Attribute (Tooltip msg -> Tooltip msg)
+
+
+type alias Tooltip msg =
+    { position : Position
+    , align : Align
+    , flipEnabled : Bool
+    , offsetPx : Float
+    , withTail : Bool
+    , content : List (Html msg)
+    , extraStyles : List Style
+    , extraAttributes : List (Root.Attribute Never)
+    , width : Width
+    , padding : Padding
+    , trigger : Maybe (Trigger msg)
+    , triggerKeyDownEvents : List (Key.Event msg)
+    , purpose : Purpose
+    , isOpen : Bool
+    , breakpointOverrides : List ( Breakpoint, Override )
+    , breakpointStyles : List ( Breakpoint, List Style )
+    }
+
+
+type Width
+    = Exactly Int
+    | FitContent
+
+
+type Padding
+    = SmallPadding
+    | NormalPadding
+    | CustomPadding Float
+
+
+type Trigger msg
+    = OnHover (Bool -> msg)
+
+
+type Purpose
+    = PrimaryLabel
+    | AuxiliaryDescription
+    | HelpfullyDisabled
+    | Disclosure { triggerId : String, lastId : Maybe String }
+
+
+type alias Override =
+    { position : Maybe Position
+    , align : Maybe Align
+    }
+
+
+emptyOverride : Override
+emptyOverride =
+    { position = Nothing, align = Nothing }
+
+
+buildAttributes : List (Attribute msg) -> Tooltip msg
+buildAttributes =
+    let
+        defaults : Tooltip msg
+        defaults =
+            { position = Top
+            , align = AlignMiddle
+            , flipEnabled = True
+            , offsetPx = 8
+            , withTail = True
+            , content = []
+            , extraStyles = []
+            , extraAttributes = []
+            , width = Exactly 320
+            , padding = NormalPadding
+            , trigger = Nothing
+            , triggerKeyDownEvents = []
+            , purpose = PrimaryLabel
+            , isOpen = False
+            , breakpointOverrides = []
+            , breakpointStyles = []
+            }
+    in
+    List.foldl (\(Attribute f) acc -> f acc) defaults
+
+
+
+-- CONTENT
+
+
+{-| -}
+plaintext : String -> Attribute msg
+plaintext str =
+    Attribute (Content.plaintext str)
+
+
+{-| -}
+paragraph : String -> Attribute msg
+paragraph str =
+    Attribute (Content.paragraph str)
+
+
+{-| -}
+markdown : String -> Attribute msg
+markdown str =
+    Attribute (\t -> { t | content = Content.markdownInline str })
+
+
+{-| -}
+html : List (Html msg) -> Attribute msg
+html nodes =
+    Attribute (Content.html nodes)
+
+
+
+-- POSITION
+
+
+{-| Prefer to place the tooltip above the trigger.
+-}
+above : Attribute msg
+above =
+    Attribute (\t -> { t | position = Top })
+
+
+{-| Prefer to place the tooltip below the trigger.
+-}
+below : Attribute msg
+below =
+    Attribute (\t -> { t | position = Bottom })
+
+
+{-| Prefer to place the tooltip before the trigger (to its left in LTR).
+-}
+before : Attribute msg
+before =
+    Attribute (\t -> { t | position = Left })
+
+
+{-| Prefer to place the tooltip after the trigger (to its right in LTR).
+-}
+after : Attribute msg
+after =
+    Attribute (\t -> { t | position = Right })
+
+
+{-| -}
+align : Align -> Attribute msg
+align a =
+    Attribute (\t -> { t | align = a })
+
+
+{-| -}
+alignStart : Attribute msg
+alignStart =
+    align AlignStart
+
+
+{-| -}
+alignMiddle : Attribute msg
+alignMiddle =
+    align AlignMiddle
+
+
+{-| -}
+alignEnd : Attribute msg
+alignEnd =
+    align AlignEnd
+
+
+{-| Auto-flipping is on by default; this is here for symmetry.
+-}
+flip : Attribute msg
+flip =
+    Attribute (\t -> { t | flipEnabled = True })
+
+
+{-| Disable auto-flipping. The tooltip will stay on the preferred side
+even if it clips the viewport.
+-}
+noFlip : Attribute msg
+noFlip =
+    Attribute (\t -> { t | flipEnabled = False })
+
+
+{-| Pixel gap between the trigger and the tooltip. Default is 8px.
+-}
+offset : Float -> Attribute msg
+offset px =
+    Attribute (\t -> { t | offsetPx = px })
+
+
+{-| -}
+withoutTail : Attribute msg
+withoutTail =
+    Attribute (\t -> { t | withTail = False })
+
+
+
+-- RESPONSIVE
+
+
+{-| Apply position/align overrides at a specific breakpoint.
+
+    Tooltip.forBreakpoint Tooltip.mobile [ Tooltip.below, Tooltip.alignStart ]
+
+The overrides are merged onto the base configuration in order; smaller
+breakpoints inherit from larger ones.
+
+-}
+forBreakpoint : Breakpoint -> List (Attribute msg) -> Attribute msg
+forBreakpoint bp atts =
+    Attribute
+        (\t ->
+            let
+                folded =
+                    List.foldl (\(Attribute f) acc -> f acc)
+                        { t | extraStyles = [], breakpointStyles = [] }
+                        atts
+
+                override =
+                    { position =
+                        if folded.position /= t.position then
+                            Just folded.position
+
+                        else
+                            Nothing
+                    , align =
+                        if folded.align /= t.align then
+                            Just folded.align
+
+                        else
+                            Nothing
+                    }
+            in
+            { t
+                | breakpointOverrides = ( bp, override ) :: t.breakpointOverrides
+                , breakpointStyles =
+                    if List.isEmpty folded.extraStyles then
+                        t.breakpointStyles
+
+                    else
+                        ( bp, folded.extraStyles ) :: t.breakpointStyles
+            }
+        )
+
+
+
+-- SIZE / PADDING
+
+
+{-| -}
+width : Int -> Attribute msg
+width w =
+    Attribute (\t -> { t | width = Exactly w })
+
+
+{-| -}
+exactWidth : Int -> Attribute msg
+exactWidth =
+    width
+
+
+{-| -}
+fitToContent : Attribute msg
+fitToContent =
+    Attribute (\t -> { t | width = FitContent })
+
+
+{-| -}
+padding : Padding -> Attribute msg
+padding p =
+    Attribute (\t -> { t | padding = p })
+
+
+{-| -}
+smallPadding : Attribute msg
+smallPadding =
+    padding SmallPadding
+
+
+{-| -}
+normalPadding : Attribute msg
+normalPadding =
+    padding NormalPadding
+
+
+{-| -}
+customPadding : Float -> Attribute msg
+customPadding px =
+    padding (CustomPadding px)
+
+
+
+-- BEHAVIOUR
+
+
+{-| -}
+onToggle : (Bool -> msg) -> Attribute msg
+onToggle msg =
+    Attribute (\t -> { t | trigger = Just (OnHover msg) })
+
+
+{-| -}
+onTriggerKeyDown : List (Key.Event msg) -> Attribute msg
+onTriggerKeyDown events =
+    Attribute (\t -> { t | triggerKeyDownEvents = t.triggerKeyDownEvents ++ events })
+
+
+{-| -}
+open : Bool -> Attribute msg
+open isOpen =
+    Attribute (\t -> { t | isOpen = isOpen })
+
+
+
+-- PURPOSE
+
+
+{-| -}
+primaryLabel : Attribute msg
+primaryLabel =
+    Attribute (\t -> { t | purpose = PrimaryLabel })
+
+
+{-| -}
+auxiliaryDescription : Attribute msg
+auxiliaryDescription =
+    Attribute (\t -> { t | purpose = AuxiliaryDescription })
+
+
+{-| -}
+helpfullyDisabled : Attribute msg
+helpfullyDisabled =
+    Attribute (\t -> { t | purpose = HelpfullyDisabled })
+
+
+{-| -}
+disclosure : { triggerId : String, lastId : Maybe String } -> Attribute msg
+disclosure config =
+    Attribute (\t -> { t | purpose = Disclosure config })
+
+
+
+-- ESCAPE HATCHES
+
+
+{-| -}
+css : List Style -> Attribute msg
+css styles =
+    Attribute (\t -> { t | extraStyles = t.extraStyles ++ styles })
+
+
+{-| -}
+custom : List (Root.Attribute Never) -> Attribute msg
+custom atts =
+    Attribute (\t -> { t | extraAttributes = t.extraAttributes ++ atts })
+
+
+{-| -}
+nriDescription : String -> Attribute msg
+nriDescription desc =
+    custom [ ExtraAttributes.nriDescription desc ]
+
+
+{-| -}
+testId : String -> Attribute msg
+testId id =
+    custom [ ExtraAttributes.testId id ]
+
+
+
+-- VIEW
+
+
+{-| -}
+view :
+    { trigger : List (Root.Attribute msg) -> Html msg
+    , id : String
+    }
+    -> List (Attribute msg)
+    -> Html msg
+view config attrs =
+    let
+        tooltip =
+            buildAttributes attrs
+
+        triggerId =
+            "tooltip-trigger__" ++ config.id
+
+        ( containerEvents, triggerEvents ) =
+            triggerEventHandlers tooltip
+    in
+    Nri.Ui.styled Root.div
+        "Nri-Ui-Tooltip-V4"
+        [ Css.boxSizing Css.borderBox
+        , Css.display Css.inlineBlock
+        , Css.textAlign Css.left
+        , Css.position Css.relative
+        ]
+        containerEvents
+        [ Root.div
+            [ Attributes.css [ Css.displayFlex ]
+            , Attributes.id triggerId
+            ]
+            [ config.trigger
+                (purposeAttributes config.id tooltip ++ triggerEvents)
+            ]
+        , wrapInAuto tooltip
+            { triggerId = triggerId, tooltipId = config.id }
+            (viewTooltip config.id triggerId tooltip)
+        ]
+
+
+wrapInAuto :
+    Tooltip msg
+    -> { triggerId : String, tooltipId : String }
+    -> Html msg
+    -> Html msg
+wrapInAuto tooltip ids inner =
+    if tooltip.flipEnabled then
+        Root.node "nri-tooltip-auto"
+            [ Attributes.attribute "data-trigger-id" ids.triggerId
+            , Attributes.attribute "data-tooltip-id" ids.tooltipId
+            , Attributes.attribute "data-preferred-position"
+                (positionToString tooltip.position)
+            , Attributes.attribute "data-preferred-align"
+                (alignToString tooltip.align)
+            , Attributes.attribute "data-offset"
+                (String.fromFloat tooltip.offsetPx)
+            , Attributes.css [ Css.display Css.contents ]
+            ]
+            [ inner ]
+
+    else
+        inner
+
+
+purposeAttributes : String -> Tooltip msg -> List (Root.Attribute msg)
+purposeAttributes id tooltip =
+    case tooltip.purpose of
+        PrimaryLabel ->
+            []
+
+        AuxiliaryDescription ->
+            [ Aria.describedBy [ id ] ]
+
+        HelpfullyDisabled ->
+            [ Aria.describedBy [ id ] ]
+
+        Disclosure _ ->
+            [ Aria.expanded tooltip.isOpen
+            , Aria.controls [ id ]
+            ]
+
+
+triggerEventHandlers :
+    Tooltip msg
+    -> ( List (Root.Attribute msg), List (Root.Attribute msg) )
+triggerEventHandlers tooltip =
+    case tooltip.trigger of
+        Just (OnHover msg) ->
+            case tooltip.purpose of
+                Disclosure { triggerId, lastId } ->
+                    ( [ Events.onMouseEnter (msg True)
+                      , Events.onMouseLeave (msg False)
+                      , WhenFocusLeaves.onKeyDown []
+                            { firstIds = [ triggerId ]
+                            , lastIds = [ Maybe.withDefault triggerId lastId ]
+                            , tabBackAction = msg False
+                            , tabForwardAction = msg False
+                            }
+                      ]
+                    , [ EventExtras.onClickPreventDefaultAndStopPropagation
+                            (msg (not tooltip.isOpen))
+                      , Key.onKeyDown
+                            (Key.escape (msg False) :: tooltip.triggerKeyDownEvents)
+                      ]
+                    )
+
+                _ ->
+                    ( [ Events.onMouseEnter (msg True)
+                      , Events.onMouseLeave (msg False)
+                      ]
+                    , [ Events.onFocus (msg True)
+                      , Events.onBlur (msg False)
+                      , Key.onKeyDown
+                            (Key.escape (msg False) :: tooltip.triggerKeyDownEvents)
+                      ]
+                    )
+
+        Nothing ->
+            ( [], [ Key.onKeyDown tooltip.triggerKeyDownEvents ] )
+
+
+viewTooltip : String -> String -> Tooltip msg -> Html msg
+viewTooltip tooltipId triggerId config =
+    Root.div
+        ([ Attributes.id tooltipId
+         , Attributes.attribute "data-position" (positionToString config.position)
+         , Attributes.attribute "data-align" (alignToString config.align)
+         , Attributes.attribute "data-tooltip-visible"
+            (if config.isOpen then
+                "true"
+
+             else
+                "false"
+            )
+         , Aria.hidden (config.purpose == PrimaryLabel)
+         , Attributes.css
+            (containerStyles config
+                ++ List.concatMap breakpointBlock config.breakpointOverrides
+                ++ List.concatMap breakpointStyleBlock config.breakpointStyles
+            )
+         ]
+            ++ List.map (Attributes.map never) config.extraAttributes
+        )
+        [ Css.Global.global tooltipScopedStyles
+        , Root.div
+            [ Attributes.css (innerStyles config) ]
+            config.content
+        ]
+
+
+breakpointBlock : ( Breakpoint, Override ) -> List Style
+breakpointBlock ( bp, override ) =
+    let
+        styles =
+            List.filterMap identity
+                [ Maybe.map overridePositionStyle override.position
+                , Maybe.map overrideAlignStyle override.align
+                ]
+    in
+    if List.isEmpty styles then
+        []
+
+    else
+        [ Css.Media.withMedia
+            [ Css.Media.only Css.Media.screen
+                [ Css.Media.maxWidth (breakpointMaxPx bp) ]
+            ]
+            styles
+        ]
+
+
+breakpointStyleBlock : ( Breakpoint, List Style ) -> List Style
+breakpointStyleBlock ( bp, styles ) =
+    [ Css.Media.withMedia
+        [ Css.Media.only Css.Media.screen
+            [ Css.Media.maxWidth (breakpointMaxPx bp) ]
+        ]
+        styles
+    ]
+
+
+overridePositionStyle : Position -> Style
+overridePositionStyle p =
+    Css.batch (positionStyles p)
+
+
+overrideAlignStyle : Align -> Style
+overrideAlignStyle a =
+    Css.batch (alignStyles a)
+
+
+
+-- STYLES
+
+
+containerStyles : Tooltip msg -> List Style
+containerStyles config =
+    [ Css.position Css.absolute
+    , Css.boxSizing Css.borderBox
+    , Css.zIndex (Css.int 100)
+    , if config.isOpen then
+        Css.batch []
+
+      else
+        Css.display Css.none
+    , Css.batch (positionStyles config.position)
+    , Css.batch (alignStyles config.align)
+    , Css.property "--nri-tooltip-offset"
+        (String.fromFloat config.offsetPx ++ "px")
+    ]
+
+
+positionStyles : Position -> List Style
+positionStyles p =
+    case p of
+        Top ->
+            [ Css.property "bottom" "calc(100% + var(--nri-tooltip-offset, 8px))" ]
+
+        Bottom ->
+            [ Css.property "top" "calc(100% + var(--nri-tooltip-offset, 8px))" ]
+
+        Left ->
+            [ Css.property "right" "calc(100% + var(--nri-tooltip-offset, 8px))" ]
+
+        Right ->
+            [ Css.property "left" "calc(100% + var(--nri-tooltip-offset, 8px))" ]
+
+
+alignStyles : Align -> List Style
+alignStyles a =
+    case a of
+        AlignStart ->
+            [ Css.left Css.zero ]
+
+        AlignMiddle ->
+            [ Css.left (Css.pct 50)
+            , Css.property "transform" "translateX(-50%)"
+            ]
+
+        AlignEnd ->
+            [ Css.right Css.zero ]
+
+
+innerStyles : Tooltip msg -> List Style
+innerStyles config =
+    [ Css.boxSizing Css.borderBox
+    , Css.borderRadius (Css.px 8)
+    , case config.width of
+        Exactly w ->
+            Css.width (Css.px (toFloat w))
+
+        FitContent ->
+            Css.whiteSpace Css.noWrap
+    , paddingToStyle config.padding
+    , Css.backgroundColor tooltipColor
+    , Css.color Colors.white
+    , Css.border3 (Css.px 1) Css.solid outlineColor
+    , Fonts.baseFont
+    , Css.fontSize (Css.px 14)
+    , Css.lineHeight (Css.num 1.4)
+    , Css.batch config.extraStyles
+    ]
+
+
+paddingToStyle : Padding -> Style
+paddingToStyle p =
+    case p of
+        SmallPadding ->
+            Css.padding2 (Css.px 4) (Css.px 8)
+
+        NormalPadding ->
+            Css.padding2 (Css.px 8) (Css.px 16)
+
+        CustomPadding px ->
+            Css.padding (Css.px px)
+
+
+
+-- ATTRIBUTE-KEYED OVERRIDE STYLES (used by the custom element)
+--
+-- The custom element rewrites `data-position` and `data-align` on the
+-- outer tooltip div. These global styles re-apply the corresponding
+-- positioning so the flip happens without a re-render from Elm.
+
+
+tooltipScopedStyles : List Css.Global.Snippet
+tooltipScopedStyles =
+    let
+        positionRule pos =
+            Css.Global.selector
+                ("[data-position=\"" ++ positionToString pos ++ "\"]")
+                (positionStyles pos)
+
+        alignRule a =
+            Css.Global.selector
+                ("[data-align=\"" ++ alignToString a ++ "\"]")
+                (alignStyles a)
+    in
+    [ positionRule Top
+    , positionRule Bottom
+    , positionRule Left
+    , positionRule Right
+    , alignRule AlignStart
+    , alignRule AlignMiddle
+    , alignRule AlignEnd
+    ]
+
+
+
+-- COLORS
+
+
+tooltipColor : Color
+tooltipColor =
+    Colors.navy
+
+
+outlineColor : Color
+outlineColor =
+    Nri.Ui.Colors.Extra.withAlpha 0.4 Colors.white

--- a/src/Nri/Ui/Tooltip/V4.elm
+++ b/src/Nri/Ui/Tooltip/V4.elm
@@ -94,6 +94,7 @@ import Nri.Ui.Colors.V1 as Colors
 import Nri.Ui.Fonts.V1 as Fonts
 import Nri.Ui.Html.Attributes.V2 as ExtraAttributes
 import Nri.Ui.MediaQuery.V1 as MediaQuery
+import Nri.Ui.Shadows.V1 as Shadows
 import Nri.Ui.WhenFocusLeaves.V2 as WhenFocusLeaves
 
 
@@ -259,7 +260,7 @@ buildAttributes =
             { position = Top
             , align = AlignMiddle
             , flipEnabled = True
-            , offsetPx = 8
+            , offsetPx = 12
             , withTail = True
             , content = []
             , extraStyles = []
@@ -621,7 +622,7 @@ wrapInAuto tooltip ids inner =
                 (alignToString tooltip.align)
             , Attributes.attribute "data-offset"
                 (String.fromFloat tooltip.offsetPx)
-            , Attributes.css [ Css.display Css.contents ]
+            , Attributes.css [ Css.property "display" "contents" ]
             ]
             [ inner ]
 
@@ -690,8 +691,16 @@ viewTooltip : String -> String -> Tooltip msg -> Html msg
 viewTooltip tooltipId triggerId config =
     Root.div
         ([ Attributes.id tooltipId
+         , Attributes.attribute "data-nri-tooltip" "v4"
          , Attributes.attribute "data-position" (positionToString config.position)
          , Attributes.attribute "data-align" (alignToString config.align)
+         , Attributes.attribute "data-tail"
+            (if config.withTail then
+                "shown"
+
+             else
+                "hidden"
+            )
          , Attributes.attribute "data-tooltip-visible"
             (if config.isOpen then
                 "true"
@@ -710,7 +719,9 @@ viewTooltip tooltipId triggerId config =
         )
         [ Css.Global.global tooltipScopedStyles
         , Root.div
-            [ Attributes.css (innerStyles config) ]
+            [ Attributes.class bubbleClass
+            , Attributes.css (innerStyles config)
+            ]
             config.content
         ]
 
@@ -781,36 +792,44 @@ positionStyles : Position -> List Style
 positionStyles p =
     case p of
         Top ->
-            [ Css.property "bottom" "calc(100% + var(--nri-tooltip-offset, 8px))" ]
+            [ Css.property "bottom" "calc(100% + var(--nri-tooltip-offset, 12px))" ]
 
         Bottom ->
-            [ Css.property "top" "calc(100% + var(--nri-tooltip-offset, 8px))" ]
+            [ Css.property "top" "calc(100% + var(--nri-tooltip-offset, 12px))" ]
 
         Left ->
-            [ Css.property "right" "calc(100% + var(--nri-tooltip-offset, 8px))" ]
+            [ Css.property "right" "calc(100% + var(--nri-tooltip-offset, 12px))" ]
 
         Right ->
-            [ Css.property "left" "calc(100% + var(--nri-tooltip-offset, 8px))" ]
+            [ Css.property "left" "calc(100% + var(--nri-tooltip-offset, 12px))" ]
 
 
 alignStyles : Align -> List Style
 alignStyles a =
     case a of
         AlignStart ->
-            [ Css.left Css.zero ]
+            [ Css.property "left" "0"
+            , Css.property "right" "auto"
+            , Css.property "transform" "none"
+            ]
 
         AlignMiddle ->
-            [ Css.left (Css.pct 50)
+            [ Css.property "left" "50%"
+            , Css.property "right" "auto"
             , Css.property "transform" "translateX(-50%)"
             ]
 
         AlignEnd ->
-            [ Css.right Css.zero ]
+            [ Css.property "right" "0"
+            , Css.property "left" "auto"
+            , Css.property "transform" "none"
+            ]
 
 
 innerStyles : Tooltip msg -> List Style
 innerStyles config =
     [ Css.boxSizing Css.borderBox
+    , Css.position Css.relative
     , Css.borderRadius (Css.px 8)
     , case config.width of
         Exactly w ->
@@ -822,8 +841,9 @@ innerStyles config =
     , Css.backgroundColor tooltipColor
     , Css.color Colors.white
     , Css.border3 (Css.px 1) Css.solid outlineColor
+    , Shadows.high
     , Fonts.baseFont
-    , Css.fontSize (Css.px 14)
+    , Css.fontSize (Css.px 15)
     , Css.lineHeight (Css.num 1.4)
     , Css.batch config.extraStyles
     ]
@@ -833,10 +853,10 @@ paddingToStyle : Padding -> Style
 paddingToStyle p =
     case p of
         SmallPadding ->
-            Css.padding2 (Css.px 4) (Css.px 8)
+            Css.padding2 (Css.px 8) (Css.px 12)
 
         NormalPadding ->
-            Css.padding2 (Css.px 8) (Css.px 16)
+            Css.padding (Css.px 16)
 
         CustomPadding px ->
             Css.padding (Css.px px)
@@ -853,14 +873,17 @@ paddingToStyle p =
 tooltipScopedStyles : List Css.Global.Snippet
 tooltipScopedStyles =
     let
+        scope =
+            "[data-nri-tooltip=\"v4\"]"
+
         positionRule pos =
             Css.Global.selector
-                ("[data-position=\"" ++ positionToString pos ++ "\"]")
+                (scope ++ "[data-position=\"" ++ positionToString pos ++ "\"]")
                 (positionStyles pos)
 
         alignRule a =
             Css.Global.selector
-                ("[data-align=\"" ++ alignToString a ++ "\"]")
+                (scope ++ "[data-align=\"" ++ alignToString a ++ "\"]")
                 (alignStyles a)
     in
     [ positionRule Top
@@ -871,6 +894,162 @@ tooltipScopedStyles =
     , alignRule AlignMiddle
     , alignRule AlignEnd
     ]
+        ++ tailScopedStyles
+
+
+bubbleClass : String
+bubbleClass =
+    "nri-tooltip-v4-bubble"
+
+
+tailSize : Float
+tailSize =
+    8
+
+
+{-| Tail pseudo-element styles, scoped by `[data-position]` and
+`[data-align]` so the JS auto-flip can move the tail with the tooltip
+without an Elm re-render.
+
+Each tail uses two pseudo-elements:
+
+  - `::before` is the outer outline (border alpha)
+  - `::after` is the inner fill (tooltip background)
+
+Both are pure CSS triangles via the classic border-trick.
+
+-}
+tailScopedStyles : List Css.Global.Snippet
+tailScopedStyles =
+    let
+        scope =
+            "[data-nri-tooltip=\"v4\"]"
+
+        bubble pos =
+            scope ++ "[data-position=\"" ++ positionToString pos ++ "\"] > ." ++ bubbleClass
+
+        tailBase =
+            [ Css.property "content" "\" \""
+            , Css.position Css.absolute
+            , Css.height Css.zero
+            , Css.width Css.zero
+            , Css.pointerEvents Css.none
+            , Css.property "border" "solid transparent"
+            ]
+
+        tailHidden =
+            Css.Global.selector
+                (scope ++ "[data-tail=\"hidden\"] > ." ++ bubbleClass ++ "::before, "
+                    ++ scope
+                    ++ "[data-tail=\"hidden\"] > ."
+                    ++ bubbleClass
+                    ++ "::after"
+                )
+                [ Css.property "content" "none" ]
+
+        -- Outline ("::before") and fill ("::after") rules, per side.
+        --
+        -- The tail is a 0×0 pseudo-element with all-transparent borders
+        -- except the one that points TOWARD the bubble — that's the
+        -- visible triangle. We anchor the pseudo-element to the bubble
+        -- edge nearest the trigger (e.g. for a `top` tooltip, anchor to
+        -- the bubble's bottom edge → tail visible below).
+        sideRules pos =
+            let
+                ( visibleBorderProp, anchorProp ) =
+                    case pos of
+                        Top ->
+                            ( "border-top-color", "top" )
+
+                        Bottom ->
+                            ( "border-bottom-color", "bottom" )
+
+                        Left ->
+                            ( "border-left-color", "left" )
+
+                        Right ->
+                            ( "border-right-color", "right" )
+
+                outlineSelector =
+                    bubble pos ++ "::before"
+
+                fillSelector =
+                    bubble pos ++ "::after"
+            in
+            [ Css.Global.selector outlineSelector
+                (tailBase
+                    ++ [ Css.property visibleBorderProp (cssColor outlineColor)
+                       , Css.property "border-width"
+                            (String.fromFloat (tailSize + 1) ++ "px")
+                       , Css.property anchorProp "100%"
+                       ]
+                )
+            , Css.Global.selector fillSelector
+                (tailBase
+                    ++ [ Css.property visibleBorderProp (cssColor tooltipColor)
+                       , Css.property "border-width"
+                            (String.fromFloat tailSize ++ "px")
+                       , Css.property anchorProp "100%"
+                       ]
+                )
+            ]
+
+        -- Cross-axis position: where along the tooltip edge the tail sits.
+        -- For top/bottom tooltips the cross axis is X; for left/right it's Y.
+        crossAxisRule pos a =
+            let
+                isHorizontal =
+                    pos == Top || pos == Bottom
+
+                ( startProp, endProp, transformProp ) =
+                    if isHorizontal then
+                        ( "left", "right", "translateX(-50%)" )
+
+                    else
+                        ( "top", "bottom", "translateY(-50%)" )
+
+                styles =
+                    case a of
+                        AlignStart ->
+                            [ Css.property startProp (String.fromFloat (tailSize + 8) ++ "px")
+                            , Css.property endProp "auto"
+                            , Css.property "transform" "none"
+                            ]
+
+                        AlignMiddle ->
+                            [ Css.property startProp "50%"
+                            , Css.property endProp "auto"
+                            , Css.property "transform" transformProp
+                            ]
+
+                        AlignEnd ->
+                            [ Css.property startProp "auto"
+                            , Css.property endProp (String.fromFloat (tailSize + 8) ++ "px")
+                            , Css.property "transform" "none"
+                            ]
+
+                positionAlignSelector =
+                    scope
+                        ++ "[data-position=\""
+                        ++ positionToString pos
+                        ++ "\"][data-align=\""
+                        ++ alignToString a
+                        ++ "\"] > ."
+                        ++ bubbleClass
+            in
+            [ Css.Global.selector (positionAlignSelector ++ "::before") styles
+            , Css.Global.selector (positionAlignSelector ++ "::after") styles
+            ]
+    in
+    List.concatMap sideRules [ Top, Bottom, Left, Right ]
+        ++ List.concatMap (\pos -> List.concatMap (crossAxisRule pos) [ AlignStart, AlignMiddle, AlignEnd ])
+            [ Top, Bottom, Left, Right ]
+        ++ [ tailHidden ]
+
+
+cssColor : Color -> String
+cssColor c =
+    Nri.Ui.Colors.Extra.toCssString c
 
 
 


### PR DESCRIPTION
## Context

`Nri.Ui.Tooltip.V3` had grown a large surface area — 16 directional functions (4 sides × 4 breakpoints), 12 alignment functions (3 alignments × 4 breakpoints), four `*Css` breakpoint helpers, three padding functions, two width functions — and still required callers to pre-decide which side the tooltip should appear on. When tooltips appeared near a viewport edge, they clipped instead of flipping.

V4 is a clean-break rewrite. Same a11y semantics, much smaller API, and tooltips auto-flip when they would otherwise clip the viewport.

V3 is **untouched**. Existing consumers keep working.

## :wrench: What changes

### New module: `Nri.Ui.Tooltip.V4`

- **Positioning collapses to four functions.** `above` / `below` / `before` / `after` (logical, RTL-friendly). Auto-flipping is on by default — these are *preferred* sides, and the tooltip moves to the opposite side only if it would clip.
- **Alignment is one function** taking a sum type: `align Start | Middle | End`. (Plus convenience wrappers `alignStart` / `alignMiddle` / `alignEnd`.) The pixel-offset arg is gone.
- **Breakpoints are one mechanism.** `forBreakpoint Tooltip.mobile [ Tooltip.below, Tooltip.alignStart ]` replaces all 28 of V3's `*ForMobile` / `*ForQuizEngineMobile` / `*ForNarrowMobile` direction and alignment variants and the per-breakpoint `*Css` helpers.
- **Padding and width are one attribute each:** `padding (Padding)` with `Small` / `Normal` / `Custom Float`, `width Int` or `fitToContent`.
- **`flip` / `noFlip`** to opt out of auto-flipping.
- **`offset Float`** to tune the gap between trigger and tooltip (default 12px, was hardcoded in V3).
- Same purpose attributes: `primaryLabel`, `auxiliaryDescription`, `helpfullyDisabled`, `disclosure`.
- Same behavior attributes: `onToggle`, `onTriggerKeyDown`, `open`.
- Same escape hatches: `css`, `custom`, `nriDescription`, `testId`.

### Auto-flipping engine

Powered by a new `<nri-tooltip-auto>` custom element (`lib/Tooltip/V4.js`):

- Wraps the trigger + tooltip when `flip` is enabled (default).
- Runs a `requestAnimationFrame` loop while connected; on each frame, reads the trigger's bounding rect and only rewrites `data-position` / `data-align` when the rect changed. This is the same approach Floating UI uses for `autoUpdate`, and catches every kind of position change including ancestor-driven movement (e.g. drag).
- The tooltip's positioning, alignment, and tail rendering CSS are all keyed off `[data-position="…"]` / `[data-align="…"]` attributes via `Css.Global` rules, so the flip happens without an Elm re-render.

### Catalog

- `Examples/Tooltip.elm` migrated to V4 (version bumped to 4). Direction/alignment controls flattened from 8 to 2; per-breakpoint multipliers gone.
- New **auto-flip playground**: a launcher card that opens a fullscreen overlay with a draggable trigger and a "preferred side" picker. The playground tooltip inherits the customizable example's settings so reviewers can experiment with `noFlip` / `withoutTail` / padding / etc. while dragging.
- Body now has `Fonts.baseFont`, `gray20` color, and `line-height: 1.5` set globally so unstyled text on example pages inherits Muli rather than Times New Roman.

## Migration

| V3 | V4 |
|---|---|
| `onTop` | `above` |
| `onBottom` | `below` |
| `onLeft` | `before` |
| `onRight` | `after` |
| `alignStart 10` | `alignStart` (offset removed) |
| `alignMiddle` | `alignMiddle` (or omit — default) |
| `alignEnd 10` | `alignEnd` |
| `onTopForMobile` | `forBreakpoint Tooltip.mobile [ above ]` |
| `alignMiddleForMobile` | `forBreakpoint Tooltip.mobile [ alignMiddle ]` |
| `mobileCss [...]` | `forBreakpoint Tooltip.mobile [ css [...] ]` |
| `exactWidth 320` | `exactWidth 320` (kept) |
| `fitToContent` | `fitToContent` (kept) |
| `smallPadding` / `normalPadding` / `customPadding x` | `smallPadding` / `normalPadding` / `customPadding x` (kept) or `padding Small` / etc. |

Most of the migration is mechanical find-and-replace. The biggest win is callers that today need 6+ attributes to express different behavior at three breakpoints — those collapse to three `forBreakpoint` calls.

## Component completion checklist

- [x] Documentation: V4 module is fully `@docs`-ed
- [x] Component Catalog updated to use V4
- [x] Customizable example produces sample code
- [x] Keyboard support unchanged from V3
- [x] V3 left intact — consumers migrate at their own pace
- [ ] Reviewers
  - [ ] Component library owner
  - [x] Designer (visible behavior change — auto-flip)

## Notes for reviewers

- **JS dependency:** the auto-flip is powered by `lib/Tooltip/V4.js`, which is required by `lib/index.js` and so loads automatically wherever the noredink-ui JS is bundled (catalog included). Apps that bundle Elm without `noredink-ui/lib` would lose auto-flip and fall back to whatever side was passed (no flip), which is graceful but worth flagging.
- **No `viewToggleTip` yet.** The "?" icon helper is V3-only for now; consumers using it should stay on V3 until we port it.
- **Tail rendering is attribute-keyed.** That means the four directions × three alignments worth of pseudo-element CSS ships once on the page (via `Css.Global.global` inside the tooltip), and the JS just toggles attributes. Slightly more CSS in the page than V3, but simpler to reason about and cheaper at flip-time (no re-render).
- **`primaryLabel` is still the default** — keep using `auxiliaryDescription` / `helpfullyDisabled` / `disclosure` consciously.