### PR TITLE
Add ochreLight to Colors.V1

### DIFF
--- a/component-catalog/src/Examples/Colors.elm
+++ b/component-catalog/src/Examples/Colors.elm
@@ -164,6 +164,7 @@ yellowColors =
     Nonempty ( "mustard", Colors.mustard, "Diagnostic assignments, some Premium elements" )
         [ ( "ochre", Colors.ochre, "Practice assignments background color, some Premium elements" )
         , ( "ochreDark", Colors.ochreDark, "Practice assignments text color" )
+        , ( "ochreLight", Colors.ochreLight, "Light ochre backgrounds, e.g. proficiency pills" )
         , ( "sunshine", Colors.sunshine, "Yellow highlights, tips" )
         ]
 

--- a/script/netlify.sh
+++ b/script/netlify.sh
@@ -8,7 +8,9 @@ set -xeuo pipefail
 
 # get our dependencies (--ignore-scripts=false is needed for puppeteer)
 npm install --ignore-scripts=false
-npm install elm
+# pin to Elm 0.19.1: unpinned `npm install elm` resolves to 0.19.2+, which
+# refuses to build our elm.json ("elm-version": "0.19.1")
+npm install elm@latest-0.19.1
 
 # make sure we're building into a clean folder
 if test -d public; then rm -rf public; fi

--- a/src/Nri/Ui/Colors/V1.elm
+++ b/src/Nri/Ui/Colors/V1.elm
@@ -17,7 +17,7 @@ module Nri.Ui.Colors.V1 exposing
     , lichen
     , magenta
     , navy
-    , orange, ochre, ochreDark
+    , orange, ochre, ochreDark, ochreLight
     , purple, purpleDark, purpleLight
     , red, redDark, redLight
     , sunshine
@@ -55,7 +55,7 @@ consider [elm-color-extra](http://package.elm-lang.org/packages/eskimoblood/elm-
 @docs lichen
 @docs magenta
 @docs navy
-@docs orange, ochre, ochreDark
+@docs orange, ochre, ochreDark, ochreLight
 @docs purple, purpleDark, purpleLight
 @docs red, redDark, redLight
 @docs sunshine
@@ -584,6 +584,13 @@ ochre =
 ochreDark : Css.Color
 ochreDark =
     hex "#ad6500"
+
+
+{-| See <https://noredink-ui.netlify.com/#/doodad/Colors>
+-}
+ochreLight : Css.Color
+ochreLight =
+    hex "#ffe9d6"
 
 
 {-| See <https://noredink-ui.netlify.com/#/doodad/Colors>


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

The Read Write Reason "Demonstration of Skill" pills in the monolith need a light ochre tint (`#ffe9d6`) as a pill background, sitting alongside the existing light tints (`greenLightest`, `redLight`, `purpleLight`). `Colors.V1` has `ochre`/`ochreDark` but no light variant, so the monolith currently hardcodes the hex.

Raised by @macoca in https://github.com/NoRedInk/NoRedInk/pull/54879#discussion_r3668522710 (cc @bendansby on whether this is the right call vs. reusing an existing token).

## :framed_picture: What does this change look like?

A new `ochreLight` (`#ffe9d6`) swatch in the Colors doodad, listed with the other yellows:

- `ochre` `#f28f00`
- `ochreDark` `#ad6500`
- `ochreLight` `#ffe9d6` (new)

In the monolith it's used as a pill background with `ochreDark` text.

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
  - :warning: One thing for the design review: `ochreDark` text on `ochreLight` is a **3.85:1** contrast ratio — passes WCAG AA for large text (3:1) but not for normal text (4.5:1). The intended monolith usage is 13px bold, which doesn't qualify as large text. For comparison, the existing `ochreDark`-on-`sunshine` pairing is 4.30:1, also below 4.5:1. @bendansby — worth confirming the intended text pairing for this background.
- [x] Changes are clearly documented
  - [x] Component docs include a changelog — n/a, `Colors.V1` doesn't keep a changelog; the new color carries the same doc comment as every other color
  - [x] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate — added `ochreLight` to the Yellows grouping in the Colors example
  - [x] The Component Catalog example version number is updated, if appropriate — n/a
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has an accurate preview, valid sample code, correct keyboard behavior, and correct guidance
- [x] Changes to the component are tested/the new version of the component is tested — colors have no Elm specs; the Colors doodad is covered by the automatic axe checks and Percy snapshots
- [x] Component API follows standard patterns in noredink-ui — matches `purpleLight`/`redLight`/`turquoiseLight` naming
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component — this is not a new major version
- [x] Please assign the following reviewers:
  - [x] Someone from your team who can review your PR in full: @macoca
  - [x] Component library owner
  - [x] Designer for the user-facing change: @bendansby (a11y-related/general components)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## :construction_worker: Netlify fix along the way

Deploy previews for this site have been broken since June: unpinned `npm install elm` in `script/netlify.sh` started resolving to Elm 0.19.2-0, which refuses to build our 0.19.1 elm.json. Pinned to `elm@latest-0.19.1` in this PR so the preview (and every future PR's) works again.
