### PR TITLE
[PD-3873] Add `premiumFlag` icon

### DIFF
--- a/component-catalog/src/Examples/UiIcon.elm
+++ b/component-catalog/src/Examples/UiIcon.elm
@@ -217,6 +217,7 @@ all =
       , [ ( "key", UiIcon.key, [] )
         , ( "lock", UiIcon.lock, [] )
         , ( "premiumLock", UiIcon.premiumLock, [] )
+        , ( "premiumFlag", UiIcon.premiumFlag, [] )
         ]
       )
     , ( "Tips & Tricks"

--- a/src/Nri/Ui/UiIcon/V2.elm
+++ b/src/Nri/Ui/UiIcon/V2.elm
@@ -19,7 +19,7 @@ module Nri.Ui.UiIcon.V2 exposing
     , attention, exclamation
     , flag, star, starFilled, starOutline, no
     , equals, plus, null
-    , key, lock, premiumLock
+    , key, lock, premiumLock, premiumFlag
     , badge, tada, count
     , bold, italic, underline, list, link, undo, redo
     , home, homeInCircle, library
@@ -58,7 +58,7 @@ module Nri.Ui.UiIcon.V2 exposing
 @docs attention, exclamation
 @docs flag, star, starFilled, starOutline, no
 @docs equals, plus, null
-@docs key, lock, premiumLock
+@docs key, lock, premiumLock, premiumFlag
 @docs badge, tada, count
 @docs bold, italic, underline, list, link, undo, redo
 @docs home, homeInCircle, library
@@ -4118,6 +4118,21 @@ dictionary =
             , Attributes.strokeLinecap "round"
             , Attributes.strokeLinejoin "round"
             , Attributes.fill "none"
+            ]
+            []
+        ]
+
+
+{-| Pennant-style flag to indicate premium content. Supports color overrides via `Nri.Ui.Svg.V1.withColor`.
+-}
+premiumFlag : Nri.Ui.Svg.V1.Svg
+premiumFlag =
+    Nri.Ui.Svg.V1.init "0 0 25 25"
+        [ Svg.path
+            [ Attributes.d "M1.60942 3C0.720563 3 0 3.70888 0 4.58333V20.4167C0 21.2911 0.720562 22 1.60942 22H23.3875C24.752 22 25.4974 20.4343 24.6239 19.403L19.6352 13.5136C19.1378 12.9265 19.1378 12.0735 19.6352 11.4864L24.6239 5.59696C25.4974 4.56569 24.752 3 23.3875 3H1.60942Z"
+            , Attributes.fill "currentColor"
+            , Attributes.fillRule "evenodd"
+            , Attributes.clipRule "evenodd"
             ]
             []
         ]


### PR DESCRIPTION
# :wrench: Modifying a component

## Context

Adds a `premiumFlag` icon.

## :framed_picture: What does this change look like?

<img width="1421" height="536" alt="Screenshot 2026-08-03 at 11 06 36" src="https://github.com/user-attachments/assets/2ed6aaa7-658a-4f63-aa0f-4874dcaddee2" />

## Component completion checklist

- [x] I've gone through the relevant sections of the [Development Accessibility guide](https://paper.dropbox.com/doc/Accessibility-guide-4-Development--BiIVdijSaoijjOuhz3iTCJJ1Ag-rGoHpC91pFg3zTrYpvOCQ) with the changes I made to this component in mind
- [ ] Changes are clearly documented
  - [ ] Component docs include a changelog
  - [ ] Any new exposed functions or properties have docs
- [x] Changes extend to the Component Catalog
  - [x] The Component Catalog is updated to use the newest version, if appropriate
  - [x] The Component Catalog example version number is updated, if appropriate
  - [x] Any new customizations are available from the Component Catalog
  - [x] The component example still has:
    - an accurate preview
    - valid sample code
    - correct keyboard behavior
    - correct and comprehensive guidance around how to use the component
- [x] Changes to the component are tested/the new version of the component is tested
- [x] Component API follows standard patterns in noredink-ui
  - e.g., as a dev, I can conveniently add an `nriDescription`
  - and adding a new feature to the component will _not_ require major API changes to the component
- [x] If this is a new major version of the component, our team has stories created to upgrade all instances of the old component. Here are links to the stories:
  - add your story links here OR just write this is not a new major version
- [x] Please assign the following reviewers:
  - [x] Someone from your team who can review your PR in full and review requirements from your team's perspective.
  - [x] Component library owner - Someone from this group will review your PR for accessibility and adherence to component library foundations.
  - [x] If there are user-facing changes, a designer. (You may want to direct your designer to the [deploy preview](https://github.com/NoRedInk/noredink-ui#reviews--preview-environments) for easy review):
    - For writing-related component changes, add Stacey (staceyadams)
    - For quiz engine-related components, add Ravi (ravi-morbia)
    - For a11y-related changes to general components, add Ben (bendansby)
    - For general component-related changes or if you’re not sure about something, add the Design group (NoRedInk/design)
