### PR TITLE
Bump for version 35.8.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "NoRedInk/noredink-ui",
     "summary": "UI Widgets we use at NRI",
     "license": "BSD-3-Clause",
-    "version": "35.7.0",
+    "version": "35.8.0",
     "exposed-modules": [
         "Browser.Events.Extra",
         "Nri.Test.KeyboardHelpers.V1",


### PR DESCRIPTION
## What changes does this release include?

This PR bumps the version after adding the new ReadWriteReason icon and iconCircled:

https://github.com/NoRedInk/noredink-ui/pull/1813

## How has the API changed?

```
This is a MINOR change.

---- Nri.Ui.AssignmentIcon.V2 - MINOR ----

    Added:
        readWriteReason : Nri.Ui.Svg.V1.Svg
        readWriteReasonCircled : Nri.Ui.Svg.V1.Svg
```

## Releasing

After this PR merges, and you've pulled down latest master, finish following the [publishing process](https://github.com/NoRedInk/noredink-ui/blob/master/README.md#publishing-a-new-version).